### PR TITLE
[Sandbox] Fix coordinator cancel-teardown leaks in analytics-engine

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -99,9 +99,11 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     private static final int REDUCE_POOL_SIZE = Math.max(8, Runtime.getRuntime().availableProcessors() * 4);
     private static final int REDUCE_QUEUE_SIZE = 200;
 
+    // Per-query coordinator allocator cap in bytes. 0 (default) → no per-query child allocator;
+    // queries share the coordinator allocator with no per-query cap.
     public static final Setting<Long> COORDINATOR_BUFFER_LIMIT = Setting.longSetting(
         "analytics.coordinator.buffer_limit",
-        256L * 1024 * 1024,
+        0L,
         0L,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -39,6 +39,9 @@ import java.util.List;
  * {@code QueryPhaseResultConsumer} for coordinator-reduce in the core
  * search path.
  */
+// TODO: refactor this push-based flow — it's brittle with multiple failure points (feed racing
+// close, partial buffering on early exit). Revisit the locking as part of that (e.g. tryLock with
+// timeout); the current single-monitor synchronization is correct but worth reconsidering then.
 public class RowProducingSink implements ExchangeSink, ExchangeSource {
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -54,6 +54,8 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
     private final List<String> fieldNames = new ArrayList<>();
     private final long maxRows;
     private long totalRows;
+    /** Set by {@link #close}; a {@link #feed} after this frees the batch instead of buffering it. */
+    private boolean closed;
 
     /**
      * Creates a sink with the default row limit.
@@ -71,6 +73,11 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
 
     @Override
     public synchronized void feed(VectorSchemaRoot batch) {
+        // Feed racing close(): buffering now would strand the batch, so free it here instead.
+        if (closed) {
+            batch.close();
+            return;
+        }
         if (fieldNames.isEmpty() && batch.getSchema().getFields().isEmpty() == false) {
             for (Field f : batch.getSchema().getFields()) {
                 fieldNames.add(f.getName());
@@ -93,6 +100,7 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
      */
     @Override
     public synchronized void close() {
+        closed = true;
         for (VectorSchemaRoot batch : batches) {
             batch.close();
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/StageExecution.java
@@ -138,8 +138,10 @@ public interface StageExecution {
      *   no per-child resources); decrements a counter; on zero, collects
      *   {@link #publishedMetadata} from each child and hands off via {@link #consumeChildMetadata};
      *   default-mode parents are scheduled here (eager parents already scheduled).
-     *   <li>FAILED — propagates via {@link #failWithCause}.
-     *   <li>CANCELLED — intentionally not propagated (cancel initiator owns the parent's lifecycle).
+     *   <li>FAILED — invokes {@link #closeChildInput} then propagates via {@link #failWithCause}.
+     *   <li>CANCELLED — invokes {@link #closeChildInput} (so a parent reduce drain sees EOF and
+     *   unwinds) but does NOT propagate cancel to the parent's state (the cancel initiator owns the
+     *   parent's lifecycle).
      * </ul>
      *
      * <p>Parent→sibling cancel sweep: on FAILED / CANCELLED, sweep still-running children.
@@ -189,8 +191,13 @@ public interface StageExecution {
                                 : new RuntimeException("child stage " + child.getStageId() + " failed without recorded cause")
                         );
                     }
+                    case CANCELLED ->
+                        // Close this parent's input for the cancelled child so a parent reduce drain
+                        // blocked on streamNext sees EOF and unwinds. Cancel is not propagated to the
+                        // parent's state (it stays owner-driven).
+                        closeChildInput(childId);
                     default -> {
-                    }  // CANCELLED intentionally not propagated
+                    }
                 }
             });
         }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
@@ -203,6 +203,26 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         sink.close();
     }
 
+    // ─── Feed racing close (leak fix) ────────────────────────────────────
+
+    /**
+     * A {@code feed} after {@code close} must free the batch immediately rather than buffer it
+     * (close already cleared the list and will not run again, so a buffered batch would leak).
+     */
+    public void testFeedAfterCloseClosesBatchAndDoesNotBuffer() {
+        RowProducingSink sink = new RowProducingSink();
+        sink.close();
+
+        VectorSchemaRoot late = makeVsr(List.of("id"), new Object[][] { { "1" } });
+        assertTrue("batch holds buffers before the late feed", allocator.getAllocatedMemory() > 0);
+
+        sink.feed(late);
+
+        assertEquals("late batch must be closed, not buffered", 0, allocator.getAllocatedMemory());
+        assertEquals("late batch must not count toward rows", 0, sink.getRowCount());
+        assertFalse("nothing retained from a post-close feed", sink.readResult().iterator().hasNext());
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────
 
     private VectorSchemaRoot makeVsr(List<String> fieldNames, Object[][] rows) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/AttachChildrenTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/AttachChildrenTests.java
@@ -92,12 +92,11 @@ public class AttachChildrenTests extends OpenSearchTestCase {
     }
 
     /**
-     * Early-termination contract: when a parent cancels its own child (e.g. coordinator-side
-     * LIMIT satisfied, stop the shard stream), the child transitions to CANCELLED. The
-     * cascade must NOT propagate that cancel back to the parent — the parent is the one
-     * who issued the cancel and must stay RUNNING.
+     * Cancelled-child contract: the cascade must close the parent's per-child input (so a parent
+     * reduce drain blocked on {@code streamNext} sees EOF and unwinds) but must NOT propagate cancel
+     * to the parent's state or schedule it.
      */
-    public void testCancelledChildIsNotPropagatedToParent() {
+    public void testCancelledChildClosesInputButDoesNotPropagateToParent() {
         StageExecution parent = mock(StageExecution.class, CALLS_REAL_METHODS);
         FakeChild cancelled = new FakeChild(5);  // no failure recorded
 
@@ -106,6 +105,9 @@ public class AttachChildrenTests extends OpenSearchTestCase {
         parent.attachChildren(List.of(cancelled), scheduler);
         cancelled.fire(StageExecution.State.CANCELLED);
 
+        // EOF released to the reduce input (the leak fix).
+        verify(parent).closeChildInput(eq(5));
+        // State is NOT propagated and the parent is NOT scheduled.
         verify(parent, never()).cancel(any());
         verify(parent, never()).failWithCause(any());
         verify(parent, never()).consumeChildMetadata(any());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Three coordinator-side cancellation/teardown leaks, each unit-tested (verified to fail without the fix, pass with it):

- StageExecution cascade: on a CANCELLED child, still closeChildInput(childId) so a parent COORDINATOR_REDUCE drain blocked on streamNext sees EOF and unwinds — without it the reduce thread hangs forever and its borrowed batches/GroupValues are stranded (the QTF nested-reduce leak: a mid-flight shard scan cancelled never EOFs its sender). Cancel is NOT propagated to the parent's state (owner-driven, unchanged). Test: AttachChildrenTests.
- QueryExecution.close: cancel EVERY stage before closing the per-query context, not just the root sink, so non-root reduce stages run their teardown first. Test: QueryExecutionTests.
- RowProducingSink: a feed() racing close() closes the batch instead of buffering it (close already freed+cleared the list and won't run again). Test: RowProducingSinkTests.
- AnalyticsPlugin: analytics.coordinator.buffer_limit default 0 (no per-query child allocator; queries share the coordinator allocator).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
