### PR TITLE
[Arrow Flight RPC] Make FlightServerChannel the sole owner of stream lifecycle and buffers

### DIFF
--- a/plugins/arrow-flight-rpc/docs/channel-lifecycle-ownership.md
+++ b/plugins/arrow-flight-rpc/docs/channel-lifecycle-ownership.md
@@ -1,0 +1,448 @@
+# FlightServerChannel Lifecycle & Buffer-Ownership Contract
+
+## Purpose
+
+Server-side Arrow Flight streaming frees off-heap Arrow buffers and terminates a gRPC
+call from **multiple unsynchronized threads at once**. Without a single, explicit
+ownership model this produces several classes of bug:
+
+1. **Double-close crash** — `close()` runs its teardown twice, double-firing the
+   TaskManager cancellable-channel untrack listener → `AssertionError` (with `-ea`) that
+   kills the node.
+2. **Stream-root use-after-free / double-free** — a concurrent cancel frees the reused
+   stream root while the producer is mid-`transferRoot` or mid-`putNext` (gRPC still holds
+   a zero-copy reference).
+3. **Stream-root / source-root leak** — buffers transferred into the reused root after a
+   concurrent close, or a source root for a batch whose send never runs, are owned by
+   nobody.
+4. **Consumer hang** — a batch send fails, the batch is dropped, no schema frame ever
+   reaches the client, and the consumer's `FlightStream.getRoot()` blocks forever.
+
+This document is the **authoritative model**. It was validated by an exhaustive
+case-sweep (98 enumerated cases across buffer / thread-interleaving / method-exit /
+lifecycle-state axes; 64 confirmed defects in the current code, collapsing to **12
+distinct root-cause classes** — see §9). The implementation in `FlightServerChannel` and
+`FlightOutboundHandler` MUST conform to it, and §9's coverage matrix MUST stay true.
+
+---
+
+## 1. Threads
+
+All concurrency reduces to **three** thread classes per channel. The distinction between the
+first two is load-bearing: the gap between them is where source roots can orphan (§6 S7).
+
+| Name | What it is | What it runs |
+|------|------------|--------------|
+| **`T_caller`** | The producer's calling thread (e.g. a `SEARCH` worker) inside `FlightOutboundHandler.sendResponseBatch`. | `awaitReadyOrThrow()` (the back-pressure gate) and `executor.execute(task)`. **This is where a batch is built but not yet handed to the channel.** |
+| **`T_exec`** | The channel's **single-thread** flight executor (`FlightTransport.getNextFlightExecutor()`). | Everything the handler submits: `processBatchTask`→`sendBatch`, `processCompleteTask`→`completeStream`, `processErrorTask`→`sendError`, `failStream`. Also `ArrowFlightProducer.getStream`'s bootstrap. |
+| **`T_grpc`** | gRPC's cancel-delivery thread (`cancelExecutor` in `JumpToApplicationThreadServerStreamListener`). | `onChannelCancelled()` → `close()`. |
+
+**Key consequences:**
+- The flight executor is single-threaded, so **no two `T_exec` ops run concurrently with
+  each other.** Genuine concurrency is only `T_caller`/`T_exec`/bootstrap **vs** `T_grpc`.
+- `T_caller` and `T_exec` are **different threads**: a batch can be parked in the gate on
+  `T_caller` while a *prior* batch runs on `T_exec`. The window between "batch built on
+  `T_caller`" and "`sendBatch` runs on `T_exec`" is where source roots orphan (§6 S7).
+
+### Single-writer model
+
+The stream root is the only state genuinely contended across threads: `T_exec` *uses* it
+during transfer/`putNext`, while a cancel wants to *free* it. The channel resolves this by
+**confining the root to a single thread** rather than synchronizing access to it:
+
+- **The stream `root` and every `serverStreamListener` call live only on `T_exec`** — created,
+  filled, and freed there. Because the executor is single-threaded, batch sends, terminal ops,
+  and the root free are serialized by the executor itself; none can interleave.
+- **`close()` is a signal, not a buffer operation.** From any thread it flips `open` once
+  (CAS), fires close listeners, and **posts the root free onto `T_exec`**:
+  `executor.execute(() -> { if (root != null) { root.close(); root = null; } })`. Because the
+  executor is FIFO, that free runs *after* any in-flight send completes. `close()` touches no
+  Arrow buffers and no gRPC from the caller's (possibly `T_grpc`) thread.
+
+**This is deadlock-free by construction:** nothing is ever held across a gRPC/Arrow/blocking
+call. The only mutex (`closeListenerMutex`, §4) is a leaf — its critical section only mutates an
+`ArrayList`. `close()` from `T_grpc` never blocks: `execute()` enqueues and returns. There is no
+waits-for cycle to construct. The single invariant a future change must preserve is the
+self-evident **"`root` and `serverStreamListener` are touched only on the flight executor."**
+
+The one trade-off is that `close()` frees the root **asynchronously** (on the executor) rather
+than inline — see §10.
+
+---
+
+## 2. Roles & responsibilities
+
+| Component | Role | Owns | MUST NOT |
+|-----------|------|------|----------|
+| **`FlightServerChannel`** | **Sole owner** of all Arrow buffers and the gRPC stream lifecycle. The only place a root is freed and the only place a terminal gRPC op is issued. | stream `root`, gRPC listener, `terminalSent`, close listeners | leak/double-free a root; issue two terminal ops; act on the stream after terminal or after `cancelled` |
+| **`FlightOutboundHandler`** | **Stateless translator/dispatcher.** Thread-switch onto `T_exec`, back-pressure gate, translate response→channel call, relay outcome. Owns the **hand-off discipline** (§3) for the source root until the channel takes it. | nothing persistent | touch/free the *stream* root; call `close()` directly; serialize a response itself |
+| **`FlightTransportChannel`** | Thin framework adapter. `release()` → `channel.close()`. | nothing | contain its own close/idempotency logic |
+| **`ArrowFlightProducer`** | Per-call bootstrap. May `close()` on early/inbound errors. | nothing | assume "double close is harmless" without the channel guaranteeing it |
+| **`T_grpc` (cancel)** | Signals cancellation → `close()`. | — | — |
+
+**Pivotal rule:** the handler hands the channel a `TransportResponse` and a **header
+supplier**, and receives back success or an exception. It never frees the *stream* root,
+never serializes the header itself, and never closes the channel directly. Its one buffer
+responsibility is the **source-root hand-off** (§3.1).
+
+---
+
+## 3. Buffer ownership — every buffer freed exactly once
+
+| Buffer | Created by | Freed by | When |
+|--------|-----------|----------|------|
+| **Source root** — `ArrowBatchResponse.getRoot()`, the producer's per-batch native batch | the caller/producer | **the channel** — via `sendBatch`'s `finally` if handed off, else via `channel.releaseUnsent(response)` on the failed-handoff path (§3.1) | exactly once |
+| **Stream root** — the single reused VSR (native *or* byte) sent on the wire | the channel, lazily on the first batch | **the channel**, in `close()` only | terminal, exactly once |
+| **Metadata buf** — per-batch app metadata on the Flight frame | the channel, per batch | gRPC via `putNext(ArrowBuf)`, or the channel if `putNext` throws before hand-off (§3.3) | handoff |
+| **Byte-serialization vector** — the `VarBinary` vector of the byte stream root | the channel (it *is* the stream root's vector) | **the channel**, in `close()` | terminal, exactly once — **never per-batch** (§3.2) |
+
+**Zero-copy retention:** native stream-root buffers are **not** freed right after `putNext`
+— gRPC may still hold zero-copy refs. They are freed once, at `close()`, after the
+framework's release boundary. The reused stream root lives from the first batch until
+`close()`.
+
+### 3.1 Source-root hand-off discipline (closes S7 — the orphan class)
+
+The source root has **two** potential free sites on **two** threads, and the gap between
+them is unguarded. Ownership transfers to the channel at **`sendResponseBatch` entry**, and
+the handler guarantees the source is freed in **exactly one** of two mutually-exclusive
+places via a `handedOff` flag:
+
+```
+sendResponseBatch(response, ...):                      // T_caller
+  handedOff = false
+  try:
+    if (!(channel instanceof FlightServerChannel)) { relay error; return; }   // handedOff stays false
+    flightChannel.awaitReadyOrThrow()                  // may throw CANCELLED/TIMED_OUT
+    flightChannel.getExecutor().execute(task)          // may throw RejectedExecutionException
+    handedOff = true                                   // sendBatch now owns it; its finally frees it
+  finally:
+    if (!handedOff) flightChannel.releaseUnsent(response)   // free here, exactly once
+```
+
+- **Handed off** → `sendBatch` runs on `T_exec` → its `finally` frees the source (§3.4).
+- **Not handed off** (gate throws, `execute` rejects, or wrong-channel-type early return)
+  → handler frees via `releaseUnsent`.
+- Mutually exclusive ⇒ **freed exactly once.**
+
+`releaseUnsent(response)` is a channel method (keeps "only the channel frees Arrow
+buffers" intact): it closes `response.getRoot()` **iff** `response instanceof
+ArrowBatchResponse` (the byte path has no off-heap source). It does not touch the stream
+root or lifecycle.
+
+> A second hand-off gap is **inside** `processBatchTask` on `T_exec`: `getHeaderBuffer`
+> (which `throws IOException`) and `VectorSchemaRoot.create`/`transferRoot` can throw
+> **before** the channel adopts the source. This is handled inside `sendBatch` itself
+> (§3.4), not by the handler — see the unified single-entry contract in §5.
+
+### 3.2 Byte path: stream-root vector freed once, never per-batch
+
+The byte-serialized `VectorStreamOutput.ByteSerialized` vector **is** the stream root's
+`VarBinary` vector once adopted. Freeing it per batch (today's `try (out)`) frees buffers
+gRPC may still be draining (zero-copy) and races `close()`. The channel reuses the vector
+across batches (`reset()`/`setValueCount(0)`) and frees it once in `close()`.
+`ByteSerialized.close()` must free **only** a vector it itself created (the first-batch,
+`existingRoot==null` case); when adopting the channel's existing root it releases nothing.
+
+### 3.3 Metadata buf: freed if `putNext` throws before hand-off
+
+```
+buf = allocator.buffer(len); buf.writeBytes(metadata)
+try { listener.putNext(buf) } catch (t) { if (buf.refCnt() > 0) buf.close(); throw t }
+```
+Covers the windows where Flight never adopts the buffer (`waitUntilStreamReady` throw,
+`ArrowMessage` ctor throw). The `refCnt()` guard tolerates the narrow `onNext`-throw
+subwindow where Flight's `ArrowMessage.close()` already released it.
+
+### 3.4 Source-root free inside `sendBatch` (covers transfer/create/header throws)
+
+```
+finally: if (native && sourceRoot != null) sourceRoot.close()
+```
+The native source root is owned exclusively by this `sendBatch` call, so it is freed
+**unconditionally** in the `finally` on every exit: after a successful transfer it is empty
+(close is a buffer no-op), and on any throw before the transfer — empty-field-vectors check,
+`VectorSchemaRoot.create` OOM, `transferRoot` mid-loop, the header build — it still holds its
+buffers (close frees them). **A bare `producerRoot.close()` on the happy path plus a catch-only
+cleanup is insufficient** (today's bug): the free must be in a `finally` covering every exit.
+On the native **first batch**, the freshly-created stream root is freed by
+`transferIntoStreamRoot`'s own try/finally if transfer fails before adoption, so an un-adopted
+stream root cannot leak before becoming `root`.
+
+### 3.5 Adopted stream root after a non-`Exception` `Throwable` in `sendBatch`
+
+`serverStreamListener.start`/`putNext` and `transferRoot` can throw a non-`Exception`
+`Throwable` — `OutOfMemoryError` under memory pressure, or an `AssertionError` from Arrow/gRPC
+under `-ea`. If this happens **after** the stream root is adopted (`root != null`),
+`sendBatch`'s `finally` frees only the *source* root; the *stream* root is freed only by
+`close()`. The batch task is non-terminal, so `BatchTask.close()` does not release the channel —
+nothing would call `close()` and the adopted stream root would leak. `processBatchTask` therefore
+catches `Throwable` (after `FlightRuntimeException`/`Exception`) and routes it through `failStream`
+(which releases the channel → `close()` posts the stream-root free) and reports it to the message
+listener (wrapped to honour the listener's `Exception` contract) rather than letting it escape and
+kill the executor worker. `failStream` closes the channel directly when there is no transport
+channel, so `close()` runs on every variant.
+
+```java
+private final AtomicBoolean open;          // "resources not yet freed"; flips true→false ONCE via CAS
+private volatile boolean cancelled;        // set once by T_grpc in onChannelCancelled
+private volatile VectorSchemaRoot root;    // reused native|byte stream root; T_exec-confined; nulled after free
+private boolean terminalSent;              // completed() XOR error() issued; T_exec-confined
+private final Object closeListenerMutex;   // leaf mutex: guards closeListeners + closeListenersFired only
+private final List<ActionListener<Void>> closeListeners;
+private boolean closeListenersFired;       // guarded by closeListenerMutex
+```
+
+- **`open`** — the teardown gate. `compareAndSet(true,false)` admits **exactly one** thread
+  into teardown; every other `close()` caller returns immediately. The CAS winner is the sole
+  poster of the root free and sole firer of close listeners. **Thread-agnostic.**
+- **`cancelled`** — "client gone; gRPC already terminated the call." Read by `sendBatch`,
+  `completeStream`, `sendError` to reject/no-op.
+- **`root`** — touched **only on `T_exec`** (created, filled, freed there). `volatile` only so the
+  test-only `getRoot()` reads a consistent reference; correctness rests on executor confinement,
+  not volatility. Nulled immediately after free so nothing re-frees or re-fills it.
+- **`terminalSent`** — `T_exec`-confined; at most one terminal gRPC op per stream.
+- **`closeListenerMutex`** — a leaf mutex; its critical section only mutates the listener list +
+  `closeListenersFired`, never a gRPC/Arrow/blocking call. It is the *only* mutex in the class.
+
+### Invariants (must hold under every interleaving)
+
+1. `notifyCloseListeners()` runs **exactly once** (CAS winner only) → TaskManager untrack
+   fires once → no `AssertionError`, any thread, any order.
+2. `root.close()` runs **exactly once** — only in the free task the CAS-winning `close()` posts
+   to `T_exec`; `root` is nulled there. (If a send adopted no root, the task is a no-op.)
+3. **At most one terminal gRPC op** (`completed` XOR `error`) per stream, and **never after
+   `cancelled`** (`completeStream`/`sendError` check `cancelled`, both on `T_exec`).
+4. **No root freed under an in-flight send** — the free runs on `T_exec` behind any in-flight
+   send by the executor's FIFO ordering; root use and root free never overlap (single-writer).
+5. **No source root leaked or double-freed** — freed exactly once via §3.1 (handoff) +
+   §3.4 (in-send `finally`), mutually exclusive.
+6. **No deadlock** — no lock is held across any gRPC/Arrow/blocking call; the only mutex
+   (`closeListenerMutex`) is a leaf; `close()` only `execute()`s and returns. No waits-for cycle.
+7. **Close-listener registration is safe** — `addCloseListener` either fires immediately
+   (listeners already fired) or enqueues under `closeListenerMutex`, with no lost/duplicate fire.
+8. **A throwing close listener cannot skip the rest** — `notifyCloseListeners` isolates each
+   listener in try/catch so one failure can't strand TaskManager untrack.
+9. **Single-writer invariant (the property future changes must preserve):** `root` and every
+   `serverStreamListener` call are touched **only on `T_exec`**.
+
+---
+
+## 5. Method contracts
+
+All of `sendBatch`/`completeStream`/`sendError` run on `T_exec` and take **no lock** — the
+single-threaded executor serializes them with each other and with the `close()`-posted root free.
+
+### `sendBatch(TransportResponse response, CheckedSupplier<ByteBuffer> header)` — `T_exec`, no lock
+
+Single entry; native vs byte decided **inside** the channel. The header is built via a
+supplier invoked **before any root is mutated**, so a header-build `IOException` fails fast —
+the source is freed by the `finally` and no stream root is adopted. The handler never
+serializes. The native source root is freed once on every exit by the outer `finally`
+(unconditional: empty after a successful transfer → close is a no-op; full on an early throw →
+close frees it).
+
+```
+sourceRoot = (response instanceof ArrowBatchResponse) ? response.getRoot() : null
+try:
+  if (cancelled)   throw StreamException.cancelled(...)   // reject → finally frees source
+  if (!open.get()) throw IllegalStateException(...)       // reject → finally frees source
+  firstBatch = (root == null)
+  hdr = header.get()                                      // built FIRST; throw → finally, no root mutated
+  if (native):
+    if (firstBatch) root = create VSR from sourceRoot's allocator   // create+transfer guarded so an
+    VectorTransfer.transferRoot(sourceRoot -> root)                 // un-adopted first root can't leak
+  else (byte):
+    if (firstBatch) root = new VarBinary VSR
+    else            reset root's vector
+    response.writeTo(serializer over root)
+  if (firstBatch): middleware.setHeader(hdr); listener.start(root)
+  if (metadata != null): buf=alloc; writeBytes; try{ listener.putNext(buf) } catch(t){ buf.close(); throw t }
+  else: listener.putNext()
+  batchNumber++; record stats
+finally:
+  if (native && sourceRoot != null) sourceRoot.close()    // every exit frees source ONCE
+```
+
+### `completeStream(CheckedSupplier<ByteBuffer> header)` — terminal, idempotent, `T_exec`, no lock
+
+```
+if (!open.get() || cancelled || terminalSent) { record/log; return; }   // benign no-op
+if (root == null) middleware.setHeader(header.get())   // empty stream
+listener.completed(); terminalSent = true
+recordCallEnd(OK)
+```
+Does **not** free `root` (free deferred to `close()`, §3 retention). The `cancelled` guard
+closes the "terminal-after-cancel" race.
+
+### `sendError(CheckedSupplier<ByteBuffer> header, Exception error)` — terminal, idempotent, `T_exec`, no lock
+
+```
+if (!open.get() || cancelled || terminalSent) { record/log; return; }   // benign no-op
+flightExc = map(error); middleware.setHeader(header.get())
+listener.error(flightExc); terminalSent = true
+recordCallEnd(mapped)
+```
+
+### `releaseUnsent(TransportResponse response)` — `T_caller`/`T_exec` failed-handoff (§3.1)
+
+```
+if (response instanceof ArrowBatchResponse r && r.getRoot() != null) r.getRoot().close();
+// never touches stream root, terminalSent, or open
+```
+
+### `close()` — fire-once, idempotent, ANY thread
+
+```
+if (!open.compareAndSet(true, false)) return;          // losers exit at the door
+executor.execute(() -> { if (root != null) { root.close(); root = null; } })   // free ON T_exec, behind any send
+// (catch RejectedExecutionException on shutdown — see §10)
+notifyCloseListeners();                                // runs exactly once; touches no Arrow buffers
+```
+`close()` posts the root free to `T_exec` rather than freeing inline, so it never touches Arrow
+buffers or gRPC from the (possibly `T_grpc`) caller thread, and the free runs behind any
+in-flight send by the executor's FIFO ordering.
+
+### `addCloseListener(listener)` — registration atomic vs `notifyCloseListeners`
+
+```
+synchronized (closeListenerMutex):
+  alreadyFired = closeListenersFired
+  if (!alreadyFired) closeListeners.add(listener)
+if (alreadyFired) listener.onResponse(null)            // fire outside the mutex
+```
+Prevents the register-vs-fire race (lost fire / double fire).
+
+### `notifyCloseListeners()` — fault-isolated
+
+```
+synchronized (closeListenerMutex): snapshot = copy(closeListeners); clear(); closeListenersFired = true
+for (l : snapshot) try { l.onResponse(null) } catch (e) { log; continue }   // one throw can't strand others
+```
+
+### `onChannelCancelled()` — `T_grpc`
+
+```
+if (cancelled) return;
+cancelled = true; recordCallEnd(CANCELLED); close();
+```
+
+---
+
+## 6. Scenario walk-through
+
+`✓` = happens exactly once / as intended.
+
+- **S1 Normal multi-batch success** — `sendBatch×N` (each frees its source ✓) →
+  `completeStream` (`completed()` ✓) → `release()→close()` (free root ✓, notify ✓).
+- **S2 App error / batch-send failure** — send throws → `sendError` (`error()` ✓) →
+  `release()→close()`. Consumer gets an error frame, no hang.
+- **S3 Client cancel, idle channel** — `T_grpc close()` frees root ✓, notify ✓. Later queued
+  `sendBatch` sees `cancelled` → throws → `finally` frees source ✓. Later
+  `completeStream`/`sendError` → `cancelled` no-op ✓.
+- **S4 Cancel races an in-flight `sendBatch` (UAF/double-free)** — `T_exec` is mid
+  transfer+`putNext` (occupying the single executor thread); `T_grpc close()` wins the CAS,
+  **posts the root free onto the busy executor**, and returns without touching buffers. The
+  free runs only after `sendBatch` finishes (FIFO) → frees root ✓ strictly after `putNext`. No
+  UAF, freed once, notify once.
+- **S5 Cancel races a `release()`-driven close (the crash)** — both call `close()`;
+  `compareAndSet` admits one; the other returns. notify once ✓ → no `AssertionError`.
+- **S6 Early/inbound error in `getStream`** — `listener.error` then `channel.close()`; CAS
+  admits one closer even if `T_grpc` also cancels ✓.
+- **S7 Cancel/timeout while a batch is parked in the gate (the orphan)** —
+  `awaitReadyOrThrow()` throws on `T_caller` **before** `execute`; `handedOff==false` →
+  handler's `finally` calls `releaseUnsent` → source freed ✓. Same for `execute` rejection
+  and the wrong-channel early return.
+- **S8 `getHeaderBuffer`/`transferRoot`/`create` throws inside `sendBatch`** — lands in the
+  `finally`; source freed once ✓; no stream root adopted (or freed by a later `close()` if
+  adopted). No orphan.
+- **S9 Byte multi-batch + cancel** — vector reused across batches on `T_exec`; freed once at
+  `close()` (on `T_exec`, behind any send) ✓; no per-batch free, no write-vs-free race.
+- **S10 Non-`Exception` `Throwable` after stream-root adoption** — `putNext`/`start`/transfer
+  throws OOM/`AssertionError` once `root != null`. `sendBatch`'s `finally` frees the source ✓;
+  `processBatchTask`'s `catch (Throwable)` runs `failStream` → channel released → `close()` posts
+  the stream-root free ✓; listener notified, worker survives. No leak (§3.5).
+
+---
+
+## 7. Design decisions (explicit)
+
+1. **Terminal op separate from root-free.** `completeStream`/`sendError` issue the gRPC
+   terminal op and set `terminalSent`; `root` is freed later in `close()`, preserving the
+   zero-copy drain window. (Folding free into `completeStream` shrinks that window — not
+   chosen.)
+2. **Single `sendBatch(response, headerSupplier)` entry.** Native/byte decided in the
+   channel; the handler never touches a stream root and never serializes the header.
+3. **Header built by the channel via a supplier, before any root is mutated.** This is
+   correctness-critical (not cosmetic): `getHeaderBuffer` throws `IOException`, and building it
+   inside `sendBatch` puts that throw inside the source-freeing `finally` — and building it
+   before the transfer means a header failure adopts no stream root.
+4. **Single-writer confinement, not synchronization.** The stream root and all
+   `serverStreamListener` calls are confined to the flight executor; `close()` posts the root
+   free there rather than coordinating concurrent access to it. This makes the design
+   deadlock-free by construction (nothing is held across a gRPC/Arrow call) at the cost of an
+   asynchronous root free (§10). The invariant future changes must keep is the self-evident
+   "root is touched only on the executor."
+
+---
+
+## 8. Relationship to the consumer-hang fix (PR #22117)
+
+PR #22117 fixes **S2's symptom** (a failed batch send calls `sendError`+release so the
+consumer gets an error, not a hang) and relocates the native transfer into the channel.
+That behaviour is preserved here. What this contract adds is the **concurrency safety** PR
+#22117 lacks: it leaves `close()` non-atomic and the stream root accessible from both the
+producer and the gRPC cancel thread, so S4 (UAF/double-free) and S5 (crash) remain reachable —
+and its new `failStream → releaseChannel → close()` adds *another* concurrent `close()` caller.
+This model closes S4/S5/S7–S9 while keeping S2 fixed.
+
+---
+
+## 9. Coverage matrix — the 12 distinct root-cause classes
+
+The case-sweep confirmed 64 defects in the current code; verified-and-deduplicated they are
+12 classes. Each MUST map to a model mechanism. (`#` = confirmed-defect count folded in.)
+
+| # | Root-cause class | Sev | Bug type | Closed by |
+|---|------------------|-----|----------|-----------|
+| 1 | Non-atomic `close()` double-entry → double-free root + double `notifyCloseListeners` (crash) | blocker | crash/double-free | `open.compareAndSet` (inv 1,2); S5 |
+| 2 | Cancel frees stream root mid-`transferRoot`/`putNext` (UAF) | blocker | UAF | single-writer: root free posted to `T_exec`, behind any send (inv 4); S4 |
+| 3 | Cancel after transfer-into-reused-root, send rejects → transferred buffers leak; `root` never nulled | blocker | leak/UAF | gate **before** transfer + null-after-free; free serialized on `T_exec` (inv 2,4); S4 |
+| 4 | Source root orphaned when send never runs: gate throw / `execute` reject / wrong-channel return | blocker | leak | `handedOff` + `releaseUnsent` (§3.1, inv 5); S7 |
+| 5 | Source root orphaned inside `sendBatch`: `getHeaderBuffer`/`create`/`transferRoot` throw | major | leak | header built before transfer + `finally` frees source (§3.4, §5); S8 |
+| 6 | Byte path: per-batch `out.close()` frees reused vector (UAF vs zero-copy & vs cancel) | blocker | UAF | channel owns vector, freed once in `close()` (§3.2); S9 |
+| 7 | Terminal-after-cancel: `completeStream`/`sendError` issue terminal op after cancel | major | illegal transition | `cancelled` guard (inv 3) |
+| 8 | Metadata buf leaked when `putNext` throws before hand-off | minor | leak | try/catch + `refCnt` close (§3.3) |
+| 9 | `addCloseListener` races `close()` flip+clear → lost fire / CME / tracker-map leak | major | leak/visibility | atomic registration (inv 7, §5) |
+| 10 | Throwing close listener strands remaining listeners (TaskManager untrack skipped) | minor | leak | per-listener try/catch (inv 8, §5) |
+| 11 | `shutdownNow` drops queued tasks undrained → source roots leak | minor | leak (shutdown-only) | **documented limitation** — node teardown; OS reclaims on exit (§10) |
+| 12 | Wrong-channel-type / NOOP-listener early returns (defensive `instanceof`) | info | n/a | covered by §3.1 handoff (handedOff stays false → `releaseUnsent`) |
+| 13 | Non-`Exception` `Throwable` (OOM / `AssertionError`) from `start`/`putNext`/transfer **after** stream-root adoption → `processBatchTask` only caught `Exception`, so the channel was never released → adopted stream root leaks | major | leak | `catch (Throwable)` in `processBatchTask` routes through `failStream` (releases channel → `close()` frees the root) + notifies the listener; `failStream` closes the channel directly when there is no transport channel (§3.5); S10 |
+
+---
+
+## 10. Known limitations (not closed by this model)
+
+- **Asynchronous stream-root free (a consequence of the single-writer choice).** Because
+  `close()` posts the root free onto the flight executor, the buffers are freed slightly after
+  `close()` returns, not inline. Functionally this is the point (it serializes the free behind
+  any in-flight send), but two implications follow: (a) tests asserting allocator state after
+  `close()` must drain the executor first; (b) if the executor is already shut down when
+  `close()` runs, the `execute()` is rejected and the stream root is not freed — see the next
+  bullet. This is the deliberate trade the single-writer model makes for being deadlock-free by
+  construction (§1, §7 decision 4).
+- **Node-shutdown drain gap.** On `executor.shutdownNow()`, queued tasks — including a
+  `close()`-posted root free, and any never-run `BatchTask`s — are dropped without running, so
+  their roots are not freed. Likewise, if `close()`'s `executor.execute(...)` is rejected
+  (executor already shut down), the root free never runs; `close()` logs this at **WARN** (not
+  debug) so the shutdown-time leak is visible. We deliberately do **not** free the root inline on
+  rejection: a rejection from `shutdown()` refuses new tasks while an already-running send may
+  still be touching the root on the executor thread, so freeing from the (possibly gRPC) caller
+  thread would reintroduce the use-after-free this model prevents. This is **shutdown-only** (the
+  node is stopping; the OS reclaims off-heap memory on process exit), so impact is limited to
+  noisy Arrow leak assertions / test flakiness, not a sustained production leak. Closing it fully
+  would require draining queued tasks before `shutdownNow`; tracked separately.
+- **Final-frame zero-copy drain.** Whether gRPC can still hold a reference to the *last*
+  frame's buffers when `close()` frees `root` is a pre-existing concern with the same shape
+  in today's code; out of scope here.
+```

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -9,11 +9,10 @@
 package org.opensearch.arrow.flight.transport;
 
 import org.apache.arrow.flight.FlightRuntimeException;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
-import org.opensearch.arrow.transport.ArrowBatchResponse;
-import org.opensearch.arrow.transport.VectorTransfer;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -31,15 +30,27 @@ import org.opensearch.transport.stream.StreamException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Set;
 
 /**
  * Outbound handler for Arrow Flight streaming responses.
- * It must invoke messageListener and relay any exception back to the caller and not supress them
+ *
+ * <p>This handler is a stateless translator: it switches onto the channel's flight executor, gates
+ * on back-pressure, and hands each {@link TransportResponse} to {@link FlightServerChannel}. It does
+ * not own or free the stream root and never closes the channel directly — the channel is the sole
+ * owner of all Arrow buffers (see {@code docs/channel-lifecycle-ownership.md}).
+ *
+ * <p>Its one buffer responsibility is the <em>source-root hand-off</em>: ownership of a native
+ * response's root transfers to the channel when {@link #sendResponseBatch} is called, and the handler
+ * guarantees it is freed exactly once — by {@link FlightServerChannel#sendBatch} once the batch is
+ * handed off, or by {@link FlightServerChannel#releaseUnsent} if the batch never reaches the channel
+ * (the back-pressure gate threw or the executor rejected the task).
+ *
+ * <p>It must invoke the messageListener and relay any exception back to the caller and not suppress them.
  * @opensearch.internal
  */
 class FlightOutboundHandler extends ProtocolOutboundHandler {
+    private static final Logger logger = LogManager.getLogger(FlightOutboundHandler.class);
     private volatile TransportMessageListener messageListener = TransportMessageListener.NOOP_LISTENER;
     private final String nodeName;
     private final Version version;
@@ -127,23 +138,38 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         );
 
         if (!(channel instanceof FlightServerChannel flightChannel)) {
+            // Defensive: this transport always uses FlightServerChannel. There is no channel to take
+            // ownership, so free the source here so it cannot leak.
+            FlightServerChannel.releaseUnsentSource(response);
             messageListener.onResponseSent(requestId, action, new IllegalStateException("Expected FlightServerChannel"));
             return;
         }
 
-        // Block the producer thread before queuing the batch so a slow consumer throttles
-        // allocation rather than letting the eventloop's queue grow. Note: isReady()
-        // reflects only gRPC's outbound buffer, not our own queue depth — see
-        // docs/backpressure.md "Known limitation: unbounded eventloop queue".
-        flightChannel.awaitReadyOrThrow();
+        // The channel owns the response's buffers from this point. The batch is freed exactly once:
+        // either sendBatch runs on the executor (its finally frees the source), or it never does
+        // (gate throws / executor rejects) and releaseUnsent frees it here. The handedOff flag keeps
+        // these two paths mutually exclusive.
+        boolean handedOff = false;
+        try {
+            // Block the producer thread before queuing the batch so a slow consumer throttles
+            // allocation rather than letting the eventloop's queue grow. Note: isReady()
+            // reflects only gRPC's outbound buffer, not our own queue depth — see
+            // docs/backpressure.md "Known limitation: unbounded eventloop queue".
+            flightChannel.awaitReadyOrThrow();
 
-        flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
-            try (BatchTask ignored = task) {
-                processBatchTask(task);
-            } catch (Exception e) {
-                messageListener.onResponseSent(requestId, action, e);
+            flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
+                try (BatchTask ignored = task) {
+                    processBatchTask(task);
+                } catch (Exception e) {
+                    messageListener.onResponseSent(requestId, action, e);
+                }
+            }));
+            handedOff = true;
+        } finally {
+            if (handedOff == false) {
+                flightChannel.releaseUnsent(response);
             }
-        }));
+        }
     }
 
     private void processBatchTask(BatchTask task) {
@@ -154,38 +180,60 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         }
 
         try {
-            VectorStreamOutput out;
-            byte[] metadata = null;
-            if (task.response() instanceof ArrowBatchResponse arrowResponse) {
-                metadata = arrowResponse.getMetadata();
-                // Native Arrow path: zero-copy transfer producer's vectors into stream root
-                VectorSchemaRoot streamRoot = flightChannel.getRoot();
-                if (streamRoot == null) {
-                    // Create stream root using the producer's allocator for same-allocator transfer.
-                    // This avoids an Arrow bug where cross-allocator transferOwnership of foreign-backed
-                    // buffers (from C data import) doesn't properly free the ArrowArray C struct.
-                    // The producer's allocator must be long-lived (not closed per-request).
-                    List<FieldVector> fieldVectors = arrowResponse.getRoot().getFieldVectors();
-                    if (fieldVectors.isEmpty()) {
-                        throw new IllegalStateException("Native Arrow batch has no field vectors");
-                    }
-                    streamRoot = VectorSchemaRoot.create(arrowResponse.getRoot().getSchema(), fieldVectors.getFirst().getAllocator());
-                }
-                VectorTransfer.transferRoot(arrowResponse.getRoot(), streamRoot);
-                arrowResponse.getRoot().close();
-                out = VectorStreamOutput.forNativeArrow(streamRoot);
-            } else {
-                out = VectorStreamOutput.create(flightChannel.getAllocator(), flightChannel.getRoot());
-                task.response().writeTo(out);
-            }
-            try (out) {
-                flightChannel.sendBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), out, metadata);
-                messageListener.onResponseSent(task.requestId(), task.action(), task.response());
-            }
+            // The channel owns the stream root end to end (create/transfer/adopt/free) and builds the
+            // header itself before mutating any root, so a header-serialization failure cannot orphan the source.
+            flightChannel.sendBatch(task.response(), () -> getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()));
+            messageListener.onResponseSent(task.requestId(), task.action(), task.response());
         } catch (FlightRuntimeException e) {
+            // Fail the stream before notifying the listener so the consumer surfaces an error instead
+            // of blocking forever on a never-arriving first frame.
+            failStream(flightChannel, task, e);
             messageListener.onResponseSent(task.requestId(), task.action(), FlightErrorMapper.fromFlightException(e));
         } catch (Exception e) {
+            failStream(flightChannel, task, e);
             messageListener.onResponseSent(task.requestId(), task.action(), e);
+        } catch (Throwable t) {
+            // A non-Exception Throwable (e.g. OutOfMemoryError, or an AssertionError from Arrow/gRPC
+            // under -ea) can be thrown by start()/putNext()/transfer AFTER the channel adopted the
+            // stream root. The batch task is non-terminal, so BatchTask.close() does not release the
+            // channel; without failing the stream here, the adopted stream root would never be freed.
+            // Route it through the same fail path (which releases the channel -> close() frees the
+            // root) and report it to the listener rather than letting it kill the executor worker and
+            // strand the caller. Wrapped so the listener's Exception contract is honoured.
+            Exception wrapped = new RuntimeException("Fatal error sending Arrow batch", t);
+            failStream(flightChannel, task, wrapped);
+            messageListener.onResponseSent(task.requestId(), task.action(), wrapped);
+        }
+    }
+
+    /**
+     * Fails the stream after a batch send error: sends the error so the consumer's
+     * {@code FlightStream.getRoot()} surfaces an exception instead of hanging on a never-arriving first
+     * frame, then releases the channel so a later {@code completeStream} no-ops on its open guard. The
+     * stream root and the source root are owned and freed by the channel, so there is nothing to free
+     * here. {@code sendError} and {@code releaseChannel} are both idempotent / best-effort.
+     */
+    private void failStream(FlightServerChannel flightChannel, BatchTask task, Exception cause) {
+        try {
+            Exception flightError = cause instanceof StreamException se ? FlightErrorMapper.toFlightException(se) : cause;
+            flightChannel.sendError(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), flightError);
+        } catch (Exception suppressed) {
+            // sendError is a no-op when the channel is already closed/cancelled/terminal, so reaching
+            // here means it genuinely failed (e.g. header serialization). Attach to the original cause
+            // so the second failure's context travels with the exception the listener receives, and log
+            // at WARN — this is a cascading failure, not routine.
+            cause.addSuppressed(suppressed);
+            logger.warn(new ParameterizedMessage("failStream: could not send error for requestId [{}]", task.requestId()), suppressed);
+        } finally {
+            // Make the channel terminal so a later completeStream can't double-terminate the listener,
+            // and so close() runs to free the adopted stream root. Prefer releasing via the transport
+            // channel (also untracks the framework task); fall back to closing the channel directly when
+            // there is no transport channel. Both are idempotent (close() is fire-once).
+            if (task.transportChannel() != null) {
+                task.transportChannel().releaseChannel(true);
+            } else {
+                flightChannel.close();
+            }
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -14,24 +14,31 @@ import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.OpenSearchException;
 import org.opensearch.arrow.flight.stats.FlightCallTracker;
+import org.opensearch.arrow.transport.ArrowBatchResponse;
+import org.opensearch.arrow.transport.VectorTransfer;
+import org.opensearch.common.CheckedSupplier;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.transport.TcpChannel;
 import org.opensearch.transport.stream.StreamErrorCode;
 import org.opensearch.transport.stream.StreamException;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -41,11 +48,34 @@ import static org.opensearch.arrow.flight.transport.FlightErrorMapper.mapFromCal
  * TcpChannel implementation for Arrow Flight. Created per call in {@link ArrowFlightProducer}.
  *
  * <p>Honours gRPC's {@code isReady()} contract via {@link CompositeBackpressureStrategy}:
- * producer threads call {@link #awaitReadyOrThrow()} before {@code sendBatch} is queued
- * and park until gRPC's outbound buffer drains below {@code setOnReadyThreshold}.
+ * producer threads call {@link #awaitReadyOrThrow()} before a batch is submitted and park
+ * until gRPC's outbound buffer drains below {@code setOnReadyThreshold}.
  *
- * <p>This implementation is not thread safe; the producer must invoke {@code sendBatch}
- * serially and call {@code completeStream()} at the end.
+ * <p><b>Ownership &amp; concurrency — single-writer model.</b> This channel is the sole owner of
+ * every Arrow buffer it sends and of the gRPC stream lifecycle. It keeps that ownership safe by
+ * confining the stream root to a single thread:
+ * <ul>
+ *   <li><b>The stream {@link #root} and every {@code serverStreamListener} call
+ *       ({@code start}/{@code putNext}/{@code completed}/{@code error}) happen only on the channel's
+ *       single-threaded flight executor</b> ({@link #getExecutor()}). The executor serializes batch
+ *       sends, {@code completeStream}/{@code sendError}, and the root free among themselves, so none
+ *       can interleave.</li>
+ *   <li>{@link #close()} may be called from any thread (the gRPC cancel callback, the flight executor
+ *       via {@code release()}, or producer bootstrap). It is a <em>signal</em>, not a buffer
+ *       operation: it flips {@link #open} exactly once via {@code compareAndSet}, fires close
+ *       listeners, and <b>posts the root free onto the flight executor</b>. Because the executor is
+ *       FIFO and single-threaded, that free runs only after any in-flight send completes.
+ *       {@code close()} never touches Arrow buffers or gRPC from the caller's thread, so it cannot
+ *       race an in-flight {@code putNext} and never blocks the cancel thread.</li>
+ *   <li>A native source root is freed exactly once by {@link #sendBatch} (in a {@code finally} on
+ *       every exit), or by {@link #releaseUnsent} when the batch never reached {@code sendBatch}.</li>
+ * </ul>
+ * The only cross-thread state is the close-listener list, guarded by a small leaf mutex
+ * ({@link #closeListenerMutex}) whose critical section only mutates that list. See
+ * {@code docs/channel-lifecycle-ownership.md} for the full contract.
+ *
+ * <p>The producer must invoke {@link #sendBatch} serially and finish with {@link #completeStream}
+ * (success) or {@link #sendError} (failure).
  */
 class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private static final String PROFILE_NAME = "flight";
@@ -56,9 +86,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final AtomicBoolean open = new AtomicBoolean(true);
     private final InetSocketAddress localAddress;
     private final InetSocketAddress remoteAddress;
-    private final List<ActionListener<Void>> closeListeners = Collections.synchronizedList(new ArrayList<>());
     private final ServerHeaderMiddleware middleware;
-    private volatile VectorSchemaRoot root = null;
     private final FlightCallTracker callTracker;
     private volatile boolean cancelled = false;
     private final ExecutorService executor;
@@ -66,6 +94,20 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final AtomicInteger batchNumber = new AtomicInteger(0);
     private final CompositeBackpressureStrategy bp;
     private final long readyTimeoutMillis;
+
+    /**
+     * The reused stream root (native or byte-serialized). Confined to the flight-executor thread:
+     * created, filled, and freed only there. {@code volatile} so the test-only {@link #getRoot()}
+     * sees a consistent reference; correctness relies on executor confinement, not on volatility.
+     */
+    private volatile VectorSchemaRoot root = null;
+    /** Whether a terminal gRPC op ({@code completed()} XOR {@code error()}) was issued. Flight-executor confined. */
+    private boolean terminalSent = false;
+
+    /** Leaf mutex guarding {@link #closeListeners} and {@link #closeListenersFired}; its critical section only mutates them. */
+    private final Object closeListenerMutex = new Object();
+    private final List<ActionListener<Void>> closeListeners = new ArrayList<>();
+    private boolean closeListenersFired = false;
 
     public FlightServerChannel(
         ServerStreamListener serverStreamListener,
@@ -138,6 +180,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         return allocator;
     }
 
+    /** Returns the current stream root. Package-private; intended for tests/assertions only. */
     VectorSchemaRoot getRoot() {
         return root;
     }
@@ -149,109 +192,248 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         return executor;
     }
 
-    public void sendBatch(ByteBuffer header, VectorStreamOutput output) {
-        sendBatch(header, output, null);
-    }
-
     /**
-     * Sends a batch, optionally with application metadata attached to the same Flight
-     * frame via {@code putNext(ArrowBuf)}. Metadata is opaque to the transport.
-     */
-    public void sendBatch(ByteBuffer header, VectorStreamOutput output, byte[] metadata) {
-        if (cancelled) {
-            throw StreamException.cancelled("Cannot flush more batches. Stream cancelled by the client");
-        }
-        if (!open.get()) {
-            throw new IllegalStateException("FlightServerChannel already closed.");
-        }
-        batchNumber.incrementAndGet();
-        long batchStartTime = System.nanoTime();
-        if (root == null) {
-            middleware.setHeader(header);
-            root = output.getRoot();
-            serverStreamListener.start(root);
-        } else {
-            root = output.getRoot();
-        }
-        logger.debug("Sending batch #{} for correlation ID: {}", batchNumber, correlationId);
-        // Roots are not closed right after putNext: gRPC may still hold zero-copy refs.
-        // They're released at completeStream. TODO: optimize.
-        if (metadata != null) {
-            // Flight takes ownership of metadataBuf via putNext(ArrowBuf).
-            ArrowBuf metadataBuf = allocator.buffer(metadata.length);
-            metadataBuf.writeBytes(metadata);
-            serverStreamListener.putNext(metadataBuf);
-        } else {
-            serverStreamListener.putNext();
-        }
-        long putNextTime = (System.nanoTime() - batchStartTime) / 1_000_000;
-        if (callTracker != null) {
-            long rootSize = FlightUtils.calculateVectorSchemaRootSize(root);
-            callTracker.recordBatchSent(rootSize, System.nanoTime() - batchStartTime);
-            logger.debug(
-                "Batch #{} sent for correlation ID: {}, size: {} bytes, putNext: {}ms",
-                batchNumber,
-                correlationId,
-                rootSize,
-                putNextTime
-            );
-        } else {
-            logger.debug("Batch #{} sent for correlation ID: {}, putNext: {}ms", batchNumber, correlationId, putNextTime);
-        }
-    }
-
-    /**
-     * Completes the streaming response and closes all pending roots.
+     * Sends one streaming batch. <b>Must run on the flight executor thread</b> (it is dispatched there
+     * by {@link FlightOutboundHandler}). The channel takes ownership of the response's buffers and is
+     * the sole place they are transferred onto the wire and freed.
      *
+     * <p>For an {@link ArrowBatchResponse} (native path) the producer's root is zero-copy transferred
+     * into the reused stream root and the producer root is freed here exactly once (on every exit, via
+     * the {@code finally}). For any other response (byte-serialized path) the response is written into
+     * the reused {@code VarBinary} stream root. The stream root itself is freed once, at {@link #close()}
+     * — never per batch — to preserve gRPC's zero-copy retention window.
+     *
+     * <p>This method, the terminal ops, and the {@link #close()} root-free all run on the
+     * single-threaded executor and are serialized by it. The header is built before any root is
+     * mutated, so a header-serialization failure fails fast (the source is freed by the {@code finally})
+     * without adopting a stream root.
+     *
+     * @param response the batch to send; the channel takes ownership of its buffers
+     * @param headerSupplier builds the response header
+     * @throws IOException if header serialization or byte-path serialization fails
      */
-    public void completeStream(ByteBuffer header) {
+    public void sendBatch(TransportResponse response, CheckedSupplier<ByteBuffer, IOException> headerSupplier) throws IOException {
+        final boolean isNative = response instanceof ArrowBatchResponse;
+        final VectorSchemaRoot sourceRoot = isNative ? ((ArrowBatchResponse) response).getRoot() : null;
+        final byte[] metadata = isNative ? ((ArrowBatchResponse) response).getMetadata() : null;
         try {
+            if (cancelled) {
+                throw StreamException.cancelled("Cannot flush more batches. Stream cancelled by the client");
+            }
             if (!open.get()) {
                 throw new IllegalStateException("FlightServerChannel already closed.");
             }
-            if (root == null) {
-                // Set header if no batches were sent
-                middleware.setHeader(header);
-                logger.debug("Completing empty stream for correlation ID: {}", correlationId);
+
+            final boolean firstBatch = (root == null);
+            final long batchStartTime = System.nanoTime();
+
+            // Build the header before mutating any root so a header-serialization failure fails fast
+            // (the source root is still freed by the finally) without adopting a stream root.
+            final ByteBuffer header = headerSupplier.get();
+
+            if (isNative) {
+                transferIntoStreamRoot(sourceRoot, firstBatch);
             } else {
-                logger.debug("Completing stream for correlation ID: {} after {} batches", correlationId, batchNumber);
+                serializeIntoStreamRoot(response, firstBatch);
             }
-            serverStreamListener.completed();
+
+            batchNumber.incrementAndGet();
+            if (firstBatch) {
+                middleware.setHeader(header);
+                serverStreamListener.start(root);
+            }
+
+            logger.debug("Sending batch #{} for correlation ID: {}", batchNumber, correlationId);
+            if (metadata != null) {
+                // Flight takes ownership of metadataBuf via putNext(ArrowBuf); free it ourselves
+                // only if putNext never adopted it.
+                ArrowBuf metadataBuf = allocator.buffer(metadata.length);
+                metadataBuf.writeBytes(metadata);
+                try {
+                    serverStreamListener.putNext(metadataBuf);
+                } catch (Throwable t) {
+                    if (metadataBuf.refCnt() > 0) {
+                        metadataBuf.close();
+                    }
+                    throw t;
+                }
+            } else {
+                serverStreamListener.putNext();
+            }
+
+            long putNextTime = (System.nanoTime() - batchStartTime) / 1_000_000;
+            if (callTracker != null) {
+                long rootSize = FlightUtils.calculateVectorSchemaRootSize(root);
+                callTracker.recordBatchSent(rootSize, System.nanoTime() - batchStartTime);
+                logger.debug(
+                    "Batch #{} sent for correlation ID: {}, size: {} bytes, putNext: {}ms",
+                    batchNumber,
+                    correlationId,
+                    rootSize,
+                    putNextTime
+                );
+            } else {
+                logger.debug("Batch #{} sent for correlation ID: {}, putNext: {}ms", batchNumber, correlationId, putNextTime);
+            }
         } finally {
-            callTracker.recordCallEnd(StreamErrorCode.OK.name());
+            // The native source root is exclusively owned by this call. Free it exactly once on every
+            // exit: after a successful transfer it is empty (close is a no-op); on any early throw it
+            // still holds its buffers (close frees them).
+            if (isNative && sourceRoot != null) {
+                sourceRoot.close();
+            }
         }
     }
 
     /**
-     * Sends an error and closes the channel.
+     * Native path: zero-copy transfers {@code sourceRoot}'s vectors into the reused stream root,
+     * creating it on the first batch. On the first batch, if transfer fails before the channel adopts
+     * the freshly-created root, that root is freed here so it cannot leak (it has not yet become
+     * {@link #root}, so {@link #close()} would not free it). Flight-executor confined.
+     */
+    private void transferIntoStreamRoot(VectorSchemaRoot sourceRoot, boolean firstBatch) {
+        if (firstBatch) {
+            List<FieldVector> fieldVectors = sourceRoot.getFieldVectors();
+            if (fieldVectors.isEmpty()) {
+                throw new IllegalStateException("Native Arrow batch has no field vectors");
+            }
+            // Create using the producer's allocator: cross-allocator transferOwnership of foreign-backed
+            // buffers (from C data import) does not properly free the ArrowArray C struct. The producer's
+            // allocator must be long-lived (not closed per-request).
+            VectorSchemaRoot created = VectorSchemaRoot.create(sourceRoot.getSchema(), fieldVectors.getFirst().getAllocator());
+            boolean adopted = false;
+            try {
+                VectorTransfer.transferRoot(sourceRoot, created);
+                root = created;
+                adopted = true;
+            } finally {
+                if (!adopted) {
+                    created.close();
+                }
+            }
+        } else {
+            VectorTransfer.transferRoot(sourceRoot, root);
+        }
+    }
+
+    /**
+     * Byte-serialized path: writes {@code response} into the reused {@code VarBinary} stream root,
+     * creating it on the first batch and clearing it for reuse on later batches. On the first batch,
+     * if serialization fails before the channel adopts the freshly-created root, the output's vector is
+     * freed here so it cannot leak. Flight-executor confined.
+     */
+    private void serializeIntoStreamRoot(TransportResponse response, boolean firstBatch) throws IOException {
+        VectorStreamOutput out = VectorStreamOutput.create(allocator, root);
+        boolean adopted = false;
+        try {
+            if (!firstBatch) {
+                out.reset();
+            }
+            response.writeTo(out);
+            root = out.getRoot();
+            adopted = true;
+        } finally {
+            // Only the first-batch output owns a freshly-allocated vector; on reuse the output wraps the
+            // channel-owned root, which close() frees.
+            if (firstBatch && !adopted) {
+                try {
+                    out.close();
+                } catch (IOException ignore) {
+                    // best-effort cleanup of the un-adopted first-batch vector
+                }
+            }
+        }
+    }
+
+    /**
+     * Frees the source buffers of a batch that was built but never handed to {@link #sendBatch}
+     * (the back-pressure gate threw, the executor rejected the task, or the channel was the wrong
+     * type). The channel owns the source root from the moment the producer enqueues the batch, so on a
+     * failed hand-off it is freed here — the mutually-exclusive counterpart to {@link #sendBatch}'s own
+     * {@code finally}. No-op for the byte-serialized path (no off-heap source root).
+     */
+    public void releaseUnsent(TransportResponse response) {
+        releaseUnsentSource(response);
+    }
+
+    /**
+     * Static variant of {@link #releaseUnsent} for the defensive path where the channel is the wrong
+     * type and no instance is available. Frees the native source root of an unsent batch; no-op for the
+     * byte-serialized path (no off-heap source root).
+     */
+    static void releaseUnsentSource(TransportResponse response) {
+        if (response instanceof ArrowBatchResponse arrowResponse) {
+            VectorSchemaRoot sourceRoot = arrowResponse.getRoot();
+            if (sourceRoot != null) {
+                sourceRoot.close();
+            }
+        }
+    }
+
+    /**
+     * Completes the streaming response. <b>Must run on the flight executor thread.</b> Terminal and
+     * idempotent: a no-op if the channel is already closed, cancelled, or terminal. Does not free the
+     * stream root — that is deferred to {@link #close()} to preserve gRPC's zero-copy retention window.
+     */
+    public void completeStream(ByteBuffer header) {
+        if (!open.get() || cancelled || terminalSent) {
+            logger.debug(
+                "completeStream is a no-op (open={}, cancelled={}, terminalSent={}) for correlation ID: {}",
+                open.get(),
+                cancelled,
+                terminalSent,
+                correlationId
+            );
+            return;
+        }
+        if (root == null) {
+            // Set header if no batches were sent
+            middleware.setHeader(header);
+            logger.debug("Completing empty stream for correlation ID: {}", correlationId);
+        } else {
+            logger.debug("Completing stream for correlation ID: {} after {} batches", correlationId, batchNumber);
+        }
+        serverStreamListener.completed();
+        terminalSent = true;
+        callTracker.recordCallEnd(StreamErrorCode.OK.name());
+    }
+
+    /**
+     * Sends a terminal error to the consumer. <b>Must run on the flight executor thread.</b> Terminal
+     * and idempotent: a no-op if the channel is already closed, cancelled, or terminal (the consumer is
+     * then already done). Does not free the stream root — that is deferred to {@link #close()}.
      *
      * @param error the error to send
      */
     public void sendError(ByteBuffer header, Exception error) {
-        FlightRuntimeException flightExc = null;
-        try {
-            if (!open.get()) {
-                throw new IllegalStateException("FlightServerChannel already closed.");
-            }
-            if (error instanceof FlightRuntimeException fre) {
-                flightExc = fre;
-            } else {
-                flightExc = CallStatus.INTERNAL.withCause(error)
-                    .withDescription(error.getMessage() != null ? error.getMessage() : "Stream error")
-                    .toRuntimeException();
-            }
-            middleware.setHeader(header);
-            if (error instanceof OpenSearchException) {
-                logger.debug("Error in Flight stream: {}", error.getMessage());
-            } else {
-                logger.error("Unexpected error in Flight stream", error);
-            }
-            logger.debug("Sending error for correlation ID: {} after {} batches: {}", correlationId, batchNumber, error.getMessage());
-            serverStreamListener.error(flightExc);
-        } finally {
-            StreamErrorCode errorCode = flightExc != null ? mapFromCallStatus(flightExc) : StreamErrorCode.UNKNOWN;
-            callTracker.recordCallEnd(errorCode.name());
+        if (!open.get() || cancelled || terminalSent) {
+            logger.debug(
+                "sendError is a no-op (open={}, cancelled={}, terminalSent={}) for correlation ID: {}",
+                open.get(),
+                cancelled,
+                terminalSent,
+                correlationId
+            );
+            return;
         }
+        FlightRuntimeException flightExc;
+        if (error instanceof FlightRuntimeException fre) {
+            flightExc = fre;
+        } else {
+            flightExc = CallStatus.INTERNAL.withCause(error)
+                .withDescription(error.getMessage() != null ? error.getMessage() : "Stream error")
+                .toRuntimeException();
+        }
+        middleware.setHeader(header);
+        if (error instanceof OpenSearchException) {
+            logger.debug("Error in Flight stream: {}", error.getMessage());
+        } else {
+            logger.error("Unexpected error in Flight stream", error);
+        }
+        logger.debug("Sending error for correlation ID: {} after {} batches: {}", correlationId, batchNumber, error.getMessage());
+        serverStreamListener.error(flightExc);
+        terminalSent = true;
+        callTracker.recordCallEnd(mapFromCallStatus(flightExc).name());
     }
 
     @Override
@@ -292,22 +474,56 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
 
     @Override
     public void close() {
-        if (!open.get()) {
+        // Fire-once: exactly one caller wins the CAS, regardless of thread (gRPC cancel, the flight
+        // executor via release, or producer bootstrap) or interleaving.
+        if (!open.compareAndSet(true, false)) {
             return;
         }
-        open.set(false);
-        if (root != null) {
-            root.close();
+        // The stream root is owned exclusively by the flight-executor thread (created, filled, and
+        // freed there). Post the free onto that executor so it is serialized behind any in-flight send
+        // by the executor's own FIFO ordering; we never touch Arrow buffers from this (possibly gRPC)
+        // thread.
+        try {
+            executor.execute(() -> {
+                if (root != null) {
+                    root.close();
+                    root = null;
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Executor shut down (node shutdown): the posted free will not run, so the stream root is
+            // reclaimed by the OS on process exit (documented limitation, channel-lifecycle-ownership
+            // §10). We deliberately do NOT free inline: a rejection from ExecutorService.shutdown()
+            // means new tasks are refused while an already-running send may still be touching the root
+            // on the executor thread, so freeing from this (possibly gRPC) thread would reintroduce the
+            // use-after-free this single-writer model exists to prevent. Logged at WARN so the
+            // shutdown-time leak is visible rather than buried.
+            logger.warn(
+                new ParameterizedMessage(
+                    "flight executor rejected stream-root release for correlation ID: {}; root reclaimed at process exit",
+                    correlationId
+                ),
+                e
+            );
         }
         notifyCloseListeners();
     }
 
     @Override
     public void addCloseListener(ActionListener<Void> listener) {
-        if (!open.get()) {
+        // Register atomically against notifyCloseListeners under the leaf mutex: either the listeners
+        // have not fired yet and we enqueue (notifyCloseListeners will fire it), or they have already
+        // fired and we fire immediately. Never both, never neither. The mutex's critical section only
+        // mutates the list.
+        boolean alreadyFired;
+        synchronized (closeListenerMutex) {
+            alreadyFired = closeListenersFired;
+            if (!alreadyFired) {
+                closeListeners.add(listener);
+            }
+        }
+        if (alreadyFired) {
             listener.onResponse(null);
-        } else {
-            closeListeners.add(listener);
         }
     }
 
@@ -317,9 +533,22 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     }
 
     private void notifyCloseListeners() {
-        for (ActionListener<Void> listener : closeListeners) {
-            listener.onResponse(null);
+        // Snapshot+mark-fired under the leaf mutex so a concurrent addCloseListener cannot be lost or
+        // double-fired, then fire outside the mutex so foreign listener code never runs while we hold
+        // it. Isolate each listener so one failure cannot strand the rest (e.g. the TaskManager untrack
+        // listener).
+        final List<ActionListener<Void>> toFire;
+        synchronized (closeListenerMutex) {
+            toFire = new ArrayList<>(closeListeners);
+            closeListeners.clear();
+            closeListenersFired = true;
         }
-        closeListeners.clear();
+        for (ActionListener<Void> listener : toFire) {
+            try {
+                listener.onResponse(null);
+            } catch (Exception e) {
+                logger.warn(new ParameterizedMessage("close listener failed for correlation ID: {}", correlationId), e);
+            }
+        }
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -26,6 +28,8 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.StatsTracker;
 import org.opensearch.transport.TransportMessageListener;
+import org.opensearch.transport.stream.StreamErrorCode;
+import org.opensearch.transport.stream.StreamException;
 import org.junit.After;
 import org.junit.Before;
 
@@ -36,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,6 +50,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -70,7 +76,6 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         mockFlightChannel = mock(FlightServerChannel.class);
         when(mockFlightChannel.getExecutor()).thenReturn(executor);
         when(mockFlightChannel.getAllocator()).thenReturn(mock(BufferAllocator.class));
-        when(mockFlightChannel.getRoot()).thenReturn(mock(VectorSchemaRoot.class));
 
         mockListener = mock(TransportMessageListener.class);
         handler.setMessageListener(mockListener);
@@ -213,40 +218,27 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         assertEquals("Caller's thread context should be preserved after completeStream", HEADER_VALUE, threadContext.getHeader(HEADER_KEY));
     }
 
-    // --- Native Arrow branch in processBatchTask ---
+    // --- processBatchTask delegates to the channel ---
+    // The channel owns the stream root (create/transfer/adopt/free) and builds the header internally;
+    // these tests verify delegation + listener notification. Root ownership is covered in
+    // FlightServerChannelTests.
 
-    public void testProcessBatchTaskNativeArrowFirstBatch() throws Exception {
+    public void testProcessBatchTaskDelegatesToChannelSendBatch() throws Exception {
         try (RootAllocator allocator = new RootAllocator()) {
-            Schema schema = new Schema(List.of(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null)));
-            VectorSchemaRoot producerRoot = VectorSchemaRoot.create(schema, allocator);
-            IntVector vec = (IntVector) producerRoot.getVector("val");
-            vec.allocateNew();
-            vec.setSafe(0, 42);
-            vec.setValueCount(1);
-            producerRoot.setRowCount(1);
-
-            // First batch: streamRoot is null, so it should be created
-            when(mockFlightChannel.getRoot()).thenReturn(null);
+            VectorSchemaRoot producerRoot = newSingleIntRoot(allocator, 42);
 
             CountDownLatch latch = new CountDownLatch(1);
-            AtomicReference<Exception> error = new AtomicReference<>();
-
             doAnswer(invocation -> {
                 latch.countDown();
                 return null;
             }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
 
+            // The channel takes the response; the handler must not touch its root.
+            AtomicReference<TransportResponse> sent = new AtomicReference<>();
             doAnswer(invocation -> {
-                // Verify the output has a root with transferred data
-                VectorStreamOutput out = invocation.getArgument(1);
-                VectorSchemaRoot sentRoot = out.getRoot();
-                assertNotNull(sentRoot);
-                assertEquals(1, sentRoot.getRowCount());
-                assertEquals(42, ((IntVector) sentRoot.getVector("val")).get(0));
-                // Clean up the stream root created by the handler
-                sentRoot.close();
+                sent.set(invocation.getArgument(0));
                 return null;
-            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class), any());
+            }).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
 
             TestArrowResponse response = new TestArrowResponse(producerRoot);
             handler.sendResponseBatch(
@@ -262,44 +254,55 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             );
 
             assertTrue("Task should complete", latch.await(5, TimeUnit.SECONDS));
-            assertNull("No error expected", error.get());
+            verify(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+            assertSame("handler should pass the response straight to the channel", response, sent.get());
+            // Channel mock did not consume buffers; free the producer root so teardown is clean.
+            producerRoot.close();
         }
     }
 
-    public void testProcessBatchTaskNativeArrowWithExistingStreamRoot() throws Exception {
-        try (RootAllocator allocator = new RootAllocator()) {
-            Schema schema = new Schema(List.of(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+    public void testProcessBatchTaskNonArrowResponseDelegatesToSendBatch() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
 
-            // Simulate existing stream root (second batch scenario)
-            VectorSchemaRoot streamRoot = VectorSchemaRoot.create(schema, allocator);
-            when(mockFlightChannel.getRoot()).thenReturn(streamRoot);
+        doAnswer(invocation -> null).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
 
-            VectorSchemaRoot producerRoot = VectorSchemaRoot.create(schema, allocator);
-            IntVector vec = (IntVector) producerRoot.getVector("val");
-            vec.allocateNew();
-            vec.setSafe(0, 99);
-            vec.setValueCount(1);
-            producerRoot.setRowCount(1);
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
 
-            CountDownLatch latch = new CountDownLatch(1);
+        assertTrue("Task should complete", latch.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+    }
 
-            doAnswer(invocation -> {
-                VectorStreamOutput out = invocation.getArgument(1);
-                VectorSchemaRoot sentRoot = out.getRoot();
-                // Should reuse the existing stream root
-                assertSame(streamRoot, sentRoot);
-                assertEquals(1, sentRoot.getRowCount());
-                assertEquals(99, ((IntVector) sentRoot.getVector("val")).get(0));
-                return null;
-            }).when(mockFlightChannel).sendBatch(any(), any(VectorStreamOutput.class), any());
+    // --- Hand-off discipline: a batch that never reaches the channel must be released (S7) ---
 
-            doAnswer(invocation -> {
-                latch.countDown();
-                return null;
-            }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+    /**
+     * When the back-pressure gate throws (cancel/timeout), the batch is never submitted, so the
+     * handler must free the source root via releaseUnsent and must NOT submit the task.
+     */
+    public void testSendResponseBatchReleasesSourceWhenGateThrows() {
+        ExecutorService submitTrap = mock(ExecutorService.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(submitTrap);
 
-            TestArrowResponse response = new TestArrowResponse(producerRoot);
-            handler.sendResponseBatch(
+        StreamException cancelled = StreamException.cancelled("client gone");
+        doThrow(cancelled).when(mockFlightChannel).awaitReadyOrThrow();
+
+        TransportResponse response = mock(TransportResponse.class);
+        StreamException thrown = expectThrows(
+            StreamException.class,
+            () -> handler.sendResponseBatch(
                 Version.CURRENT,
                 Collections.emptySet(),
                 mockFlightChannel,
@@ -309,11 +312,257 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 response,
                 false,
                 false
-            );
+            )
+        );
 
-            assertTrue("Task should complete", latch.await(5, TimeUnit.SECONDS));
-            streamRoot.close();
-        }
+        assertSame(cancelled, thrown);
+        verify(mockFlightChannel).releaseUnsent(response); // freed on the failed-handoff path
+        verify(submitTrap, never()).execute(any());        // not submitted after the gate failed
+    }
+
+    /**
+     * When the executor rejects the task (e.g. shutdown), the batch never runs, so the handler must
+     * free the source root via releaseUnsent.
+     */
+    public void testSendResponseBatchReleasesSourceWhenExecutorRejects() {
+        ExecutorService rejectingExecutor = mock(ExecutorService.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(rejectingExecutor);
+        doThrow(new RejectedExecutionException("shutting down")).when(rejectingExecutor).execute(any());
+
+        TransportResponse response = mock(TransportResponse.class);
+        expectThrows(
+            RejectedExecutionException.class,
+            () -> handler.sendResponseBatch(
+                Version.CURRENT,
+                Collections.emptySet(),
+                mockFlightChannel,
+                mock(FlightTransportChannel.class),
+                1L,
+                "test-action",
+                response,
+                false,
+                false
+            )
+        );
+
+        verify(mockFlightChannel).releaseUnsent(response);
+    }
+
+    /** A successful hand-off must NOT also release the source (it is owned by sendBatch's finally). */
+    public void testSendResponseBatchDoesNotReleaseOnSuccessfulHandoff() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+        doAnswer(invocation -> null).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        TransportResponse response = mock(TransportResponse.class);
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            response,
+            false,
+            false
+        );
+
+        assertTrue("Task should complete", latch.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel, never()).releaseUnsent(any());
+    }
+
+    // --- failStream: a batch send failure fails the stream instead of hanging the consumer ---
+
+    public void testProcessBatchTaskFailureSendsErrorAndReleasesChannel() throws Exception {
+        doThrow(new RuntimeException("send failed")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        FlightTransportChannel transportChannel = mock(FlightTransportChannel.class);
+        CountDownLatch notified = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            notified.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            transportChannel,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("failed batch send must terminate the stream", notified.await(5, TimeUnit.SECONDS));
+        // Stream is failed BEFORE the listener is notified (consumer sees an error, not a hang).
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(mockFlightChannel, transportChannel, mockListener);
+        inOrder.verify(mockFlightChannel).sendError(any(), any(Exception.class));
+        inOrder.verify(transportChannel).releaseChannel(true);
+        inOrder.verify(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+    }
+
+    public void testProcessBatchTaskFlightRuntimeExceptionFailsStreamWithMappedError() throws Exception {
+        FlightRuntimeException flightError = CallStatus.INTERNAL.withDescription("flight send failed").toRuntimeException();
+        doThrow(flightError).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        FlightTransportChannel transportChannel = mock(FlightTransportChannel.class);
+        CountDownLatch notified = new CountDownLatch(1);
+        AtomicReference<Object> notifiedArg = new AtomicReference<>();
+        doAnswer(invocation -> {
+            notifiedArg.set(invocation.getArgument(2));
+            notified.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            transportChannel,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("FlightRuntimeException must terminate the stream", notified.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel).sendError(any(), any(Exception.class));
+        verify(transportChannel).releaseChannel(true);
+        assertTrue("listener should receive the mapped StreamException", notifiedArg.get() instanceof StreamException);
+    }
+
+    public void testFailStreamSwallowsSendErrorFailureAndStillReleases() throws Exception {
+        doThrow(new RuntimeException("send failed")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+        // sendError itself fails (consumer already gone) — must be swallowed.
+        doThrow(new RuntimeException("sendError failed too")).when(mockFlightChannel).sendError(any(), any(Exception.class));
+
+        FlightTransportChannel transportChannel = mock(FlightTransportChannel.class);
+        CountDownLatch released = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            released.countDown();
+            return null;
+        }).when(transportChannel).releaseChannel(true);
+
+        CountDownLatch notified = new CountDownLatch(1);
+        AtomicReference<Object> notifiedArg = new AtomicReference<>();
+        doAnswer(invocation -> {
+            notifiedArg.set(invocation.getArgument(2));
+            notified.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            transportChannel,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("channel must still be released after sendError fails", released.await(5, TimeUnit.SECONDS));
+        assertTrue("listener must still be notified after sendError fails", notified.await(5, TimeUnit.SECONDS));
+        verify(transportChannel).releaseChannel(true);
+        // The sendError failure must not be lost: it is attached as a suppressed exception on the
+        // original cause that the listener receives.
+        assertTrue("listener arg must be the original cause", notifiedArg.get() instanceof Exception);
+        Throwable[] suppressed = ((Throwable) notifiedArg.get()).getSuppressed();
+        assertEquals("the sendError failure must be attached as suppressed", 1, suppressed.length);
+        assertEquals("sendError failed too", suppressed[0].getMessage());
+    }
+
+    public void testFailStreamWithNullTransportChannelDoesNotThrow() throws Exception {
+        doThrow(new RuntimeException("send failed")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        CountDownLatch notified = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            notified.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            null,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("stream must still be failed and the listener notified", notified.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel).sendError(any(), any(Exception.class));
+    }
+
+    /**
+     * A non-Exception {@code Throwable} from the send (e.g. OOM / AssertionError after the channel
+     * adopted the stream root) must still release the channel so its close()-posted stream-root free
+     * runs — the batch task is non-terminal, so {@code BatchTask.close()} would not release it. The
+     * {@code Throwable} must not be swallowed.
+     */
+    public void testProcessBatchTaskThrowableReleasesChannel() throws Exception {
+        doThrow(new AssertionError("putNext boom")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        FlightTransportChannel transportChannel = mock(FlightTransportChannel.class);
+        CountDownLatch released = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            released.countDown();
+            return null;
+        }).when(transportChannel).releaseChannel(true);
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            transportChannel,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        // The Throwable path must release the channel (-> close() -> stream-root free) even though
+        // failStream is not invoked for a non-Exception Throwable.
+        assertTrue("channel must be released on a non-Exception Throwable", released.await(5, TimeUnit.SECONDS));
+        verify(transportChannel).releaseChannel(true);
+    }
+
+    /** With no transport channel, the Throwable path must close the channel directly (still frees the root). */
+    public void testProcessBatchTaskThrowableClosesChannelWhenNoTransportChannel() throws Exception {
+        doThrow(new AssertionError("putNext boom")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+        CountDownLatch closed = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            closed.countDown();
+            return null;
+        }).when(mockFlightChannel).close();
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            null,
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("channel must be closed directly when there is no transport channel", closed.await(5, TimeUnit.SECONDS));
+        verify(mockFlightChannel).close();
     }
 
     // --- processCompleteTask error path ---
@@ -391,14 +640,11 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         ExecutorService submitTrap = mock(ExecutorService.class);
         when(mockFlightChannel.getExecutor()).thenReturn(submitTrap);
 
-        org.opensearch.transport.stream.StreamException timeoutEx = new org.opensearch.transport.stream.StreamException(
-            org.opensearch.transport.stream.StreamErrorCode.TIMED_OUT,
-            "consumer not ready"
-        );
+        StreamException timeoutEx = new StreamException(StreamErrorCode.TIMED_OUT, "consumer not ready");
         doThrow(timeoutEx).when(mockFlightChannel).awaitReadyOrThrow();
 
-        org.opensearch.transport.stream.StreamException thrown = expectThrows(
-            org.opensearch.transport.stream.StreamException.class,
+        StreamException thrown = expectThrows(
+            StreamException.class,
             () -> handler.sendResponseBatch(
                 Version.CURRENT,
                 Collections.emptySet(),
@@ -413,7 +659,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         );
         assertSame(timeoutEx, thrown);
         // Crucially: we must not have submitted the BatchTask after the gate failed.
-        verify(submitTrap, org.mockito.Mockito.never()).execute(any());
+        verify(submitTrap, never()).execute(any());
     }
 
     public void testBatchTaskCloseWithIsErrorCallsReleaseChannelWithTrue() {
@@ -439,7 +685,18 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         verify(mockTransportChannel).releaseChannel(true);
     }
 
-    // --- Test helper ---
+    // --- Test helpers ---
+
+    private static VectorSchemaRoot newSingleIntRoot(BufferAllocator allocator, int value) {
+        Schema schema = new Schema(List.of(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+        IntVector vec = (IntVector) root.getVector("val");
+        vec.allocateNew();
+        vec.setSafe(0, value);
+        vec.setValueCount(1);
+        root.setRowCount(1);
+        return root;
+    }
 
     static class TestArrowResponse extends ArrowBatchResponse {
         TestArrowResponse(VectorSchemaRoot root) {

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
@@ -19,10 +19,15 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.arrow.flight.stats.FlightCallTracker;
+import org.opensearch.arrow.transport.ArrowBatchResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.stream.StreamErrorCode;
 import org.opensearch.transport.stream.StreamException;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -32,10 +37,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -90,6 +97,19 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
 
     private FlightServerChannel newChannel(long readyTimeoutMillis) {
         return new FlightServerChannel(listener, allocator, middleware, callTracker, executor, readyTimeoutMillis);
+    }
+
+    private static ByteBuffer emptyHeader() {
+        return ByteBuffer.allocate(0);
+    }
+
+    /**
+     * close() posts the stream-root free onto the flight executor (single-writer model). Drain the
+     * executor so the free has run before asserting allocator state — submitting a no-op and waiting
+     * for it guarantees the earlier-queued free task completed (FIFO, single-threaded).
+     */
+    private void drainExecutor() throws Exception {
+        executor.submit(() -> {}).get(5, TimeUnit.SECONDS);
     }
 
     public void testAwaitReadyFastPath() {
@@ -262,6 +282,8 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
         assertEquals(StreamErrorCode.CANCELLED, ex.getErrorCode());
     }
 
+    // ── Native send: metadata framing ──
+
     /**
      * sendBatch with non-null metadata must call {@code putNext(ArrowBuf)} (not {@code putNext()})
      * with a buffer carrying the exact bytes the producer attached.
@@ -285,14 +307,15 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
                 return null;
             }).when(listener).putNext(any(ArrowBuf.class));
 
-            try (VectorStreamOutput out = VectorStreamOutput.forNativeArrow(root)) {
-                ch.sendBatch(ByteBuffer.allocate(0), out, metadata);
-            }
+            ch.sendBatch(new TestArrowResponse(root, metadata), FlightServerChannelTests::emptyHeader);
 
             verify(listener, times(1)).putNext(any(ArrowBuf.class));
             verify(listener, never()).putNext();
             assertArrayEquals("metadata bytes must round-trip into the ArrowBuf", metadata, capturedMetadata.get());
-            root.close();
+            // Channel owns the (transferred) stream root; close() posts the free to the executor.
+            ch.close();
+            drainExecutor();
+            assertEquals("all buffers must be freed", 0, realAllocator.getAllocatedMemory());
         }
     }
 
@@ -302,13 +325,381 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
             FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
             VectorSchemaRoot root = newSingleIntRoot(realAllocator, 1);
 
-            try (VectorStreamOutput out = VectorStreamOutput.forNativeArrow(root)) {
-                ch.sendBatch(ByteBuffer.allocate(0), out);
-            }
+            ch.sendBatch(new TestArrowResponse(root), FlightServerChannelTests::emptyHeader);
 
             verify(listener, times(1)).putNext();
             verify(listener, never()).putNext(any(ArrowBuf.class));
-            root.close();
+            ch.close();
+            drainExecutor();
+            assertEquals("all buffers must be freed", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    // ── Source-root ownership (the channel frees it exactly once) ──
+
+    /** A successful native send empties+frees the source root and retains the stream root until close(). */
+    public void testSendBatchFreesSourceRootRetainsStreamRoot() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 5);
+
+            ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader);
+
+            assertEquals("source root must be empty after transfer", 0, source.getRowCount());
+            assertNotNull("channel must retain the stream root", ch.getRoot());
+            assertTrue("stream root buffers must still be alive before close", realAllocator.getAllocatedMemory() > 0);
+
+            ch.close();
+            drainExecutor();
+            assertEquals("close must free the stream root", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /** When the channel is cancelled, sendBatch rejects and frees the source root exactly once (no leak). */
+    public void testSendBatchAfterCancelRejectsAndFreesSource() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            listenerCancelled.set(true);
+            capturedCancelHandler.get().run(); // cancel -> close
+
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 9);
+            StreamException ex = expectThrows(
+                StreamException.class,
+                () -> ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader)
+            );
+            assertEquals(StreamErrorCode.CANCELLED, ex.getErrorCode());
+            verify(listener, never()).start(any());
+            assertEquals("rejected source must be freed (no leak, no stream root created)", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /** When the channel is closed, sendBatch rejects and frees the source root exactly once. */
+    public void testSendBatchAfterCloseRejectsAndFreesSource() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            ch.close();
+
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 3);
+            expectThrows(
+                IllegalStateException.class,
+                () -> ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader)
+            );
+            assertEquals("rejected source must be freed", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /** An empty-field-vector native batch throws but still frees the source (S8 early-throw path). */
+    public void testSendBatchEmptyFieldVectorsFreesSource() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot empty = new VectorSchemaRoot(new ArrayList<>(), new ArrayList<>(), 0);
+
+            expectThrows(
+                IllegalStateException.class,
+                () -> ch.sendBatch(new TestArrowResponse(empty), FlightServerChannelTests::emptyHeader)
+            );
+            assertEquals("source must be freed even on the empty-vectors throw", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /** If the header supplier throws (S8), the source root is still freed and no stream root leaks. */
+    public void testSendBatchHeaderThrowsFreesSource() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 2);
+
+            expectThrows(IOException.class, () -> ch.sendBatch(new TestArrowResponse(source), () -> { throw new IOException("boom"); }));
+
+            verify(listener, never()).start(any());
+            assertEquals("header-throw must not leak source or created stream root", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /**
+     * If {@code putNext} throws a non-Exception {@code Throwable} (e.g. OOM / AssertionError) AFTER the
+     * channel adopted the stream root, the source root is still freed by sendBatch's finally, the stream
+     * root is retained (owned by the channel), and a subsequent close() frees it — no leak. (The handler
+     * is responsible for invoking close() on this path; see FlightOutboundHandlerTests.)
+     */
+    public void testSendBatchPutNextThrowableFreesSourceAndStreamRootClosable() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 15);
+            doThrow(new AssertionError("putNext boom")).when(listener).putNext();
+
+            expectThrows(AssertionError.class, () -> ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader));
+
+            assertEquals("source root must be empty/freed after the throw", 0, source.getRowCount());
+            assertNotNull("stream root was adopted before putNext threw", ch.getRoot());
+            assertTrue("stream root buffers are still alive (owned by the channel)", realAllocator.getAllocatedMemory() > 0);
+
+            ch.close();
+            drainExecutor();
+            assertEquals("close() must free the adopted stream root after a putNext Throwable", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /** releaseUnsent frees the source root of a batch that never reached sendBatch (failed hand-off). */
+    public void testReleaseUnsentFreesSource() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 11);
+
+            ch.releaseUnsent(new TestArrowResponse(source));
+            assertEquals("releaseUnsent must free the unsent source root", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    // ── Byte-serialized path: stream root reused, freed once ──
+
+    /** Multi-batch byte path reuses one VarBinary stream root and frees it exactly once at close(). */
+    public void testByteMultiBatchReusesStreamRootFreedOnce() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+
+            ch.sendBatch(new BytesResponse(new byte[] { 1, 2, 3 }), FlightServerChannelTests::emptyHeader);
+            VectorSchemaRoot afterFirst = ch.getRoot();
+            assertNotNull("byte path must create a stream root", afterFirst);
+
+            ch.sendBatch(new BytesResponse(new byte[] { 4, 5 }), FlightServerChannelTests::emptyHeader);
+            assertSame("byte path must reuse the same stream root across batches", afterFirst, ch.getRoot());
+
+            verify(listener, times(1)).start(any()); // start only on the first batch
+            verify(listener, times(2)).putNext();
+
+            ch.close();
+            drainExecutor();
+            assertEquals("byte stream root must be freed exactly once at close", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    // ── Terminal-op contracts ──
+
+    /** completeStream is a no-op after the channel was cancelled (no terminal op after cancel). */
+    public void testCompleteStreamNoOpAfterCancel() {
+        FlightServerChannel ch = newChannel(5_000);
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run(); // cancel -> close
+
+        ch.completeStream(emptyHeader());
+        verify(listener, never()).completed();
+    }
+
+    /** sendError is a no-op after the channel was cancelled. */
+    public void testSendErrorNoOpAfterCancel() {
+        FlightServerChannel ch = newChannel(5_000);
+        listenerCancelled.set(true);
+        capturedCancelHandler.get().run();
+
+        ch.sendError(emptyHeader(), new RuntimeException("late"));
+        verify(listener, never()).error(any());
+    }
+
+    /** At most one terminal gRPC op: a second completeStream is a no-op. */
+    public void testCompleteStreamOnlyOnce() {
+        FlightServerChannel ch = newChannel(5_000);
+        ch.completeStream(emptyHeader());
+        ch.completeStream(emptyHeader());
+        verify(listener, times(1)).completed();
+    }
+
+    /** Once completed(), a later sendError must not also issue error() (single terminal op). */
+    public void testSendErrorNoOpAfterComplete() {
+        FlightServerChannel ch = newChannel(5_000);
+        ch.completeStream(emptyHeader());
+        ch.sendError(emptyHeader(), new RuntimeException("after complete"));
+        verify(listener, times(1)).completed();
+        verify(listener, never()).error(any());
+    }
+
+    // ── close() fire-once + listener semantics ──
+
+    /** Concurrent close() callers must each fire every close listener exactly once (no double-fire). */
+    public void testCloseIsFireOnceUnderConcurrentCallers() throws Exception {
+        FlightServerChannel ch = newChannel(5_000);
+        AtomicInteger fires = new AtomicInteger(0);
+        int listeners = 3;
+        for (int i = 0; i < listeners; i++) {
+            ch.addCloseListener(org.opensearch.core.action.ActionListener.wrap(r -> fires.incrementAndGet(), e -> {}));
+        }
+
+        int threads = 8;
+        CountDownLatch start = new CountDownLatch(1);
+        List<Thread> ts = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                ch.close();
+            });
+            ts.add(t);
+            t.start();
+        }
+        start.countDown();
+        for (Thread t : ts) {
+            t.join(5_000);
+        }
+        assertEquals("each close listener must fire exactly once across all concurrent close() callers", listeners, fires.get());
+    }
+
+    /** A close listener registered after close() fires immediately. */
+    public void testAddCloseListenerAfterCloseFiresImmediately() {
+        FlightServerChannel ch = newChannel(5_000);
+        ch.close();
+        AtomicBoolean fired = new AtomicBoolean(false);
+        ch.addCloseListener(org.opensearch.core.action.ActionListener.wrap(r -> fired.set(true), e -> {}));
+        assertTrue("listener added after close must fire immediately", fired.get());
+    }
+
+    /** A throwing close listener must not strand the remaining listeners. */
+    public void testThrowingCloseListenerDoesNotStrandOthers() {
+        FlightServerChannel ch = newChannel(5_000);
+        AtomicBoolean secondFired = new AtomicBoolean(false);
+        ch.addCloseListener(org.opensearch.core.action.ActionListener.wrap(r -> { throw new RuntimeException("listener boom"); }, e -> {}));
+        ch.addCloseListener(org.opensearch.core.action.ActionListener.wrap(r -> secondFired.set(true), e -> {}));
+
+        ch.close();
+        assertTrue("a throwing listener must not prevent later listeners from firing", secondFired.get());
+    }
+
+    // ── S4: cancel races an in-flight send; the root free must run behind the send (no use-after-free) ──
+
+    /**
+     * Single-writer model: the send runs on the flight executor and {@code close()} posts the
+     * stream-root free onto that same executor. While a send is mid-{@code putNext} (occupying the
+     * single executor thread), a concurrent cancel -> {@code close()} must NOT free the stream root —
+     * the free is queued behind the in-flight send and runs only after it returns. The close listener
+     * fires immediately on {@code close()} (it touches no Arrow buffers), but the buffers stay alive
+     * until the send completes, then are freed exactly once.
+     */
+    public void testCancelDuringInFlightSendDefersRootFree() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            VectorSchemaRoot source = newSingleIntRoot(realAllocator, 13);
+
+            CountDownLatch inPutNext = new CountDownLatch(1);
+            CountDownLatch releasePutNext = new CountDownLatch(1);
+            doAnswer(inv -> {
+                inPutNext.countDown();
+                assertTrue("test timed out waiting to release putNext", releasePutNext.await(5, TimeUnit.SECONDS));
+                return null;
+            }).when(listener).putNext();
+
+            // Run the send ON the executor, exactly as production does — this is what serializes the
+            // close()-posted free behind it.
+            AtomicReference<Throwable> sendError = new AtomicReference<>();
+            executor.execute(() -> {
+                try {
+                    ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader);
+                } catch (Throwable t) {
+                    sendError.set(t);
+                }
+            });
+
+            assertTrue("send must reach putNext", inPutNext.await(5, TimeUnit.SECONDS));
+
+            // Fire the cancel -> close() from this (gRPC-like) thread. It must NOT block, and must post
+            // the root free onto the busy executor rather than freeing inline.
+            capturedCancelHandler.get().run();
+            assertFalse("channel must be marked closed immediately", ch.isOpen());
+
+            // The executor thread is still inside putNext, so the queued free has not run: buffers live.
+            assertTrue("stream root must still be alive while the send occupies the executor", realAllocator.getAllocatedMemory() > 0);
+
+            // Let the send finish; the executor then runs the queued free task. drainExecutor() waits
+            // behind both the send and the free.
+            releasePutNext.countDown();
+            drainExecutor();
+
+            assertNull("send must complete without error", sendError.get());
+            assertEquals("stream root must be freed exactly once after the send drains", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /**
+     * Cross-thread close() never frees buffers inline: when close() is called from a non-executor
+     * thread, the stream root is freed on the executor (single-writer), so it stays alive until the
+     * executor runs the posted free.
+     */
+    public void testCloseFreesStreamRootOnExecutor() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+            // Send a batch on the executor so the channel adopts a stream root, then drain.
+            executor.submit(() -> {
+                ch.sendBatch(new TestArrowResponse(newSingleIntRoot(realAllocator, 8)), FlightServerChannelTests::emptyHeader);
+                return null;
+            }).get(5, TimeUnit.SECONDS);
+            assertTrue("stream root should be alive after a batch", realAllocator.getAllocatedMemory() > 0);
+
+            ch.close(); // from the test thread (not the executor)
+            drainExecutor();
+            assertEquals("close() must free the stream root via the executor", 0, realAllocator.getAllocatedMemory());
+        }
+    }
+
+    /**
+     * Batches queued behind a cancel must not leak. While the executor is busy, we enqueue several
+     * native batches, then fire the cancel (which sets cancelled/closed and posts the root free behind
+     * them). When the executor drains: each queued batch hits the {@code cancelled} guard in
+     * {@code sendBatch}, rejects before touching the stream root, and frees its own source root in the
+     * {@code finally}; the posted root-free task (last in FIFO order) frees the stream root. Nothing is
+     * dropped, leaked, or double-freed.
+     */
+    public void testBatchesQueuedBehindCancelAreRejectedAndFreed() throws Exception {
+        try (RootAllocator realAllocator = new RootAllocator()) {
+            FlightServerChannel ch = new FlightServerChannel(listener, realAllocator, middleware, callTracker, executor, 5_000);
+
+            // Occupy the single executor thread so the batches below sit in the queue, not run.
+            CountDownLatch blockExecutor = new CountDownLatch(1);
+            CountDownLatch executorBusy = new CountDownLatch(1);
+            executor.execute(() -> {
+                executorBusy.countDown();
+                try {
+                    assertTrue(blockExecutor.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertTrue("executor must be busy", executorBusy.await(5, TimeUnit.SECONDS));
+
+            // Queue several native batches behind the blocked task. Each carries its own source root.
+            int queued = 4;
+            List<Throwable> sendErrors = new ArrayList<>();
+            for (int i = 0; i < queued; i++) {
+                VectorSchemaRoot source = newSingleIntRoot(realAllocator, i);
+                executor.execute(() -> {
+                    try {
+                        ch.sendBatch(new TestArrowResponse(source), FlightServerChannelTests::emptyHeader);
+                    } catch (Throwable t) {
+                        synchronized (sendErrors) {
+                            sendErrors.add(t);
+                        }
+                    }
+                });
+            }
+            assertTrue("all queued sources must be allocated", realAllocator.getAllocatedMemory() > 0);
+
+            // Cancel now (from the gRPC-like thread): sets cancelled, flips open, posts the root free
+            // to the BACK of the executor queue (after the queued batches).
+            capturedCancelHandler.get().run();
+            assertFalse("channel must be marked closed immediately", ch.isOpen());
+
+            // Release the executor and let it drain the blocked task, the queued batches, and the free.
+            blockExecutor.countDown();
+            drainExecutor();
+
+            assertEquals("every queued batch must have rejected", queued, sendErrors.size());
+            for (Throwable t : sendErrors) {
+                assertTrue("queued batches must reject with CANCELLED, got " + t, t instanceof StreamException);
+                assertEquals(StreamErrorCode.CANCELLED, ((StreamException) t).getErrorCode());
+            }
+            // No stream root was ever created (every batch rejected before transfer), and each queued
+            // source was freed by its own sendBatch finally.
+            verify(listener, never()).start(any());
+            assertEquals("no queued source root may leak after cancel", 0, realAllocator.getAllocatedMemory());
         }
     }
 
@@ -321,5 +712,34 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
         vec.setValueCount(1);
         root.setRowCount(1);
         return root;
+    }
+
+    /** Minimal send-side ArrowBatchResponse for tests. */
+    static final class TestArrowResponse extends ArrowBatchResponse {
+        TestArrowResponse(VectorSchemaRoot root) {
+            super(root);
+        }
+
+        TestArrowResponse(VectorSchemaRoot root, byte[] metadata) {
+            super(root, metadata);
+        }
+
+        TestArrowResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
+    /** Minimal non-Arrow response that drives the byte-serialization path. */
+    static final class BytesResponse extends TransportResponse {
+        private final byte[] data;
+
+        BytesResponse(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeByteArray(data);
+        }
     }
 }


### PR DESCRIPTION
### Description

Server-side Arrow Flight streaming frees off-heap Arrow buffers and terminates the gRPC call from **two unsynchronized threads**: the producer runs serially on the flight executor, while a client cancellation (`onChannelCancelled` → `close()`) is delivered concurrently on a gRPC thread. Split ownership between `FlightOutboundHandler` and `FlightServerChannel`, combined with a non-atomic `close()`, made several interleavings unsafe:

- **Double-close → node crash.** `close()` used a non-atomic get-then-set, so two callers (the gRPC cancel path and a `release()`-driven close) could both pass the open-check and both run `notifyCloseListeners()`, double-firing the TaskManager cancellable-channel untrack listener → `AssertionError` (with `-ea`) that kills the node.
- **Use-after-free / leak.** The handler transferred the producer root into the reused stream root and called `putNext` while a concurrent `close()` could free that same root (gRPC may still hold a zero-copy reference), or the producer refilled the reused root after `close()` had already done its single free → stranded buffers.
- **Source-root orphan.** A batch built but never sent (the back-pressure gate threw, or the executor rejected the task) freed nothing.
- **Consumer hang.** A failed batch send dropped the batch with no error frame, so the consumer's `FlightStream.getRoot()` blocked forever.

### Fix — single-writer ownership model

Make `FlightServerChannel` the **sole owner** of every Arrow buffer and of the gRPC stream lifecycle, and keep that ownership safe by **confining the stream root to a single thread** rather than synchronizing access to it:

- **The stream root and every `serverStreamListener` call (`start`/`putNext`/`completed`/`error`) happen only on the channel's single-threaded flight executor.** The executor serializes batch sends, `completeStream`/`sendError`, and the root free among themselves, so none can interleave.
- **`close()` is fire-once and a signal, not a buffer operation.** Via `open.compareAndSet(true, false)`, exactly one caller (any thread) proceeds; it fires close listeners and **posts the root free onto the flight executor**. Because the executor is FIFO, that free runs only after any in-flight send completes. `close()` never touches Arrow buffers or gRPC from the caller (cancel) thread, so it cannot race an in-flight `putNext` and never blocks. **This is deadlock-free by construction** — nothing is ever held across a gRPC/Arrow/blocking call.
- **Single `sendBatch(response, headerSupplier)` entry.** The channel decides native vs byte-serialized internally and builds the header itself; the handler no longer touches a stream root. The native source root is freed exactly once on every exit (`finally`), and a never-handed-off batch is freed via `releaseUnsent` (a `handedOff` discipline keeps the two free sites mutually exclusive). Batches queued behind a cancel reject at the `cancelled` guard and free their own source root.
- **Byte-serialized stream root** is reused across batches and freed once at `close()`, never per batch (fixes a zero-copy use-after-free).
- **`completeStream`/`sendError` are terminal and idempotent** (no-op after close/cancel/terminal), so a failed batch send fails the stream instead of hanging the consumer, and a late terminal op after a cancel is benign.
- Close-listener registration and firing are atomic (a small leaf mutex) and fault-isolated.

**Trade-off (documented):** `close()` frees the stream root asynchronously (on the executor) rather than inline; on node shutdown a dropped free task leaks the root until process exit. Both are called out in `docs/channel-lifecycle-ownership.md` §10.

The full ownership/lifecycle contract — threads, invariants, per-method behavior, and a scenario walk-through (S1–S9) — is documented in `plugins/arrow-flight-rpc/docs/channel-lifecycle-ownership.md`.

### Related Issues

Supersedes the consumer-hang fix in #22117 (that scenario is the S2 path here) and additionally closes the double-close crash, the transfer-vs-cancel use-after-free/leak, and the source-root orphan that #22117 leaves open.

### Testing

- New unit tests: cancel-vs-in-flight-send race (root free runs behind the in-flight send on the executor), **batches queued behind a cancel (each rejects and frees its own source; stream root freed last; no leak)**, fire-once `close()` under concurrent callers, source-root freed on every exit (reject / closed / empty-vectors / header-throw), byte-path reuse freed once, terminal-op idempotency, and the hand-off discipline (gate-throw / executor-reject release).
- `./gradlew :plugins:arrow-flight-rpc:check` — green (tests, internalClusterTest, precommit: spotless, checkstyle, forbiddenApis, loggerUsage, license, javadoc).
- `internalClusterTest`: `NativeArrowTransportIT`, `BackpressureProducerIT`, `StreamMetadataIT`, `FlightTransportIT` — green.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
