### PR TITLE
Wait for reduce teardown before closing Arrow allocator on cancel

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -81,6 +81,10 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
     /** Guards the teardown body so concurrent + sequential close paths don't run it twice. */
     final java.util.concurrent.atomic.AtomicBoolean torndown = new java.util.concurrent.atomic.AtomicBoolean();
 
+    /** Signalled when reduce's finally completes teardown. closeImpl awaits this
+     *  when cancelled during REDUCING state so the allocator isn't closed prematurely. */
+    private final java.util.concurrent.CountDownLatch reduceDone = new java.util.concurrent.CountDownLatch(1);
+
     public DatafusionReduceSink(ExchangeSinkContext ctx, NativeRuntimeHandle runtimeHandle) {
         this(ctx, runtimeHandle, null);
     }
@@ -359,9 +363,17 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
     protected Exception closeImpl() {
         SinkState before = state.compareAndExchange(SinkState.READY, SinkState.DONE);
         if (before == SinkState.REDUCING) {
-            // Drain parked — dropping senders/outStream now would panic in drop_in_place.
+            // Drain in flight — fire cancel so it unblocks, then wait for reduce's
+            // finally to complete teardown (releases Arrow batches from the allocator).
             fireCancelQuery();
-            return null;  // reduce()'s finally calls closeImpl directly to tear down.
+            try {
+                if (!reduceDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                    logger.warn("[reduce-sink] timed out waiting for reduce teardown: taskId={}", ctx.taskId());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
         }
         // before == READY (we just won) or DONE (reduce's finally calling us, or duplicate close).
         if (torndown.compareAndSet(false, true) == false) {
@@ -419,6 +431,9 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
             } catch (Exception t) {
                 failure = accumulate(failure, t);
             }
+            // Signal that teardown is complete — unblocks any concurrent closeImpl()
+            // waiting on REDUCING state (cancel path) so the allocator can close safely.
+            reduceDone.countDown();
         }
         if (failure == null) {
             listener.onResponse(null);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
@@ -123,7 +123,6 @@ public class QueryExecution {
     public void close() {
         if (closed.compareAndSet(false, true) == false) return;
         runQuietly("terminal sink close", this::closeTerminalSink);
-        // TODO: Re-evaluate this per query child allocator
         logAllocatorState();
         runQuietly("query context close", config::close);
     }


### PR DESCRIPTION
## Summary

When a coordinator query is cancelled while the reduce drain loop is actively consuming batches, the cancel thread closes the per-query Arrow allocator before the reduce thread releases its in-flight batches. This causes:

```
java.lang.IllegalStateException: Memory was leaked by query. Memory leaked: (1583272)
Allocator(query-...) 0/1583272/46138432/268435456 (res/actual/peak/limit)
```

## Root Cause

The cancel path calls `QueryExecution.close()` → `closeTerminalSink()` → `DatafusionReduceSink.closeImpl()`. When state is `REDUCING`, `closeImpl()` fires `cancelQuery` and returns `null` (deferring teardown to the reduce thread's `finally`). But `QueryExecution.close()` then immediately proceeds to `config.close()` which closes the allocator — while the reduce thread still holds Arrow batch references.

## Fix

Add a `CountDownLatch` to `DatafusionReduceSink` signalled by `reduce()`'s `finally` after teardown completes. When `closeImpl()` observes state=REDUCING on the cancel path, it fires `cancelQuery` then awaits the latch (up to 5s timeout) before returning — ensuring the reduce thread releases all Arrow batches before the allocator closes.

## Test plan

- [ ] Run coordinator cancel workload — verify no "Memory was leaked" errors in logs
- [ ] Verify normal (non-cancelled) queries are unaffected (latch is pre-counted-down on the happy path via reduce's finally)