### PR TITLE
Add indexing throttle on merge pressure for DataFormatAwareEngine

### DIFF
--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -109,7 +109,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(secondaryMerger.merge(any())).thenReturn(secondaryResult);
 
         MergeHandler handler = createHandler();
-        MergeResult result = handler.doMerge(oneMerge);
+        MergeResult result = handler.doMerge(oneMerge, Double.POSITIVE_INFINITY);
 
         assertNotNull(result);
         assertEquals(2, result.getMergedWriterFileSet().size());
@@ -147,7 +147,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
             () -> 1L
         );
 
-        MergeResult result = handler.doMerge(oneMerge);
+        MergeResult result = handler.doMerge(oneMerge, Double.POSITIVE_INFINITY);
         assertNotNull(result);
         assertEquals(1, result.getMergedWriterFileSet().size());
         assertSame(mergedWfs, result.getMergedWriterFileSetForDataformat(primaryFormat));
@@ -165,7 +165,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(primaryMerger.merge(any())).thenThrow(new IOException("primary disk error"));
 
         MergeHandler handler = createHandler();
-        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         assertNotNull(ex.getCause());
         assertEquals("primary disk error", ex.getCause().getMessage());
     }
@@ -185,7 +185,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(secondaryMerger.merge(any())).thenThrow(new IOException("secondary disk error"));
 
         MergeHandler handler = createHandler();
-        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         assertNotNull(ex.getCause());
         assertEquals("secondary disk error", ex.getCause().getMessage());
     }
@@ -232,7 +232,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
             () -> 1L
         );
 
-        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         assertNotNull(ex.getCause());
         // Fail-fast: only the first secondary failure is reported, no suppressed exceptions
         assertEquals(0, ex.getCause().getSuppressed().length);
@@ -253,7 +253,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(primaryMerger.merge(any())).thenReturn(primaryResult);
 
         MergeHandler handler = createHandler();
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> handler.doMerge(oneMerge));
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         assertTrue(ex.getMessage().contains("row-ID mapping"));
         assertTrue(ex.getMessage().contains("secondaries"));
     }
@@ -278,7 +278,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(secondaryMerger.merge(any())).thenThrow(new IOException("secondary fail"));
 
         MergeHandler handler = createHandler();
-        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
 
         assertFalse("Stale merged file should be deleted on failure", Files.exists(staleFile));
     }
@@ -300,7 +300,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
 
         MergeHandler handler = createHandler();
         // Should not throw during cleanup even though file doesn't exist
-        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
     }
 
     // ========== doMerge: no cleanup when mergedWriterFileSet is empty ==========
@@ -315,7 +315,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(primaryMerger.merge(any())).thenThrow(new IOException("primary fail"));
 
         MergeHandler handler = createHandler();
-        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        UncheckedIOException ex = expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         assertEquals("primary fail", ex.getCause().getMessage());
     }
 
@@ -341,7 +341,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         when(secondaryMerger.merge(any())).thenReturn(secondaryResult);
 
         MergeHandler handler = createHandler();
-        MergeResult result = handler.doMerge(oneMerge);
+        MergeResult result = handler.doMerge(oneMerge, Double.POSITIVE_INFINITY);
 
         assertNotNull(result);
         assertEquals(2, result.getMergedWriterFileSet().size());
@@ -384,7 +384,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
             () -> 1L
         );
 
-        MergeResult result = handler.doMerge(oneMerge);
+        MergeResult result = handler.doMerge(oneMerge, Double.POSITIVE_INFINITY);
         assertNotNull(result);
         assertEquals(1, result.getMergedWriterFileSet().size());
     }
@@ -562,7 +562,7 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         MergeHandler handler = createHandler();
         // The merge fails due to secondary, cleanup tries to delete "mp.dat" (a non-empty dir)
         // which throws DirectoryNotEmptyException — caught and logged, not re-thrown
-        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge));
+        expectThrows(UncheckedIOException.class, () -> handler.doMerge(oneMerge, Double.POSITIVE_INFINITY));
         // The directory should still exist since deleteIfExists fails on non-empty dirs
         assertTrue(Files.exists(dirAsFile));
     }

--- a/server/src/internalClusterTest/java/org/opensearch/index/ClusterMergeSchedulerConfigsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/ClusterMergeSchedulerConfigsIT.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.common.util.concurrent.OpenSearchExecutors.NODE_PROCESSORS_SETTING;
 import static org.opensearch.indices.ClusterMergeSchedulerConfig.CLUSTER_AUTO_THROTTLE_SETTING;
+import static org.opensearch.indices.ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING;
 import static org.opensearch.indices.ClusterMergeSchedulerConfig.CLUSTER_MAX_MERGE_COUNT_SETTING;
 import static org.opensearch.indices.ClusterMergeSchedulerConfig.CLUSTER_MAX_THREAD_COUNT_SETTING;
 
