### PR TITLE
[Draft] Fix Arrow buffer + native GroupValues leaks in analytics reduce/flight paths

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -105,6 +105,16 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                     future.completeExceptionally(FlightErrorMapper.fromFlightException(e));
                 } catch (Exception e) {
                     future.completeExceptionally(new StreamException(StreamErrorCode.INTERNAL, "Stream open/prefetch failed", e));
+                } finally {
+                    // close() may have run while this thread was opening the stream / prefetching the
+                    // first batch. If so it saw flightStream as it was at that instant and may have
+                    // missed the stream (or the prefetched root) we just produced — leaving the
+                    // first batch's buffers (on the 'client' flight allocator) stranded. Re-close here
+                    // once the stream is fully published so the prefetched root is always released.
+                    // FlightStream.close() is idempotent, so a double close with the close() path is safe.
+                    if (closed) {
+                        closeStreamQuietly();
+                    }
                 }
             });
         }
@@ -188,10 +198,19 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     public void close() {
         if (closed) return;
         closed = true;
+        // Set closed=true FIRST: the async prefetch thread re-checks closed in its finally and
+        // self-closes the stream it produced, covering the race where close() runs before the
+        // prefetch has published flightStream (it would otherwise be null here and the prefetched
+        // first-batch root would leak on the 'client' flight allocator).
+        closeStreamQuietly();
+    }
 
