### PR TITLE
Fix Flight/transport response leaks on abnormal exit

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -105,6 +105,13 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                     future.completeExceptionally(FlightErrorMapper.fromFlightException(e));
                 } catch (Exception e) {
                     future.completeExceptionally(new StreamException(StreamErrorCode.INTERNAL, "Stream open/prefetch failed", e));
+                } finally {
+                    // If close() ran while we were opening/prefetching, it may have missed the stream
+                    // we just published. Re-close here so the prefetched first-batch root is released
+                    // (FlightStream.close() is idempotent).
+                    if (closed) {
+                        closeStreamQuietly();
+                    }
                 }
             });
         }
@@ -187,11 +194,18 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     @Override
     public void close() {
         if (closed) return;
+        // Set closed=true before closing so a prefetch still in flight re-checks it and self-closes
+        // the stream it publishes (covers close() racing ahead of flightStream being set).
         closed = true;
+        closeStreamQuietly();
+    }
 
-        if (flightStream != null) {
+    /** Closes the flight stream if present, swallowing the benign already-closed error. Idempotent. */
+    private void closeStreamQuietly() {
+        FlightStream stream = flightStream;
+        if (stream != null) {
             try {
-                flightStream.close();
+                stream.close();
             } catch (IllegalStateException ignore) {} catch (Exception e) {
                 throw new StreamException(StreamErrorCode.INTERNAL, "Error closing flight stream", e);
             }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -8,18 +8,37 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
 import org.opensearch.arrow.transport.ArrowBatchResponse;
 import org.opensearch.arrow.transport.ArrowBatchResponseHandler;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.Header;
 import org.opensearch.transport.StreamTransportResponseHandler;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.stream.StreamException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class FlightTransportResponseTests extends OpenSearchTestCase {
 
@@ -43,6 +62,134 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         // MetricsTrackingResponseHandler in production path; null tracker is fine for this check.
         MetricsTrackingResponseHandler<TestArrowResponse> wrapped = new MetricsTrackingResponseHandler<>(new TestArrowHandler(), null);
         assertTrue(wrapped.skipsDeserialization());
+    }
+
+    // ── close() / prefetch-race stream lifecycle ─────────────────────────────
+
+    /**
+     * Builds a response wired to the given client. Uses package-private collaborators
+     * directly (the test lives in the same package).
+     */
+    private FlightTransportResponse<TestArrowResponse> newResponse(FlightClient client, HeaderContext headerContext) {
+        return new FlightTransportResponse<>(
+            new TestArrowHandler(),
+            1L,
+            client,
+            headerContext,
+            new Ticket(new byte[0]),
+            new NamedWriteableRegistry(List.of()),
+            new FlightTransportConfig()
+        );
+    }
+
+    /** Normal path: once the stream is published, close() closes it. */
+    public void testCloseClosesPublishedStream() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS); // prefetch finished → flightStream published
+
+        response.close();
+        // close() ran after publish; the finally in the prefetch saw closed=false, so close() owns the close.
+        verify(stream, timeout(5_000).atLeastOnce()).close();
+    }
+
+    /**
+     * The race the fix targets: close() runs while the prefetch thread is still inside getStream(),
+     * so close() sees flightStream==null and closes nothing. When the prefetch then publishes the
+     * stream, its finally block must self-close it (closed already true) so the first-batch root is
+     * not stranded on the client allocator.
+     */
+    public void testCloseDuringPrefetchSelfClosesStream() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+
+        CountDownLatch enteredGetStream = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenAnswer(inv -> {
+            enteredGetStream.countDown();
+            assertTrue("test must release getStream", proceed.await(5, TimeUnit.SECONDS));
+            return stream;
+        });
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+
+        // Prefetch thread is parked inside getStream(); flightStream is still null.
+        assertTrue(enteredGetStream.await(5, TimeUnit.SECONDS));
+        response.close(); // sees flightStream==null → closes nothing itself
+        verify(stream, never()).close();
+
+        // Let the prefetch publish the stream; its finally must self-close it.
+        proceed.countDown();
+        verify(stream, timeout(5_000)).close();
+    }
+
+    /** close() before any prefetch has a null stream — must be a no-op, no NPE. */
+    public void testCloseBeforePrefetchIsNoOp() {
+        FlightClient client = mock(FlightClient.class);
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        response.close(); // no stream yet
+        // A second close is still safe.
+        response.close();
+    }
+
+    /** close() is idempotent: a second call short-circuits and does not re-close the stream. */
+    public void testCloseIsIdempotent() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        response.close();
+        response.close();
+        response.close();
+        // The prefetch finally saw closed=false (publish happened first), so only the first close() closes.
+        verify(stream, times(1)).close();
+    }
+
+    /** A benign already-closed error from the stream is swallowed. */
+    public void testCloseSwallowsAlreadyClosedError() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+        doThrow(new IllegalStateException("already closed")).when(stream).close();
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        response.close(); // must not propagate the IllegalStateException
+    }
+
+    /** An unexpected error from the stream is wrapped as a StreamException. */
+    public void testCloseRethrowsUnexpectedErrorAsStreamException() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(stream).close();
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        expectThrows(StreamException.class, response::close);
     }
 
     public void testCopyMetadataNullBuffer() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -288,6 +288,9 @@ public class AnalyticsSearchTransportService {
                 // the cursor, not claimed roots).
                 FragmentExecutionArrowResponse last = null;
                 FragmentExecutionArrowResponse next = null;
+                // Set true only on an expected end (full drain or sentinel). Any other exit leaves it
+                // false so the finally cancel()s the stream rather than just closing the cursor.
+                boolean terminatedCleanly = false;
                 try {
                     last = stream.nextResponse();
                     while (last != null) {
@@ -296,6 +299,7 @@ public class AnalyticsSearchTransportService {
                             listener.onStreamComplete(last.getMetadata());
                             last.getRoot().close();
                             last = null;
+                            terminatedCleanly = true;
                             return;
                         }
 
@@ -320,25 +324,40 @@ public class AnalyticsSearchTransportService {
                         FragmentExecutionArrowResponse delivering = last;
                         last = null;
                         boolean keepReading = listener.onStreamResponse(delivering, isLast);
-                        if (!keepReading || nextIsSentinel) {
+                        if (nextIsSentinel) {
+                            // Sentinel = clean end-of-stream; producer is already completing.
+                            terminatedCleanly = true;
+                            return;
+                        }
+                        if (!keepReading) {
+                            // Consumer stopped early (satisfied or stage failed); the finally cancels
+                            // the stream. Release any undelivered prefetch first.
                             if (!isLast && next != null) {
                                 if (next.getRoot() != null) next.getRoot().close();
                                 next = null;
-                                stream.cancel("reduce input satisfied (downstream consumer finished)", null);
                             }
                             return;
                         }
                         last = next;
                         next = null;
                     }
+                    // Loop exited because nextResponse() returned null — the stream drained fully.
+                    terminatedCleanly = true;
                 } catch (Exception e) {
                     listener.onFailure(e);
                 } finally {
                     // Release any batches the loop still owns and never delivered.
                     closeResponseQuietly(last);
                     closeResponseQuietly(next);
+                    // On an abnormal exit, cancel() (not close()) so the data-node producer tears down
+                    // its FlightServerChannel; close() alone frees only this cursor and strands the
+                    // producer's streamRoot. Mirrors core StreamSearchTransportService.
                     try {
-                        stream.close();
+                        if (terminatedCleanly) {
+                            stream.close();
+                        } else {
+                            stream.cancel("analytics stream aborted before clean end-of-stream", null);
+                        }
                     } catch (Exception ignore) {}
                     pending.finishAndRunNext();
                 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsSearchTransportServiceTests.java
@@ -40,9 +40,11 @@ import org.mockito.ArgumentCaptor;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -111,7 +113,11 @@ public class AnalyticsSearchTransportServiceTests extends OpenSearchTestCase {
             if (!isClosed(lastRoot)) {
                 lastRoot.close();
             }
-            verify(stream).close();
+            // Consumer threw mid-stream → abnormal exit → cancel() (not plain close()) so the data-node
+            // producer is notified and tears down its FlightServerChannel; close() alone would strand
+            // the producer's streamRoot in the allocator ledger.
+            verify(stream).cancel(anyString(), any());
+            verify(stream, never()).close();
         }
     }
 


### PR DESCRIPTION
Two leaks on the streaming-transport response path, each unit-tested (fails without the fix, passes with it):

- FlightTransportResponse: close() racing the async prefetch could miss the stream the prefetch publishes, stranding the prefetched first-batch root. Set closed first and have the prefetch self-close on that flag. Test: FlightTransportResponseTests.
- AnalyticsSearchTransportService: on an abnormal exit (consumer throw or stage failure), cancel() the flight stream instead of close() so the data-node producer tears down its FlightServerChannel rather than stranding its streamRoot. Test: AnalyticsSearchTransportServiceTests.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