@@ -1039,6 +1040,76 @@ public class ClusterMergeSchedulerConfigsIT extends OpenSearchIntegTestCase {
         assertEquals(60, indexService.getIndexSettings().getMergeSchedulerConfig().getMaxThreadCount());
         assertEquals("80", clusterSettings.get(CLUSTER_MAX_MERGE_COUNT_SETTING).toString());
         assertEquals("60", clusterSettings.get(CLUSTER_MAX_THREAD_COUNT_SETTING).toString());
+    }
+
+    public void testClusterIORateLimitPropagates() throws Exception {
+        String clusterManagerName = internalCluster().getClusterManagerName();
+        List<String> dataNodes = new ArrayList<>(internalCluster().getDataNodeNames());
+
+        String indexName = "test-io-rate-limit";
+        createIndex(indexName, indexSettings());
+        ensureYellowAndNoInitializingShards(indexName);
+        ensureGreen(indexName);
+
+        GetIndexResponse getIndexResponse = client(clusterManagerName).admin().indices().getIndex(new GetIndexRequest()).get();
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, randomFrom(dataNodes));
+        String uuid = getIndexResponse.getSettings().get(indexName).get(IndexMetadata.SETTING_INDEX_UUID);
+        IndexService indexService = getIndexService(indicesService, new Index(indexName, uuid));
+
+        // default is infinity (no cap)
+        assertEquals(
+            Double.POSITIVE_INFINITY,
+            indexService.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(),
+            0.0
+        );
+
+        // set cluster-level IO rate limit
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put(CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.getKey(), 50.0))
+            .get();
+
+        assertEquals(50.0, indexService.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(), 0.0);
+
+        // update to a different value
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put(CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.getKey(), 100.0))
+            .get();
+
+        assertEquals(100.0, indexService.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(), 0.0);
+
+        // create a second index and verify it also picks up the rate limit
+        String indexName2 = "test-io-rate-limit-2";
+        createIndex(indexName2, indexSettings());
+        ensureYellowAndNoInitializingShards(indexName2);
+        ensureGreen(indexName2);
+
+        getIndexResponse = client(clusterManagerName).admin().indices().getIndex(new GetIndexRequest()).get();
+        uuid = getIndexResponse.getSettings().get(indexName2).get(IndexMetadata.SETTING_INDEX_UUID);
+        IndexService indexService2 = getIndexService(indicesService, new Index(indexName2, uuid));
+
+        assertEquals(100.0, indexService2.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(), 0.0);
+
+        // remove the setting (reset to default infinity)
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().putNull(CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.getKey()))
+            .get();
+
+        assertEquals(
+            Double.POSITIVE_INFINITY,
+            indexService.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(),
+            0.0
+        );
+        assertEquals(
+            Double.POSITIVE_INFINITY,
+            indexService2.getIndexSettings().getMergeSchedulerConfig().getIORateLimitMBPerSec(),
+            0.0
+        );
     }
 
     private IndexService getIndexService(IndicesService indicesService, Index index) throws Exception {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -316,6 +316,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ClusterMergeSchedulerConfig.CLUSTER_MAX_THREAD_COUNT_SETTING,
                 ClusterMergeSchedulerConfig.CLUSTER_MAX_MERGE_COUNT_SETTING,
                 ClusterMergeSchedulerConfig.CLUSTER_AUTO_THROTTLE_SETTING,
+                ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING,
                 IndicesService.CLUSTER_DEFAULT_INDEX_MAX_MERGE_AT_ONCE_SETTING,
                 IndicesService.CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING,
                 IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -1359,6 +1359,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
     }
 