-        if (flightStream != null) {
+    /** Closes the flight stream if present, swallowing the benign already-closed error. Idempotent. */
+    private void closeStreamQuietly() {
+        FlightStream stream = flightStream;
+        if (stream != null) {
             try {
-                flightStream.close();
+                stream.close();
             } catch (IllegalStateException ignore) {} catch (Exception e) {
                 throw new StreamException(StreamErrorCode.INTERNAL, "Error closing flight stream", e);
             }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -8,18 +8,37 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
 import org.opensearch.arrow.transport.ArrowBatchResponse;
 import org.opensearch.arrow.transport.ArrowBatchResponseHandler;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.Header;
 import org.opensearch.transport.StreamTransportResponseHandler;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.stream.StreamException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class FlightTransportResponseTests extends OpenSearchTestCase {
 
@@ -43,6 +62,134 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         // MetricsTrackingResponseHandler in production path; null tracker is fine for this check.
         MetricsTrackingResponseHandler<TestArrowResponse> wrapped = new MetricsTrackingResponseHandler<>(new TestArrowHandler(), null);
         assertTrue(wrapped.skipsDeserialization());
+    }
+
+    // ── close() / prefetch-race stream lifecycle ─────────────────────────────
+
+    /**
+     * Builds a response wired to the given client. Uses package-private collaborators
+     * directly (the test lives in the same package).
+     */
+    private FlightTransportResponse<TestArrowResponse> newResponse(FlightClient client, HeaderContext headerContext) {
+        return new FlightTransportResponse<>(
+            new TestArrowHandler(),
+            1L,
+            client,
+            headerContext,
+            new Ticket(new byte[0]),
+            new NamedWriteableRegistry(List.of()),
+            new FlightTransportConfig()
+        );
+    }
+
+    /** Normal path: once the stream is published, close() closes it. */
+    public void testCloseClosesPublishedStream() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS); // prefetch finished → flightStream published
+
+        response.close();
+        // close() ran after publish; the finally in the prefetch saw closed=false, so close() owns the close.
+        verify(stream, timeout(5_000).atLeastOnce()).close();
+    }
+
+    /**
+     * The race the fix targets: close() runs while the prefetch thread is still inside getStream(),
+     * so close() sees flightStream==null and closes nothing. When the prefetch then publishes the
+     * stream, its finally block must self-close it (closed already true) so the first-batch root is
+     * not stranded on the client allocator.
+     */
+    public void testCloseDuringPrefetchSelfClosesStream() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+
+        CountDownLatch enteredGetStream = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenAnswer(inv -> {
+            enteredGetStream.countDown();
+            assertTrue("test must release getStream", proceed.await(5, TimeUnit.SECONDS));
+            return stream;
+        });
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+
+        // Prefetch thread is parked inside getStream(); flightStream is still null.
+        assertTrue(enteredGetStream.await(5, TimeUnit.SECONDS));
+        response.close(); // sees flightStream==null → closes nothing itself
+        verify(stream, never()).close();
+
+        // Let the prefetch publish the stream; its finally must self-close it.
+        proceed.countDown();
+        verify(stream, timeout(5_000)).close();
+    }
+
+    /** close() before any prefetch has a null stream — must be a no-op, no NPE. */
+    public void testCloseBeforePrefetchIsNoOp() {
+        FlightClient client = mock(FlightClient.class);
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        response.close(); // no stream yet
+        // A second close is still safe.
+        response.close();
+    }
+
+    /** close() is idempotent: a second call short-circuits and does not re-close the stream. */
+    public void testCloseIsIdempotent() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        response.close();
+        response.close();
+        response.close();
+        // The prefetch finally saw closed=false (publish happened first), so only the first close() closes.
+        verify(stream, times(1)).close();
+    }
+
+    /** A benign already-closed error from the stream is swallowed. */
+    public void testCloseSwallowsAlreadyClosedError() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+        doThrow(new IllegalStateException("already closed")).when(stream).close();
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        response.close(); // must not propagate the IllegalStateException
+    }
+
+    /** An unexpected error from the stream is wrapped as a StreamException. */
+    public void testCloseRethrowsUnexpectedErrorAsStreamException() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(stream).close();
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        expectThrows(StreamException.class, response::close);
     }
 
     public void testCopyMetadataNullBuffer() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1822,11 +1822,13 @@ pub async unsafe fn execute_local_plan(
     // drain this handle unchanged. Use the cancellable variant so the CPU
     // task can be aborted mid-execution when cancel_query fires.
     let cpu_exec = manager.cpu_executor();
-    let (cross_rt_stream, abort_handle, task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone());
-    if let Some(h) = abort_handle {
-        query_tracker::set_abort_handle(context_id, h);
-    }
+    let (cross_rt_stream, _abort_handle, task_done) =
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone(), token.clone());
+    // LEAK FIX: do NOT register the abort handle on the reduce path. cancel_query fires the
+    // cancellation_token, which the cross_rt future now selects on and BREAKS cooperatively,
+    // running its drop(stream)+drain cleanup. Registering the abort handle would let cancel_query
+    // also abort()-kill the future mid-`send().await`, skipping that cleanup and leaking the
+    // in-flight GroupValues (the cancel-path leak). Cooperative cancel is sufficient here.
     if let Some(rt) = cpu_exec.handle() {
         query_tracker::set_cpu_runtime_handle(context_id, rt);
     }
