### PR TITLE
Wire up history retention lock for DataFormatAware (composite) engine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -1681,7 +1681,7 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public Closeable acquireHistoryRetentionLock() {
-        return () -> {};
+        return translogManager.acquireHistoryRetentionLock();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -21,6 +21,7 @@ import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.translog.listener.TranslogEventListener;
 import org.opensearch.index.translog.transfer.TranslogUploadFailedException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -430,6 +431,11 @@ public class InternalTranslogManager implements TranslogManager {
      */
     public String getTranslogUUID() {
         return translog.getTranslogUUID();
+    }
+
+    @Override
+    public Closeable acquireHistoryRetentionLock() {
+        return translog.acquireRetentionLock();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -185,4 +185,12 @@ public interface TranslogManager extends Closeable {
      * @return the uuid of the translog
      */
     String getTranslogUUID();
+
+    /**
+     * Acquire retention lock on the translog
+     * @return releasable for releasing the lock
+     */
+    default Closeable acquireHistoryRetentionLock() {
+        return () -> {};
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -59,8 +59,10 @@ import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.FsDirectoryFactory;
 import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.InternalTranslogManager;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.index.translog.TranslogDeletionPolicy;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.plugins.SearchBackEndPlugin;
 import org.opensearch.test.DummyShardLock;
@@ -69,6 +71,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -324,6 +327,64 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
                 engine.getProcessedLocalCheckpoint(),
                 equalTo((long) numDocs - 1)
             );
+        }
+    }
+
+    /**
+     * {@link DataFormatAwareEngine#acquireHistoryRetentionLock()} must return a lock that pins a translog
+     * generation in the deletion policy for as long as it is held, and releases that generation when closed.
+     * Peer recovery / primary relocation relies on this to keep translog history available for the duration
+     * of recovery.
+     */
+    public void testAcquireHistoryRetentionLockPinsTranslogGeneration() throws IOException {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            int numDocs = randomIntBetween(1, 20);
+            for (int i = 0; i < numDocs; i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+            }
+
+            // The retention lock pins a generation in the translog's deletion policy.
+            TranslogDeletionPolicy deletionPolicy = ((InternalTranslogManager) engine.translogManager()).getTranslog().getDeletionPolicy();
+            // No retention locks are held before acquiring one.
+            deletionPolicy.assertNoOpenTranslogRefs();
+
+            Closeable retentionLock = engine.acquireHistoryRetentionLock();
+            assertThat(retentionLock, notNullValue());
+            // While the lock is held there is an open translog reference pinning a generation.
+            expectThrows(AssertionError.class, deletionPolicy::assertNoOpenTranslogRefs);
+
+            // Releasing the lock releases the pinned generation.
+            retentionLock.close();
+            deletionPolicy.assertNoOpenTranslogRefs();
+        }
+    }
+
+    /**
+     * {@link DataFormatAwareEngine#countNumberOfHistoryOperations(String, long, long)} must count only the
+     * operations whose seqNo falls within the requested {@code [fromSeqNo, toSeqNo]} range, de-duplicated --
+     * i.e. the operations actually yielded by the changes snapshot for that range, not the raw operation
+     * count of the underlying translog generations.
+     */
+    public void testCountNumberOfHistoryOperationsRespectsSeqNoRange() throws IOException {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            int numDocs = 10;
+            for (int i = 0; i < numDocs; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+                assertThat(result.getSeqNo(), equalTo((long) i));
+            }
+            // Ensure the buffered translog operations are durable and readable by the changes snapshot.
+            engine.translogManager().syncTranslog();
+
+            // Full range counts every operation.
+            assertThat(engine.countNumberOfHistoryOperations("test", 0, Long.MAX_VALUE), equalTo(numDocs));
+
+            // Sub-ranges count only the operations whose seqNo lies within [fromSeqNo, toSeqNo].
+            assertThat(engine.countNumberOfHistoryOperations("test", 5, 9), equalTo(5));
+            assertThat(engine.countNumberOfHistoryOperations("test", 0, 4), equalTo(5));
+            assertThat(engine.countNumberOfHistoryOperations("test", 3, 6), equalTo(4));
+            assertThat(engine.countNumberOfHistoryOperations("test", 7, Long.MAX_VALUE), equalTo(3));
+            // A range above the highest seqNo contains no operations.
+            assertThat(engine.countNumberOfHistoryOperations("test", numDocs, Long.MAX_VALUE), equalTo(0));
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -16,6 +16,7 @@ import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.translog.listener.TranslogEventListener;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -293,6 +294,70 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             assertThat(translogManager.getTranslog().currentFileGeneration(), equalTo(2L));
             assertThat(translogManager.getTranslog().getMinFileGeneration(), equalTo(2L));
             assertTrue(syncListenerInvoked.get());
+        } finally {
+            translogManager.close();
+        }
+    }
+
+    /**
+     * {@link InternalTranslogManager#acquireHistoryRetentionLock()} must return a lock backed by
+     * {@link Translog#acquireRetentionLock()} that pins a translog generation in the deletion policy while
+     * it is held, and releases that generation when closed. This is the translog-layer support that
+     * {@link org.opensearch.index.engine.DataFormatAwareEngine} relies on to keep history available for
+     * the duration of peer recovery / primary relocation.
+     */
+    public void testAcquireHistoryRetentionLock() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        final LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
+        // Hold a reference to the deletion policy so we can observe the retention locks it tracks.
+        final TranslogDeletionPolicy deletionPolicy = createTranslogDeletionPolicy(INDEX_SETTINGS);
+        InternalTranslogManager translogManager = null;
+        try {
+            translogManager = new InternalTranslogManager(
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, "", false),
+                primaryTerm,
+                globalCheckpoint::get,
+                deletionPolicy,
+                shardId,
+                new ReleasableLock(new ReentrantReadWriteLock().readLock()),
+                () -> tracker,
+                translogUUID,
+                TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
+                () -> {},
+                new InternalTranslogFactory(),
+                () -> Boolean.TRUE,
+                TranslogOperationHelper.DEFAULT
+            );
+
+            // Index a few operations spread over multiple generations.
+            final int docs = randomIntBetween(1, 10);
+            for (int i = 0; i < docs; i++) {
+                final ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocumentWithTextField(), SOURCE, null);
+                final Engine.Index index = indexForDoc(doc);
+                final Engine.IndexResult indexResult = new Engine.IndexResult(index.version(), index.primaryTerm(), i, true);
+                tracker.markSeqNoAsProcessed(i);
+                translogManager.add(new Translog.Index(index, indexResult));
+                translogManager.rollTranslogGeneration();
+            }
+
+            // The manager must expose the same deletion policy instance the lock pins against.
+            assertSame(deletionPolicy, translogManager.getTranslog().getDeletionPolicy());
+
+            // No retention locks are held before acquiring one.
+            assertEquals(0, deletionPolicy.pendingTranslogRefCount());
+            deletionPolicy.assertNoOpenTranslogRefs();
+
+            // Acquiring the history retention lock pins a translog generation.
+            final Closeable retentionLock = translogManager.acquireHistoryRetentionLock();
+            assertNotNull(retentionLock);
+            assertEquals(1, deletionPolicy.pendingTranslogRefCount());
+            // While the lock is held there is an open translog reference.
+            expectThrows(AssertionError.class, deletionPolicy::assertNoOpenTranslogRefs);
+
+            // Releasing the lock releases the pinned generation.
+            retentionLock.close();
+            assertEquals(0, deletionPolicy.pendingTranslogRefCount());
+            deletionPolicy.assertNoOpenTranslogRefs();
         } finally {
             translogManager.close();
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
#### What
  
  Make DataFormatAwareEngine.acquireHistoryRetentionLock() return a real translog retention lock instead of a no-op, and add the supporting method to the translog-manager layer.
  
  ##### Why — this fixes the blue/green (B/G) hang
  
  A blue/green deployment provisions new nodes and relocates the primary to them. That primary relocation is a peer recovery via LocalStorePeerRecoverySourceHandler, which calls acquireHistoryRetentionLock() to pin the source translog for the duration of recovery. On the composite (segment-replication + remote-store) engine this was a no-op () -> {}, so nothing was pinned.
  
  Under sustained ingest during the relocation, the source's local translog generations were trimmed mid-recovery (minSeqNoToKeep advancing past the target's restored checkpoint).
  Phase-2 replays history from the source's local translog only, so the trimmed operations were lost — the relocation target's persisted local checkpoint never advanced and the  relocation hung indefinitely (translog stuck at 100%). The practical effect: B/G deployments on composite domains never completed (the old node couldn't hand off the primary).
 Pure-Lucene is unaffected because its recovery history is coupled to the safe commit the target receives.
  
  With the fix, the retention lock pins the minimum translog generation in the deletion policy at the start of recovery, so concurrent trimming can't remove the operations phase-2 needs the relocation finalizes and B/G completes.
  
  #### Change
  - DataFormatAwareEngine: acquireHistoryRetentionLock() delegates to translogManager.acquireHistoryRetentionLock() (was a no-op).
  - InternalTranslogManager: implements acquireHistoryRetentionLock() → translog.acquireRetentionLock().
  - TranslogManager: adds a default acquireHistoryRetentionLock() returning a no-op so other implementations are unaffected.
  
  Testing
  
  Validated on a real staging domain (composite, remote-store, segment-replication) under production-like load: pre-fix, a B/G triggered during sustained ingest hung for hours; post-fix,
  the B/G relocation finalizes cleanly (finalizing recovery took [~Xs], zero skipped updating local checkpoint), confirmed across multiple B/G cycles. An in-memory internalClusterTest
  repro was attempted but the gap depends on long-window, sustained-ingest remote-translog trimming that the single-process harness doesn't recreate (core op-retention pins the ops for the recovering target).
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