+    public void onClusterLevelIORateLimitUpdate(double ioRateLimitMBPerSec) {
+        indexSettings.getMergeSchedulerConfig().setIORateLimitMBPerSec(ioRateLimitMBPerSec);
+    }
+
     /**
      * Called whenever the refresh interval changes. This can happen in 2 cases -
      * 1. {@code cluster.default.index.refresh_interval} cluster setting changes. The change would only happen for

--- a/server/src/main/java/org/opensearch/index/MergeSchedulerConfig.java
+++ b/server/src/main/java/org/opensearch/index/MergeSchedulerConfig.java
@@ -143,6 +143,7 @@ public final class MergeSchedulerConfig {
     private volatile int maxThreadCount;
     private volatile int maxMergeCount;
     private volatile double maxForceMergeMBPerSec;
+    private volatile double ioRateLimitMBPerSec = Double.POSITIVE_INFINITY;
     private static volatile Boolean clusterAutoThrottleEnabledDefault;
     private static volatile Integer clusterMaxThreadCountDefault;
     private static volatile Integer clusterMaxMergeCountDefault;
@@ -235,6 +236,9 @@ public final class MergeSchedulerConfig {
 
         setAutoThrottle(autoThrottleEnabled);
         setMaxThreadAndMergeCount(maxThread, maxMerge);
+        this.ioRateLimitMBPerSec = ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.get(
+            indexSettings.getNodeSettings()
+        );
         logger.info(
             new ParameterizedMessage(
                 "Initialized index {} with maxMergeCount={}, maxThreadCount={}, autoThrottleEnabled={}",
@@ -333,6 +337,22 @@ public final class MergeSchedulerConfig {
      */
     void setMaxForceMergeMBPerSec(double maxForceMergeMBPerSec) {
         this.maxForceMergeMBPerSec = maxForceMergeMBPerSec;
+    }
+
+    /**
+     * Returns the IO rate limit for background merges in MB per second.
+     * A value of Double.POSITIVE_INFINITY indicates no rate limiting.
+     */
+    public double getIORateLimitMBPerSec() {
+        return ioRateLimitMBPerSec;
+    }
+
+    /**
+     * Sets the IO rate limit for background merges in MB per second.
+     * A value of Double.POSITIVE_INFINITY disables rate limiting.
+     */
+    public void setIORateLimitMBPerSec(double ioRateLimitMBPerSec) {
+        this.ioRateLimitMBPerSec = ioRateLimitMBPerSec;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/MergeSchedulerConfig.java
+++ b/server/src/main/java/org/opensearch/index/MergeSchedulerConfig.java
@@ -147,6 +147,7 @@ public final class MergeSchedulerConfig {
     private static volatile Boolean clusterAutoThrottleEnabledDefault;
     private static volatile Integer clusterMaxThreadCountDefault;
     private static volatile Integer clusterMaxMergeCountDefault;
+    private static volatile Double clusterIORateLimitDefault;
 
     MergeSchedulerConfig(IndexSettings indexSettings) {
         indexName = indexSettings.getIndex().getName();
@@ -236,9 +237,9 @@ public final class MergeSchedulerConfig {
 
         setAutoThrottle(autoThrottleEnabled);
         setMaxThreadAndMergeCount(maxThread, maxMerge);
-        this.ioRateLimitMBPerSec = ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.get(
-            indexSettings.getNodeSettings()
-        );
+        this.ioRateLimitMBPerSec = clusterIORateLimitDefault != null
+            ? clusterIORateLimitDefault
+            : ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.get(indexSettings.getNodeSettings());
         logger.info(
             new ParameterizedMessage(
                 "Initialized index {} with maxMergeCount={}, maxThreadCount={}, autoThrottleEnabled={}",
@@ -353,6 +354,13 @@ public final class MergeSchedulerConfig {
      */
     public void setIORateLimitMBPerSec(double ioRateLimitMBPerSec) {
         this.ioRateLimitMBPerSec = ioRateLimitMBPerSec;
+    }
+
+    /**
+     * Updates the cluster-level default IO rate limit so newly created indices inherit the value.
+     */
+    public static void setDefaultIORateLimitMBPerSec(double rateLimitMBPerSec) {
+        clusterIORateLimitDefault = rateLimitMBPerSec;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -500,7 +500,7 @@ public class DataFormatAwareEngine implements Indexer {
                         refreshLock.unlock();
                     }
                 }
-            }, shardId, engineConfig.getIndexSettings(), engineConfig.getThreadPool());
+            }, this::activateThrottling, this::deactivateThrottling, shardId, engineConfig.getIndexSettings(), engineConfig.getThreadPool());
             success = true;
             logger.trace("created new DataFormatBasedEngine");
         } catch (IOException | TranslogCorruptedException e) {

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/MergeInput.java
@@ -23,14 +23,14 @@ import java.util.Objects;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long newWriterGeneration) {
+public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long newWriterGeneration, double rateLimitMBPerSec) {
 
     public MergeInput {
         segments = List.copyOf(segments);
     }
 
     private MergeInput(Builder builder) {
-        this(new ArrayList<>(builder.segments), builder.rowIdMapping, builder.newWriterGeneration);
+        this(new ArrayList<>(builder.segments), builder.rowIdMapping, builder.newWriterGeneration, builder.rateLimitMBPerSec);
     }
 
     /**
@@ -60,6 +60,7 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
         private List<Segment> segments = new ArrayList<>();
         private RowIdMapping rowIdMapping;
         private long newWriterGeneration;
+        private double rateLimitMBPerSec = Double.POSITIVE_INFINITY;
 
         private Builder() {}
 
@@ -104,6 +105,18 @@ public record MergeInput(List<Segment> segments, RowIdMapping rowIdMapping, long
          */
         public Builder newWriterGeneration(long newWriterGeneration) {
             this.newWriterGeneration = newWriterGeneration;
+            return this;
+        }
+
+        /**
+         * Sets the IO rate limit in MB per second for the merge.
+         * A value of Double.POSITIVE_INFINITY means no rate limiting.
+         *
+         * @param rateLimitMBPerSec the rate limit in MB/s
+         * @return this builder
+         */
+        public Builder rateLimitMBPerSec(double rateLimitMBPerSec) {
+            this.rateLimitMBPerSec = rateLimitMBPerSec;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
@@ -246,14 +246,19 @@ public class MergeHandler {
      * Executes the given merge operation by delegating to the {@link Merger}.
      *
      * @param oneMerge the merge to execute
+     * @param rateLimitMBPerSec IO rate limit in MB/s; Double.POSITIVE_INFINITY means unlimited
      * @return the result of the merge
      * @throws IOException if the merge operation fails
      */
-    public MergeResult doMerge(OneMerge oneMerge) throws IOException {
+    public MergeResult doMerge(OneMerge oneMerge, double rateLimitMBPerSec) throws IOException {
         assert oneMerge.getSegmentsToMerge().isEmpty() == false : "merge must have at least one segment";
         long generation = generationProvider.get();
         assert generation > 0 : "merge writer generation must be positive but was: " + generation;
-        MergeInput mergeInput = MergeInput.builder().segments(oneMerge.getSegmentsToMerge()).newWriterGeneration(generation).build();
+        MergeInput mergeInput = MergeInput.builder()
+            .segments(oneMerge.getSegmentsToMerge())
+            .newWriterGeneration(generation)
+            .rateLimitMBPerSec(rateLimitMBPerSec)
+            .build();
         MergeResult result = merger.merge(mergeInput);
         assert result != null : "merger must return a non-null MergeResult";
         assert result.getMergedWriterFileSet().isEmpty() == false : "merge result must contain at least one format's files";

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -415,6 +415,7 @@ public class MergeScheduler {
                 try {
                     activateThrottling.run();
                 } catch (Exception e) {
+                    isThrottling.set(false);
                     logger.warn("exception in activateThrottling callback", e);
                 }
             }
@@ -424,6 +425,7 @@ public class MergeScheduler {
                 try {
                     deactivateThrottling.run();
                 } catch (Exception e) {
+                    isThrottling.set(true);
                     logger.warn("exception in deactivateThrottling callback", e);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -48,8 +48,11 @@ public class MergeScheduler {
     private final MergeHandler mergeHandler;
     private final BiConsumer<MergeResult, OneMerge> applyMergeChanges;
     private final Runnable onMergeFailureCleanup;
+    private final Runnable activateThrottling;
+    private final Runnable deactivateThrottling;
     private final ThreadPool threadPool;
     private final AtomicInteger activeMerges = new AtomicInteger(0);
+    private final AtomicBoolean isThrottling = new AtomicBoolean(false);
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
     private final Semaphore forceMergeLock = new Semaphore(1);
     private final AtomicBoolean frozen = new AtomicBoolean(false);
@@ -75,6 +78,8 @@ public class MergeScheduler {
      * @param mergeHandler          the handler that selects and executes merges
      * @param applyMergeChanges     callback to apply merge results (e.g., update the catalog)
      * @param onMergeFailureCleanup callback invoked when a merge fails and cleanup is performed
+     * @param activateThrottling    callback to activate indexing throttle when merge pressure is high
+     * @param deactivateThrottling  callback to deactivate indexing throttle when merge pressure subsides
      * @param shardId               the shard this scheduler is associated with
      * @param indexSettings         the index settings providing merge scheduler configuration
      * @param threadPool            the OpenSearch thread pool for executing merge tasks
@@ -83,6 +88,8 @@ public class MergeScheduler {
         MergeHandler mergeHandler,
         BiConsumer<MergeResult, OneMerge> applyMergeChanges,
         Runnable onMergeFailureCleanup,
+        Runnable activateThrottling,
+        Runnable deactivateThrottling,
         ShardId shardId,
         IndexSettings indexSettings,
         ThreadPool threadPool
@@ -90,6 +97,8 @@ public class MergeScheduler {
         this.mergeHandler = mergeHandler;
         this.applyMergeChanges = applyMergeChanges;
         this.onMergeFailureCleanup = onMergeFailureCleanup;
+        this.activateThrottling = activateThrottling;
+        this.deactivateThrottling = deactivateThrottling;
         this.threadPool = threadPool;
         logger = Loggers.getLogger(getClass(), shardId);
         this.indexSettings = indexSettings;
@@ -138,6 +147,7 @@ public class MergeScheduler {
         if (!isFrozen()) {
             mergeHandler.findAndRegisterMerges();
         }
+        evaluateThrottle();
         executeMerge();
     }
 
@@ -318,6 +328,7 @@ public class MergeScheduler {
             try {
                 submitMergeTask(oneMerge);
             } catch (Exception e) {
+                activeMerges.decrementAndGet();
                 mergeHandler.onMergeFailure(oneMerge);
                 onMergeFailureCleanup.run();
             }
@@ -343,6 +354,7 @@ public class MergeScheduler {
                 // uncaught exception on the merge thread pool.
             } finally {
                 activeMerges.decrementAndGet();
+                evaluateThrottle();
                 // Fire all drain listeners if all merges completed and none pending
                 if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
                     List<Runnable> listeners = List.copyOf(onDrainedListeners);
@@ -392,6 +404,29 @@ public class MergeScheduler {
             throw e instanceof IOException ? (IOException) e : new IOException(e);
         } finally {
             mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
+        }
+    }
+
+    private synchronized void evaluateThrottle() {
+        int numMergesInFlight = activeMerges.get() + mergeHandler.getPendingMergeCount();
+        if (numMergesInFlight > maxMergeCount) {
+            if (isThrottling.getAndSet(true) == false) {
+                logger.info("now throttling indexing: numMergesInFlight={}, maxMergeCount={}", numMergesInFlight, maxMergeCount);
+                try {
+                    activateThrottling.run();
+                } catch (Exception e) {
+                    logger.warn("exception in activateThrottling callback", e);
+                }
+            }
+        } else if (numMergesInFlight < maxMergeCount) {
+            if (isThrottling.getAndSet(false)) {
+                logger.info("stop throttling indexing: numMergesInFlight={}, maxMergeCount={}", numMergesInFlight, maxMergeCount);
+                try {
+                    deactivateThrottling.run();
+                } catch (Exception e) {
+                    logger.warn("exception in deactivateThrottling callback", e);
+                }
+            }
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -59,6 +59,7 @@ public class MergeScheduler {
     private final List<Runnable> onDrainedListeners = new CopyOnWriteArrayList<>();
     private volatile int maxConcurrentMerges;
     private volatile int maxMergeCount;
+    private volatile double ioRateLimitMBPerSec;
     private final MergeSchedulerConfig mergeSchedulerConfig;
     private final IndexSettings indexSettings;
     private final MergeStatsTracker mergeStatsTracker = new MergeStatsTracker();
@@ -113,23 +114,29 @@ public class MergeScheduler {
     public synchronized void refreshConfig() {
         int newMaxThreadCount = mergeSchedulerConfig.getMaxThreadCount();
         int newMaxMergeCount = mergeSchedulerConfig.getMaxMergeCount();
+        double newIORateLimit = mergeSchedulerConfig.getIORateLimitMBPerSec();
 
-        if (newMaxThreadCount == this.maxConcurrentMerges && newMaxMergeCount == this.maxMergeCount) {
+        if (newMaxThreadCount == this.maxConcurrentMerges && newMaxMergeCount == this.maxMergeCount
+            && newIORateLimit == this.ioRateLimitMBPerSec) {
             return;
         }
 
         logger.info(
             () -> new ParameterizedMessage(
-                "Updating from merge scheduler config: maxThreadCount {} -> {}, " + "maxMergeCount {} -> {}",
+                "Updating from merge scheduler config: maxThreadCount {} -> {}, "
+                    + "maxMergeCount {} -> {}, ioRateLimitMBPerSec {} -> {}",
                 this.maxConcurrentMerges,
                 newMaxThreadCount,
                 this.maxMergeCount,
-                newMaxMergeCount
+                newMaxMergeCount,
+                this.ioRateLimitMBPerSec,
+                newIORateLimit
             )
         );
 
         this.maxConcurrentMerges = newMaxThreadCount;
         this.maxMergeCount = newMaxMergeCount;
+        this.ioRateLimitMBPerSec = newIORateLimit;
     }
 
     /**
@@ -307,6 +314,14 @@ public class MergeScheduler {
     }
 
     /**
+     * Returns the cluster-level IO rate limit for background merges in MB per second.
+     * A value of Double.POSITIVE_INFINITY indicates no rate limiting.
+     */
+    public double getMergeIORateLimitMBPerSec() {
+        return mergeSchedulerConfig.getIORateLimitMBPerSec();
+    }
+
+    /**
      * Returns the current merge statistics for this scheduler.
      *
      * @return the merge stats
@@ -392,7 +407,7 @@ public class MergeScheduler {
         long tookMS = 0;
         try {
             mergeStatsTracker.beforeMerge(totalNumDocs, totalSizeInBytes);
-            MergeResult mergeResult = mergeHandler.doMerge(oneMerge);
+            MergeResult mergeResult = mergeHandler.doMerge(oneMerge, mergeSchedulerConfig.getIORateLimitMBPerSec());
             applyMergeChanges.accept(mergeResult, oneMerge);
             mergeHandler.onMergeFinished(oneMerge, isFrozen());
             tookMS = TimeValue.nsecToMSec((System.nanoTime() - timeNS));

--- a/server/src/main/java/org/opensearch/indices/ClusterMergeSchedulerConfig.java
+++ b/server/src/main/java/org/opensearch/indices/ClusterMergeSchedulerConfig.java
@@ -109,10 +109,20 @@ public class ClusterMergeSchedulerConfig {
         Property.NodeScope
     );
 
+    public static final Setting<Double> CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING = Setting.doubleSetting(
+        "cluster.index.merge.scheduler.io_rate_limit_mb_per_sec",
+        Double.POSITIVE_INFINITY,
+        0.0d,
+        Double.POSITIVE_INFINITY,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     private volatile static String clusterMaxThreadCountDefault;
     private volatile int clusterMaxThreadCount;
     private volatile int clusterMaxMergeCount;
     private volatile boolean clusterAutoThrottleEnabled;
+    private volatile double clusterIORateLimitMBPerSec;
     private final IndicesService indicesService;
 
     public ClusterMergeSchedulerConfig(IndicesService indicesService) {
@@ -123,6 +133,7 @@ public class ClusterMergeSchedulerConfig {
         clusterMaxThreadCount = CLUSTER_MAX_THREAD_COUNT_SETTING.get(clusterSettings);
         clusterMaxMergeCount = CLUSTER_MAX_MERGE_COUNT_SETTING.get(clusterSettings);
         clusterAutoThrottleEnabled = CLUSTER_AUTO_THROTTLE_SETTING.get(clusterSettings);
+        clusterIORateLimitMBPerSec = CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.get(clusterSettings);
 
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(
@@ -132,6 +143,8 @@ public class ClusterMergeSchedulerConfig {
             );
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(CLUSTER_AUTO_THROTTLE_SETTING, this::onClusterMergeAutoThrottleUpdate);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING, this::onClusterIORateLimitUpdate);
     }
 
     private void validateMaxThreadAndMergeCount(Settings settings) {
@@ -160,6 +173,13 @@ public class ClusterMergeSchedulerConfig {
         }
     }
 
+    private void onClusterIORateLimitUpdate(Double value) {
+        clusterIORateLimitMBPerSec = value;
+        for (IndexService indexService : indicesService) {
+            indexService.onClusterLevelIORateLimitUpdate(clusterIORateLimitMBPerSec);
+        }
+    }
+
     public Integer getClusterMaxMergeCount() {
         return this.clusterMaxMergeCount;
     }
@@ -170,6 +190,10 @@ public class ClusterMergeSchedulerConfig {
 
     public Boolean getClusterMergeAutoThrottleEnabled() {
         return this.clusterAutoThrottleEnabled;
+    }
+
+    public Double getClusterIORateLimitMBPerSec() {
+        return this.clusterIORateLimitMBPerSec;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/ClusterMergeSchedulerConfig.java
+++ b/server/src/main/java/org/opensearch/indices/ClusterMergeSchedulerConfig.java
@@ -175,6 +175,7 @@ public class ClusterMergeSchedulerConfig {
 
     private void onClusterIORateLimitUpdate(Double value) {
         clusterIORateLimitMBPerSec = value;
+        MergeSchedulerConfig.setDefaultIORateLimitMBPerSec(value);
         for (IndexService indexService : indicesService) {
             indexService.onClusterLevelIORateLimitUpdate(clusterIORateLimitMBPerSec);
         }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -892,6 +892,45 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "access private fields to simulate merge pressure and verify throttle integration")
+    public void testMergeThrottleIntegration() throws Exception {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            assertFalse("engine should not be throttled initially", engine.isThrottled());
+
+            // Access the private mergeScheduler
+            java.lang.reflect.Field schedulerField = DataFormatAwareEngine.class.getDeclaredField("mergeScheduler");
+            schedulerField.setAccessible(true);
+            org.opensearch.index.engine.dataformat.merge.MergeScheduler scheduler =
+                (org.opensearch.index.engine.dataformat.merge.MergeScheduler) schedulerField.get(engine);
+
+            // Access the scheduler's activeMerges to simulate in-flight merge pressure
+            java.lang.reflect.Field activeMergesField = scheduler.getClass().getDeclaredField("activeMerges");
+            activeMergesField.setAccessible(true);
+            java.util.concurrent.atomic.AtomicInteger activeMerges =
+                (java.util.concurrent.atomic.AtomicInteger) activeMergesField.get(scheduler);
+
+            // Access maxMergeCount to know the threshold
+            java.lang.reflect.Field maxMergeCountField = scheduler.getClass().getDeclaredField("maxMergeCount");
+            maxMergeCountField.setAccessible(true);
+            int maxMergeCount = (int) maxMergeCountField.get(scheduler);
+            assertTrue("maxMergeCount should be positive", maxMergeCount > 0);
+
+            // Simulate merge pressure: set activeMerges above maxMergeCount
+            activeMerges.set(maxMergeCount + 1);
+
+            // triggerMerges evaluates throttle: activeMerges + pendingMerges > maxMergeCount
+            scheduler.triggerMerges();
+            assertTrue("engine should be throttled when merge pressure exceeds threshold", engine.isThrottled());
+
+            // Simulate merges completing: drop activeMerges below threshold
+            activeMerges.set(0);
+            scheduler.triggerMerges();
+            assertFalse("engine should not be throttled after merge pressure subsides", engine.isThrottled());
+        }
+    }
+
     public void testEngineConfig() throws IOException {
         try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
             assertThat(engine.config(), notNullValue());

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeHandlerTests.java
@@ -219,7 +219,7 @@ public class MergeHandlerTests extends OpenSearchTestCase {
         when(merger.merge(any(MergeInput.class))).thenReturn(result);
 
         OneMerge merge = new OneMerge(List.of(s1));
-        MergeResult actual = handler.doMerge(merge);
+        MergeResult actual = handler.doMerge(merge, Double.POSITIVE_INFINITY);
 
         assertSame(result, actual);
         verify(merger).merge(any(MergeInput.class));

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
@@ -67,7 +67,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
         scheduler.onDrained(() -> listenerCalled.set(true));
@@ -84,7 +84,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
         scheduler.onDrained(() -> listenerCalled.set(true));
@@ -101,7 +101,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -177,7 +177,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         CountDownLatch latch = new CountDownLatch(3);
         AtomicInteger callCount = new AtomicInteger(0);
@@ -223,7 +223,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         // First call to hasPendingMerges returns true (first check fails, goes to add),
         // second call returns false (double-check succeeds, fires the listener)
@@ -248,7 +248,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         // Register listeners individually via the double-check path.
         // Each onDrained call is independent — if one listener throws during its own
@@ -285,7 +285,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         assertTrue("hasPendingMerges should delegate to handler when handler reports true", scheduler.hasPendingMerges());
 
@@ -302,7 +302,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         assertEquals("Active merge count should be 0 initially", 0, scheduler.getActiveMergeCount());
     }
@@ -336,7 +336,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
 
         // Register an onDrained listener BEFORE triggering merges.
         // Reset hasPendingMerges stub for the full flow:
@@ -416,7 +416,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
         when(mockHandler.hasPendingMerges()).thenReturn(false);
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        return new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        return new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -332,7 +334,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
         // getNextMerge: return oneMerge first, then null
         when(mockHandler.getNextMerge()).thenReturn(oneMerge, (OneMerge) null);
         // doMerge returns the mock result
-        when(mockHandler.doMerge(oneMerge)).thenReturn(mockMergeResult);
+        when(mockHandler.doMerge(any(), anyDouble())).thenReturn(mockMergeResult);
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
@@ -356,7 +358,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
         // allowing us to freeze the scheduler while the merge is in-flight.
         CountDownLatch mergeStarted = new CountDownLatch(1);
         CountDownLatch mergeCanProceed = new CountDownLatch(1);
-        when(mockHandler.doMerge(oneMerge)).thenAnswer(invocation -> {
+        when(mockHandler.doMerge(any(), anyDouble())).thenAnswer(invocation -> {
             mergeStarted.countDown(); // Signal that merge has started
             mergeCanProceed.await();  // Wait until test allows merge to proceed
             return mockMergeResult;

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -150,7 +152,7 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
         OneMerge merge2 = new OneMerge(List.of(s2));
 
         when(mergeHandler.findForceMerges(1)).thenReturn(List.of(merge1, merge2));
-        when(mergeHandler.doMerge(merge1)).thenReturn(new MergeResult(Map.of()));
+        when(mergeHandler.doMerge(any(), anyDouble())).thenReturn(new MergeResult(Map.of()));
 
         final java.util.concurrent.atomic.AtomicReference<MergeScheduler> schedulerRef =
             new java.util.concurrent.atomic.AtomicReference<>();
@@ -175,8 +177,8 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
             Thread.currentThread().setName(oldName);
         }
 
-        verify(mergeHandler).doMerge(merge1);
-        verify(mergeHandler, never()).doMerge(merge2);
+        verify(mergeHandler).doMerge(any(), anyDouble());
+        verify(mergeHandler, times(1)).doMerge(any(), anyDouble());
     }
 
     public void testThrottlingActivatesWhenMergesExceedMaxCount() {

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
@@ -15,6 +15,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.MergeSchedulerConfig;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.test.IndexSettingsModule;
@@ -25,6 +26,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -67,7 +69,7 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
     }
 
     private MergeScheduler newScheduler(MergeHandler mergeHandler, IndexModule.TieringState tieringState) {
-        return new MergeScheduler(mergeHandler, (result, merge) -> {}, () -> {}, shardId, indexSettings(tieringState), threadPool);
+        return new MergeScheduler(mergeHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, shardId, indexSettings(tieringState), threadPool);
     }
 
     public void testFreezeBlocksTriggerMerges() {
@@ -157,6 +159,8 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
             mergeHandler,
             (result, merge) -> { schedulerRef.get().shutdown(); },
             () -> {},
+            () -> {},
+            () -> {},
             shardId,
             indexSettings(IndexModule.TieringState.HOT),
             threadPool
@@ -173,5 +177,74 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
 
         verify(mergeHandler).doMerge(merge1);
         verify(mergeHandler, never()).doMerge(merge2);
+    }
+
+    public void testThrottlingActivatesWhenMergesExceedMaxCount() {
+        AtomicInteger activateCount = new AtomicInteger();
+        AtomicInteger deactivateCount = new AtomicInteger();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+                .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "2")
+                .build()
+        );
+
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+        // After findAndRegisterMerges, 3 pending merges exceed maxMergeCount=2
+        when(mergeHandler.getPendingMergeCount()).thenReturn(3);
+        when(mergeHandler.hasPendingMerges()).thenReturn(false);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> {},
+            () -> {},
+            activateCount::incrementAndGet,
+            deactivateCount::incrementAndGet,
+            shardId,
+            idxSettings,
+            threadPool
+        );
+
+        scheduler.triggerMerges();
+        assertEquals("throttle should have activated", 1, activateCount.get());
+
+        // Now simulate merges draining below threshold
+        when(mergeHandler.getPendingMergeCount()).thenReturn(1);
+        scheduler.triggerMerges();
+        assertEquals("throttle should have deactivated", 1, deactivateCount.get());
+    }
+
+    public void testThrottlingNotActivatedWhenMergesWithinLimit() {
+        AtomicInteger activateCount = new AtomicInteger();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+                .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "6")
+                .build()
+        );
+
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+        when(mergeHandler.getPendingMergeCount()).thenReturn(2);
+        when(mergeHandler.hasPendingMerges()).thenReturn(false);
+
+        MergeScheduler scheduler = new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> {},
+            () -> {},
+            activateCount::incrementAndGet,
+            () -> {},
+            shardId,
+            idxSettings,
+            threadPool
+        );
+
+        scheduler.triggerMerges();
+        assertEquals("throttle should not activate when merges within limit", 0, activateCount.get());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -180,6 +180,8 @@ public class MergeTests extends OpenSearchTestCase {
             createNoopHandler(emptySnapshotSupplier()),
             (mergeResult, oneMerge) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             idxSettings,
             mockThreadPool()
@@ -402,6 +404,8 @@ public class MergeTests extends OpenSearchTestCase {
             createNoopHandler(emptySnapshotSupplier()),
             (mr, om) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             idxSettings,
             mockThreadPool()
@@ -430,6 +434,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> captured.set(mr),
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -454,8 +460,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );
@@ -479,7 +484,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(handler, (mr, om) -> {
             captured.set(mr);
             latch.countDown();
-        }, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        }, () -> {}, () -> {}, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
 
         onForceMergeThread(() -> scheduler.forceMerge(1));
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -521,8 +526,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );
@@ -583,8 +587,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );
@@ -605,8 +608,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );
@@ -634,6 +636,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> {},
             () -> cleanupCalled.set(true),
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -665,8 +669,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             applyCallback,
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );
@@ -678,7 +681,7 @@ public class MergeTests extends OpenSearchTestCase {
     public void testForceMergeWithNoSegmentsIsNoop() throws Exception {
         MergeScheduler scheduler = new MergeScheduler(createNoopHandler(emptySnapshotSupplier()), (mr, om) -> {
             fail("applyMergeChanges should not be called");
-        }, () -> { fail("onMergeFailureCleanup should not be called"); }, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        }, () -> { fail("onMergeFailureCleanup should not be called"); }, () -> {}, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
 
         onForceMergeThread(() -> scheduler.forceMerge(1));
     }
@@ -695,8 +698,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
-            () -> {},
-            SHARD_ID,
+            () -> {}, () -> {}, () -> {}, SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
         );

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -347,7 +347,7 @@ public class MergeTests extends OpenSearchTestCase {
             NOOP_MERGE_LISTENER,
             () -> 1L
         );
-        MergeResult result = handler.doMerge(new OneMerge(List.of(seg)));
+        MergeResult result = handler.doMerge(new OneMerge(List.of(seg)), Double.POSITIVE_INFINITY);
 
         assertSame(expectedResult, result);
     }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -15,6 +15,8 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.MergeSchedulerConfig;
+import org.opensearch.index.engine.dataformat.MergeInput;
+import org.opensearch.indices.ClusterMergeSchedulerConfig;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.Merger;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
@@ -412,6 +414,72 @@ public class MergeTests extends OpenSearchTestCase {
         );
         scheduler.enableAutoIOThrottle();
         assertNotNull(scheduler.stats());
+    }
+
+    public void testMergeIORateLimitDefaultsToInfinity() {
+        MergeScheduler scheduler = createMergeScheduler();
+        assertEquals(Double.POSITIVE_INFINITY, scheduler.getMergeIORateLimitMBPerSec(), 0.0);
+    }
+
+    public void testMergeIORateLimitFromClusterSetting() {
+        Settings nodeSettings = Settings.builder()
+            .put(ClusterMergeSchedulerConfig.CLUSTER_IO_RATE_LIMIT_MB_PER_SEC_SETTING.getKey(), "50.0")
+            .build();
+        Settings indexSettings = Settings.builder()
+            .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+            .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "6")
+            .build();
+        IndexSettings idxSettings = new IndexSettings(newIndexMeta("test", indexSettings), nodeSettings);
+        MergeScheduler scheduler = new MergeScheduler(
+            createNoopHandler(emptySnapshotSupplier()),
+            (mr, om) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            SHARD_ID,
+            idxSettings,
+            mockThreadPool()
+        );
+        assertEquals(50.0, scheduler.getMergeIORateLimitMBPerSec(), 0.0);
+    }
+
+    public void testMergeIORateLimitDynamicUpdate() {
+        Settings indexSettings = Settings.builder()
+            .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+            .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "6")
+            .build();
+        IndexSettings idxSettings = new IndexSettings(newIndexMeta("test", indexSettings), Settings.EMPTY);
+        MergeScheduler scheduler = new MergeScheduler(
+            createNoopHandler(emptySnapshotSupplier()),
+            (mr, om) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            SHARD_ID,
+            idxSettings,
+            mockThreadPool()
+        );
+        assertEquals(Double.POSITIVE_INFINITY, scheduler.getMergeIORateLimitMBPerSec(), 0.0);
+
+        idxSettings.getMergeSchedulerConfig().setIORateLimitMBPerSec(25.0);
+        assertEquals(25.0, scheduler.getMergeIORateLimitMBPerSec(), 0.0);
+    }
+
+    public void testMergeInputCarriesRateLimit() {
+        MergeInput input = MergeInput.builder()
+            .segments(List.of())
+            .newWriterGeneration(1L)
+            .rateLimitMBPerSec(42.0)
+            .build();
+        assertEquals(42.0, input.rateLimitMBPerSec(), 0.0);
+    }
+
+    public void testMergeInputDefaultRateLimitIsInfinity() {
+        MergeInput input = MergeInput.builder()
+            .segments(List.of())
+            .newWriterGeneration(1L)
+            .build();
+        assertEquals(Double.POSITIVE_INFINITY, input.rateLimitMBPerSec(), 0.0);
     }
 
     // ---- MergeScheduler: integration with real merge execution ----


### PR DESCRIPTION
When outstanding merges (active + pending) exceed maxMergeCount, the MergeScheduler now activates indexing throttle via the engine's existing IndexingThrottler, serializing write threads to a single thread until merge pressure subsides. This mirrors the behavior already present in InternalEngine's EngineMergeScheduler.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
