### PR TITLE
Redact internal details from analytics engine 500 error responses

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -17,6 +17,7 @@ import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.TimeoutTaskCancellationUtility;
@@ -50,6 +51,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.tasks.TaskId;
 import org.opensearch.search.SearchService;
 import org.opensearch.tasks.Task;
@@ -409,7 +411,21 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // immediately. The listener is wrapped to convert backend-specific exceptions.
         ActionListener<AnalyticsQueryResponse> convertingListener = ActionListener.wrap(listener::onResponse, e -> {
             Exception converted = e instanceof Exception ex ? contextProvider.convertException(ex) : new RuntimeException(e);
-            listener.onFailure(converted);
+            // If convertException returned unrecognized 500 — redact internal details and log the original.
+            if (converted == e && isInternalError(converted)) {
+                AnalyticsQueryTask queryTask = (AnalyticsQueryTask) task;
+                String queryId = queryTask.getQueryId();
+                String identifier = "unassigned".equals(queryId)
+                    ? "task_id=" + task.getId()
+                    : "task_id=" + task.getId() + ", query_id=" + queryId;
+                logger.error(
+                    new org.apache.logging.log4j.message.ParameterizedMessage("[analytics-engine] internal error [{}]", identifier),
+                    converted
+                );
+                listener.onFailure(new RuntimeException("Internal error [" + identifier + "]"));
+            } else {
+                listener.onFailure(converted);
+            }
         });
         ContextAwareExecutor.wrap(searchExecutor, threadPool).execute(() -> {
             try {
@@ -441,6 +457,13 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
                 );
             }
         });
+    }
+
+    /**
+     * Returns true if the exception would produce a 500 response and should be redacted.
+     */
+    private static boolean isInternalError(Exception e) {
+        return ExceptionsHelper.status(e) == RestStatus.INTERNAL_SERVER_ERROR;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
@@ -195,7 +195,7 @@ public final class IndexResolution {
         for (IndexMetadata index : open) {
             AliasMetadata aliasMd = index.getAliases().get(aliasName);
             if (aliasMd != null && aliasMd.filteringRequired()) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                     "Alias ["
                         + aliasName
                         + "] declares a filter on index ["
@@ -252,7 +252,7 @@ public final class IndexResolution {
                     OpenSearchSchemaBuilder.mapFieldType(previous.type),
                     OpenSearchSchemaBuilder.mapFieldType(type)
                 )) {
-                    throw new IllegalStateException(
+                    throw new IllegalArgumentException(
                         "Alias ["
                             + aliasName
                             + "] resolves to indices with incompatible field types: ["

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionTests.java
@@ -57,7 +57,7 @@ public class IndexResolutionTests extends OpenSearchTestCase {
         IndexMetadata.Builder b = indexBuilder("bank_b", keywordField("age")).putAlias(AliasMetadata.builder("bank_all").build());
         ClusterState state = clusterStateOf(a, b);
 
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> IndexResolution.resolve("bank_all", state));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> IndexResolution.resolve("bank_all", state));
         assertTrue("error must mention the conflicting field: " + ex.getMessage(), ex.getMessage().contains("age"));
         assertTrue(
             "error must mention both indices: " + ex.getMessage(),
@@ -103,7 +103,7 @@ public class IndexResolutionTests extends OpenSearchTestCase {
         IndexMetadata.Builder a = indexBuilder("bank_a", longField("age")).putAlias(filterAlias);
         ClusterState state = clusterStateOf(a);
 
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> IndexResolution.resolve("active_only", state));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> IndexResolution.resolve("active_only", state));
         assertTrue("error must mention the alias name: " + ex.getMessage(), ex.getMessage().contains("active_only"));
         assertTrue("error must mention 'filter': " + ex.getMessage(), ex.getMessage().toLowerCase(Locale.ROOT).contains("filter"));
     }
@@ -142,7 +142,7 @@ public class IndexResolutionTests extends OpenSearchTestCase {
     public void testWildcardRejectsIncompatibleSchemasAcrossMatches() {
         ClusterState state = clusterStateOf(indexBuilder("test", longField("age")), indexBuilder("test1", keywordField("age")));
 
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> IndexResolution.resolve("test*", state, RESOLVER));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> IndexResolution.resolve("test*", state, RESOLVER));
         assertTrue("error must mention the conflicting field: " + ex.getMessage(), ex.getMessage().contains("age"));
     }
 
@@ -268,7 +268,7 @@ public class IndexResolutionTests extends OpenSearchTestCase {
             )
             .build();
 
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> IndexResolution.resolve("logs", state, RESOLVER));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> IndexResolution.resolve("logs", state, RESOLVER));
         assertTrue("error must mention the conflicting field: " + ex.getMessage(), ex.getMessage().contains("age"));
     }
 


### PR DESCRIPTION
### Description

Unrecognized exceptions from the analytics engine (those not converted by `NativeErrorConverter` to 400/429) currently leak internal details in the error response: cause and wrapped exception types.

### Change

At the top-level `convertingListener` in `DefaultPlanExecutor.doExecute()`:
- If the exception was NOT converted to a recognized type (400/429), replace it with a generic message: `Internal error [task_id=X, query_id=Y]`
- Log the full original exception at ERROR level server-side for operator debugging

### User sees (after)

```json
{
  "error": {
    "type": "runtime_exception",
    "reason": "Internal error [task_id=12345, query_id=8ffee8b8-944b-4fcd-9f71-6f4601f8034b]"
  },
  "status": 500
}
```

Operators grep server logs for the task/query ID to find the full stack trace.