### PR TITLE
Fix NPE in bitmap terms lookup when stored field is missing (#21995)

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
@@ -582,13 +582,19 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> i
             client.get(getRequest, ActionListener.delegateFailure(actionListener, (delegatedListener, getResponse) -> {
                 List<Object> terms = new ArrayList<>();
                 if (termsLookup.store()) {
-                    List<Object> values = getResponse.getField(termsLookup.path()).getValues();
-                    if (values.size() != 1 && valueType == ValueType.BITMAP) {
-                        throw new IllegalArgumentException(
-                            "Invalid value for bitmap type: Expected a single base64 encoded serialized bitmap."
-                        );
+                    // getField(...) may be null when the document exists but the stored field is missing.
+                    // Treat a missing stored field as an empty terms list (no matches) instead of throwing NPE.
+                    if (getResponse.getField(termsLookup.path()) != null) {
+                        List<Object> values = getResponse.getField(termsLookup.path()).getValues();
+                        if (values.size() != 1 && valueType == ValueType.BITMAP) {
+                            throw new IllegalArgumentException(
+                                "Invalid value for bitmap type: Expected a single base64 encoded serialized bitmap."
+                            );
+                        }
+                        terms.addAll(values);
+                    } else {
+                        // missing stored field -> no terms to add (treat as empty)
                     }
-                    terms.addAll(values);
                 } else {
                     if (getResponse.isSourceEmpty() == false) { // extract terms only if the doc source exists
                         List<Object> extractedValues = XContentMapValues.extractRawValues(termsLookup.path(), getResponse.getSourceAsMap());

--- a/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.support.XContentMapValues;
@@ -584,8 +585,9 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> i
                 if (termsLookup.store()) {
                     // getField(...) may be null when the document exists but the stored field is missing.
                     // Treat a missing stored field as an empty terms list (no matches) instead of throwing NPE.
-                    if (getResponse.getField(termsLookup.path()) != null) {
-                        List<Object> values = getResponse.getField(termsLookup.path()).getValues();
+                    DocumentField field = getResponse.getField(termsLookup.path());
+                    if (field != null) {
+                        List<Object> values = field.getValues();
                         if (values.size() != 1 && valueType == ValueType.BITMAP) {
                             throw new IllegalArgumentException(
                                 "Invalid value for bitmap type: Expected a single base64 encoded serialized bitmap."

--- a/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
@@ -51,13 +51,11 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.transport.client.Client;
-import static org.mockito.Mockito.*;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -65,6 +63,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.indices.TermsLookup;
 import org.opensearch.test.AbstractQueryTestCase;
+import org.opensearch.transport.client.Client;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 
@@ -83,6 +82,9 @@ import java.util.stream.Collectors;
 
 import org.roaringbitmap.RoaringBitmap;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.opensearch.index.query.BoolQueryBuilderTests.getIndexSearcher;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;

--- a/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
@@ -51,6 +51,9 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.transport.client.Client;
+import static org.mockito.Mockito.*;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.util.io.IOUtils;
@@ -285,6 +288,53 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         return new GetResponse(
             new GetResult(getRequest.index(), getRequest.id(), 0, 1, 0, true, new BytesArray(json), documentField, null)
         );
+    }
+
+    public void testStoredFieldMissingIsTreatedAsEmpty() throws IOException {
+        // Mock the client to return a GetResponse with no stored fields for the requested path
+        Client mockClient = mock(Client.class);
+        doAnswer(invocation -> {
+            GetRequest req = invocation.getArgument(0);
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            String json = "{}";
+            Map<String, DocumentField> documentField = new HashMap<>();
+            GetResponse getResponse = new GetResponse(
+                new GetResult(req.index(), req.id(), 0, 1, 0, true, new BytesArray(json), documentField, null)
+            );
+            listener.onResponse(getResponse);
+            return null;
+        }).when(mockClient).get(any(GetRequest.class), any(ActionListener.class));
+
+        BaseQueryRewriteContext ctx = new BaseQueryRewriteContext(xContentRegistry(), namedWriteableRegistry(), mockClient, () -> 0L);
+
+        TermsLookup lookup = new TermsLookup(getIndex().getName(), "1", termsPath).store(true);
+        TermsQueryBuilder query = new TermsQueryBuilder(TEXT_FIELD_NAME, lookup);
+        QueryBuilder rewritten = rewriteAndFetch(query, ctx);
+        // With the stored field missing, the lookup should produce no terms -> MatchNone
+        assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
+    }
+
+    public void testStoredFieldMissingForBitmapDoesNotThrowNPE() throws IOException {
+        Client mockClient = mock(Client.class);
+        doAnswer(invocation -> {
+            GetRequest req = invocation.getArgument(0);
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            String json = "{}";
+            Map<String, DocumentField> documentField = new HashMap<>();
+            GetResponse getResponse = new GetResponse(
+                new GetResult(req.index(), req.id(), 0, 1, 0, true, new BytesArray(json), documentField, null)
+            );
+            listener.onResponse(getResponse);
+            return null;
+        }).when(mockClient).get(any(GetRequest.class), any(ActionListener.class));
+
+        BaseQueryRewriteContext ctx = new BaseQueryRewriteContext(xContentRegistry(), namedWriteableRegistry(), mockClient, () -> 0L);
+
+        TermsLookup lookup = new TermsLookup(getIndex().getName(), "1", termsPath).store(true);
+        TermsQueryBuilder query = new TermsQueryBuilder(INT_FIELD_NAME, lookup).valueType(TermsQueryBuilder.ValueType.BITMAP);
+        QueryBuilder rewritten = rewriteAndFetch(query, ctx);
+        // Missing stored field should be treated as empty terms -> MatchNone
+        assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
     }
 
     public void testNumeric() throws IOException {


### PR DESCRIPTION
When a terms query with value_type=bitmap and store=true uses a terms lookup, and the lookup document exists but the stored field at path is missing, the server threw an NPE.

This change adds a null-check before dereferencing stored fields in TermsQueryBuilder.fetch(...) and treats a missing stored field as an empty term list (rewriting to match_none). 
Unit tests (Mockito) added to validate behavior and avoid regressions.

Fixes: #21995