### PR TITLE
Flatten RexNode recursively to ensure Calcite assertion passes

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -16,9 +16,12 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
 import org.opensearch.analytics.planner.rel.OpenSearchConvention;
 import org.opensearch.analytics.planner.rel.OpenSearchDistribution;
@@ -308,5 +311,23 @@ public class RelNodeUtils {
             }
             return new RexInputRef(newIdx, newRowType.getFieldList().get(newIdx).getType());
         }
+    }
+
+    /**
+     * Recursively flattens nested same-operator AND/OR calls so the condition satisfies
+     * {@link RexUtil#isFlat(RexNode)} (the invariant asserted by {@link org.apache.calcite.rel.core.Filter}'s
+     * constructor). Calcite's {@code RexUtil.flatten(RexBuilder, RexNode)} only flattens the root
+     * call's direct operands; wrapping it in a {@link RexShuttle} applies it bottom-up, so each
+     * node is flattened after its children — making one pass fully recursive. Pure structural
+     * flatten: {@code flatten} splices same-op children only, with no de-duplication or
+     * simplification.
+     */
+    public static RexNode deepFlatten(RexBuilder rexBuilder, RexNode node) {
+        return node.accept(new RexShuttle() {
+            @Override
+            public RexNode visitCall(RexCall call) {
+                return RexUtil.flatten(rexBuilder, super.visitCall(call));
+            }
+        });
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -14,7 +14,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -564,7 +563,7 @@ public class FragmentConversionDriver {
             if (node instanceof OpenSearchFilter filter && resolver instanceof AnnotationResolver ar) {
                 // Combine delegated predicates in a single pass, then strip with simple unwrapper
                 RexNode resolved = ar.resolveTree(filter.getCondition());
-                RexNode flattened = RexUtil.flatten(node.getCluster().getRexBuilder(), resolved);
+                RexNode flattened = RelNodeUtils.deepFlatten(node.getCluster().getRexBuilder(), resolved);
                 return LogicalFilter.create(strippedChildren.getFirst(), flattened);
             }
             return openSearchNode.stripAnnotations(strippedChildren, resolver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchFilter.java
@@ -19,7 +19,6 @@ import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexUtil;
 import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 
@@ -38,8 +37,11 @@ public class OpenSearchFilter extends Filter implements OpenSearchRelNode {
     private final List<String> viableBackends;
 
     public OpenSearchFilter(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RexNode condition, List<String> viableBackends) {
-        // Filter.<init> asserts RexUtil.isFlat — flatten any nested AND/OR before super().
-        super(cluster, traitSet, input, RexUtil.flatten(cluster.getRexBuilder(), condition));
+        // Filter.<init> asserts RexUtil.isFlat — deep-flatten any nested AND/OR before super().
+        // TODO: the condition is currently deep-flattened in multiple places (here, in
+        // stripAnnotations(), and in FragmentConversionDriver.strip()). Revisit whether this can
+        // be enforced centrally at a single chokepoint so multiple flatten call sites aren't needed.
+        super(cluster, traitSet, input, RelNodeUtils.deepFlatten(cluster.getRexBuilder(), condition));
         this.viableBackends = viableBackends;
     }
 
@@ -109,7 +111,8 @@ public class OpenSearchFilter extends Filter implements OpenSearchRelNode {
         // AND child, and an OR must not contain an OR child. Adapter substitutions in
         // BackendPlanAdapter.adaptRex can introduce that nesting (e.g. SargAdapter expands
         // SEARCH into AND(>=, <=) under a parent AND). Flatten canonicalizes the tree.
-        RexNode flattened = RexUtil.flatten(getCluster().getRexBuilder(), resolved);
+        // TODO: see the constructor — revisit centralizing this flatten so multiple sites aren't needed.
+        RexNode flattened = RelNodeUtils.deepFlatten(getCluster().getRexBuilder(), resolved);
         return LogicalFilter.create(strippedChildren.getFirst(), flattened);
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -20,8 +20,10 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -36,6 +38,7 @@ import org.opensearch.analytics.planner.BasePlannerRulesTests;
 import org.opensearch.analytics.planner.MockDataFusionBackend;
 import org.opensearch.analytics.planner.MockLuceneBackend;
 import org.opensearch.analytics.planner.PlannerContext;
+import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
 import org.opensearch.analytics.planner.rel.AnnotatedProjectExpression;
 import org.opensearch.analytics.planner.rel.OpenSearchAggregate;
@@ -1366,6 +1369,68 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         var r = runCombining(makeAnd(or(matchPhrase("hello"), fuzzy("wrld")), or(wildcard("h*"), amountEquals(200))));
         assertEquals(2, r.plan.delegatedExpressions().size());
         assertEquals(FilterTreeShape.INTERLEAVED_BOOLEAN_EXPRESSION, treeShapeOf(r.plan));
+    }
+
+    /**
+     * Regression for the RexUtil.isFlat AssertionError. After predicate delegation strips the
+     * annotation wrappers in FragmentConversionDriver.strip(), an {@code IN (1,2,3)} expands to
+     * a bare OR(=,=,=) nested directly inside another OR — e.g.
+     * {@code AND(OR(delegated_predicate(0), >), OR(delegated_predicate(2), OR(=,=,=)), =)}.
+     * Calcite's shallow RexUtil.flatten does not descend into the inner OR, so
+     * LogicalFilter.create's recursive isFlat assertion fires. RelNodeUtils.deepFlatten walks the
+     * tree bottom-up and removes the nesting. This builds that exact tree and asserts it.
+     */
+    public void testDeepFlatten_removesNestedSameOpOr() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode ref = rexBuilder.makeInputRef(intType, 0);
+        RexNode eq1 = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(1, intType, true));
+        RexNode eq2 = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(2, intType, true));
+        RexNode eq3 = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(3, intType, true));
+        RexNode innerOr = or(eq1, eq2, eq3);
+        // Mirror production: the OR(=,=,=) is nested one level DOWN inside an AND, not at the
+        // root — so a shallow root-only flatten never visits it. AND(OR(eq2, OR(=,=,=)), eq3).
+        RexNode nested = makeAnd(or(eq2, innerOr), eq3);
+        assertFalse("precondition: tree is not flat", RexUtil.isFlat(nested));
+
+        RexNode flat = RelNodeUtils.deepFlatten(rexBuilder, nested);
+        assertTrue("deepFlatten must produce a flat tree", RexUtil.isFlat(flat));
+        // Pure flatten: the inner OR's 3 operands splice into the middle OR (eq2 + 3 = 4), none deduped.
+        RexCall andCall = (RexCall) flat;
+        assertEquals(SqlKind.AND, andCall.getKind());
+        RexNode middleOr = andCall.getOperands().get(0);
+        assertEquals(SqlKind.OR, middleOr.getKind());
+        assertEquals(4, ((RexCall) middleOr).getOperands().size());
+    }
+
+    /** Same-op nesting hidden under a NOT — NOT(OR(eqA, OR(eqB, eqC))) AND eqD. */
+    public void testDeepFlatten_removesNestedOrUnderNot() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode ref = rexBuilder.makeInputRef(intType, 0);
+        RexNode eqA = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(1, intType, true));
+        RexNode eqB = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(2, intType, true));
+        RexNode eqC = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(3, intType, true));
+        RexNode eqD = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(4, intType, true));
+        RexNode nested = makeAnd(not(or(eqA, or(eqB, eqC))), eqD);
+        assertFalse("precondition: tree is not flat", RexUtil.isFlat(nested));
+
+        RexNode flat = RelNodeUtils.deepFlatten(rexBuilder, nested);
+        // The OR nested under NOT must also be flattened (shuttle recurses through NOT).
+        assertTrue("deepFlatten must produce a flat tree", RexUtil.isFlat(flat));
+    }
+
+    /** An already-flat tree is returned unchanged (and stays flat). */
+    public void testDeepFlatten_alreadyFlatUnchanged() {
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode ref = rexBuilder.makeInputRef(intType, 0);
+        RexNode eqA = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(1, intType, true));
+        RexNode eqB = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, ref, rexBuilder.makeLiteral(2, intType, true));
+        // AND(eqA, OR(eqA, eqB)) — mixed operators, no same-op nesting → already flat.
+        RexNode flatInput = makeAnd(eqA, or(eqA, eqB));
+        assertTrue("precondition: input already flat", RexUtil.isFlat(flatInput));
+
+        RexNode flat = RelNodeUtils.deepFlatten(rexBuilder, flatInput);
+        assertTrue(RexUtil.isFlat(flat));
+        assertEquals(2, ((RexCall) flat).getOperands().size());
     }
 
     // ---- OR conditions ----


### PR DESCRIPTION
## What
Filter conditions with nested same-operator boolean expressions (e.g. an `OR` inside an `OR`) no longer crash query execution.

## Why
A query mixing a delegated full-text predicate with an `IN (...)` under an `OR` — e.g. `WHERE match(Title,'x') OR field IN (1,2,3)` — failed at backend conversion with `AssertionError: RexUtil.isFlat should be true ...` (HTTP 500). After predicate delegation strips annotation wrappers, the `IN` expansion surfaces as a bare `OR` nested directly inside another `OR`. Calcite's `RexUtil.flatten(RexBuilder, RexNode)` only flattens the top node, so the nested boolean survived and tripped the recursive flatness invariant asserted when the filter is rebuilt.

## How
Added a deep-flatten helper that applies Calcite's flatten bottom-up over the whole expression tree (children first), so all same-operator nesting is removed in a single pass. It is a pure structural flatten — no de-duplication or simplification. All filter-condition flatten points now route through it.

## Follow-ups
The condition is flattened in more than one place; a `TODO` is left to centralize this at a single chokepoint so multiple flatten call sites aren't needed.