@@ -1862,6 +1864,7 @@ pub unsafe fn execute_local_prepared_plan(
     // The token is held via the QueryStreamHandle's context and consulted by
     // stream_next on each batch pull.
     let query_context = QueryTrackingContext::new(context_id, session.memory_pool(), query_tracker::QueryType::Coordinator);
+    let token = query_tracker::get_cancellation_token(context_id);
 
     // DataFusion's execute_stream is sync, but kicks off RepartitionExec /
     // stream channels that require a Tokio reactor. Enter the IO runtime's
@@ -1870,11 +1873,13 @@ pub unsafe fn execute_local_prepared_plan(
     let df_stream = session.execute_prepared()?;
 
     let cpu_exec = manager.cpu_executor();
-    let (cross_rt_stream, abort_handle, task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone());
-    if let Some(h) = abort_handle {
-        query_tracker::set_abort_handle(context_id, h);
-    }
+    let (cross_rt_stream, _abort_handle, task_done) =
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_exec.clone(), token.clone());
+    // LEAK FIX (mirror execute_local_plan): pass the cancellation token so cancel_query fires it and
+    // the cross_rt future BREAKS cooperatively, running its drop(stream)+drain cleanup that releases
+    // the aggregate's in-flight GroupValues + borrowed input batches. Do NOT register the abort
+    // handle — an abort()-kill mid-`send().await` skips that cleanup and strands the borrowed input
+    // export buffers in the per-query allocator (the prepared-reduce cancel-path leak).
     if let Some(rt) = cpu_exec.handle() {
         query_tracker::set_cpu_runtime_handle(context_id, rt);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
@@ -23,6 +23,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::oneshot;
 use tokio::task::AbortHandle;
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 
 /// Fires its `oneshot` when dropped. Held inside the spawned task body so the signal is sent on
 /// every exit path (drain, error, abort-unwind, panic).
@@ -72,16 +73,23 @@ impl CrossRtStream {
         stream: SendableRecordBatchStream,
         exec: DedicatedExecutor,
     ) -> Self {
-        let (cross_rt, _abort_handle, _done_rx) = Self::new_with_df_error_stream_cancellable(stream, exec);
+        let (cross_rt, _abort_handle, _done_rx) = Self::new_with_df_error_stream_cancellable(stream, exec, None);
         cross_rt
     }
 
     /// Like [`new_with_df_error_stream`](Self::new_with_df_error_stream), but also returns an
     /// [`AbortHandle`] and a `oneshot::Receiver` that fires once the spawned task has fully dropped
     /// (completion or abort) — the barrier `stream_close` waits on before the allocator closes.
+    ///
+    /// When `cancel_token` is supplied, cancellation is COOPERATIVE: the producer future selects each
+    /// await against the token and breaks on cancel, falling through to the drop(stream)+yield
+    /// cleanup below — instead of being hard-`abort()`ed mid-`send().await` (which skips cleanup and
+    /// leaks the inner aggregate's GroupValues). Reduce path passes a token + does NOT register the
+    /// abort handle; other paths pass `None` (behavior unchanged).
     pub fn new_with_df_error_stream_cancellable(
         stream: SendableRecordBatchStream,
         exec: DedicatedExecutor,
+        cancel_token: Option<CancellationToken>,
     ) -> (Self, Option<AbortHandle>, oneshot::Receiver<()>) {
         let schema = stream.schema();
         let (tx, rx) = channel(1);
@@ -90,11 +98,40 @@ impl CrossRtStream {
 
         let fut = async move {
             let _done = DoneGuard(Some(done_tx));
-            tokio::pin!(stream);
-            while let Some(res) = stream.next().await {
-                if tx_captured.send(res).await.is_err() {
-                    return;
+            let mut stream = Box::pin(stream);
+            // Cooperative cancellation: select each await against the token so a cancel makes the
+            // loop BREAK and fall through to the drop(stream)+drain cleanup below — instead of
+            // abort_handle.abort() force-dropping this future mid-`send().await` and skipping it.
+            loop {
+                let next = tokio::select! {
+                    biased;
+                    _ = async { match &cancel_token { Some(t) => t.cancelled().await, None => std::future::pending::<()>().await } } => break,
+                    n = stream.next() => n,
+                };
+                let res = match next {
+                    Some(r) => r,
+                    None => break,
+                };
+                let sent = tokio::select! {
+                    biased;
+                    _ = async { match &cancel_token { Some(t) => t.cancelled().await, None => std::future::pending::<()>().await } } => break,
+                    r = tx_captured.send(res) => r,
+                };
+                if sent.is_err() {
+                    break;
                 }
+            }
+            // LEAK FIX: drop the inner DataFusion stream HERE, while this future is still alive and
+            // being polled on the CPU runtime, then yield so the runtime can actually reclaim the
+            // child tasks. The inner stream owns a JoinSet of producer tasks parked on
+            // `tx.send().await`; relying on drop-time JoinSet::abort() alone leaks them (abort only
+            // schedules cancellation). Dropping the stream closes the receiver, waking every parked
+            // send with an error so each child returns; the yields hand control back so those
+            // just-woken children are polled to completion (and their GroupValues freed) before this
+            // future ends.
+            drop(stream);
+            for _ in 0..2 {
+                tokio::task::yield_now().await;
             }
         };
 
@@ -296,7 +333,7 @@ mod tests {
             stream::iter(vec![Ok(test_batch(&[1, 2, 3]))]),
         ));
 
-        let (cross, _abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone());
+        let (cross, _abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone(), None);
         let wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
         tokio::pin!(wrapped);
         while wrapped.next().await.is_some() {}
@@ -315,7 +352,7 @@ mod tests {
             stream::pending::<Result<RecordBatch, DataFusionError>>(),
         ));
 
-        let (cross, abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone());
+        let (cross, abort, done_rx) = CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone(), None);
         // Hold the stream so the abort, not a drop, is what ends the task.
         let _wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
 
@@ -323,6 +360,80 @@ mod tests {
 
         let fired = tokio::time::timeout(std::time::Duration::from_secs(5), done_rx).await;
         assert!(fired.is_ok(), "done_rx must fire after the task is aborted");
+        exec.join_blocking();
+    }
+
+    // Cooperative cancellation (the reduce-path leak fix): firing the CancellationToken makes the
+    // producer loop BREAK and fall through to drop(stream)+drain, so done_rx fires WITHOUT anyone
+    // calling abort(). This is the path that lets the inner aggregate's GroupValues be freed instead
+    // of leaked by an abort()-kill mid-`send().await`.
+    #[tokio::test]
+    async fn cancellation_token_breaks_loop_and_fires_done_rx() {
+        let exec = test_exec();
+        let schema = test_schema();
+        // Never-ending stream: the only way the task ends is the cooperative cancel.
+        let inner = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::pending::<Result<RecordBatch, DataFusionError>>(),
+        ));
+
+        let token = CancellationToken::new();
+        let (cross, _abort, done_rx) =
+            CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone(), Some(token.clone()));
+        // Hold the stream so a consumer-side drop is NOT what ends the task — the token is.
+        let _wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
+
+        token.cancel();
+
+        let fired = tokio::time::timeout(std::time::Duration::from_secs(5), done_rx).await;
+        assert!(fired.is_ok(), "cancelling the token must break the loop and fire done_rx");
+        assert!(fired.unwrap().is_ok(), "done_rx must complete, not be dropped");
+        exec.join_blocking();
+    }
+
+    // A token that is never fired must not perturb the normal drain path: the stream completes and
+    // all its batches are delivered.
+    #[tokio::test]
+    async fn uncancelled_token_drains_normally() {
+        let exec = test_exec();
+        let schema = test_schema();
+        let batches = vec![Ok(test_batch(&[1, 2, 3])), Ok(test_batch(&[4, 5]))];
+        let inner = Box::pin(RecordBatchStreamAdapter::new(schema.clone(), stream::iter(batches)));
+
+        let token = CancellationToken::new(); // never cancelled
+        let (cross, _abort, done_rx) =
+            CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone(), Some(token));
+        let wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
+        tokio::pin!(wrapped);
+
+        let mut total_rows = 0;
+        while let Some(batch) = wrapped.next().await {
+            total_rows += batch.unwrap().num_rows();
+        }
+        assert_eq!(total_rows, 5, "all rows delivered when the token is never fired");
+        assert!(done_rx.await.is_ok(), "done_rx fires on normal drain even with a token present");
+        exec.join_blocking();
+    }
+
+    // Cancelling BEFORE the first poll still terminates cleanly (the biased select checks the token
+    // first), exercising the immediate-cancel race.
+    #[tokio::test]
+    async fn cancel_before_first_poll_terminates() {
+        let exec = test_exec();
+        let schema = test_schema();
+        let inner = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::pending::<Result<RecordBatch, DataFusionError>>(),
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel(); // already cancelled before the task runs
+        let (cross, _abort, done_rx) =
+            CrossRtStream::new_with_df_error_stream_cancellable(inner, exec.clone(), Some(token));
+        let _wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
+
+        let fired = tokio::time::timeout(std::time::Duration::from_secs(5), done_rx).await;
+        assert!(fired.is_ok(), "a pre-cancelled token must still terminate the task");
         exec.join_blocking();
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -745,7 +745,7 @@ async unsafe fn execute_indexed_with_context_inner(
         let empty_exec = EmptyExec::new(Arc::clone(&plan_schema));
         let df_stream = empty_exec.execute(0, handle.ctx.task_ctx())?;
         let (cross_rt_stream, abort_handle, _task_done) =
-            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
         if let Some(h) = abort_handle {
             crate::query_tracker::set_abort_handle(context_id_early, h);
         }
@@ -1226,7 +1226,7 @@ async unsafe fn execute_indexed_with_context_inner(
         .map_err(|e| DataFusionError::Execution(format!("execute_stream: {}", e)))?;
 
     let (cross_rt_stream, abort_handle, _task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
 
     if let Some(h) = abort_handle {
         crate::query_tracker::set_abort_handle(context_id, h);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -198,7 +198,7 @@ pub async fn execute_query(
 
     // Wrap in CrossRtStream — CPU work runs on DedicatedExecutor
     let (cross_rt_stream, abort_handle, _task_done) =
-        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+        CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
 
     if let Some(h) = abort_handle {
         crate::query_tracker::set_abort_handle(context_id, h);
@@ -296,7 +296,7 @@ pub async fn execute_with_context(
                 e
             })?;
             let (cross_rt_stream, abort_handle, _task_done) =
-                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
             }
@@ -336,7 +336,7 @@ pub async fn execute_with_context(
             })?;
 
             let (cross_rt_stream, abort_handle, _task_done) =
-                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+                CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
             if let Some(h) = abort_handle {
                 crate::query_tracker::set_abort_handle(context_id, h);
             }
@@ -365,7 +365,7 @@ pub async fn execute_with_context(
         })?;
 
         let (cross_rt_stream, abort_handle, _task_done) =
-            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone());
+            CrossRtStream::new_with_df_error_stream_cancellable(df_stream, cpu_executor.clone(), None);
 
         if let Some(h) = abort_handle {
             crate::query_tracker::set_abort_handle(context_id, h);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -99,9 +99,11 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     private static final int REDUCE_POOL_SIZE = Math.max(8, Runtime.getRuntime().availableProcessors() * 4);
     private static final int REDUCE_QUEUE_SIZE = 200;
 
+    // Per-query coordinator allocator cap in bytes. 0 (default) → no per-query child allocator;
+    // queries share the coordinator allocator with no per-query cap.
     public static final Setting<Long> COORDINATOR_BUFFER_LIMIT = Setting.longSetting(
         "analytics.coordinator.buffer_limit",
-        256L * 1024 * 1024,
+        0L,
         0L,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -288,6 +288,12 @@ public class AnalyticsSearchTransportService {
                 // the cursor, not claimed roots).
                 FragmentExecutionArrowResponse last = null;
                 FragmentExecutionArrowResponse next = null;
+                // True only when the stream terminated the way the producer expects (fully drained,
+                // sentinel/metadata end, or the downstream consumer was satisfied and we already
+                // cancelled). Any other exit (exception, or onStreamResponse aborting due to a stage
+                // failure) leaves it false → finally cancel()s so the data-node producer tears down
+                // its FlightServerChannel instead of leaking its streamRoot.
+                boolean terminatedCleanly = false;
                 try {
                     last = stream.nextResponse();
                     while (last != null) {
@@ -296,6 +302,7 @@ public class AnalyticsSearchTransportService {
                             listener.onStreamComplete(last.getMetadata());
                             last.getRoot().close();
                             last = null;
+                            terminatedCleanly = true;
                             return;
                         }
 
@@ -320,25 +327,43 @@ public class AnalyticsSearchTransportService {
                         FragmentExecutionArrowResponse delivering = last;
                         last = null;
                         boolean keepReading = listener.onStreamResponse(delivering, isLast);
-                        if (!keepReading || nextIsSentinel) {
+                        if (nextIsSentinel) {
+                            // Sentinel = clean end-of-stream; producer is already completing.
+                            terminatedCleanly = true;
+                            return;
+                        }
+                        if (!keepReading) {
+                            // The consumer stopped early — either satisfied (LimitExec) or the stage
+                            // failed. Either way the producer must stop: cancel undelivered batches +
+                            // the stream so the data-node tears down its channel (handled in finally).
                             if (!isLast && next != null) {
                                 if (next.getRoot() != null) next.getRoot().close();
                                 next = null;
-                                stream.cancel("reduce input satisfied (downstream consumer finished)", null);
                             }
                             return;
                         }
                         last = next;
                         next = null;
                     }
+                    // Loop exited because nextResponse() returned null — the stream drained fully.
+                    terminatedCleanly = true;
                 } catch (Exception e) {
                     listener.onFailure(e);
                 } finally {
                     // Release any batches the loop still owns and never delivered.
                     closeResponseQuietly(last);
                     closeResponseQuietly(next);
+                    // Unless the stream terminated the way the producer expects, cancel() it so the
+                    // data-node PRODUCER is notified and tears down its FlightServerChannel. close()
+                    // alone only frees this client cursor and leaves the producer's streamRoot stranded
+                    // (it never sees a cancel, never closes, and its buffers leak in the allocator
+                    // ledger). Mirrors core StreamSearchTransportService's cancel-on-abnormal-exit.
                     try {
-                        stream.close();
+                        if (terminatedCleanly) {
+                            stream.close();
+                        } else {
+                            stream.cancel("analytics stream aborted before clean end-of-stream", null);
+                        }
                     } catch (Exception ignore) {}
                     pending.finishAndRunNext();
                 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
@@ -122,9 +122,29 @@ public class QueryExecution {
      */
     public void close() {
         if (closed.compareAndSet(false, true) == false) return;
+        // Tear down EVERY stage before closing the per-query allocator, not just the root sink.
+        // A non-root stage (notably the coordinator reduce) can still hold Arrow batches borrowed
+        // by native DataFusion when a sibling stage (e.g. a shard scan hitting the buffer limit)
+        // fails and drives this query terminal. Closing only the root sink leaves the reduce stage's
+        // teardown to its own async onTerminalTransition, which races — and usually loses to — the
+        // allocator close here, stranding the borrowed batches in the ledger ("Memory was leaked").
+        // Cancelling each stage runs its onTerminalTransition synchronously; the reduce stage's
+        // closeImpl then awaits its reduceDone latch so the native borrows are released first.
+        runQuietly("stage teardown", this::cancelAllStages);
         runQuietly("terminal sink close", this::closeTerminalSink);
         logAllocatorState();
         runQuietly("query context close", config::close);
+    }
+
+    /** Cancels every stage (idempotent — no-op when already terminal) so each runs its teardown. */
+    private void cancelAllStages() {
+        for (StageExecution exec : graph.allExecutions()) {
+            try {
+                exec.cancel("query closing");
+            } catch (Exception e) {
+                logger.warn(new ParameterizedMessage("[QueryExecution] stage teardown threw for stageId={}", exec.getStageId()), e);
+            }
+        }
     }
 
     private void logAllocatorState() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -54,6 +54,14 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
     private final List<String> fieldNames = new ArrayList<>();
     private final long maxRows;
     private long totalRows;
+    /**
+     * Set once {@link #close} has released the buffered batches. A late {@link #feed} (e.g. the
+     * coordinator reduce drain still running on its own thread when the query fails and closes this
+     * sink) must NOT add to {@code batches} after that — close() already ran and won't run again, so
+     * the batch would strand its Arrow buffers in the per-query allocator. Post-close feeds close the
+     * batch immediately instead.
+     */
+    private boolean closed;
 
     /**
      * Creates a sink with the default row limit.
@@ -71,6 +79,12 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
 
     @Override
     public synchronized void feed(VectorSchemaRoot batch) {
+        // Feed racing close(): the sink is already torn down, so buffering would strand the batch
+        // (close already freed+cleared the list and won't run again). Free it here instead.
+        if (closed) {
+            batch.close();
+            return;
+        }
         if (fieldNames.isEmpty() && batch.getSchema().getFields().isEmpty() == false) {
             for (Field f : batch.getSchema().getFields()) {
                 fieldNames.add(f.getName());
@@ -93,6 +107,7 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
      */
     @Override
     public synchronized void close() {
+        closed = true;
         for (VectorSchemaRoot batch : batches) {
             batch.close();
         }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
@@ -40,9 +40,11 @@ import org.mockito.ArgumentCaptor;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -111,7 +113,11 @@ public class AnalyticsSearchTransportServiceTests extends OpenSearchTestCase {
             if (!isClosed(lastRoot)) {
                 lastRoot.close();
             }
-            verify(stream).close();
+            // Consumer threw mid-stream → abnormal exit → cancel() (not plain close()) so the data-node
+            // producer is notified and tears down its FlightServerChannel; close() alone would strand
+            // the producer's streamRoot in the allocator ledger.
+            verify(stream).cancel(anyString(), any());
+            verify(stream, never()).close();
         }
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/QueryExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/QueryExecutionTests.java
@@ -184,6 +184,59 @@ public class QueryExecutionTests extends OpenSearchTestCase {
         assertSame("original stage failure must reach the listener even when terminal sink close throws", rootCause, onFailure.get());
     }
 
+    // ── close() tears down EVERY stage, not just the root sink (leak fix) ──
+
+    /**
+     * On close, {@link QueryExecution} must cancel every stage in the graph — not only the root —
+     * before the per-query allocator closes. A non-root stage (notably the coordinator reduce) can
+     * still hold native-borrowed Arrow batches; cancelling it runs its synchronous teardown so the
+     * borrows are released first. Here a root success drives close(); the non-root child must still
+     * see cancel().
+     */
+    public void testCloseCancelsNonRootStages() {
+        Stage rootStage = stageWithId(0);
+        Stage childStage = stageWithId(1);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        TestRootExecution child = new TestRootExecution(childStage, new CountingCloseSink());
+
+        QueryContext ctx = queryCtx(rootStage);
+        java.util.Map<Integer, StageExecution> execs = new java.util.HashMap<>();
+        execs.put(0, root);
+        execs.put(1, child);
+        ExecutionGraph graph = new ExecutionGraph("q-test", execs, root, List.of(child));
+
+        QueryExecution qe = new QueryExecution(ctx, graph, StageExecution::start, ActionListener.wrap(r -> {}, e -> {}));
+        qe.start();
+        root.succeed(); // terminal → close()
+
+        assertEquals("non-root stage cancelled exactly once on close", 1, child.cancelCalls.get());
+        assertEquals(QueryExecution.State.SUCCEEDED, qe.getState());
+    }
+
+    /** A stage whose cancel() throws during teardown must not stop the other stages being torn down. */
+    public void testCloseContinuesStageTeardownWhenOneCancelThrows() {
+        Stage rootStage = stageWithId(0);
+        Stage badStage = stageWithId(1);
+        Stage goodStage = stageWithId(2);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        TestRootExecution bad = new TestRootExecution(badStage, new CountingCloseSink());
+        bad.throwOnCancel = true;
+        TestRootExecution good = new TestRootExecution(goodStage, new CountingCloseSink());
+
+        QueryContext ctx = queryCtx(rootStage);
+        java.util.Map<Integer, StageExecution> execs = new java.util.LinkedHashMap<>();
+        execs.put(0, root);
+        execs.put(1, bad);
+        execs.put(2, good);
+        ExecutionGraph graph = new ExecutionGraph("q-test", execs, root, List.of(good));
+
+        QueryExecution qe = new QueryExecution(ctx, graph, StageExecution::start, ActionListener.wrap(r -> {}, e -> {}));
+        qe.start();
+        root.succeed();
+
+        assertEquals("teardown of the good stage still ran despite the bad stage throwing", 1, good.cancelCalls.get());
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────
 
     private QueryExecution newQueryExecution(Stage rootStage, ActionListener<Iterable<VectorSchemaRoot>> listener) {
@@ -226,6 +279,8 @@ public class QueryExecutionTests extends OpenSearchTestCase {
         private final AtomicReference<Exception> failure = new AtomicReference<>();
         private final List<StageStateListener> listeners = new ArrayList<>();
         private final StageMetrics metrics = new StageMetrics();
+        final AtomicInteger cancelCalls = new AtomicInteger();
+        boolean throwOnCancel;
 
         TestRootExecution(Stage stage, ExchangeSource source) {
             this.stage = stage;
@@ -285,6 +340,10 @@ public class QueryExecutionTests extends OpenSearchTestCase {
 
         @Override
         public void cancel(String reason) {
+            cancelCalls.incrementAndGet();
+            if (throwOnCancel) {
+                throw new RuntimeException("cancel boom for stage " + getStageId());
+            }
             State prev = state.getAndSet(State.CANCELLED);
             if (prev == State.FAILED || prev == State.SUCCEEDED || prev == State.CANCELLED) {
                 return;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
@@ -203,6 +203,29 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         sink.close();
     }
 
+    // ─── Feed racing close (leak fix) ────────────────────────────────────
+
+    /**
+     * A {@code feed} that arrives after {@code close} (e.g. the coordinator reduce drain still
+     * running on its own thread when the query fails and closes this sink) must close the batch
+     * immediately rather than buffer it — close() already freed and cleared the list and will not
+     * run again, so a buffered batch would strand its Arrow buffers. Verified by the allocator
+     * returning to zero outstanding bytes.
+     */
+    public void testFeedAfterCloseClosesBatchAndDoesNotBuffer() {
+        RowProducingSink sink = new RowProducingSink();
+        sink.close();
+
+        VectorSchemaRoot late = makeVsr(List.of("id"), new Object[][] { { "1" } });
+        assertTrue("batch holds buffers before the late feed", allocator.getAllocatedMemory() > 0);
+
+        sink.feed(late);
+
+        assertEquals("late batch must be closed, not buffered", 0, allocator.getAllocatedMemory());
+        assertEquals("late batch must not count toward rows", 0, sink.getRowCount());
+        assertFalse("nothing retained from a post-close feed", sink.readResult().iterator().hasNext());
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────
 
     private VectorSchemaRoot makeVsr(List<String> fieldNames, Object[][] rows) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Memory-leak fixes for the analytics engine on the coordinator-reduce path.

Java / Arrow FFI:
analytics.coordinator.buffer_limit defaults to 0 (unbounded; listener is a no-op).
- DefaultPlanExecutor: always create a per-query child allocator (with the listener) so its buffers are isolated and released deterministically at query close, instead of accumulating on the shared coordinator allocator.
- DatafusionReduceSink.feedToSender: reserve/release the export footprint.
- DatafusionReduceSink.closeImpl: explicitly close every input sender so the reduce mpsc signals EOF and the aggregate frees its GroupValues, instead of leaving the senders to a Cleaner that doesn't run under native pressure.
- DatafusionResultStream: close the partially-built VectorSchemaRoot if create()/importIntoVectorSchemaRoot throws mid-operation.
- AbstractDatafusionReduceSink.drainOutputIntoDownstream: closeLastBatch on early exit (cancel/throw).
- RowProducingSink: a feed() racing close() closes the batch instead of buffering into a freed list.
- QueryExecution.close: tear down every stage before closing the per-query allocator; QueryContext.close waits (bounded) for the allocator to drain so an in-flight shard-fragment stream or reduce drain releases its batches first.
- AnalyticsSearchTransportService: cancel the flight stream on abort so its streamRoot is not stranded.
- FlightTransportResponse: a close() racing the async prefetch self-closes the stream the prefetch published.
- FlightServerChannel/FlightOutboundHandler: guard the native transfer+send against a concurrent channel close (fire-once CAS + isOpen recheck).
- TransportService/StreamTransportService: initialize tracer include/exclude arrays so enabling transport.tracer.include doesn't NPE the stream transport.

Native / DataFusion:
- CrossRtStream: optional cooperative CancellationToken — the coordinator reduce paths pass the query token and stop registering the abort handle, so a cancel BREAKs the producer loop and runs drop(stream)+drain (freeing in-flight GroupValues) instead of an abort()-kill that skips cleanup.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
