### PR TITLE
Move serial filter initialization from Bootstrap to BootstrapSettings

### DIFF
--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -70,7 +70,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.ObjectInputFilter;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
@@ -126,17 +125,8 @@ final class Bootstrap {
      * Gated behind the {@code bootstrap.serial_filter} setting (disabled by default).
      */
     static void initializeSerialFilter() {
-        try {
-            ObjectInputFilter.Config.setSerialFilter(REJECT_ALL_FILTER);
-        } catch (IllegalStateException e) {
-            // Filter already set (e.g., via -Djdk.serialFilter system property or in tests)
-            LogManager.getLogger(Bootstrap.class).debug("Serial filter already initialized", e);
-        }
+        BootstrapSettings.initializeSerialFilter();
     }
-
-    static final ObjectInputFilter REJECT_ALL_FILTER = filterInfo -> filterInfo.serialClass() == null
-        ? ObjectInputFilter.Status.UNDECIDED
-        : ObjectInputFilter.Status.REJECTED;
 
     /** initialize native resources */
     public static void initializeNatives(Path tmpFile, boolean mlockAll, boolean systemCallFilter, boolean ctrlHandler) {
@@ -204,10 +194,6 @@ final class Bootstrap {
 
     private void setup(boolean addShutdownHook, Environment environment) throws BootstrapException {
         Settings settings = environment.settings();
-
-        if (BootstrapSettings.SERIAL_FILTER_SETTING.get(settings)) {
-            initializeSerialFilter();
-        }
 
         try {
             spawner.spawnNativeControllers(environment, true);

--- a/server/src/main/java/org/opensearch/bootstrap/BootstrapSettings.java
+++ b/server/src/main/java/org/opensearch/bootstrap/BootstrapSettings.java
@@ -32,8 +32,11 @@
 
 package org.opensearch.bootstrap;
 
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
+
+import java.io.ObjectInputFilter;
 
 /**
  * Settings used for bootstrapping OpenSearch
@@ -60,5 +63,21 @@ public final class BootstrapSettings {
     public static final Setting<Boolean> CTRLHANDLER_SETTING = Setting.boolSetting("bootstrap.ctrlhandler", true, Property.NodeScope);
 
     public static final Setting<Boolean> SERIAL_FILTER_SETTING = Setting.boolSetting("bootstrap.serial_filter", false, Property.NodeScope);
+
+    static final ObjectInputFilter REJECT_ALL_FILTER = filterInfo -> filterInfo.serialClass() == null
+        ? ObjectInputFilter.Status.UNDECIDED
+        : ObjectInputFilter.Status.REJECTED;
+
+    /**
+     * Installs a process-wide ObjectInputFilter that rejects all Java deserialization by default.
+     * Code that needs deserialization can opt in by calling setObjectInputFilter on their stream.
+     */
+    public static void initializeSerialFilter() {
+        try {
+            ObjectInputFilter.Config.setSerialFilter(REJECT_ALL_FILTER);
+        } catch (IllegalStateException e) {
+            LogManager.getLogger(BootstrapSettings.class).debug("Serial filter already initialized", e);
+        }
+    }
 
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -60,6 +60,7 @@ import org.opensearch.arrow.spi.NativeAllocator;
 import org.opensearch.arrow.spi.PoolGroup;
 import org.opensearch.bootstrap.BootstrapCheck;
 import org.opensearch.bootstrap.BootstrapContext;
+import org.opensearch.bootstrap.BootstrapSettings;
 import org.opensearch.cluster.ClusterInfoService;
 import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.ClusterModule;
@@ -577,6 +578,10 @@ public class Node implements Closeable {
             );
 
             final Settings settings = pluginsService.updatedSettings();
+
+            if (BootstrapSettings.SERIAL_FILTER_SETTING.get(settings)) {
+                BootstrapSettings.initializeSerialFilter();
+            }
 
             final List<IdentityPlugin> identityPlugins = new ArrayList<>();
             identityPlugins.addAll(pluginsService.filterPlugins(IdentityPlugin.class));

--- a/server/src/test/java/org/opensearch/bootstrap/BootstrapSerialFilterTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/BootstrapSerialFilterTests.java
@@ -40,7 +40,7 @@ public class BootstrapSerialFilterTests extends OpenSearchTestCase {
         // or the framework already set it, the end-to-end tests are skipped.
         boolean installed = false;
         try {
-            ObjectInputFilter.Config.setSerialFilter(Bootstrap.REJECT_ALL_FILTER);
+            ObjectInputFilter.Config.setSerialFilter(BootstrapSettings.REJECT_ALL_FILTER);
             installed = true;
         } catch (IllegalStateException e) {
             // Already set
@@ -51,16 +51,16 @@ public class BootstrapSerialFilterTests extends OpenSearchTestCase {
     // --- Unit tests for the filter logic (always run) ---
 
     public void testRejectAllFilterRejectsClasses() {
-        assertEquals(ObjectInputFilter.Status.REJECTED, Bootstrap.REJECT_ALL_FILTER.checkInput(filterInfo(String.class)));
+        assertEquals(ObjectInputFilter.Status.REJECTED, BootstrapSettings.REJECT_ALL_FILTER.checkInput(filterInfo(String.class)));
     }
 
     public void testRejectAllFilterRejectsAnyClass() {
-        assertEquals(ObjectInputFilter.Status.REJECTED, Bootstrap.REJECT_ALL_FILTER.checkInput(filterInfo(Runtime.class)));
+        assertEquals(ObjectInputFilter.Status.REJECTED, BootstrapSettings.REJECT_ALL_FILTER.checkInput(filterInfo(Runtime.class)));
     }
 
     public void testRejectAllFilterUndecidedForNullClass() {
         // null serialClass = stream metadata check (depth, bytes, refs), not a class resolution
-        assertEquals(ObjectInputFilter.Status.UNDECIDED, Bootstrap.REJECT_ALL_FILTER.checkInput(filterInfo(null)));
+        assertEquals(ObjectInputFilter.Status.UNDECIDED, BootstrapSettings.REJECT_ALL_FILTER.checkInput(filterInfo(null)));
     }
 
     // --- End-to-end tests showing actual runtime behavior ---


### PR DESCRIPTION
## Description

Moves the `bootstrap.serial_filter` initialization from `Bootstrap.setup()` into the `Node` constructor.

## Why

The serial filter (introduced in #22073) was installed in `Bootstrap.setup()`, which only runs when OpenSearch starts as a standalone process via `bin/opensearch`. However, integration tests (both in core and plugins like the security plugin) instantiate nodes directly via `new PluginAwareNode(settings).start()`, bypassing `Bootstrap` entirely.

This means the serial filter was never active during integration tests, making it impossible for plugins to verify their deserialization opt-ins work correctly against the filter.

By moving the initialization into `Node`'s constructor, the filter is installed regardless of how the node is started:

- **Production**: `Bootstrap` → `new Node()` → filter installed ✅
- **Integration tests**: `new PluginAwareNode()` → `Node` constructor → filter installed ✅

## Changes

- `Bootstrap.java`: Made `initializeSerialFilter()` public, removed the call from `setup()`
- `Node.java`: Added call to `Bootstrap.initializeSerialFilter()` in the constructor after settings are loaded, gated behind `BootstrapSettings.SERIAL_FILTER_SETTING`

## Testing

- Verified locally with security plugin integration tests that the filter blocks deserialization on inter-node transport when the plugin's `setObjectInputFilter` opt-in is removed