### PR TITLE
[DFAE] Fix races between merge and force merge

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/merge/LuceneMerger.java
@@ -119,8 +119,11 @@ public class LuceneMerger implements Merger {
             }
 
             if (segmentInfos.size() == 0) {
-                logger.warn("No segments in IndexWriter — skipping merge");
-                return new MergeResult(Map.of());
+                throw new IOException(
+                    "IndexWriter has no segments — cannot proceed with Lucene merge for generations "
+                        + generationsToMerge
+                        + ". This may indicate a concurrent commit cleared the segment list."
+                );
             }
 
             List<SegmentCommitInfo> matchingSegments = findMatchingSegments(segmentInfos, generationsToMerge);
@@ -130,6 +133,22 @@ public class LuceneMerger implements Merger {
                     "No Lucene segments found matching writer generations "
                         + generationsToMerge
                         + " — segments may have been consumed by a concurrent merge"
+                );
+            }
+
+            if (matchingSegments.size() != generationsToMerge.size()) {
+                throw new IllegalStateException(
+                    "Expected "
+                        + generationsToMerge.size()
+                        + " Lucene segments for generations "
+                        + generationsToMerge
+                        + " but found only "
+                        + matchingSegments.size()
+                        + ". Missing segments may have been consumed by a concurrent merge. "
+                        + "Found generations: "
+                        + matchingSegments.stream()
+                            .map(sci -> sci.info.getAttribute(WRITER_GENERATION_ATTRIBUTE))
+                            .collect(java.util.stream.Collectors.toList())
                 );
             }
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/merge/CompositeMergeExecutor.java
@@ -58,7 +58,36 @@ public class CompositeMergeExecutor {
                 : null;
 
             for (DataFormat secondary : plan.secondaryFormats()) {
-                completed.add(mergeFormat(plan, secondary, mapping));
+                FormatMergeResult secondaryResult = mergeFormat(plan, secondary, mapping);
+                // Verify secondary produced output when primary did
+                if (primaryResult.mergedFiles() != null && secondaryResult.mergedFiles() == null) {
+                    throw new IllegalStateException(
+                        "Primary format ["
+                            + plan.primaryFormat().name()
+                            + "] produced merged output but secondary format ["
+                            + secondary.name()
+                            + "] returned null — possible concurrent merge consumed segments"
+                    );
+                }
+                // Verify secondary merged row count matches primary
+                if (primaryResult.mergedFiles() != null && secondaryResult.mergedFiles() != null) {
+                    long primaryRows = primaryResult.mergedFiles().numRows();
+                    long secondaryRows = secondaryResult.mergedFiles().numRows();
+                    if (primaryRows != secondaryRows) {
+                        throw new IllegalStateException(
+                            "Row count mismatch after merge: primary format ["
+                                + plan.primaryFormat().name()
+                                + "] has "
+                                + primaryRows
+                                + " rows but secondary format ["
+                                + secondary.name()
+                                + "] has "
+                                + secondaryRows
+                                + " rows"
+                        );
+                    }
+                }
+                completed.add(secondaryResult);
             }
 
             return toMergeResult(completed, mapping);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/merge/CompositeMergerTests.java
@@ -21,6 +21,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.MergeInput;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.dataformat.Merger;
 import org.opensearch.index.engine.dataformat.PackedRowIdMapping;
@@ -642,5 +643,80 @@ public class CompositeMergerTests extends OpenSearchTestCase {
         CatalogSnapshot snapshot = mock(CatalogSnapshot.class);
         when(snapshot.getSegments()).thenReturn(segments);
         return snapshot;
+    }
+
+    // ── Cross-format merge verification tests ──
+
+    public void testExecutorThrowsWhenSecondaryReturnsNullButPrimaryHasOutput() throws IOException {
+        Merger primaryMerger = mock(Merger.class);
+        Merger secondaryMerger = mock(Merger.class);
+
+        DataFormat primary = stubFormat("parquet", 0);
+        DataFormat secondary = stubFormat("lucene", 50);
+
+        String dir = createTempDir().toString();
+        WriterFileSet primaryFiles = new WriterFileSet(dir, 10L, Set.of("file.parquet"), 100, 1L);
+
+        RowIdMapping mapping = mock(RowIdMapping.class);
+        when(mapping.size()).thenReturn(100);
+
+        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), mapping));
+        when(secondaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of()));
+
+        CompositeMergeExecutor executor = new CompositeMergeExecutor(Map.of(primary, primaryMerger, secondary, secondaryMerger));
+
+        WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
+        WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
+
+        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)));
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
+        assertTrue(ex.getMessage().contains("returned null"));
+    }
+
+    public void testExecutorThrowsOnRowCountMismatch() throws IOException {
+        Merger primaryMerger = mock(Merger.class);
+        Merger secondaryMerger = mock(Merger.class);
+
+        DataFormat primary = stubFormat("parquet", 0);
+        DataFormat secondary = stubFormat("lucene", 50);
+
+        WriterFileSet primaryFiles = new WriterFileSet(createTempDir().toString(), 10L, Set.of("file.parquet"), 100, 1L);
+        WriterFileSet secondaryFiles = new WriterFileSet(createTempDir().toString(), 10L, Set.of("file.si"), 90, 1L);
+
+        RowIdMapping mapping = mock(RowIdMapping.class);
+        when(mapping.size()).thenReturn(100);
+
+        when(primaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(primary, primaryFiles), mapping));
+        when(secondaryMerger.merge(any(MergeInput.class))).thenReturn(new MergeResult(Map.of(secondary, secondaryFiles)));
+
+        CompositeMergeExecutor executor = new CompositeMergeExecutor(Map.of(primary, primaryMerger, secondary, secondaryMerger));
+
+        WriterFileSet inputP = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.parquet"), 50, 1L);
+        WriterFileSet inputS = new WriterFileSet(createTempDir().toString(), 1L, Set.of("in.si"), 50, 1L);
+
+        MergePlan plan = new MergePlan(10L, primary, List.of(secondary), Map.of(primary, List.of(inputP), secondary, List.of(inputS)));
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> executor.execute(plan));
+        assertTrue(ex.getMessage().contains("Row count mismatch"));
+    }
+
+    private static DataFormat stubFormat(String name, long priority) {
+        return new DataFormat() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public long priority() {
+                return priority;
+            }
+
+            @Override
+            public Set<FieldTypeCapabilities> supportedFields() {
+                return Set.of();
+            }
+        };
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -2132,6 +2132,8 @@ public class DataFormatAwareEngine implements Indexer {
                 : "Either the write lock must be held or the engine must be currently failing";
             try {
                 this.versionMap.clear();
+                // Stop accepting new merges immediately
+                mergeScheduler.shutdown();
                 // Discard any pending segments not yet picked up by refresh
                 pendingSegments.clear();
                 // Close any writers queued for deferred close (their files won't reach the catalog)

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeHandler.java
@@ -107,7 +107,22 @@ public class MergeHandler {
             List<Segment> segmentList = catalogSnapshotRef.get().getSegments();
             List<List<Segment>> mergeCandidates = mergePolicy.findForceMergeCandidates(segmentList, maxSegmentCount);
             for (List<Segment> mergeGroup : mergeCandidates) {
-                oneMerges.add(new OneMerge(mergeGroup));
+                boolean hasConflict = false;
+                synchronized (this) {
+                    for (Segment seg : mergeGroup) {
+                        if (currentlyMergingSegments.contains(seg)) {
+                            hasConflict = true;
+                            break;
+                        }
+                    }
+                    if (!hasConflict) {
+                        OneMerge oneMerge = new OneMerge(mergeGroup);
+                        if (registerMerge(oneMerge, false)) {
+                            oneMerges.add(oneMerge);
+                        }
+                    }
+                }
+
             }
         } catch (Exception e) {
             logger.warn("Failed to acquire snapshots", e);
@@ -142,21 +157,28 @@ public class MergeHandler {
      * @param merge the merge to register
      */
     public synchronized void registerMerge(OneMerge merge) {
+        registerMerge(merge, true);
+    }
+
+    private synchronized boolean registerMerge(OneMerge merge, boolean addToPending) {
         try (GatedCloseable<CatalogSnapshot> catalogSnapshotRef = snapshotSupplier.get()) {
             List<Segment> catalogSegments = catalogSnapshotRef.get().getSegments();
             for (Segment mergeSegment : merge.getSegmentsToMerge()) {
                 if (!catalogSegments.contains(mergeSegment)) {
-                    return;
+                    return false;
                 }
             }
         } catch (Exception e) {
             logger.warn("Failed to acquire snapshots", e);
             throw new RuntimeException(e);
         }
-        pendingMerges.add(merge);
+        if (addToPending) { // Skips this for force merges. Avoid 2 workers executing the merge.
+            pendingMerges.add(merge);
+        }
         currentlyMergingSegments.addAll(merge.getSegmentsToMerge());
         mergeListener.addMergingSegment(merge.getSegmentsToMerge());
         logger.debug(() -> new ParameterizedMessage("Registered merge [{}], pendingMerges: [{}]", merge, pendingMerges));
+        return true;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -155,8 +155,16 @@ public class MergeScheduler {
             : "forceMerge must be called on FORCE_MERGE thread but was: " + Thread.currentThread().getName();
         forceMergeLock.acquireUninterruptibly();
         try {
+            if (isShutdown.get()) {
+                logger.debug("MergeScheduler is shutdown, skipping force merge");
+                return;
+            }
             Collection<OneMerge> oneMerges = mergeHandler.findForceMerges(maxNumSegment);
             for (OneMerge oneMerge : oneMerges) {
+                if (isShutdown.get()) {
+                    logger.debug("MergeScheduler shutdown during force merge, aborting remaining merges");
+                    break;
+                }
                 runMerge(oneMerge);
             }
         } finally {

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -157,18 +158,38 @@ public class CatalogSnapshotManager implements Closeable {
         Set<Segment> segmentsToRemove = new HashSet<>(oneMerge.getSegmentsToMerge());
 
         // All source segments must exist in the current snapshot
-        assert segmentList.containsAll(segmentsToRemove) : "merge source segments must all exist in the current catalog snapshot";
+        if (!segmentList.containsAll(segmentsToRemove)) {
+            throw new IllegalStateException(
+                "Merge source segments must all exist in the current catalog snapshot. Missing: "
+                    + segmentsToRemove.stream()
+                        .filter(s -> !segmentList.contains(s))
+                        .map(s -> "gen=" + s.generation())
+                        .collect(java.util.stream.Collectors.joining(", "))
+            );
+        }
 
         // Merged segment generation must not collide with any segment that will be retained
-        assert segmentList.stream()
-            .filter(s -> segmentsToRemove.contains(s) == false)
-            .noneMatch(s -> s.generation() == segmentToAdd.generation()) : "merged segment generation ["
-                + segmentToAdd.generation()
-                + "] collides with a retained segment generation";
+        if (segmentList.stream().filter(s -> !segmentsToRemove.contains(s)).anyMatch(s -> s.generation() == segmentToAdd.generation())) {
+            throw new IllegalStateException(
+                "Merged segment generation [" + segmentToAdd.generation() + "] collides with a retained segment generation"
+            );
+        }
 
         // Row count conservation: merged output must have the same total rows as the inputs
-        assert assertRowCountConservation(segmentsToRemove, segmentToAdd)
-            : "merged segment row count must equal sum of source segment row counts";
+        if (!assertRowCountConservation(segmentsToRemove, segmentToAdd)) {
+            long inputRows = segmentsToRemove.stream()
+                .flatMap(s -> s.dfGroupedSearchableFiles().values().stream())
+                .mapToLong(WriterFileSet::numRows)
+                .sum();
+            long outputRows = segmentToAdd.dfGroupedSearchableFiles().values().stream().mapToLong(WriterFileSet::numRows).sum();
+            throw new IllegalStateException(
+                "Merged segment row count mismatch: input segments have "
+                    + inputRows
+                    + " total rows but merged output has "
+                    + outputRows
+                    + " rows"
+            );
+        }
 
         boolean inserted = false;
         int newSegIdx = 0;
@@ -276,7 +297,7 @@ public class CatalogSnapshotManager implements Closeable {
         // one of the writers dropped or duplicated rows during a single refresh —
         // exactly the class of bug that silently produced different match/LIKE
         // counts at query time.
-        assert assertPerSegmentCrossFormatRowCountParity(refreshedSegments) : "per-segment row count must be equal across all formats";
+        verifyPerSegmentCrossFormatRowCountParity(refreshedSegments);
         installSnapshot(newSnapshot);
     }
 
@@ -673,7 +694,7 @@ public class CatalogSnapshotManager implements Closeable {
      * single refresh — which produces silent correctness issues like different counts
      * from {@code match} vs {@code LIKE} over the same field.
      */
-    private boolean assertPerSegmentCrossFormatRowCountParity(List<Segment> segments) {
+    private void verifyPerSegmentCrossFormatRowCountParity(List<Segment> segments) {
         for (Segment seg : segments) {
             long expected = -1L;
             String referenceFormat = null;
@@ -683,18 +704,19 @@ public class CatalogSnapshotManager implements Closeable {
                     expected = rows;
                     referenceFormat = entry.getKey();
                 } else if (rows != expected) {
-                    logger.error(
-                        "Per-segment row count mismatch at generation {}: format [{}] has {} rows but format [{}] has {} rows",
-                        seg.generation(),
-                        referenceFormat,
-                        expected,
-                        entry.getKey(),
-                        rows
+                    throw new IllegalStateException(
+                        String.format(
+                            Locale.ROOT,
+                            "Per-segment row count mismatch at generation %s: format [%s] has %s rows but format [%s] has %s rows",
+                            seg.generation(),
+                            referenceFormat,
+                            expected,
+                            entry.getKey(),
+                            rows
+                        )
                     );
-                    return false;
                 }
             }
         }
-        return true;
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -4230,6 +4231,107 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             Engine.Get getWithBadTranslog = realtimeGet("1");
             DocumentLookupResult translogNullResult = getByIdLookup(engine, getWithBadTranslog);
             assertNotNull("should fall through when translog returns null", translogNullResult);
+        }
+    }
+
+    /**
+     * Tests that engine close is graceful when concurrent index, refresh, and flush operations
+     * are in flight. Verifies no unhandled exceptions escape and the engine transitions to closed.
+     */
+    public void testGracefulCloseUnderConcurrentLoad() throws Exception {
+        try (Store store = createStore()) {
+            DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+
+            final AtomicBoolean stop = new AtomicBoolean(false);
+            final AtomicReference<Exception> failure = new AtomicReference<>();
+            final CountDownLatch started = new CountDownLatch(3);
+
+            // Thread 1: continuous indexing
+            Thread indexThread = new Thread(() -> {
+                started.countDown();
+                int i = 0;
+                while (stop.get() == false) {
+                    try {
+                        engine.index(indexOp(createParsedDocWithInput(Integer.toString(i++), null)));
+                    } catch (AlreadyClosedException e) {
+                        break; // expected during close
+                    } catch (Exception e) {
+                        if (stop.get() == false) {
+                            failure.compareAndSet(null, e);
+                        }
+                        break;
+                    }
+                }
+            });
+
+            // Thread 2: continuous refresh
+            Thread refreshThread = new Thread(() -> {
+                started.countDown();
+                while (stop.get() == false) {
+                    try {
+                        engine.refresh("concurrent-test");
+                    } catch (AlreadyClosedException e) {
+                        break;
+                    } catch (Exception e) {
+                        if (stop.get() == false) {
+                            failure.compareAndSet(null, e);
+                        }
+                        break;
+                    }
+                }
+            });
+
+            // Thread 3: periodic flush
+            Thread flushThread = new Thread(() -> {
+                started.countDown();
+                while (stop.get() == false) {
+                    try {
+                        engine.flush(false, true);
+                        Thread.sleep(10);
+                    } catch (AlreadyClosedException e) {
+                        break;
+                    } catch (FlushFailedEngineException e) {
+                        // flush may be disabled during translog recovery or after close
+                        break;
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    } catch (Exception e) {
+                        if (stop.get() == false) {
+                            failure.compareAndSet(null, e);
+                        }
+                        break;
+                    }
+                }
+            });
+
+            indexThread.start();
+            refreshThread.start();
+            flushThread.start();
+
+            // Wait for all threads to start
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+
+            // Let them run briefly
+            Thread.sleep(200);
+
+            // Close the engine while operations are in-flight
+            stop.set(true);
+            engine.close();
+
+            // Wait for threads to finish
+            indexThread.join(10_000);
+            refreshThread.join(10_000);
+            flushThread.join(10_000);
+
+            assertFalse("Index thread should have stopped", indexThread.isAlive());
+            assertFalse("Refresh thread should have stopped", refreshThread.isAlive());
+            assertFalse("Flush thread should have stopped", flushThread.isAlive());
+
+            // No unexpected exceptions
+            if (failure.get() != null) {
+                throw new AssertionError("Unexpected exception during concurrent close", failure.get());
+            }
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeHandlerTests.java
@@ -224,4 +224,91 @@ public class MergeHandlerTests extends OpenSearchTestCase {
         assertSame(result, actual);
         verify(merger).merge(any(MergeInput.class));
     }
+
+    /**
+     * Verifies that {@code findForceMerges} excludes segments that are already being merged
+     * by a background merge. Without this fix, a concurrent force merge + background merge
+     * could pick the same segments, causing the Lucene secondary to merge fewer docs than
+     * parquet (row count mismatch).
+     */
+    public void testFindForceMergesExcludesAlreadyMergingSegments() throws Exception {
+        Segment s1 = seg(1);
+        Segment s2 = seg(2);
+        Segment s3 = seg(3);
+        Segment s4 = seg(4);
+
+        MergeHandler handler = newHandler(snapshotWith(s1, s2, s3, s4));
+
+        // Simulate merge policy returning all segments as force merge candidates
+        when(mergePolicy.findForceMergeCandidates(any(), any(Integer.class))).thenReturn(List.of(List.of(s1, s2, s3, s4)));
+
+        // Register a background merge for segments [s1, s2] — marks them as currently merging
+        OneMerge backgroundMerge = new OneMerge(List.of(s1, s2));
+        handler.registerMerge(backgroundMerge);
+
+        // Now findForceMerges should exclude s1 and s2 since they're already merging
+        var forceMerges = handler.findForceMerges(1);
+
+        // The force merge group [s1, s2, s3, s4] contains merging segments → should be filtered out
+        assertTrue("Force merge should not pick segments already being merged by background merge", forceMerges.isEmpty());
+    }
+
+    /**
+     * Verifies that {@code findForceMerges} returns candidates when no segments overlap
+     * with currently merging segments.
+     */
+    public void testFindForceMergesReturnsNonConflictingCandidates() throws Exception {
+        Segment s1 = seg(1);
+        Segment s2 = seg(2);
+        Segment s3 = seg(3);
+        Segment s4 = seg(4);
+
+        MergeHandler handler = newHandler(snapshotWith(s1, s2, s3, s4));
+
+        // Merge policy returns two groups: [s1, s2] and [s3, s4]
+        when(mergePolicy.findForceMergeCandidates(any(), any(Integer.class))).thenReturn(List.of(List.of(s1, s2), List.of(s3, s4)));
+
+        // Register background merge for [s1, s2]
+        OneMerge backgroundMerge = new OneMerge(List.of(s1, s2));
+        handler.registerMerge(backgroundMerge);
+
+        // findForceMerges should return only the non-conflicting group [s3, s4]
+        var forceMerges = handler.findForceMerges(1);
+
+        assertEquals("Should return 1 non-conflicting merge group", 1, forceMerges.size());
+        OneMerge remaining = forceMerges.iterator().next();
+        assertEquals(2, remaining.getSegmentsToMerge().size());
+        assertTrue(remaining.getSegmentsToMerge().contains(s3));
+        assertTrue(remaining.getSegmentsToMerge().contains(s4));
+    }
+
+    /**
+     * Verifies that {@code findForceMerges} does NOT register conflicting merge groups
+     * in currentlyMergingSegments. Only non-conflicting groups should be registered.
+     */
+    public void testFindForceMergesOnlyRegistersNonConflictingGroups() throws Exception {
+        Segment s1 = seg(1);
+        Segment s2 = seg(2);
+        Segment s3 = seg(3);
+
+        MergeHandler handler = newHandler(snapshotWith(s1, s2, s3));
+
+        // Merge policy returns two groups: [s1, s2] (will conflict) and [s3] (won't conflict)
+        when(mergePolicy.findForceMergeCandidates(any(), any(Integer.class))).thenReturn(List.of(List.of(s1, s2), List.of(s3)));
+
+        // Register background merge for s1 — makes [s1, s2] group conflicting
+        handler.registerMerge(new OneMerge(List.of(s1)));
+
+        // findForceMerges should only return and register [s3]
+        var forceMerges = handler.findForceMerges(1);
+        assertEquals(1, forceMerges.size());
+
+        // s2 should NOT be stuck in currentlyMergingSegments
+        // Verify by registering a merge containing s2 — should succeed
+        OneMerge s2Merge = new OneMerge(List.of(s2));
+        handler.registerMerge(s2Merge);
+        // background s1 is pending (from registerMerge), force s3 is NOT pending (only in currentlyMerging),
+        // newly registered s2 is pending → 2 pending total
+        assertEquals(2, handler.getPendingMergeCount());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
@@ -15,11 +15,18 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.MergeResult;
+import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -113,5 +120,58 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
         MergeHandler mergeHandler = mock(MergeHandler.class);
         MergeScheduler scheduler = newScheduler(mergeHandler, IndexModule.TieringState.HOT);
         assertFalse("HOT tiering state must not report frozen", scheduler.isFrozen());
+    }
+
+    public void testForceMergeSkipsAfterShutdown() throws IOException {
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+        MergeScheduler scheduler = newScheduler(mergeHandler, IndexModule.TieringState.HOT);
+
+        scheduler.shutdown();
+
+        String oldName = Thread.currentThread().getName();
+        Thread.currentThread().setName("TEST-" + ThreadPool.Names.FORCE_MERGE + "-0");
+        try {
+            scheduler.forceMerge(1);
+        } finally {
+            Thread.currentThread().setName(oldName);
+        }
+
+        verify(mergeHandler, never()).findForceMerges(anyInt());
+    }
+
+    public void testForceMergeAbortsRemainingMergesOnShutdown() throws Exception {
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+
+        Segment s1 = new Segment(1L, Map.of());
+        Segment s2 = new Segment(2L, Map.of());
+        OneMerge merge1 = new OneMerge(List.of(s1));
+        OneMerge merge2 = new OneMerge(List.of(s2));
+
+        when(mergeHandler.findForceMerges(1)).thenReturn(List.of(merge1, merge2));
+        when(mergeHandler.doMerge(merge1)).thenReturn(new MergeResult(Map.of()));
+
+        final java.util.concurrent.atomic.AtomicReference<MergeScheduler> schedulerRef =
+            new java.util.concurrent.atomic.AtomicReference<>();
+
+        MergeScheduler scheduler = new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> { schedulerRef.get().shutdown(); },
+            () -> {},
+            shardId,
+            indexSettings(IndexModule.TieringState.HOT),
+            threadPool
+        );
+        schedulerRef.set(scheduler);
+
+        String oldName = Thread.currentThread().getName();
+        Thread.currentThread().setName("TEST-" + ThreadPool.Names.FORCE_MERGE + "-0");
+        try {
+            scheduler.forceMerge(1);
+        } finally {
+            Thread.currentThread().setName(oldName);
+        }
+
+        verify(mergeHandler).doMerge(merge1);
+        verify(mergeHandler, never()).doMerge(merge2);
     }
 }


### PR DESCRIPTION
## Problem

A force merge running concurrently with a background merge could pick the same segments, causing the Lucene secondary to merge a different segment set than Parquet. This produced a row count mismatch between formats:

```
IllegalStateException: Segment [gen=4466] has inconsistent row counts across data formats:
686758681 vs 668676254 (format=lucene)
```

## Root Causes

1. `MergeHandler.findForceMerges()` did not filter out segments already being merged by background merges
2. `LuceneMerger` silently returned an empty result when `IndexWriter.segmentInfos` was transiently empty, allowing parquet to merge successfully while lucene produced nothing
3. `CompositeMergeExecutor` skipped the cross-format row count check when the secondary returned null
4. `MergeScheduler.shutdown()` was never called during engine close, allowing new merges to start during shutdown
5. `forceMerge` had no shutdown check, potentially running long merges on a closing engine

## Fixes

**Race prevention:**
- `MergeHandler.findForceMerges()` now filters out `currentlyMergingSegments` and atomically registers selected segments within the same synchronized block

**Fail-fast integrity checks (production-grade, not assertions):**
- `LuceneMerger`: throws `IOException` when segmentInfos is empty (was: silent return)
- `LuceneMerger`: throws `IllegalStateException` when matched segments < requested (partial match = concurrent consumption)
- `CompositeMergeExecutor`: throws `IllegalStateException` when primary has output but secondary returns null
- `CompositeMergeExecutor`: throws `IllegalStateException` on cross-format row count mismatch
- `CatalogSnapshotManager`: converts three merge invariants from assertions to `IllegalStateException` (source segments exist, generation no-collision, row count conservation)

**Graceful shutdown:**
- `DataFormatAwareEngine.closeNoLock()` now calls `mergeScheduler.shutdown()` as the first step
- `MergeScheduler.forceMerge()` checks `isShutdown` before starting and between merge iterations

## Testing

| Test | Validates |
|------|-----------|
| `MergeHandlerTests.testFindForceMergesExcludesAlreadyMergingSegments` | Race fix: **fails without fix**, passes with it |
| `MergeHandlerTests.testFindForceMergesReturnsNonConflictingCandidates` | Non-conflicting groups still returned |
| `CompositeMergerTests.testExecutorThrowsWhenSecondaryReturnsNullButPrimaryHasOutput` | Null secondary detection |
| `CompositeMergerTests.testExecutorThrowsOnRowCountMismatch` | Cross-format divergence caught |
| `MergeSchedulerTests.testForceMergeSkipsAfterShutdown` | Force merge respects shutdown |
| `MergeSchedulerTests.testForceMergeAbortsRemainingMergesOnShutdown` | Mid-merge shutdown abort |
| `DataFormatAwareEngineTests.testGracefulCloseUnderConcurrentLoad` | Concurrent index/refresh/flush + close |

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
