### PR TITLE
Changes in Datafusion plugin to stitch clear cache rest action, cache settings and cache stats

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1326,6 +1326,48 @@ pub unsafe extern "C" fn df_execute_local_prepared_plan(
     api::execute_local_prepared_plan(session_ptr, &mgr, context_id, None).map_err(|e| e.to_string())
 }
 
+// ── Scoped page-index cache limit setters ────────────────────────────────────
+//
+// These are wired from Java at startup (CacheUtils.createCacheConfig) and on
+// dynamic setting changes (DataFusionPlugin settings consumers). They forward
+// to the process-global caches in crate::cache::page_index.
+//
+// NOTE: On main these are stubs that do nothing — the cache module from PR 1
+// is not yet present. Once PR 1 merges the bodies replace these no-ops.
+
+/// Set the byte budget of the process-global scoped ColumnIndex cache.
+/// Zero is ignored; negative returns an error.
+#[ffm_safe]
+#[no_mangle]
+pub extern "C" fn df_set_column_index_cache_limit(size_limit: i64) -> i64 {
+    if size_limit < 0 {
+        return Err(format!("df_set_column_index_cache_limit: negative limit {}", size_limit));
+    }
+    // TODO(PR1): crate::cache::page_index::set_column_index_cache_limit(size_limit as usize);
+    Ok(0)
+}
+
+/// Set the byte budget of the process-global scoped OffsetIndex cache.
+/// Zero is ignored; negative returns an error.
+#[ffm_safe]
+#[no_mangle]
+pub extern "C" fn df_set_offset_index_cache_limit(size_limit: i64) -> i64 {
+    if size_limit < 0 {
+        return Err(format!("df_set_offset_index_cache_limit: negative limit {}", size_limit));
+    }
+    // TODO(PR1): crate::cache::page_index::set_offset_index_cache_limit(size_limit as usize);
+    Ok(0)
+}
+
+/// Clear the process-global scoped page-index cache (drop entries + reset
+/// counters, keep the budget). No-op stub until PR 1 merges.
+#[ffm_safe]
+#[no_mangle]
+pub extern "C" fn df_clear_scoped_page_index_cache() -> i64 {
+    // TODO(PR1): crate::cache::page_index::clear_scoped_cache();
+    Ok(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -19,6 +19,7 @@ import org.opensearch.arrow.spi.PoolGroup;
 import org.opensearch.be.datafusion.action.stats.DataFusionStatsActionType;
 import org.opensearch.be.datafusion.action.stats.RestDataFusionStatsAction;
 import org.opensearch.be.datafusion.action.stats.TransportDataFusionStatsAction;
+import org.opensearch.be.datafusion.cache.CacheSettings;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -101,7 +102,8 @@ public class DataFusionPlugin extends Plugin
      * ({@link ResourceTrackerSettings#NODE_NATIVE_MEMORY_LIMIT_SETTING}), which is
      * the same off-heap budget admission control throttles against. The DataFusion Rust
      * runtime is the dominant native-memory consumer for analytics workloads (see PR #21732
-     * partitioning model), so the default takes 74% of {@code node.native_memory.limit}.
+     * partitioning model), so the default takes 71% of {@code node.native_memory.limit}
+     * (reduced from 74% to fund the 3% parquet cache budget).
      * If the AC limit is unset (== 0), the default is {@link Long#MAX_VALUE} — unbounded — to
      * preserve pre-AC behaviour rather than make up a number from JVM heap (which is a
      * separate, already-allocated region with no relation to native-memory sizing).
@@ -124,9 +126,15 @@ public class DataFusionPlugin extends Plugin
     );
 
     /**
-     * Computes the default for {@link #DATAFUSION_MEMORY_POOL_LIMIT} as 74% of
+     * Computes the default for {@link #DATAFUSION_MEMORY_POOL_LIMIT} as 71% of
      * {@link ResourceTrackerSettings#NODE_NATIVE_MEMORY_LIMIT_SETTING}, falling back to
      * {@link Long#MAX_VALUE} when AC is unconfigured.
+     *
+     * <p>Reduced from 74% to 71%: 3% of {@code node.native_memory.limit} is now reserved for
+     * the DataFusion parquet caches (footer metadata, ColumnIndex, OffsetIndex). That 3% is
+     * funded by 2% from the operator pool and 1% from the unmanaged headroom (which expanded
+     * from 21% to 20% of off-heap via the 79→80% change to
+     * {@code ResourceTrackerSettings.deriveNativeMemoryLimitDefault}).
      *
      * <p>The fraction is taken straight from {@code node.native_memory.limit}, not from
      * {@code limit - buffer_percent}. {@code buffer_percent} is an admission-control throttle
@@ -140,10 +148,8 @@ public class DataFusionPlugin extends Plugin
         if (nativeLimit.getBytes() <= 0) {
             return Long.toString(Long.MAX_VALUE);
         }
-        // 74% of node.native_memory.limit. DataFusion is the dominant native consumer for
-        // analytics workloads; operators tune via the dynamic setting once they characterize
-        // their workload.
-        long pool = Math.max(0L, nativeLimit.getBytes() * 74 / 100);
+        // 71% of node.native_memory.limit (reduced from 74% to fund the parquet cache budget).
+        long pool = Math.max(0L, nativeLimit.getBytes() * 71 / 100);
         return Long.toString(pool);
     }
 
@@ -444,6 +450,28 @@ public class DataFusionPlugin extends Plugin
         // cluster settings API take effect without restarting the node.
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_SPILL_MEMORY_LIMIT, this::updateSpillMemoryLimit);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DATAFUSION_MIN_TARGET_PARTITIONS, this::updateMinTargetPartitions);
+        // Recompute and push absolute cache limits whenever the total budget or any
+        // sub-cache percentage changes. Validates that percentages sum to 100 first.
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE,
+                v -> recomputePageCacheLimits(clusterService.getClusterSettings())
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.FOOTER_METADATA_CACHE_PERCENT,
+                v -> recomputePageCacheLimits(clusterService.getClusterSettings())
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.OFFSET_INDEX_CACHE_PERCENT,
+                v -> recomputePageCacheLimits(clusterService.getClusterSettings())
+            );
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.COLUMN_INDEX_CACHE_PERCENT,
+                v -> recomputePageCacheLimits(clusterService.getClusterSettings())
+            );
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_REDUCE_TARGET_PARTITIONS, NativeBridge::setReduceTargetPartitions);
         clusterService.getClusterSettings()
@@ -681,6 +709,24 @@ public class DataFusionPlugin extends Plugin
         logger.info("Updated DataFusion min_target_partitions to {}", value);
     }
 
+    /**
+     * Recompute absolute ColumnIndex and OffsetIndex cache limits from the current
+     * {@link CacheSettings#METADATA_INDEX_CACHE_TOTAL_SIZE} and percent settings, then push them
+     * to native. Validates that percentages sum to 100 before applying.
+     */
+    private void recomputePageCacheLimits(org.opensearch.common.settings.ClusterSettings cs) {
+        long total = cs.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        int metaPct = cs.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
+        int oiPct = cs.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
+        int ciPct = cs.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
+        CacheSettings.validatePercentSum(metaPct, oiPct, ciPct);
+        long ciLimit = total * ciPct / 100;
+        long oiLimit = total * oiPct / 100;
+        logger.info("Updating page-index cache limits: column_index={} bytes, offset_index={} bytes", ciLimit, oiLimit);
+        NativeBridge.setColumnIndexCacheLimit(ciLimit);
+        NativeBridge.setOffsetIndexCacheLimit(oiLimit);
+    }
+
     private void updateMemoryGuardThresholds() {
         double admissionThrottle = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD);
         double admissionReject = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_GUARD_ADMISSION_REJECT_THRESHOLD);
@@ -748,7 +794,13 @@ public class DataFusionPlugin extends Plugin
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return List.of(new ActionHandler<>(DataFusionStatsActionType.INSTANCE, TransportDataFusionStatsAction.class));
+        return List.of(
+            new ActionHandler<>(DataFusionStatsActionType.INSTANCE, TransportDataFusionStatsAction.class),
+            new ActionHandler<>(
+                org.opensearch.be.datafusion.action.stats.ClearCacheActionType.INSTANCE,
+                org.opensearch.be.datafusion.action.stats.TransportClearCacheAction.class
+            )
+        );
     }
 
     @Override
@@ -764,7 +816,7 @@ public class DataFusionPlugin extends Plugin
         if (dataFusionService == null) {
             return Collections.emptyList();
         }
-        return List.of(new RestDataFusionStatsAction());
+        return List.of(new RestDataFusionStatsAction(), new org.opensearch.be.datafusion.action.stats.RestClearCacheAction());
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -148,7 +148,9 @@ public class DataFusionPlugin extends Plugin
         if (nativeLimit.getBytes() <= 0) {
             return Long.toString(Long.MAX_VALUE);
         }
-        // 71% of node.native_memory.limit (reduced from 74% to fund the parquet cache budget).
+        // 71% of node.native_memory.limit. DataFusion is the dominant native consumer for
+        // analytics workloads; operators tune via the dynamic setting once they characterize
+        // their workload.
         long pool = Math.max(0L, nativeLimit.getBytes() * 71 / 100);
         return Long.toString(pool);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -720,7 +720,7 @@ public class DataFusionPlugin extends Plugin
      * to native. Validates that percentages sum to 100 before applying.
      */
     private void recomputePageCacheLimits(org.opensearch.common.settings.ClusterSettings cs) {
-        long total = cs.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        long total = cs.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE).getBytes();
         int metaPct = cs.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         int oiPct = cs.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         int ciPct = cs.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -473,6 +473,11 @@ public class DataFusionPlugin extends Plugin
                 v -> recomputePageCacheLimits(clusterService.getClusterSettings())
             );
         clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CacheSettings.STATISTICS_CACHE_PERCENT,
+                v -> recomputePageCacheLimits(clusterService.getClusterSettings())
+            );
+        clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_REDUCE_TARGET_PARTITIONS, NativeBridge::setReduceTargetPartitions);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DATAFUSION_MEMORY_GUARD_ADMISSION_THROTTLE_THRESHOLD, v -> updateMemoryGuardThresholds());
@@ -719,10 +724,24 @@ public class DataFusionPlugin extends Plugin
         int metaPct = cs.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         int oiPct = cs.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         int ciPct = cs.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
-        CacheSettings.validatePercentSum(metaPct, oiPct, ciPct);
+        int statsPct = cs.get(CacheSettings.STATISTICS_CACHE_PERCENT);
+        CacheSettings.validatePercentSum(metaPct, oiPct, ciPct, statsPct);
+        long metaLimit = total * metaPct / 100;
         long ciLimit = total * ciPct / 100;
         long oiLimit = total * oiPct / 100;
-        logger.info("Updating page-index cache limits: column_index={} bytes, offset_index={} bytes", ciLimit, oiLimit);
+        long statsLimit = total * statsPct / 100;
+        logger.info(
+            "Updating cache limits: footer_metadata={} bytes (node restart required), "
+                + "column_index={} bytes, offset_index={} bytes, statistics={} bytes (node restart required)",
+            metaLimit,
+            ciLimit,
+            oiLimit,
+            statsLimit
+        );
+        // CI and OI limits take effect immediately via FFI.
+        // Footer metadata and statistics cache limits require a node restart
+        // (no runtime FFI to update the Java-side DefaultFilesMetadataCache limits).
+        // TODO: add df_update_metadata_cache_limit FFI to make them dynamic.
         NativeBridge.setColumnIndexCacheLimit(ciLimit);
         NativeBridge.setOffsetIndexCacheLimit(oiLimit);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -302,6 +302,7 @@ public final class DatafusionSettings {
         CacheSettings.FOOTER_METADATA_CACHE_PERCENT,
         CacheSettings.OFFSET_INDEX_CACHE_PERCENT,
         CacheSettings.COLUMN_INDEX_CACHE_PERCENT,
+        CacheSettings.STATISTICS_CACHE_PERCENT,
 
         // Concurrency gate settings
         CONCURRENCY_DATANODE_MULTIPLIER,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -291,13 +291,17 @@ public final class DatafusionSettings {
         DataFusionPlugin.DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD,
         DATAFUSION_MEMORY_POOL_MIN,
 
-        // Cache settings — metadata and statistics cache configuration
+        // Cache settings — metadata, statistics, and metadata-index cache configuration
         CacheSettings.METADATA_CACHE_SIZE_LIMIT,
         CacheSettings.STATISTICS_CACHE_SIZE_LIMIT,
         CacheSettings.METADATA_CACHE_EVICTION_TYPE,
         CacheSettings.STATISTICS_CACHE_EVICTION_TYPE,
         CacheSettings.METADATA_CACHE_ENABLED,
         CacheSettings.STATISTICS_CACHE_ENABLED,
+        CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE,
+        CacheSettings.FOOTER_METADATA_CACHE_PERCENT,
+        CacheSettings.OFFSET_INDEX_CACHE_PERCENT,
+        CacheSettings.COLUMN_INDEX_CACHE_PERCENT,
 
         // Concurrency gate settings
         CONCURRENCY_DATANODE_MULTIPLIER,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -292,8 +292,6 @@ public final class DatafusionSettings {
         DATAFUSION_MEMORY_POOL_MIN,
 
         // Cache settings — metadata, statistics, and metadata-index cache configuration
-        CacheSettings.METADATA_CACHE_SIZE_LIMIT,
-        CacheSettings.STATISTICS_CACHE_SIZE_LIMIT,
         CacheSettings.METADATA_CACHE_EVICTION_TYPE,
         CacheSettings.STATISTICS_CACHE_EVICTION_TYPE,
         CacheSettings.METADATA_CACHE_ENABLED,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheActionType.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheActionType.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action type for the broadcast "clear datafusion caches" transport action.
+ *
+ * <p>The datafusion caches are process-global singletons, one per node. Clearing
+ * them must fan out to every node so a single-node REST handler doesn't leave
+ * other nodes' caches populated.
+ *
+ * @opensearch.internal
+ */
+public class ClearCacheActionType extends ActionType<ClearCacheNodesResponse> {
+
+    public static final String NAME = "cluster:admin/_analytics_backend_datafusion/cache/clear";
+    public static final ClearCacheActionType INSTANCE = new ClearCacheActionType();
+
+    private ClearCacheActionType() {
+        super(NAME, ClearCacheNodesResponse::new);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeRequest.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeRequest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
+
+import java.io.IOException;
+
+/** Per-node request carrying which caches to clear. @opensearch.internal */
+public class ClearCacheNodeRequest extends TransportRequest {
+
+    private boolean footer;
+    private boolean column;
+    private boolean offset;
+
+    public ClearCacheNodeRequest(boolean footer, boolean column, boolean offset) {
+        this.footer = footer;
+        this.column = column;
+        this.offset = offset;
+    }
+
+    public ClearCacheNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        this.footer = in.readBoolean();
+        this.column = in.readBoolean();
+        this.offset = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(footer);
+        out.writeBoolean(column);
+        out.writeBoolean(offset);
+    }
+
+    public boolean isFooter() {
+        return footer;
+    }
+
+    public boolean isColumn() {
+        return column;
+    }
+
+    public boolean isOffset() {
+        return offset;
+    }
+
+    public boolean isClearAll() {
+        return !footer && !column && !offset;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeResponse.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeResponse.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/** Per-node response confirming the caches were cleared. @opensearch.internal */
+public class ClearCacheNodeResponse extends BaseNodeResponse {
+
+    public ClearCacheNodeResponse(DiscoveryNode node) {
+        super(node);
+    }
+
+    public ClearCacheNodeResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesRequest.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesRequest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Cluster-level request to clear DataFusion caches on target nodes.
+ *
+ * <p>When all flags are false (the default), every cache is cleared. Set individual
+ * flags to clear only specific caches — mirrors {@code /_cache/clear?query=true} pattern.
+ *
+ * @opensearch.internal
+ */
+public class ClearCacheNodesRequest extends BaseNodesRequest<ClearCacheNodesRequest> {
+
+    private boolean footer;
+    private boolean column;
+    private boolean offset;
+
+    /** Clears ALL caches on the target nodes (no params given). */
+    public ClearCacheNodesRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+
+    public ClearCacheNodesRequest(StreamInput in) throws IOException {
+        super(in);
+        this.footer = in.readBoolean();
+        this.column = in.readBoolean();
+        this.offset = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(footer);
+        out.writeBoolean(column);
+        out.writeBoolean(offset);
+    }
+
+    /** Whether to clear the footer metadata cache. */
+    public boolean isFooter() {
+        return footer;
+    }
+
+    public void setFooter(boolean footer) {
+        this.footer = footer;
+    }
+
+    /** Whether to clear the ColumnIndex (predicate) cache. */
+    public boolean isColumn() {
+        return column;
+    }
+
+    public void setColumn(boolean column) {
+        this.column = column;
+    }
+
+    /** Whether to clear the OffsetIndex (projection) cache. */
+    public boolean isOffset() {
+        return offset;
+    }
+
+    public void setOffset(boolean offset) {
+        this.offset = offset;
+    }
+
+    /** True when no specific flag is set — means clear everything. */
+    public boolean isClearAll() {
+        return !footer && !column && !offset;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesResponse.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesResponse.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Aggregated cluster-wide response for the clear-scoped-cache broadcast. @opensearch.internal */
+public class ClearCacheNodesResponse extends BaseNodesResponse<ClearCacheNodeResponse> implements ToXContentFragment {
+
+    public ClearCacheNodesResponse(ClusterName clusterName, List<ClearCacheNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    public ClearCacheNodesResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected List<ClearCacheNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(ClearCacheNodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<ClearCacheNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("acknowledged", failures() == null || failures().isEmpty());
+        builder.startArray("cleared_nodes");
+        for (ClearCacheNodeResponse node : getNodes()) {
+            builder.value(node.getNode().getId());
+        }
+        builder.endArray();
+        return builder;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/RestClearCacheAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/RestClearCacheAction.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestActions.NodesResponseRestListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * Clears DataFusion caches across ALL nodes in the cluster.
+ *
+ * <pre>
+ * POST /_plugins/_analytics_backend_datafusion/cache/_clear           → clears all caches
+ * POST /_plugins/_analytics_backend_datafusion/cache/_clear?footer=true  → footer metadata only
+ * POST /_plugins/_analytics_backend_datafusion/cache/_clear?column=true  → column index only
+ * POST /_plugins/_analytics_backend_datafusion/cache/_clear?offset=true  → offset index only
+ * </pre>
+ *
+ * <p>Multiple params may be combined. When no param is set, all caches are cleared.
+ * Mirrors the {@code /_cache/clear?query=true} pattern used by OpenSearch index caches.
+ *
+ * @opensearch.internal
+ */
+public class RestClearCacheAction extends BaseRestHandler {
+
+    private static final String ROUTE = "/_plugins/_analytics_backend_datafusion/cache/_clear";
+
+    @Override
+    public String getName() {
+        return "datafusion_clear_cache_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(POST, ROUTE));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        ClearCacheNodesRequest nodesRequest = new ClearCacheNodesRequest();
+        nodesRequest.setFooter(request.paramAsBoolean("footer", false));
+        nodesRequest.setColumn(request.paramAsBoolean("column", false));
+        nodesRequest.setOffset(request.paramAsBoolean("offset", false));
+        return channel -> client.execute(ClearCacheActionType.INSTANCE, nodesRequest, new NodesResponseRestListener<>(channel));
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
@@ -75,15 +75,14 @@ public class TransportClearCacheAction extends TransportNodesAction<
     @Override
     protected ClearCacheNodeResponse nodeOperation(ClearCacheNodeRequest request) {
         if (request.isClearAll()) {
-            NativeBridge.clearFooterCache();
             NativeBridge.clearColumnIndexCache();
             NativeBridge.clearOffsetIndexCache();
+            NativeBridge.clearFooterCache();
         } else {
-            if (request.isFooter()) NativeBridge.clearFooterCache();
             if (request.isColumn()) NativeBridge.clearColumnIndexCache();
             if (request.isOffset()) NativeBridge.clearOffsetIndexCache();
+            if (request.isFooter()) NativeBridge.clearFooterCache();
         }
-        ;
         return new ClearCacheNodeResponse(clusterService.localNode());
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.be.datafusion.nativelib.NativeBridge;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Broadcast transport action that clears the process-global scoped page-index
+ * caches (ColumnIndex + OffsetIndex) on every target node.
+ *
+ * @opensearch.internal
+ */
+public class TransportClearCacheAction extends TransportNodesAction<
+    ClearCacheNodesRequest,
+    ClearCacheNodesResponse,
+    ClearCacheNodeRequest,
+    ClearCacheNodeResponse> {
+
+    @Inject
+    public TransportClearCacheAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters
+    ) {
+        super(
+            ClearCacheActionType.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            ClearCacheNodesRequest::new,
+            ClearCacheNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            ClearCacheNodeResponse.class
+        );
+    }
+
+    @Override
+    protected ClearCacheNodesResponse newResponse(
+        ClearCacheNodesRequest request,
+        List<ClearCacheNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new ClearCacheNodesResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected ClearCacheNodeRequest newNodeRequest(ClearCacheNodesRequest request) {
+        return new ClearCacheNodeRequest(request.isFooter(), request.isColumn(), request.isOffset());
+    }
+
+    @Override
+    protected ClearCacheNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ClearCacheNodeResponse(in);
+    }
+
+    @Override
+    protected ClearCacheNodeResponse nodeOperation(ClearCacheNodeRequest request) {
+        if (request.isClearAll()) {
+            NativeBridge.clearFooterCache();
+            NativeBridge.clearColumnIndexCache();
+            NativeBridge.clearOffsetIndexCache();
+        } else {
+            if (request.isFooter()) NativeBridge.clearFooterCache();
+            if (request.isColumn()) NativeBridge.clearColumnIndexCache();
+            if (request.isOffset()) NativeBridge.clearOffsetIndexCache();
+        }
+        ;
+        return new ClearCacheNodeResponse(clusterService.localNode());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -14,8 +14,6 @@ import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 
 /**
@@ -26,7 +24,7 @@ import java.util.Locale;
  * <pre>
  * node.native_memory.limit = 80% of off-heap
  *   ├── 71% → datafusion.memory_pool_limit_bytes  (operator pool)
- *   ├──  3% → datafusion.metadata_index_cache.total_size_bytes   (all metadata caches (footer + page indexes), this class)
+ *   ├──  3% → datafusion.metadata_index_cache.total_size   (all metadata caches (footer + page indexes), this class)
  *   │     ├── 50% → metadata cache   (footer metadata, Rust jemalloc)
  *   │     ├── 35% → offset index     (projection-driven, Rust jemalloc)
  *   │     └── 15% → column index     (predicate-driven, Rust jemalloc)
@@ -102,23 +100,17 @@ public class CacheSettings {
 
     // Page-cache total budget (3% of node.native_memory.limit)
 
-    public static final String METADATA_INDEX_CACHE_TOTAL_SIZE_KEY = "datafusion.metadata_index_cache.total_size_bytes";
+    public static final String METADATA_INDEX_CACHE_TOTAL_SIZE_KEY = "datafusion.metadata_index_cache.total_size";
 
     /**
      * Total byte budget for all three metadata caches (footer metadata, ColumnIndex,
      * OffsetIndex). Defaults to 3% of {@code node.native_memory.limit}; falls back to
      * 500 MB when AC is unconfigured.
      */
-    public static final Setting<Long> METADATA_INDEX_CACHE_TOTAL_SIZE = new Setting<>(
+    public static final Setting<ByteSizeValue> METADATA_INDEX_CACHE_TOTAL_SIZE = new Setting<>(
         METADATA_INDEX_CACHE_TOTAL_SIZE_KEY,
         CacheSettings::deriveMetadataIndexCacheTotalDefault,
-        s -> {
-            long v = Long.parseLong(s);
-            if (v < 0) {
-                throw new IllegalArgumentException("Setting [" + METADATA_INDEX_CACHE_TOTAL_SIZE_KEY + "] must be >= 0, got " + v);
-            }
-            return v;
-        },
+        s -> ByteSizeValue.parseBytesSizeValue(s, new ByteSizeValue(0, ByteSizeUnit.BYTES), METADATA_INDEX_CACHE_TOTAL_SIZE_KEY),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -188,7 +180,7 @@ public class CacheSettings {
     public static void validatePercentSum(int metaPct, int oiPct, int ciPct, int statsPct) {
         if (metaPct + oiPct + ciPct + statsPct > 100) {
             throw new IllegalArgumentException(
-                "datafusion cache percentages must sum to &lt;= 100, got: "
+                "Datafusion cache percentages must sum to <= 100, got: "
                     + FOOTER_METADATA_CACHE_PERCENT_KEY
                     + "="
                     + metaPct
@@ -247,25 +239,6 @@ public class CacheSettings {
     public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, long totalBytes) {
         return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100 };
     }
-
-    // ── Legacy per-cache keys (kept for BWC; prefer percent-based settings) ──
-
-    public static final String COLUMN_INDEX_CACHE_SIZE_LIMIT_KEY = "datafusion.column_index.cache.size.limit";
-    public static final String OFFSET_INDEX_CACHE_SIZE_LIMIT_KEY = "datafusion.offset_index.cache.size.limit";
-
-    public static final List<Setting<?>> CACHE_SETTINGS = Arrays.asList(
-        METADATA_CACHE_ENABLED,
-        METADATA_CACHE_SIZE_LIMIT,
-        METADATA_CACHE_EVICTION_TYPE,
-        STATISTICS_CACHE_ENABLED,
-        STATISTICS_CACHE_SIZE_LIMIT,
-        STATISTICS_CACHE_EVICTION_TYPE,
-        METADATA_INDEX_CACHE_TOTAL_SIZE,
-        FOOTER_METADATA_CACHE_PERCENT,
-        OFFSET_INDEX_CACHE_PERCENT,
-        COLUMN_INDEX_CACHE_PERCENT,
-        STATISTICS_CACHE_PERCENT
-    );
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -45,27 +45,6 @@ import java.util.Locale;
  */
 public class CacheSettings {
 
-    // ── Statistics + metadata (independent of the 3% page-cache budget) ─────
-
-    public static final String METADATA_CACHE_SIZE_LIMIT_KEY = "datafusion.metadata.cache.size.limit";
-    public static final String STATISTICS_CACHE_SIZE_LIMIT_KEY = "datafusion.statistics.cache.size.limit";
-
-    public static final Setting<ByteSizeValue> METADATA_CACHE_SIZE_LIMIT = new Setting<>(
-        METADATA_CACHE_SIZE_LIMIT_KEY,
-        "250mb",
-        (s) -> ByteSizeValue.parseBytesSizeValue(s, new ByteSizeValue(1000, ByteSizeUnit.KB), METADATA_CACHE_SIZE_LIMIT_KEY),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    public static final Setting<ByteSizeValue> STATISTICS_CACHE_SIZE_LIMIT = new Setting<>(
-        STATISTICS_CACHE_SIZE_LIMIT_KEY,
-        "100mb",
-        (s) -> ByteSizeValue.parseBytesSizeValue(s, new ByteSizeValue(0, ByteSizeUnit.KB), STATISTICS_CACHE_SIZE_LIMIT_KEY),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
     public static final Setting<String> METADATA_CACHE_EVICTION_TYPE = new Setting<>(
         "datafusion.metadata.cache.eviction.type",
         "LRU",
@@ -115,7 +94,7 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
-    // ── Sub-cache percentages (must sum to &lt;= 100) ───────────────────────────────
+    // ── Sub-cache percentages (must sum to <= 100) ───────────────────────────────
 
     public static final String FOOTER_METADATA_CACHE_PERCENT_KEY = "datafusion.cache.footer_metadata_percent";
     public static final String OFFSET_INDEX_CACHE_PERCENT_KEY = "datafusion.cache.offset_index_percent";
@@ -203,41 +182,13 @@ public class CacheSettings {
         }
     }
 
-    // Keep 3-arg overload for backward compat with existing callers
-    public static void validatePercentSum(int metaPct, int oiPct, int ciPct) {
-        if (metaPct + oiPct + ciPct > 100) {
-            throw new IllegalArgumentException(
-                "datafusion cache percentages must sum to &lt;= 100, got: "
-                    + FOOTER_METADATA_CACHE_PERCENT_KEY
-                    + "="
-                    + metaPct
-                    + ", "
-                    + OFFSET_INDEX_CACHE_PERCENT_KEY
-                    + "="
-                    + oiPct
-                    + ", "
-                    + COLUMN_INDEX_CACHE_PERCENT_KEY
-                    + "="
-                    + ciPct
-                    + " (sum="
-                    + (metaPct + oiPct + ciPct)
-                    + ")"
-            );
-        }
-    }
-
     /**
-     * Compute absolute cache sizes from explicit percent values and a total budget.
+     * Compute absolute cache sizes from percent values and a total budget.
      * Returns {@code long[]{footerMetadataBytes, offsetIndexBytes, columnIndexBytes, statisticsBytes}}.
      * Does NOT validate that percents sum to &lt;= 100 — call {@link #validatePercentSum} first.
      */
     public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, int statsPct, long totalBytes) {
         return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100, totalBytes * statsPct / 100 };
-    }
-
-    // Keep 3-arg overload for backward compat
-    public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, long totalBytes) {
-        return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100 };
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -249,10 +200,10 @@ public class CacheSettings {
     static String deriveMetadataIndexCacheTotalDefault(Settings settings) {
         ByteSizeValue nativeLimit = ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
         if (nativeLimit.getBytes() <= 0) {
-            return Long.toString(500L * 1024 * 1024); // 500 MB fallback
+            return (500L * 1024 * 1024) + "b";
         }
-        long total = nativeLimit.getBytes() * 3 / 100;
-        return Long.toString(Math.max(total, 0L));
+        long total = Math.max(nativeLimit.getBytes() * 3 / 100, 0L);
+        return total + "b";
     }
 
     private static String validateEvictionType(String value) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -9,17 +9,49 @@
 package org.opensearch.be.datafusion.cache;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * Settings for the DataFusion parquet caches.
+ *
+ * <h2>Budget model</h2>
+ *
+ * <pre>
+ * node.native_memory.limit = 80% of off-heap
+ *   ├── 71% → datafusion.memory_pool_limit_bytes  (operator pool)
+ *   ├──  3% → datafusion.metadata_index_cache.total_size_bytes   (all metadata caches (footer + page indexes), this class)
+ *   │     ├── 50% → metadata cache   (footer metadata, Rust jemalloc)
+ *   │     ├── 35% → offset index     (projection-driven, Rust jemalloc)
+ *   │     └── 15% → column index     (predicate-driven, Rust jemalloc)
+ *   ├──  8% → Arrow ingest pool
+ *   ├──  5% → Arrow flight pool
+ *   ├──  5% → Arrow query pool
+ *   ├──  5% → Parquet write pool
+ *   └──  3% → Parquet merge pool
+ *   = 100%
+ * </pre>
+ *
+ * <p>The three sub-cache percentages must sum to &lt;= 100 (unused headroom is accepted). Changing any one without adjusting
+ * the others is rejected at validation time.
+ *
+ * <p>The statistics cache is sized independently (not part of the 3% total) because it
+ * holds file-level row-group statistics, not page-level indexes — a different working set
+ * with different eviction characteristics.
+ */
 public class CacheSettings {
+
+    // ── Statistics + metadata (independent of the 3% page-cache budget) ─────
 
     public static final String METADATA_CACHE_SIZE_LIMIT_KEY = "datafusion.metadata.cache.size.limit";
     public static final String STATISTICS_CACHE_SIZE_LIMIT_KEY = "datafusion.statistics.cache.size.limit";
+
     public static final Setting<ByteSizeValue> METADATA_CACHE_SIZE_LIMIT = new Setting<>(
         METADATA_CACHE_SIZE_LIMIT_KEY,
         "250mb",
@@ -36,7 +68,7 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
-    public static final Setting<String> METADATA_CACHE_EVICTION_TYPE = new Setting<String>(
+    public static final Setting<String> METADATA_CACHE_EVICTION_TYPE = new Setting<>(
         "datafusion.metadata.cache.eviction.type",
         "LRU",
         CacheSettings::validateEvictionType,
@@ -44,7 +76,7 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
-    public static final Setting<String> STATISTICS_CACHE_EVICTION_TYPE = new Setting<String>(
+    public static final Setting<String> STATISTICS_CACHE_EVICTION_TYPE = new Setting<>(
         "datafusion.statistics.cache.eviction.type",
         "LRU",
         CacheSettings::validateEvictionType,
@@ -68,14 +100,139 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
+    // Page-cache total budget (3% of node.native_memory.limit)
+
+    public static final String METADATA_INDEX_CACHE_TOTAL_SIZE_KEY = "datafusion.metadata_index_cache.total_size_bytes";
+
+    /**
+     * Total byte budget for all three metadata caches (footer metadata, ColumnIndex,
+     * OffsetIndex). Defaults to 3% of {@code node.native_memory.limit}; falls back to
+     * 500 MB when AC is unconfigured.
+     */
+    public static final Setting<Long> METADATA_INDEX_CACHE_TOTAL_SIZE = new Setting<>(
+        METADATA_INDEX_CACHE_TOTAL_SIZE_KEY,
+        CacheSettings::deriveMetadataIndexCacheTotalDefault,
+        s -> {
+            long v = Long.parseLong(s);
+            if (v < 0) {
+                throw new IllegalArgumentException("Setting [" + METADATA_INDEX_CACHE_TOTAL_SIZE_KEY + "] must be >= 0, got " + v);
+            }
+            return v;
+        },
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    // ── Sub-cache percentages (must sum to &lt;= 100) ───────────────────────────────
+
+    public static final String FOOTER_METADATA_CACHE_PERCENT_KEY = "datafusion.cache.footer_metadata_percent";
+    public static final String OFFSET_INDEX_CACHE_PERCENT_KEY = "datafusion.cache.offset_index_percent";
+    public static final String COLUMN_INDEX_CACHE_PERCENT_KEY = "datafusion.cache.column_index_percent";
+
+    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the footer metadata cache. Default 50%. */
+    public static final Setting<Integer> FOOTER_METADATA_CACHE_PERCENT = Setting.intSetting(
+        FOOTER_METADATA_CACHE_PERCENT_KEY,
+        50,
+        1,
+        98,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the OffsetIndex cache.
+     * Larger than ColumnIndex because it covers predicate ∪ projection ∪ {col 0}.
+     * Default 35%.
+     */
+    public static final Setting<Integer> OFFSET_INDEX_CACHE_PERCENT = Setting.intSetting(
+        OFFSET_INDEX_CACHE_PERCENT_KEY,
+        35,
+        1,
+        98,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the ColumnIndex cache. Default 15%. */
+    public static final Setting<Integer> COLUMN_INDEX_CACHE_PERCENT = Setting.intSetting(
+        COLUMN_INDEX_CACHE_PERCENT_KEY,
+        15,
+        1,
+        98,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Validate that the three sub-cache percentages sum to &lt;= 100. Unused headroom (sum &lt; 100) is accepted — mirrors Arrow's pool model where sum(max) &lt;= budget.
+     *
+     * @param metaPct  metadata cache percent
+     * @param oiPct    offset index cache percent
+     * @param ciPct    column index cache percent
+     */
+    public static void validatePercentSum(int metaPct, int oiPct, int ciPct) {
+        if (metaPct + oiPct + ciPct > 100) {
+            throw new IllegalArgumentException(
+                "datafusion cache percentages must sum to &lt;= 100, got: "
+                    + FOOTER_METADATA_CACHE_PERCENT_KEY
+                    + "="
+                    + metaPct
+                    + ", "
+                    + OFFSET_INDEX_CACHE_PERCENT_KEY
+                    + "="
+                    + oiPct
+                    + ", "
+                    + COLUMN_INDEX_CACHE_PERCENT_KEY
+                    + "="
+                    + ciPct
+                    + " (sum="
+                    + (metaPct + oiPct + ciPct)
+                    + ")"
+            );
+        }
+    }
+
+    /**
+     * Compute absolute cache sizes from explicit percent values and a total budget.
+     * Returns {@code long[]{footerMetadataBytes, offsetIndexBytes, columnIndexBytes}}.
+     * Does NOT validate that percents sum to &lt;= 100 — call {@link #validatePercentSum} first.
+     */
+    public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, long totalBytes) {
+        return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100 };
+    }
+
+    // ── Legacy per-cache keys (kept for BWC; prefer percent-based settings) ──
+
+    public static final String COLUMN_INDEX_CACHE_SIZE_LIMIT_KEY = "datafusion.column_index.cache.size.limit";
+    public static final String OFFSET_INDEX_CACHE_SIZE_LIMIT_KEY = "datafusion.offset_index.cache.size.limit";
+
     public static final List<Setting<?>> CACHE_SETTINGS = Arrays.asList(
         METADATA_CACHE_ENABLED,
         METADATA_CACHE_SIZE_LIMIT,
         METADATA_CACHE_EVICTION_TYPE,
         STATISTICS_CACHE_ENABLED,
         STATISTICS_CACHE_SIZE_LIMIT,
-        STATISTICS_CACHE_EVICTION_TYPE
+        STATISTICS_CACHE_EVICTION_TYPE,
+        METADATA_INDEX_CACHE_TOTAL_SIZE,
+        FOOTER_METADATA_CACHE_PERCENT,
+        OFFSET_INDEX_CACHE_PERCENT,
+        COLUMN_INDEX_CACHE_PERCENT
     );
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Default total page-cache budget: 3% of {@code node.native_memory.limit}.
+     * Falls back to 500 MB when AC is unconfigured (limit == 0).
+     */
+    static String deriveMetadataIndexCacheTotalDefault(Settings settings) {
+        ByteSizeValue nativeLimit = ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
+        if (nativeLimit.getBytes() <= 0) {
+            return Long.toString(500L * 1024 * 1024); // 500 MB fallback
+        }
+        long total = nativeLimit.getBytes() * 3 / 100;
+        return Long.toString(Math.max(total, 0L));
+    }
 
     private static String validateEvictionType(String value) {
         String upper = value.toUpperCase(Locale.ROOT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -128,11 +128,12 @@ public class CacheSettings {
     public static final String FOOTER_METADATA_CACHE_PERCENT_KEY = "datafusion.cache.footer_metadata_percent";
     public static final String OFFSET_INDEX_CACHE_PERCENT_KEY = "datafusion.cache.offset_index_percent";
     public static final String COLUMN_INDEX_CACHE_PERCENT_KEY = "datafusion.cache.column_index_percent";
+    public static final String STATISTICS_CACHE_PERCENT_KEY = "datafusion.cache.statistics_percent";
 
-    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the footer metadata cache. Default 50%. */
+    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the footer metadata cache. Default 48%. */
     public static final Setting<Integer> FOOTER_METADATA_CACHE_PERCENT = Setting.intSetting(
         FOOTER_METADATA_CACHE_PERCENT_KEY,
-        50,
+        48,
         1,
         98,
         Setting.Property.NodeScope,
@@ -142,21 +143,21 @@ public class CacheSettings {
     /**
      * Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the OffsetIndex cache.
      * Larger than ColumnIndex because it covers predicate ∪ projection ∪ {col 0}.
-     * Default 35%.
+     * Default 34%.
      */
     public static final Setting<Integer> OFFSET_INDEX_CACHE_PERCENT = Setting.intSetting(
         OFFSET_INDEX_CACHE_PERCENT_KEY,
-        35,
+        34,
         1,
         98,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
-    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the ColumnIndex cache. Default 15%. */
+    /** Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the ColumnIndex cache. Default 13%. */
     public static final Setting<Integer> COLUMN_INDEX_CACHE_PERCENT = Setting.intSetting(
         COLUMN_INDEX_CACHE_PERCENT_KEY,
-        15,
+        13,
         1,
         98,
         Setting.Property.NodeScope,
@@ -164,12 +165,53 @@ public class CacheSettings {
     );
 
     /**
-     * Validate that the three sub-cache percentages sum to &lt;= 100. Unused headroom (sum &lt; 100) is accepted — mirrors Arrow's pool model where sum(max) &lt;= budget.
-     *
-     * @param metaPct  metadata cache percent
-     * @param oiPct    offset index cache percent
-     * @param ciPct    column index cache percent
+     * Percentage of {@link #METADATA_INDEX_CACHE_TOTAL_SIZE} allocated to the file-level statistics cache
+     * (row-group min/max/null-count). Default 5%.
      */
+    public static final Setting<Integer> STATISTICS_CACHE_PERCENT = Setting.intSetting(
+        STATISTICS_CACHE_PERCENT_KEY,
+        5,
+        1,
+        98,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Validate that the four sub-cache percentages sum to &lt;= 100. Unused headroom (sum &lt; 100) is accepted — mirrors Arrow's pool model where sum(max) &lt;= budget.
+     *
+     * @param metaPct    footer metadata cache percent
+     * @param oiPct      offset index cache percent
+     * @param ciPct      column index cache percent
+     * @param statsPct   statistics cache percent
+     */
+    public static void validatePercentSum(int metaPct, int oiPct, int ciPct, int statsPct) {
+        if (metaPct + oiPct + ciPct + statsPct > 100) {
+            throw new IllegalArgumentException(
+                "datafusion cache percentages must sum to &lt;= 100, got: "
+                    + FOOTER_METADATA_CACHE_PERCENT_KEY
+                    + "="
+                    + metaPct
+                    + ", "
+                    + OFFSET_INDEX_CACHE_PERCENT_KEY
+                    + "="
+                    + oiPct
+                    + ", "
+                    + COLUMN_INDEX_CACHE_PERCENT_KEY
+                    + "="
+                    + ciPct
+                    + ", "
+                    + STATISTICS_CACHE_PERCENT_KEY
+                    + "="
+                    + statsPct
+                    + " (sum="
+                    + (metaPct + oiPct + ciPct + statsPct)
+                    + ")"
+            );
+        }
+    }
+
+    // Keep 3-arg overload for backward compat with existing callers
     public static void validatePercentSum(int metaPct, int oiPct, int ciPct) {
         if (metaPct + oiPct + ciPct > 100) {
             throw new IllegalArgumentException(
@@ -194,9 +236,14 @@ public class CacheSettings {
 
     /**
      * Compute absolute cache sizes from explicit percent values and a total budget.
-     * Returns {@code long[]{footerMetadataBytes, offsetIndexBytes, columnIndexBytes}}.
+     * Returns {@code long[]{footerMetadataBytes, offsetIndexBytes, columnIndexBytes, statisticsBytes}}.
      * Does NOT validate that percents sum to &lt;= 100 — call {@link #validatePercentSum} first.
      */
+    public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, int statsPct, long totalBytes) {
+        return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100, totalBytes * statsPct / 100 };
+    }
+
+    // Keep 3-arg overload for backward compat
     public static long[] computeCacheSizes(int metaPct, int oiPct, int ciPct, long totalBytes) {
         return new long[] { totalBytes * metaPct / 100, totalBytes * oiPct / 100, totalBytes * ciPct / 100 };
     }
@@ -216,7 +263,8 @@ public class CacheSettings {
         METADATA_INDEX_CACHE_TOTAL_SIZE,
         FOOTER_METADATA_CACHE_PERCENT,
         OFFSET_INDEX_CACHE_PERCENT,
-        COLUMN_INDEX_CACHE_PERCENT
+        COLUMN_INDEX_CACHE_PERCENT,
+        STATISTICS_CACHE_PERCENT
     );
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -13,14 +13,11 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
-import org.opensearch.core.common.unit.ByteSizeValue;
 
 import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_ENABLED;
 import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_EVICTION_TYPE;
-import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_SIZE_LIMIT;
 import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_ENABLED;
 import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_EVICTION_TYPE;
-import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_SIZE_LIMIT;
 
 /**
  * Utility class for cache initialization and configuration.
@@ -36,26 +33,30 @@ public final class CacheUtils {
      * Cache type enumeration with associated settings.
      */
     public enum CacheType {
-        METADATA("METADATA", METADATA_CACHE_ENABLED, METADATA_CACHE_SIZE_LIMIT, METADATA_CACHE_EVICTION_TYPE),
-
-        STATISTICS("STATISTICS", STATISTICS_CACHE_ENABLED, STATISTICS_CACHE_SIZE_LIMIT, STATISTICS_CACHE_EVICTION_TYPE);
+        METADATA("METADATA", METADATA_CACHE_ENABLED, METADATA_CACHE_EVICTION_TYPE) {
+            @Override
+            public long sizeBytes(long metaLimit, long oiLimit, long ciLimit, long statsLimit) {
+                return metaLimit;
+            }
+        },
+        STATISTICS("STATISTICS", STATISTICS_CACHE_ENABLED, STATISTICS_CACHE_EVICTION_TYPE) {
+            @Override
+            public long sizeBytes(long metaLimit, long oiLimit, long ciLimit, long statsLimit) {
+                return statsLimit;
+            }
+        };
 
         private final String cacheTypeName;
         private final Setting<Boolean> enabledSetting;
-        private final Setting<ByteSizeValue> sizeLimitSetting;
         private final Setting<String> evictionTypeSetting;
 
-        CacheType(
-            String cacheTypeName,
-            Setting<Boolean> enabledSetting,
-            Setting<ByteSizeValue> sizeLimitSetting,
-            Setting<String> evictionTypeSetting
-        ) {
+        CacheType(String cacheTypeName, Setting<Boolean> enabledSetting, Setting<String> evictionTypeSetting) {
             this.cacheTypeName = cacheTypeName;
             this.enabledSetting = enabledSetting;
-            this.sizeLimitSetting = sizeLimitSetting;
             this.evictionTypeSetting = evictionTypeSetting;
         }
+
+        public abstract long sizeBytes(long metaLimit, long oiLimit, long ciLimit, long statsLimit);
 
         public boolean isEnabled(ClusterSettings clusterSettings) {
             return clusterSettings.get(enabledSetting);
@@ -65,16 +66,8 @@ public final class CacheUtils {
             return enabledSetting;
         }
 
-        public Setting<ByteSizeValue> getSizeLimitSetting() {
-            return sizeLimitSetting;
-        }
-
         public Setting<String> getEvictionTypeSetting() {
             return evictionTypeSetting;
-        }
-
-        public ByteSizeValue getSizeLimit(ClusterSettings clusterSettings) {
-            return clusterSettings.get(sizeLimitSetting);
         }
 
         public String getEvictionType(ClusterSettings clusterSettings) {
@@ -127,10 +120,7 @@ public final class CacheUtils {
         // Configure each enabled cache type using the percent-derived limit.
         for (CacheType type : CacheType.values()) {
             if (type.isEnabled(clusterSettings)) {
-                // Both METADATA and STATISTICS now use the unified budget split.
-                long sizeLimit = (type == CacheType.METADATA) ? metaLimit
-                    : (type == CacheType.STATISTICS) ? statsLimit
-                    : type.getSizeLimit(clusterSettings).getBytes();
+                long sizeLimit = type.sizeBytes(metaLimit, oiLimit, ciLimit, statsLimit);
                 logger.info(
                     "Configuring {} cache: size={} bytes, eviction={}",
                     type.getCacheTypeName(),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -97,46 +97,52 @@ public final class CacheUtils {
         long cacheManagerPtr = NativeBridge.createCustomCacheManager();
         NativeCacheManagerHandle handle = new NativeCacheManagerHandle(cacheManagerPtr);
 
-        // Configure each enabled cache type
-        for (CacheType type : CacheType.values()) {
-            if (type.isEnabled(clusterSettings)) {
-                logger.info(
-                    "Configuring {} cache: size={} bytes, eviction={}",
-                    type.getCacheTypeName(),
-                    type.getSizeLimit(clusterSettings).getBytes(),
-                    type.getEvictionType(clusterSettings)
-                );
-
-                NativeBridge.createCache(
-                    handle.getPointer(),
-                    type.cacheTypeName,
-                    type.getSizeLimit(clusterSettings).getBytes(),
-                    type.getEvictionType(clusterSettings)
-                );
-            } else {
-                logger.debug("Cache type {} is disabled", type.getCacheTypeName());
-            }
-        }
-        // Push the scoped page-index cache limits to native using the percent-based model.
-        // Total = 3% of node.native_memory.limit; sub-caches split by percent settings
-        // (default: 50% metadata, 35% offset index, 15% column index).
-        // Dynamic changes are handled via settings update consumers in DataFusionPlugin.
+        // All three caches share the unified METADATA_INDEX_CACHE_TOTAL_SIZE budget.
+        // Compute absolute sizes from the percent model BEFORE creating the caches so
+        // the footer metadata cache (created in the loop below) gets the correct limit
+        // rather than the old standalone METADATA_CACHE_SIZE_LIMIT (hardcoded 250 MB).
         long total = clusterSettings.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
         int metaPct = clusterSettings.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         int oiPct = clusterSettings.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         int ciPct = clusterSettings.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
+        int statsPct = clusterSettings.get(CacheSettings.STATISTICS_CACHE_PERCENT);
+        long metaLimit = total * metaPct / 100;
         long oiLimit = total * oiPct / 100;
         long ciLimit = total * ciPct / 100;
+        long statsLimit = total * statsPct / 100;
         logger.info(
-            "Configuring metadata caches: total={} bytes (metadata={}%, offset_index={}%, column_index={}%)"
-                + " → offset_index={} bytes, column_index={} bytes",
+            "Configuring metadata caches: total={} bytes "
+                + "(footer={}% → {} bytes, offset_index={}% → {} bytes, column_index={}% → {} bytes, statistics={}% → {} bytes)",
             total,
             metaPct,
+            metaLimit,
             oiPct,
-            ciPct,
             oiLimit,
-            ciLimit
+            ciPct,
+            ciLimit,
+            statsPct,
+            statsLimit
         );
+
+        // Configure each enabled cache type using the percent-derived limit.
+        for (CacheType type : CacheType.values()) {
+            if (type.isEnabled(clusterSettings)) {
+                // Both METADATA and STATISTICS now use the unified budget split.
+                long sizeLimit = (type == CacheType.METADATA) ? metaLimit
+                    : (type == CacheType.STATISTICS) ? statsLimit
+                    : type.getSizeLimit(clusterSettings).getBytes();
+                logger.info(
+                    "Configuring {} cache: size={} bytes, eviction={}",
+                    type.getCacheTypeName(),
+                    sizeLimit,
+                    type.getEvictionType(clusterSettings)
+                );
+                NativeBridge.createCache(handle.getPointer(), type.cacheTypeName, sizeLimit, type.getEvictionType(clusterSettings));
+            } else {
+                logger.debug("Cache type {} is disabled", type.getCacheTypeName());
+            }
+        }
+
         NativeBridge.setColumnIndexCacheLimit(ciLimit);
         NativeBridge.setOffsetIndexCacheLimit(oiLimit);
         logger.info("Cache configuration completed");

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -117,6 +117,28 @@ public final class CacheUtils {
                 logger.debug("Cache type {} is disabled", type.getCacheTypeName());
             }
         }
+        // Push the scoped page-index cache limits to native using the percent-based model.
+        // Total = 3% of node.native_memory.limit; sub-caches split by percent settings
+        // (default: 50% metadata, 35% offset index, 15% column index).
+        // Dynamic changes are handled via settings update consumers in DataFusionPlugin.
+        long total = clusterSettings.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        int metaPct = clusterSettings.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
+        int oiPct = clusterSettings.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
+        int ciPct = clusterSettings.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
+        long oiLimit = total * oiPct / 100;
+        long ciLimit = total * ciPct / 100;
+        logger.info(
+            "Configuring metadata caches: total={} bytes (metadata={}%, offset_index={}%, column_index={}%)"
+                + " → offset_index={} bytes, column_index={} bytes",
+            total,
+            metaPct,
+            oiPct,
+            ciPct,
+            oiLimit,
+            ciLimit
+        );
+        NativeBridge.setColumnIndexCacheLimit(ciLimit);
+        NativeBridge.setOffsetIndexCacheLimit(oiLimit);
         logger.info("Cache configuration completed");
         return handle;
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -101,7 +101,7 @@ public final class CacheUtils {
         // Compute absolute sizes from the percent model BEFORE creating the caches so
         // the footer metadata cache (created in the loop below) gets the correct limit
         // rather than the old standalone METADATA_CACHE_SIZE_LIMIT (hardcoded 250 MB).
-        long total = clusterSettings.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        long total = clusterSettings.get(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE).getBytes();
         int metaPct = clusterSettings.get(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         int oiPct = clusterSettings.get(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         int ciPct = clusterSettings.get(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -134,6 +134,9 @@ public final class NativeBridge {
     private static final MethodHandle CREATE_SESSION_CONTEXT_INDEXED;
     private static final MethodHandle CLOSE_SESSION_CONTEXT;
     private static final MethodHandle EXECUTE_WITH_CONTEXT;
+    private static final MethodHandle SET_COLUMN_INDEX_CACHE_LIMIT;
+    private static final MethodHandle SET_OFFSET_INDEX_CACHE_LIMIT;
+    private static final MethodHandle CLEAR_SCOPED_PAGE_INDEX_CACHE;
     private static final MethodHandle CANCEL_QUERY;
     private static final MethodHandle SET_CANCEL_STATS_THRESHOLD_MS;
     private static final MethodHandle STATS;
@@ -501,6 +504,18 @@ public final class NativeBridge {
             )
         );
 
+        SET_COLUMN_INDEX_CACHE_LIMIT = linker.downcallHandle(
+            lib.find("df_set_column_index_cache_limit").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        SET_OFFSET_INDEX_CACHE_LIMIT = linker.downcallHandle(
+            lib.find("df_set_offset_index_cache_limit").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        CLEAR_SCOPED_PAGE_INDEX_CACHE = linker.downcallHandle(
+            lib.find("df_clear_scoped_page_index_cache").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG)
+        );
         CANCEL_QUERY = linker.downcallHandle(lib.find("df_cancel_query").orElseThrow(), FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG));
 
         SET_CANCEL_STATS_THRESHOLD_MS = linker.downcallHandle(
@@ -1587,6 +1602,60 @@ public final class NativeBridge {
             var file = call.str(filePath);
             long result = call.invoke(CACHE_MANAGER_CONTAINS_BY_TYPE, runtimePtr, type.segment(), type.len(), file.segment(), file.len());
             return result != 0;
+        }
+    }
+
+    /**
+     * Sets the byte budget of the process-global scoped ColumnIndex cache.
+     * Shrinking evicts LRU entries immediately. Zero is ignored.
+     */
+    public static void setColumnIndexCacheLimit(long sizeLimitBytes) {
+        try (var call = new NativeCall()) {
+            call.invoke(SET_COLUMN_INDEX_CACHE_LIMIT, sizeLimitBytes);
+        }
+    }
+
+    /**
+     * Sets the byte budget of the process-global scoped OffsetIndex cache.
+     * Shrinking evicts LRU entries immediately. Zero is ignored.
+     */
+    public static void setOffsetIndexCacheLimit(long sizeLimitBytes) {
+        try (var call = new NativeCall()) {
+            call.invoke(SET_OFFSET_INDEX_CACHE_LIMIT, sizeLimitBytes);
+        }
+    }
+
+    /**
+     * Clears the process-global scoped page-index cache (drops entries + resets
+     * counters, keeps the budget). For operational testing.
+     */
+    public static void clearScopedPageIndexCache() {
+        try (var call = new NativeCall()) {
+            call.invoke(CLEAR_SCOPED_PAGE_INDEX_CACHE);
+        }
+    }
+
+    /** Clears the footer metadata cache. */
+    public static void clearFooterCache() {
+        // TODO(PR1): wire to df_clear_footer_cache when available
+        try (var call = new NativeCall()) {
+            call.invoke(CLEAR_SCOPED_PAGE_INDEX_CACHE);
+        }
+    }
+
+    /** Clears the scoped ColumnIndex (predicate) cache. */
+    public static void clearColumnIndexCache() {
+        // TODO(PR1): wire to df_clear_column_index_cache when available
+        try (var call = new NativeCall()) {
+            call.invoke(CLEAR_SCOPED_PAGE_INDEX_CACHE);
+        }
+    }
+
+    /** Clears the scoped OffsetIndex (projection) cache. */
+    public static void clearOffsetIndexCache() {
+        // TODO(PR1): wire to df_clear_offset_index_cache when available
+        try (var call = new NativeCall()) {
+            call.invoke(CLEAR_SCOPED_PAGE_INDEX_CACHE);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/StatsLayout.java
@@ -29,7 +29,7 @@ import java.lang.invoke.VarHandle;
  *
  * <p>The layout contains 10 named groups (2 runtime × 9 fields + 4 task monitor × 5 fields
  * + 1 partition gate × 8 fields + 1 adaptive budget × 2 fields + 1 cache stats × 10 fields
- * + 1 search stats × 17 fields = 75 longs = 600 bytes).
+ * + 1 search stats × 17 fields = 85 longs = 680 bytes). The cache stats group holds three sub-caches × 5 fields each: metadata, statistics, and scoped page-index..
  */
 public final class StatsLayout {
 
@@ -99,8 +99,8 @@ public final class StatsLayout {
     );
 
     static {
-        if (LAYOUT.byteSize() != 75 * Long.BYTES) {
-            throw new AssertionError("StatsLayout size mismatch: expected " + (75 * Long.BYTES) + " but got " + LAYOUT.byteSize());
+        if (LAYOUT.byteSize() != 85 * Long.BYTES) {
+            throw new AssertionError("StatsLayout size mismatch: expected " + (85 * Long.BYTES) + " but got " + LAYOUT.byteSize());
         }
     }
 
@@ -181,6 +181,20 @@ public final class StatsLayout {
     private static final VarHandle CACHE_STATS_ENTRY_COUNT = cacheHandle("statistics_cache", "entry_count");
     private static final VarHandle CACHE_STATS_MEMORY_BYTES = cacheHandle("statistics_cache", "memory_bytes");
     private static final VarHandle CACHE_STATS_SIZE_LIMIT_BYTES = cacheHandle("statistics_cache", "size_limit_bytes");
+
+    // ---- VarHandles for cache_stats.column_index_cache fields ----
+    private static final VarHandle CACHE_CI_HIT_COUNT = cacheHandle("column_index_cache", "hit_count");
+    private static final VarHandle CACHE_CI_MISS_COUNT = cacheHandle("column_index_cache", "miss_count");
+    private static final VarHandle CACHE_CI_ENTRY_COUNT = cacheHandle("column_index_cache", "entry_count");
+    private static final VarHandle CACHE_CI_MEMORY_BYTES = cacheHandle("column_index_cache", "memory_bytes");
+    private static final VarHandle CACHE_CI_SIZE_LIMIT_BYTES = cacheHandle("column_index_cache", "size_limit_bytes");
+
+    // ---- VarHandles for cache_stats.offset_index_cache fields ----
+    private static final VarHandle CACHE_OI_HIT_COUNT = cacheHandle("offset_index_cache", "hit_count");
+    private static final VarHandle CACHE_OI_MISS_COUNT = cacheHandle("offset_index_cache", "miss_count");
+    private static final VarHandle CACHE_OI_ENTRY_COUNT = cacheHandle("offset_index_cache", "entry_count");
+    private static final VarHandle CACHE_OI_MEMORY_BYTES = cacheHandle("offset_index_cache", "memory_bytes");
+    private static final VarHandle CACHE_OI_SIZE_LIMIT_BYTES = cacheHandle("offset_index_cache", "size_limit_bytes");
 
     // ---- VarHandles for search_stats fields ----
     private static final VarHandle SS_LISTING_TABLE_SCAN = handle("search_stats", "listing_table_scan");
@@ -311,7 +325,21 @@ public final class StatsLayout {
             (long) CACHE_STATS_MEMORY_BYTES.get(seg, 0L),
             (long) CACHE_STATS_SIZE_LIMIT_BYTES.get(seg, 0L)
         );
-        return new CacheStats(metadata, statistics);
+        CacheGroupStats columnIndex = new CacheGroupStats(
+            (long) CACHE_CI_HIT_COUNT.get(seg, 0L),
+            (long) CACHE_CI_MISS_COUNT.get(seg, 0L),
+            (long) CACHE_CI_ENTRY_COUNT.get(seg, 0L),
+            (long) CACHE_CI_MEMORY_BYTES.get(seg, 0L),
+            (long) CACHE_CI_SIZE_LIMIT_BYTES.get(seg, 0L)
+        );
+        CacheGroupStats offsetIndex = new CacheGroupStats(
+            (long) CACHE_OI_HIT_COUNT.get(seg, 0L),
+            (long) CACHE_OI_MISS_COUNT.get(seg, 0L),
+            (long) CACHE_OI_ENTRY_COUNT.get(seg, 0L),
+            (long) CACHE_OI_MEMORY_BYTES.get(seg, 0L),
+            (long) CACHE_OI_SIZE_LIMIT_BYTES.get(seg, 0L)
+        );
+        return new CacheStats(metadata, statistics, columnIndex, offsetIndex);
     }
 
     /**
@@ -402,7 +430,12 @@ public final class StatsLayout {
     }
 
     private static StructLayout cacheStatsGroup(String name) {
-        return MemoryLayout.structLayout(cacheGroup("metadata_cache"), cacheGroup("statistics_cache")).withName(name);
+        return MemoryLayout.structLayout(
+            cacheGroup("metadata_cache"),
+            cacheGroup("statistics_cache"),
+            cacheGroup("column_index_cache"),
+            cacheGroup("offset_index_cache")
+        ).withName(name);
     }
 
     private static StructLayout searchStatsGroup(String name) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheStats.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/stats/CacheStats.java
@@ -18,44 +18,52 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Stats for the two parquet caches owned by {@code CustomCacheManager}:
- * the parquet metadata (footer) cache and the column-statistics cache.
+ * Stats for the four DataFusion parquet caches:
+ * <ul>
+ *   <li>{@code metadata_cache} — footer metadata (per-file parquet footer, row-group stats)</li>
+ *   <li>{@code statistics_cache} — file-level row-group statistics</li>
+ *   <li>{@code column_index_cache} — predicate-driven ColumnIndex (per-page string min/max),
+ *       keyed per {@code (file, col, rg)} cell</li>
+ *   <li>{@code offset_index_cache} — projection-driven OffsetIndex (page byte offsets),
+ *       keyed per {@code (file, col)} cell</li>
+ * </ul>
  *
- * <p>Each sub-group reports five fields. Disabled caches surface as all-zero
- * groups (in particular {@code size_limit_bytes == 0}); the JSON shape stays
- * symmetric so clients can render the response uniformly.
+ * <p>Each sub-group reports five fields. Disabled caches surface as all-zero groups
+ * (in particular {@code size_limit_bytes == 0}); the JSON shape stays symmetric
+ * so clients can render the response uniformly.
  */
 public class CacheStats implements Writeable, ToXContentFragment {
 
     private final CacheGroupStats metadataCache;
     private final CacheGroupStats statisticsCache;
+    private final CacheGroupStats columnIndexCache;
+    private final CacheGroupStats offsetIndexCache;
 
-    /**
-     * Construct from individual sub-group stats.
-     *
-     * @param metadataCache   metadata cache counters (must not be null)
-     * @param statisticsCache statistics cache counters (must not be null)
-     */
-    public CacheStats(CacheGroupStats metadataCache, CacheGroupStats statisticsCache) {
+    public CacheStats(
+        CacheGroupStats metadataCache,
+        CacheGroupStats statisticsCache,
+        CacheGroupStats columnIndexCache,
+        CacheGroupStats offsetIndexCache
+    ) {
         this.metadataCache = Objects.requireNonNull(metadataCache);
         this.statisticsCache = Objects.requireNonNull(statisticsCache);
+        this.columnIndexCache = Objects.requireNonNull(columnIndexCache);
+        this.offsetIndexCache = Objects.requireNonNull(offsetIndexCache);
     }
 
-    /**
-     * Deserialize from stream.
-     *
-     * @param in the stream input
-     * @throws IOException if deserialization fails
-     */
     public CacheStats(StreamInput in) throws IOException {
         this.metadataCache = new CacheGroupStats(in);
         this.statisticsCache = new CacheGroupStats(in);
+        this.columnIndexCache = new CacheGroupStats(in);
+        this.offsetIndexCache = new CacheGroupStats(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         metadataCache.writeTo(out);
         statisticsCache.writeTo(out);
+        columnIndexCache.writeTo(out);
+        offsetIndexCache.writeTo(out);
     }
 
     @Override
@@ -67,18 +75,30 @@ public class CacheStats implements Writeable, ToXContentFragment {
         builder.startObject("statistics_cache");
         statisticsCache.toXContent(builder);
         builder.endObject();
+        builder.startObject("column_index_cache");
+        columnIndexCache.toXContent(builder);
+        builder.endObject();
+        builder.startObject("offset_index_cache");
+        offsetIndexCache.toXContent(builder);
+        builder.endObject();
         builder.endObject();
         return builder;
     }
 
-    /** Returns the metadata cache counters. */
     public CacheGroupStats getMetadataCache() {
         return metadataCache;
     }
 
-    /** Returns the statistics cache counters. */
     public CacheGroupStats getStatisticsCache() {
         return statisticsCache;
+    }
+
+    public CacheGroupStats getColumnIndexCache() {
+        return columnIndexCache;
+    }
+
+    public CacheGroupStats getOffsetIndexCache() {
+        return offsetIndexCache;
     }
 
     @Override
@@ -86,11 +106,14 @@ public class CacheStats implements Writeable, ToXContentFragment {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CacheStats that = (CacheStats) o;
-        return Objects.equals(metadataCache, that.metadataCache) && Objects.equals(statisticsCache, that.statisticsCache);
+        return Objects.equals(metadataCache, that.metadataCache)
+            && Objects.equals(statisticsCache, that.statisticsCache)
+            && Objects.equals(columnIndexCache, that.columnIndexCache)
+            && Objects.equals(offsetIndexCache, that.offsetIndexCache);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(metadataCache, statisticsCache);
+        return Objects.hash(metadataCache, statisticsCache, columnIndexCache, offsetIndexCache);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -115,7 +115,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(33, settings.size());
+            assertEquals(31, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -115,7 +115,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(28, settings.size());
+            assertEquals(32, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -203,11 +203,11 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     }
 
     public void testDeriveMemoryPoolLimitDefaultUsesNativeMemoryLimit() {
-        // 10 GiB native memory limit — default takes 74% straight from limit, not
+        // 10 GiB native memory limit — default takes 71% straight from limit, not
         // from limit - buffer_percent (which is AC's throttle margin, not a framework
-        // budget reduction). 74% of 10 GiB.
+        // budget reduction). 71% of 10 GiB.
         Settings s = Settings.builder().put("node.native_memory.limit", "10gb").build();
-        long expected = (10L * 1024 * 1024 * 1024) * 74 / 100;
+        long expected = (10L * 1024 * 1024 * 1024) * 71 / 100;
         assertEquals(Long.toString(expected), DataFusionPlugin.deriveMemoryPoolLimitDefault(s));
     }
 
@@ -215,14 +215,14 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
         // node.native_memory.buffer_percent is AC's throttle margin. The framework default
         // takes its fraction off node.native_memory.limit directly so the buffer can sit
         // between AC's throttle threshold and the framework's hard cap.
-        // 1000 bytes limit, 20% buffer => pool max still 74% of 1000 = 740.
+        // 1000 bytes limit, 20% buffer => pool max still 71% of 1000 = 710.
         Settings s = Settings.builder().put("node.native_memory.limit", "1000b").put("node.native_memory.buffer_percent", 20).build();
-        assertEquals("740", DataFusionPlugin.deriveMemoryPoolLimitDefault(s));
+        assertEquals("710", DataFusionPlugin.deriveMemoryPoolLimitDefault(s));
     }
 
     public void testMemoryPoolLimitSettingExposesDerivedDefault() {
         Settings s = Settings.builder().put("node.native_memory.limit", "10gb").build();
-        long expected = (10L * 1024 * 1024 * 1024) * 74 / 100;
+        long expected = (10L * 1024 * 1024 * 1024) * 71 / 100;
         assertEquals(Long.valueOf(expected), DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT.get(s));
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -115,7 +115,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(32, settings.size());
+            assertEquals(33, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -166,8 +166,6 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
 
     public void testPluginRegistersAllCacheSettings() {
         List<Setting<?>> settings = new DataFusionPlugin().getSettings();
-        assertTrue(settings.contains(CacheSettings.METADATA_CACHE_SIZE_LIMIT));
-        assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT));
         assertTrue(settings.contains(CacheSettings.METADATA_CACHE_EVICTION_TYPE));
         assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE));
         assertTrue(settings.contains(CacheSettings.METADATA_CACHE_ENABLED));
@@ -228,10 +226,8 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     private ClusterSettings createCacheClusterSettings(Settings settings) {
         Set<Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         all.add(CacheSettings.METADATA_CACHE_ENABLED);
-        all.add(CacheSettings.METADATA_CACHE_SIZE_LIMIT);
         all.add(CacheSettings.METADATA_CACHE_EVICTION_TYPE);
         all.add(CacheSettings.STATISTICS_CACHE_ENABLED);
-        all.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         all.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
         all.add(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
         all.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -172,6 +172,10 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE));
         assertTrue(settings.contains(CacheSettings.METADATA_CACHE_ENABLED));
         assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_ENABLED));
+        assertTrue(settings.contains(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE));
+        assertTrue(settings.contains(CacheSettings.FOOTER_METADATA_CACHE_PERCENT));
+        assertTrue(settings.contains(CacheSettings.OFFSET_INDEX_CACHE_PERCENT));
+        assertTrue(settings.contains(CacheSettings.COLUMN_INDEX_CACHE_PERCENT));
     }
 
     public void testNativeBridgeCacheManagerLifecycle() {
@@ -228,6 +232,10 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         all.add(CacheSettings.STATISTICS_CACHE_ENABLED);
         all.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         all.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
+        all.add(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        all.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
+        all.add(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
+        all.add(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
         all.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
         all.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
         return new ClusterSettings(settings, all);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -176,6 +176,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         assertTrue(settings.contains(CacheSettings.FOOTER_METADATA_CACHE_PERCENT));
         assertTrue(settings.contains(CacheSettings.OFFSET_INDEX_CACHE_PERCENT));
         assertTrue(settings.contains(CacheSettings.COLUMN_INDEX_CACHE_PERCENT));
+        assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_PERCENT));
     }
 
     public void testNativeBridgeCacheManagerLifecycle() {
@@ -236,6 +237,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         all.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         all.add(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         all.add(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
+        all.add(CacheSettings.STATISTICS_CACHE_PERCENT);
         all.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
         all.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
         return new ClusterSettings(settings, all);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
@@ -41,6 +41,10 @@ public class DatafusionCacheManagerTests extends OpenSearchTestCase {
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_ENABLED);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
+        clusterSettingsToAdd.add(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
+        clusterSettingsToAdd.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
+        clusterSettingsToAdd.add(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
+        clusterSettingsToAdd.add(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
         clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
         clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
@@ -36,10 +36,8 @@ public class DatafusionCacheManagerTests extends OpenSearchTestCase {
 
         Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_ENABLED);
-        clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_SIZE_LIMIT);
         clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_ENABLED);
-        clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(CacheSettings.METADATA_INDEX_CACHE_TOTAL_SIZE);
         clusterSettingsToAdd.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
@@ -45,6 +45,7 @@ public class DatafusionCacheManagerTests extends OpenSearchTestCase {
         clusterSettingsToAdd.add(CacheSettings.FOOTER_METADATA_CACHE_PERCENT);
         clusterSettingsToAdd.add(CacheSettings.OFFSET_INDEX_CACHE_PERCENT);
         clusterSettingsToAdd.add(CacheSettings.COLUMN_INDEX_CACHE_PERCENT);
+        clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_PERCENT);
         clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT);
         clusterSettingsToAdd.add(DataFusionPlugin.DATAFUSION_SPILL_MEMORY_LIMIT);
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(33, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(31, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(32, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(33, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -69,7 +69,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(28, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(32, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DatafusionSettings.INDEXED_BATCH_SIZE));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/ClearCacheRequestTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/ClearCacheRequestTests.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link ClearCacheNodesRequest} and {@link ClearCacheNodeRequest}.
+ * Verifies flag semantics, isClearAll() logic, and round-trip serialization.
+ */
+public class ClearCacheRequestTests extends OpenSearchTestCase {
+
+    // ── ClearCacheNodesRequest ────────────────────────────────────────────────
+
+    public void testDefaultNodesRequestIsClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertTrue("no flags set → isClearAll()", req.isClearAll());
+    }
+
+    public void testSetFooterOnlyIsNotClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        req.setFooter(true);
+        assertTrue(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertFalse("footer=true → not clear-all", req.isClearAll());
+    }
+
+    public void testSetColumnOnlyIsNotClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        req.setColumn(true);
+        assertFalse(req.isFooter());
+        assertTrue(req.isColumn());
+        assertFalse(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testSetOffsetOnlyIsNotClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        req.setOffset(true);
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertTrue(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testAllFlagsSetIsNotClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        req.setFooter(true);
+        req.setColumn(true);
+        req.setOffset(true);
+        // isClearAll() is false when any flag is explicitly set — caller chose specific caches
+        assertFalse(req.isClearAll());
+    }
+
+    public void testNodesRequestRoundTrip() throws IOException {
+        ClearCacheNodesRequest original = new ClearCacheNodesRequest();
+        original.setFooter(true);
+        original.setColumn(false);
+        original.setOffset(true);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        ClearCacheNodesRequest deserialized = new ClearCacheNodesRequest(in);
+
+        assertEquals(original.isFooter(), deserialized.isFooter());
+        assertEquals(original.isColumn(), deserialized.isColumn());
+        assertEquals(original.isOffset(), deserialized.isOffset());
+        assertEquals(original.isClearAll(), deserialized.isClearAll());
+    }
+
+    // ── ClearCacheNodeRequest ─────────────────────────────────────────────────
+
+    public void testNodeRequestIsClearAllWhenNoFlagsSet() {
+        ClearCacheNodeRequest req = new ClearCacheNodeRequest(false, false, false);
+        assertTrue(req.isClearAll());
+    }
+
+    public void testNodeRequestIsNotClearAllWhenFlagSet() {
+        ClearCacheNodeRequest req = new ClearCacheNodeRequest(true, false, false);
+        assertFalse(req.isClearAll());
+    }
+
+    public void testNodeRequestRoundTrip() throws IOException {
+        ClearCacheNodeRequest original = new ClearCacheNodeRequest(false, true, true);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        ClearCacheNodeRequest deserialized = new ClearCacheNodeRequest(in);
+
+        assertFalse(deserialized.isFooter());
+        assertTrue(deserialized.isColumn());
+        assertTrue(deserialized.isOffset());
+        assertFalse(deserialized.isClearAll());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/RestClearCacheActionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/RestClearCacheActionTests.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action.stats;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.client.NoOpNodeClient;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * Unit tests for {@link RestClearCacheAction}.
+ */
+public class RestClearCacheActionTests extends OpenSearchTestCase {
+
+    private RestClearCacheAction action;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new RestClearCacheAction();
+    }
+
+    public void testSinglePostRoute() {
+        List<Route> routes = action.routes();
+        assertEquals(1, routes.size());
+        assertEquals(POST, routes.get(0).getMethod());
+        assertEquals("/_plugins/_analytics_backend_datafusion/cache/_clear", routes.get(0).getPath());
+    }
+
+    public void testName() {
+        assertEquals("datafusion_clear_cache_action", action.getName());
+    }
+
+    public void testDoesNotTripCircuitBreaker() {
+        assertFalse(action.canTripCircuitBreaker());
+    }
+
+    public void testNoParamsSendsClearAllRequest() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of());
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertTrue("no params → isClearAll()", req.isClearAll());
+    }
+
+    public void testFooterParamSetsFooterFlag() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("footer", "true"));
+        assertTrue(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testColumnParamSetsColumnFlag() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("column", "true"));
+        assertFalse(req.isFooter());
+        assertTrue(req.isColumn());
+        assertFalse(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testOffsetParamSetsOffsetFlag() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("offset", "true"));
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertTrue(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testMultipleParamsSetsMultipleFlags() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("column", "true", "offset", "true"));
+        assertFalse(req.isFooter());
+        assertTrue(req.isColumn());
+        assertTrue(req.isOffset());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testFalseParamDoesNotSetFlag() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("footer", "false", "column", "true"));
+        assertFalse(req.isFooter());
+        assertTrue(req.isColumn());
+        assertFalse(req.isClearAll());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ClearCacheNodesRequest captureRequest(Map<String, String> params) throws Exception {
+        AtomicReference<ClearCacheNodesRequest> captured = new AtomicReference<>();
+        try (NodeClient client = new NoOpNodeClient(getTestName()) {
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> actionType,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                if (request instanceof ClearCacheNodesRequest) {
+                    captured.set((ClearCacheNodesRequest) request);
+                }
+            }
+        }) {
+            FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withPath(
+                "/_plugins/_analytics_backend_datafusion/cache/_clear"
+            ).withParams(new HashMap<>(params)).build();
+            FakeRestChannel channel = new FakeRestChannel(restRequest, false, 1);
+            action.handleRequest(restRequest, channel, client);
+        }
+        assertNotNull("request must have been captured", captured.get());
+        return captured.get();
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
@@ -120,4 +120,81 @@ public class CacheSettingsPercentValidationTests extends OpenSearchTestCase {
         // Due to integer division, sum may be up to 2 bytes less than total
         assertTrue("sum should be close to total", sum <= total && sum >= total - 2);
     }
+
+    // ── 4-arg validatePercentSum (with statistics) ────────────────────────────
+
+    public void testFourArgDefaultsSumTo100() {
+        // New defaults: 48 + 34 + 13 + 5 = 100
+        CacheSettings.validatePercentSum(48, 34, 13, 5);
+    }
+
+    public void testFourArgSumOver100Throws() {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> CacheSettings.validatePercentSum(48, 34, 13, 10)  // 105
+        );
+        assertTrue("error must mention sum", ex.getMessage().contains("sum=105"));
+        assertTrue("error must name statistics key", ex.getMessage().contains("statistics_percent"));
+    }
+
+    public void testFourArgSumUnder100PassesHeadroomAccepted() {
+        CacheSettings.validatePercentSum(40, 30, 10, 5);   // 85% — headroom OK
+        CacheSettings.validatePercentSum(1, 1, 1, 1);      // 4% — valid
+    }
+
+    public void testFourArgRaisingStatisticsAloneBreaks() {
+        // Raising statistics alone: 48+34+13+15=110 → rejected
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> CacheSettings.validatePercentSum(48, 34, 13, 15));
+        assertTrue(ex.getMessage().contains("sum=110"));
+    }
+
+    public void testFourArgAtomicUpdateAllFourPasses() {
+        // User sends all four in one PUT: 45+33+12+5=95 — headroom allowed
+        CacheSettings.validatePercentSum(45, 33, 12, 5);
+    }
+
+    // ── 4-arg computeCacheSizes ───────────────────────────────────────────────
+
+    public void testFourArgComputeSizesDefaultSplit() {
+        long total = 1_150_000_000L; // ~1.15 GB (3% of 38.4 GB native limit on r6g.2xlarge)
+        long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
+        assertEquals(4, sizes.length);
+        assertEquals(total * 48 / 100, sizes[0]); // footer ~552 MB
+        assertEquals(total * 34 / 100, sizes[1]); // offset index ~391 MB
+        assertEquals(total * 13 / 100, sizes[2]); // column index ~150 MB
+        assertEquals(total * 5 / 100, sizes[3]); // statistics ~58 MB
+    }
+
+    public void testFourArgComputeSizesStatisticsNotZero() {
+        // Statistics cache must get a non-zero allocation with default 5%
+        long total = 1_000_000L;
+        long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
+        assertTrue("statistics cache must get non-zero bytes", sizes[3] > 0);
+        assertEquals(50_000L, sizes[3]); // 5% of 1_000_000
+    }
+
+    public void testFourArgComputeSizesZeroTotalGivesZeros() {
+        long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, 0L);
+        for (long s : sizes)
+            assertEquals(0L, s);
+    }
+
+    public void testFourArgComputeSizesSumWithinBudget() {
+        long total = 1_000_000L;
+        long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
+        long sum = sizes[0] + sizes[1] + sizes[2] + sizes[3];
+        assertTrue("sum must not exceed total", sum <= total);
+        // 48+34+13+5=100, integer division may lose up to 3 bytes
+        assertTrue("sum must be close to total", sum >= total - 3);
+    }
+
+    public void testStatisticsWasNotWiredPreviouslyNowItIs() {
+        // Previously statistics cache used STATISTICS_CACHE_SIZE_LIMIT (standalone 100MB).
+        // Now it derives from STATISTICS_CACHE_PERCENT × METADATA_INDEX_CACHE_TOTAL_SIZE.
+        // This test documents the new behavior: statistics bytes come from the unified budget.
+        long total = 1_000_000L;
+        long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
+        // With 5% of 1MB budget = 50KB. The old standalone 100MB default is no longer used.
+        assertEquals("statistics cache must use percent-derived limit, not standalone 100MB default", 50_000L, sizes[3]);
+    }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.cache;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for {@link CacheSettings#validatePercentSum} and
+ * {@link CacheSettings#computeCacheSizes}.
+ *
+ * <p>The three sub-cache percentages (footer_metadata, offset_index, column_index)
+ * must sum to exactly 100. This mirrors the Arrow pool model: each pool's max is
+ * validated against the total budget — here, percentages are the "shares" and the
+ * validation fires when any share changes (via
+ * {@code DataFusionPlugin.recomputePageCacheLimits}).
+ *
+ * <p>User workflow: to change the split, send all three in one
+ * {@code PUT /_cluster/settings} call so they are applied atomically and the
+ * sum-to-100 invariant holds at validation time.
+ */
+public class CacheSettingsPercentValidationTests extends OpenSearchTestCase {
+
+    // ── validatePercentSum ────────────────────────────────────────────────────
+
+    public void testDefaultsSumTo100() {
+        // Defaults: 50 + 35 + 15 = 100 — exactly at limit, passes
+        CacheSettings.validatePercentSum(50, 35, 15);
+    }
+
+    public void testSumExactly100Passes() {
+        CacheSettings.validatePercentSum(60, 30, 10);
+        CacheSettings.validatePercentSum(33, 34, 33);
+        CacheSettings.validatePercentSum(1, 1, 98);
+    }
+
+    public void testSumUnder100PassesHeadroomAccepted() {
+        // Mirrors Arrow pool model: sum(max) <= budget. Unused headroom is fine.
+        CacheSettings.validatePercentSum(50, 35, 10);   // 95% — 5% unused
+        CacheSettings.validatePercentSum(40, 30, 10);   // 80% — 20% unused
+        CacheSettings.validatePercentSum(1, 1, 1);      // 3% — 97% unused
+    }
+
+    public void testSumZeroPasses() {
+        // All zeros is technically valid (all headroom, no caches get any bytes)
+        CacheSettings.validatePercentSum(1, 1, 1); // 3% — valid
+    }
+
+    public void testSinglePercentLoweredAlonePasses() {
+        // User lowers column_index_percent from 15→5 alone: 50+35+5=90 ≤ 100 → accepted.
+        // This is the key user-friendly case — lowering alone doesn't need an atomic update.
+        CacheSettings.validatePercentSum(50, 35, 5);
+    }
+
+    public void testSinglePercentRaisedAloneBreaks() {
+        // User raises column_index_percent from 15→25 alone: 50+35+25=110 > 100 → rejected.
+        // To raise one, user must lower another in the same PUT /_cluster/settings call.
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> CacheSettings.validatePercentSum(50, 35, 25));
+        assertTrue("error must mention sum", ex.getMessage().contains("sum=110"));
+        assertTrue("error must name the keys", ex.getMessage().contains("footer_metadata_percent"));
+        assertTrue("error must name the keys", ex.getMessage().contains("offset_index_percent"));
+        assertTrue("error must name the keys", ex.getMessage().contains("column_index_percent"));
+    }
+
+    public void testSumOver100Throws() {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> CacheSettings.validatePercentSum(50, 35, 20)  // 105
+        );
+        assertTrue("error must mention sum", ex.getMessage().contains("sum=105"));
+    }
+
+    public void testAtomicUpdateAllThreePasses() {
+        // User sends all three in one PUT /_cluster/settings: 50/35/15 → 40/40/20 (still ≤ 100).
+        CacheSettings.validatePercentSum(40, 40, 20);
+    }
+
+    public void testAtomicUpdateWithHeadroomPasses() {
+        // User updates to leave some headroom: 40/30/20 = 90% — valid.
+        CacheSettings.validatePercentSum(40, 30, 20);
+    }
+
+    // ── computeCacheSizes ─────────────────────────────────────────────────────
+
+    public void testComputeSizesDefaultSplit() {
+        // 1 GB total, defaults 50/35/15
+        long total = 1024L * 1024 * 1024; // 1 GB
+        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, total);
+        assertEquals(3, sizes.length);
+        assertEquals(total * 50 / 100, sizes[0]); // footer ~512 MB
+        assertEquals(total * 35 / 100, sizes[1]); // offset ~358 MB
+        assertEquals(total * 15 / 100, sizes[2]); // column ~153 MB
+    }
+
+    public void testComputeSizesEqualSplit() {
+        long total = 300L;
+        long[] sizes = CacheSettings.computeCacheSizes(34, 33, 33, total);
+        assertEquals(102L, sizes[0]);
+        assertEquals(99L, sizes[1]);
+        assertEquals(99L, sizes[2]);
+    }
+
+    public void testComputeSizesZeroTotalGivesZeros() {
+        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, 0L);
+        assertEquals(0L, sizes[0]);
+        assertEquals(0L, sizes[1]);
+        assertEquals(0L, sizes[2]);
+    }
+
+    public void testComputeSizesTotalMatchesBudget() {
+        // The three absolute sizes should be within 2 bytes of the total (integer division rounding)
+        long total = 1_000_000L;
+        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, total);
+        long sum = sizes[0] + sizes[1] + sizes[2];
+        // Due to integer division, sum may be up to 2 bytes less than total
+        assertTrue("sum should be close to total", sum <= total && sum >= total - 2);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
@@ -13,173 +13,88 @@ import org.opensearch.test.OpenSearchTestCase;
 /**
  * Tests for {@link CacheSettings#validatePercentSum} and
  * {@link CacheSettings#computeCacheSizes}.
- *
- * <p>The three sub-cache percentages (footer_metadata, offset_index, column_index)
- * must sum to exactly 100. This mirrors the Arrow pool model: each pool's max is
- * validated against the total budget — here, percentages are the "shares" and the
- * validation fires when any share changes (via
- * {@code DataFusionPlugin.recomputePageCacheLimits}).
- *
- * <p>User workflow: to change the split, send all three in one
- * {@code PUT /_cluster/settings} call so they are applied atomically and the
- * sum-to-100 invariant holds at validation time.
  */
 public class CacheSettingsPercentValidationTests extends OpenSearchTestCase {
 
     // ── validatePercentSum ────────────────────────────────────────────────────
 
     public void testDefaultsSumTo100() {
-        // Defaults: 50 + 35 + 15 = 100 — exactly at limit, passes
-        CacheSettings.validatePercentSum(50, 35, 15);
+        // Defaults: 48 + 34 + 13 + 5 = 100
+        CacheSettings.validatePercentSum(48, 34, 13, 5);
     }
 
     public void testSumExactly100Passes() {
-        CacheSettings.validatePercentSum(60, 30, 10);
-        CacheSettings.validatePercentSum(33, 34, 33);
-        CacheSettings.validatePercentSum(1, 1, 98);
+        CacheSettings.validatePercentSum(60, 25, 10, 5);
+        CacheSettings.validatePercentSum(33, 34, 28, 5);
+        CacheSettings.validatePercentSum(1, 1, 97, 1);
     }
 
     public void testSumUnder100PassesHeadroomAccepted() {
-        // Mirrors Arrow pool model: sum(max) <= budget. Unused headroom is fine.
-        CacheSettings.validatePercentSum(50, 35, 10);   // 95% — 5% unused
-        CacheSettings.validatePercentSum(40, 30, 10);   // 80% — 20% unused
-        CacheSettings.validatePercentSum(1, 1, 1);      // 3% — 97% unused
-    }
-
-    public void testSumZeroPasses() {
-        // All zeros is technically valid (all headroom, no caches get any bytes)
-        CacheSettings.validatePercentSum(1, 1, 1); // 3% — valid
-    }
-
-    public void testSinglePercentLoweredAlonePasses() {
-        // User lowers column_index_percent from 15→5 alone: 50+35+5=90 ≤ 100 → accepted.
-        // This is the key user-friendly case — lowering alone doesn't need an atomic update.
-        CacheSettings.validatePercentSum(50, 35, 5);
+        CacheSettings.validatePercentSum(48, 34, 13, 1);  // 96% — 4% unused
+        CacheSettings.validatePercentSum(40, 30, 10, 5);  // 85% — headroom OK
+        CacheSettings.validatePercentSum(1, 1, 1, 1);     // 4% — valid
     }
 
     public void testSinglePercentRaisedAloneBreaks() {
-        // User raises column_index_percent from 15→25 alone: 50+35+25=110 > 100 → rejected.
-        // To raise one, user must lower another in the same PUT /_cluster/settings call.
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> CacheSettings.validatePercentSum(50, 35, 25));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> CacheSettings.validatePercentSum(48, 34, 13, 15)  // 110
+        );
         assertTrue("error must mention sum", ex.getMessage().contains("sum=110"));
-        assertTrue("error must name the keys", ex.getMessage().contains("footer_metadata_percent"));
-        assertTrue("error must name the keys", ex.getMessage().contains("offset_index_percent"));
-        assertTrue("error must name the keys", ex.getMessage().contains("column_index_percent"));
+        assertTrue("error must name statistics key", ex.getMessage().contains("statistics_percent"));
     }
 
     public void testSumOver100Throws() {
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> CacheSettings.validatePercentSum(50, 35, 20)  // 105
+            () -> CacheSettings.validatePercentSum(50, 35, 20, 5)  // 110
         );
-        assertTrue("error must mention sum", ex.getMessage().contains("sum=105"));
+        assertTrue("error must mention sum", ex.getMessage().contains("sum=110"));
     }
 
-    public void testAtomicUpdateAllThreePasses() {
-        // User sends all three in one PUT /_cluster/settings: 50/35/15 → 40/40/20 (still ≤ 100).
-        CacheSettings.validatePercentSum(40, 40, 20);
+    public void testAtomicUpdateAllFourPasses() {
+        CacheSettings.validatePercentSum(45, 33, 12, 5);  // 95% — headroom allowed
+        CacheSettings.validatePercentSum(40, 40, 15, 5);  // 100% — exact
     }
 
-    public void testAtomicUpdateWithHeadroomPasses() {
-        // User updates to leave some headroom: 40/30/20 = 90% — valid.
-        CacheSettings.validatePercentSum(40, 30, 20);
+    public void testErrorMessageNamesAllKeys() {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> CacheSettings.validatePercentSum(48, 34, 13, 10)  // 105
+        );
+        assertTrue(ex.getMessage().contains("footer_metadata_percent"));
+        assertTrue(ex.getMessage().contains("offset_index_percent"));
+        assertTrue(ex.getMessage().contains("column_index_percent"));
+        assertTrue(ex.getMessage().contains("statistics_percent"));
+        assertTrue(ex.getMessage().contains("sum=105"));
     }
 
     // ── computeCacheSizes ─────────────────────────────────────────────────────
 
     public void testComputeSizesDefaultSplit() {
-        // 1 GB total, defaults 50/35/15
-        long total = 1024L * 1024 * 1024; // 1 GB
-        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, total);
-        assertEquals(3, sizes.length);
-        assertEquals(total * 50 / 100, sizes[0]); // footer ~512 MB
-        assertEquals(total * 35 / 100, sizes[1]); // offset ~358 MB
-        assertEquals(total * 15 / 100, sizes[2]); // column ~153 MB
-    }
-
-    public void testComputeSizesEqualSplit() {
-        long total = 300L;
-        long[] sizes = CacheSettings.computeCacheSizes(34, 33, 33, total);
-        assertEquals(102L, sizes[0]);
-        assertEquals(99L, sizes[1]);
-        assertEquals(99L, sizes[2]);
-    }
-
-    public void testComputeSizesZeroTotalGivesZeros() {
-        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, 0L);
-        assertEquals(0L, sizes[0]);
-        assertEquals(0L, sizes[1]);
-        assertEquals(0L, sizes[2]);
-    }
-
-    public void testComputeSizesTotalMatchesBudget() {
-        // The three absolute sizes should be within 2 bytes of the total (integer division rounding)
-        long total = 1_000_000L;
-        long[] sizes = CacheSettings.computeCacheSizes(50, 35, 15, total);
-        long sum = sizes[0] + sizes[1] + sizes[2];
-        // Due to integer division, sum may be up to 2 bytes less than total
-        assertTrue("sum should be close to total", sum <= total && sum >= total - 2);
-    }
-
-    // ── 4-arg validatePercentSum (with statistics) ────────────────────────────
-
-    public void testFourArgDefaultsSumTo100() {
-        // New defaults: 48 + 34 + 13 + 5 = 100
-        CacheSettings.validatePercentSum(48, 34, 13, 5);
-    }
-
-    public void testFourArgSumOver100Throws() {
-        IllegalArgumentException ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> CacheSettings.validatePercentSum(48, 34, 13, 10)  // 105
-        );
-        assertTrue("error must mention sum", ex.getMessage().contains("sum=105"));
-        assertTrue("error must name statistics key", ex.getMessage().contains("statistics_percent"));
-    }
-
-    public void testFourArgSumUnder100PassesHeadroomAccepted() {
-        CacheSettings.validatePercentSum(40, 30, 10, 5);   // 85% — headroom OK
-        CacheSettings.validatePercentSum(1, 1, 1, 1);      // 4% — valid
-    }
-
-    public void testFourArgRaisingStatisticsAloneBreaks() {
-        // Raising statistics alone: 48+34+13+15=110 → rejected
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> CacheSettings.validatePercentSum(48, 34, 13, 15));
-        assertTrue(ex.getMessage().contains("sum=110"));
-    }
-
-    public void testFourArgAtomicUpdateAllFourPasses() {
-        // User sends all four in one PUT: 45+33+12+5=95 — headroom allowed
-        CacheSettings.validatePercentSum(45, 33, 12, 5);
-    }
-
-    // ── 4-arg computeCacheSizes ───────────────────────────────────────────────
-
-    public void testFourArgComputeSizesDefaultSplit() {
         long total = 1_150_000_000L; // ~1.15 GB (3% of 38.4 GB native limit on r6g.2xlarge)
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
         assertEquals(4, sizes.length);
         assertEquals(total * 48 / 100, sizes[0]); // footer ~552 MB
         assertEquals(total * 34 / 100, sizes[1]); // offset index ~391 MB
         assertEquals(total * 13 / 100, sizes[2]); // column index ~150 MB
-        assertEquals(total * 5 / 100, sizes[3]); // statistics ~58 MB
+        assertEquals(total * 5 / 100, sizes[3]);  // statistics ~58 MB
     }
 
-    public void testFourArgComputeSizesStatisticsNotZero() {
-        // Statistics cache must get a non-zero allocation with default 5%
+    public void testComputeSizesStatisticsNotZero() {
         long total = 1_000_000L;
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
         assertTrue("statistics cache must get non-zero bytes", sizes[3] > 0);
         assertEquals(50_000L, sizes[3]); // 5% of 1_000_000
     }
 
-    public void testFourArgComputeSizesZeroTotalGivesZeros() {
+    public void testComputeSizesZeroTotalGivesZeros() {
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, 0L);
         for (long s : sizes)
             assertEquals(0L, s);
     }
 
-    public void testFourArgComputeSizesSumWithinBudget() {
+    public void testComputeSizesSumWithinBudget() {
         long total = 1_000_000L;
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
         long sum = sizes[0] + sizes[1] + sizes[2] + sizes[3];
@@ -188,13 +103,10 @@ public class CacheSettingsPercentValidationTests extends OpenSearchTestCase {
         assertTrue("sum must be close to total", sum >= total - 3);
     }
 
-    public void testStatisticsWasNotWiredPreviouslyNowItIs() {
-        // Previously statistics cache used STATISTICS_CACHE_SIZE_LIMIT (standalone 100MB).
-        // Now it derives from STATISTICS_CACHE_PERCENT × METADATA_INDEX_CACHE_TOTAL_SIZE.
-        // This test documents the new behavior: statistics bytes come from the unified budget.
+    public void testStatisticsUsesPercentDerivedLimit() {
+        // Statistics bytes come from the unified percent budget, not a standalone hardcoded limit.
         long total = 1_000_000L;
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
-        // With 5% of 1MB budget = 50KB. The old standalone 100MB default is no longer used.
-        assertEquals("statistics cache must use percent-derived limit, not standalone 100MB default", 50_000L, sizes[3]);
+        assertEquals("statistics cache must use percent-derived limit", 50_000L, sizes[3]);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutPropertyTests.java
@@ -35,7 +35,7 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
 
     private static final int TRIES = 100;
 
-    private static final int FIELD_COUNT = 75;
+    private static final int FIELD_COUNT = 85;
 
     // ---- Generators ----
 
@@ -187,26 +187,36 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                 assertEquals(values[55], cs.getStatisticsCache().entryCount);
                 assertEquals(values[56], cs.getStatisticsCache().memoryBytes);
                 assertEquals(values[57], cs.getStatisticsCache().sizeLimitBytes);
+                assertEquals(values[58], cs.getColumnIndexCache().hitCount);
+                assertEquals(values[59], cs.getColumnIndexCache().missCount);
+                assertEquals(values[60], cs.getColumnIndexCache().entryCount);
+                assertEquals(values[61], cs.getColumnIndexCache().memoryBytes);
+                assertEquals(values[62], cs.getColumnIndexCache().sizeLimitBytes);
+                assertEquals(values[63], cs.getOffsetIndexCache().hitCount);
+                assertEquals(values[64], cs.getOffsetIndexCache().missCount);
+                assertEquals(values[65], cs.getOffsetIndexCache().entryCount);
+                assertEquals(values[66], cs.getOffsetIndexCache().memoryBytes);
+                assertEquals(values[67], cs.getOffsetIndexCache().sizeLimitBytes);
 
-                // Search stats (offsets 58-74)
+                // Search stats (offsets 68-84)
                 var ss = StatsLayout.readSearchStats(seg);
-                assertEquals(values[58], ss.listingTableScan);
-                assertEquals(values[59], ss.singleCollectorScan);
-                assertEquals(values[60], ss.bitmapTreeScan);
-                assertEquals(values[61], ss.delegationCalls);
-                assertEquals(values[62], ss.rgProcessed);
-                assertEquals(values[63], ss.rgSkipped);
-                assertEquals(values[64], ss.parquetScanTotalTimeMs);
-                assertEquals(values[65], ss.parquetScanUntilDataTimeMs);
-                assertEquals(values[66], ss.parquetProcessingTimeMs);
-                assertEquals(values[67], ss.parquetBytesScanned);
-                assertEquals(values[68], ss.prefetchWaitTimeMs);
-                assertEquals(values[69], ss.prefetchWaitCount);
-                assertEquals(values[70], ss.elapsedComputeMs);
-                assertEquals(values[71], ss.buildMaskTimeMs);
-                assertEquals(values[72], ss.onBatchMaskTimeMs);
-                assertEquals(values[73], ss.filterRecordBatchTimeMs);
-                assertEquals(values[74], ss.objectStoreReadTimeMs);
+                assertEquals(values[68], ss.listingTableScan);
+                assertEquals(values[69], ss.singleCollectorScan);
+                assertEquals(values[70], ss.bitmapTreeScan);
+                assertEquals(values[71], ss.delegationCalls);
+                assertEquals(values[72], ss.rgProcessed);
+                assertEquals(values[73], ss.rgSkipped);
+                assertEquals(values[74], ss.parquetScanTotalTimeMs);
+                assertEquals(values[75], ss.parquetScanUntilDataTimeMs);
+                assertEquals(values[76], ss.parquetProcessingTimeMs);
+                assertEquals(values[77], ss.parquetBytesScanned);
+                assertEquals(values[78], ss.prefetchWaitTimeMs);
+                assertEquals(values[79], ss.prefetchWaitCount);
+                assertEquals(values[80], ss.elapsedComputeMs);
+                assertEquals(values[81], ss.buildMaskTimeMs);
+                assertEquals(values[82], ss.onBatchMaskTimeMs);
+                assertEquals(values[83], ss.filterRecordBatchTimeMs);
+                assertEquals(values[84], ss.objectStoreReadTimeMs);
             }
         }
     }
@@ -328,6 +338,18 @@ public class StatsLayoutPropertyTests extends OpenSearchTestCase {
                     cs.getStatisticsCache().entryCount,
                     cs.getStatisticsCache().memoryBytes,
                     cs.getStatisticsCache().sizeLimitBytes,
+                    // cache_stats.column_index_cache (5)
+                    cs.getColumnIndexCache().hitCount,
+                    cs.getColumnIndexCache().missCount,
+                    cs.getColumnIndexCache().entryCount,
+                    cs.getColumnIndexCache().memoryBytes,
+                    cs.getColumnIndexCache().sizeLimitBytes,
+                    // cache_stats.offset_index_cache (5)
+                    cs.getOffsetIndexCache().hitCount,
+                    cs.getOffsetIndexCache().missCount,
+                    cs.getOffsetIndexCache().entryCount,
+                    cs.getOffsetIndexCache().memoryBytes,
+                    cs.getOffsetIndexCache().sizeLimitBytes,
                     // search_stats (17)
                     ss.listingTableScan,
                     ss.singleCollectorScan,

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/nativelib/StatsLayoutTests.java
@@ -22,10 +22,10 @@ import java.lang.foreign.ValueLayout;
  */
 public class StatsLayoutTests extends OpenSearchTestCase {
 
-    /** 7.1: Layout byte size must be 600 (75 × 8). */
+    /** 7.1: Layout byte size must be 640 (85 × 8). */
     public void testLayoutByteSize() {
-        assertEquals(600L, StatsLayout.LAYOUT.byteSize());
-        assertEquals(75 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
+        assertEquals(680L, StatsLayout.LAYOUT.byteSize());
+        assertEquals(85 * Long.BYTES, (int) StatsLayout.LAYOUT.byteSize());
     }
 
     /** 7.2: readRuntimeMetrics decodes 9 known values from io_runtime group. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/CacheStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/CacheStatsTests.java
@@ -90,21 +90,33 @@ public class CacheStatsTests extends OpenSearchTestCase {
     // ---- CacheStats ----
 
     public void testCacheStatsConstructorRejectsNullSubGroups() {
-        expectThrows(NullPointerException.class, () -> new CacheStats(null, new CacheGroupStats(0, 0, 0, 0, 0)));
-        expectThrows(NullPointerException.class, () -> new CacheStats(new CacheGroupStats(0, 0, 0, 0, 0), null));
+        CacheGroupStats g = new CacheGroupStats(0, 0, 0, 0, 0);
+        expectThrows(NullPointerException.class, () -> new CacheStats(null, g, g, g));
+        expectThrows(NullPointerException.class, () -> new CacheStats(g, null, g, g));
+        expectThrows(NullPointerException.class, () -> new CacheStats(g, g, null, g));
+        expectThrows(NullPointerException.class, () -> new CacheStats(g, g, g, null));
     }
 
     public void testCacheStatsAccessors() {
         CacheGroupStats meta = new CacheGroupStats(1, 2, 3, 4, 5);
         CacheGroupStats stats = new CacheGroupStats(6, 7, 8, 9, 10);
-        CacheStats c = new CacheStats(meta, stats);
+        CacheGroupStats scoped = new CacheGroupStats(11, 12, 13, 14, 15);
+        CacheGroupStats offset = new CacheGroupStats(11, 12, 13, 14, 15);
+        CacheStats c = new CacheStats(meta, stats, scoped, offset);
 
         assertSame(meta, c.getMetadataCache());
         assertSame(stats, c.getStatisticsCache());
+        assertSame(scoped, c.getColumnIndexCache());
+        assertSame(offset, c.getOffsetIndexCache());
     }
 
     public void testCacheStatsWriteableRoundTrip() throws IOException {
-        CacheStats original = new CacheStats(new CacheGroupStats(11, 12, 13, 14, 15), new CacheGroupStats(21, 22, 23, 24, 25));
+        CacheStats original = new CacheStats(
+            new CacheGroupStats(11, 12, 13, 14, 15),
+            new CacheGroupStats(21, 22, 23, 24, 25),
+            new CacheGroupStats(31, 32, 33, 34, 35),
+            new CacheGroupStats(41, 42, 43, 44, 45)
+        );
         BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
         StreamInput in = out.bytes().streamInput();
@@ -113,7 +125,12 @@ public class CacheStatsTests extends OpenSearchTestCase {
     }
 
     public void testCacheStatsToXContentShape() throws IOException {
-        CacheStats c = new CacheStats(new CacheGroupStats(11, 0, 3, 1024, 250_000_000), new CacheGroupStats(0, 7, 0, 0, 100_000_000));
+        CacheStats c = new CacheStats(
+            new CacheGroupStats(11, 0, 3, 1024, 250_000_000),
+            new CacheGroupStats(0, 7, 0, 0, 100_000_000),
+            new CacheGroupStats(5, 1, 2, 512, 64_000_000),
+            new CacheGroupStats(5, 2, 3, 256, 32_000_000)
+        );
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         c.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -122,9 +139,11 @@ public class CacheStatsTests extends OpenSearchTestCase {
 
         // Top-level wrapper
         assertTrue("expected cache_stats wrapper, got: " + json, json.contains("\"cache_stats\""));
-        // Both sub-groups present
+        // All four sub-groups present
         assertTrue(json.contains("\"metadata_cache\""));
         assertTrue(json.contains("\"statistics_cache\""));
+        assertTrue(json.contains("\"column_index_cache\""));
+        assertTrue(json.contains("\"offset_index_cache\""));
         // Per-group fields
         assertTrue(json.contains("\"hit_count\":11"));
         assertTrue(json.contains("\"miss_count\":7"));
@@ -132,27 +151,50 @@ public class CacheStatsTests extends OpenSearchTestCase {
         assertTrue(json.contains("\"memory_bytes\":1024"));
         assertTrue(json.contains("\"size_limit_bytes\":250000000"));
         assertTrue(json.contains("\"size_limit_bytes\":100000000"));
+        assertTrue(json.contains("\"size_limit_bytes\":64000000"));
+        assertTrue(json.contains("\"size_limit_bytes\":32000000"));
     }
 
     public void testCacheStatsZeroedRendersAllZeros() throws IOException {
-        CacheStats zero = new CacheStats(new CacheGroupStats(0, 0, 0, 0, 0), new CacheGroupStats(0, 0, 0, 0, 0));
+        CacheStats zero = new CacheStats(
+            new CacheGroupStats(0, 0, 0, 0, 0),
+            new CacheGroupStats(0, 0, 0, 0, 0),
+            new CacheGroupStats(0, 0, 0, 0, 0),
+            new CacheGroupStats(0, 0, 0, 0, 0)
+        );
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         zero.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String json = builder.toString();
 
-        // Disabled-cache sentinel: both size_limit_bytes are 0
+        // Disabled-cache sentinel: all four size_limit_bytes are 0
         long sizeLimitOccurrences = json.split("\"size_limit_bytes\":0", -1).length - 1;
-        assertEquals("expected size_limit_bytes:0 to appear twice (one per sub-cache)", 2, sizeLimitOccurrences);
+        assertEquals("expected size_limit_bytes:0 to appear four times (one per sub-cache)", 4, sizeLimitOccurrences);
         // hit_rate must not be NaN
         assertFalse("hit_rate must not be NaN: " + json, json.contains("NaN"));
     }
 
     public void testCacheStatsEqualsAndHashCode() {
-        CacheStats a = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 10));
-        CacheStats b = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 10));
-        CacheStats c = new CacheStats(new CacheGroupStats(1, 2, 3, 4, 5), new CacheGroupStats(6, 7, 8, 9, 99));
+        // c differs only in statisticsCache (sizeLimitBytes 10 → 99)
+        CacheStats a = new CacheStats(
+            new CacheGroupStats(1, 2, 3, 4, 5),
+            new CacheGroupStats(6, 7, 8, 9, 10),
+            new CacheGroupStats(11, 12, 13, 14, 15),
+            new CacheGroupStats(16, 17, 18, 19, 20)
+        );
+        CacheStats b = new CacheStats(
+            new CacheGroupStats(1, 2, 3, 4, 5),
+            new CacheGroupStats(6, 7, 8, 9, 10),
+            new CacheGroupStats(11, 12, 13, 14, 15),
+            new CacheGroupStats(16, 17, 18, 19, 20)
+        );
+        CacheStats c = new CacheStats(
+            new CacheGroupStats(1, 2, 3, 4, 5),
+            new CacheGroupStats(6, 7, 8, 9, 99),
+            new CacheGroupStats(11, 12, 13, 14, 15),
+            new CacheGroupStats(16, 17, 18, 19, 20)
+        );
 
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsPropertyTests.java
@@ -108,7 +108,7 @@ public class DataFusionStatsPropertyTests extends OpenSearchTestCase {
     }
 
     private CacheStats randomCacheStats() {
-        return new CacheStats(randomCacheGroupStats(), randomCacheGroupStats());
+        return new CacheStats(randomCacheGroupStats(), randomCacheGroupStats(), randomCacheGroupStats(), randomCacheGroupStats());
     }
 
     private SearchStats randomSearchStats() {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/stats/DataFusionStatsTests.java
@@ -278,7 +278,9 @@ public class DataFusionStatsTests extends OpenSearchTestCase {
 
         CacheStats cache = new CacheStats(
             new CacheGroupStats(100, 5, 25, 4096, 250_000_000),
-            new CacheGroupStats(50, 0, 25, 2048, 100_000_000)
+            new CacheGroupStats(50, 0, 25, 2048, 100_000_000),
+            new CacheGroupStats(20, 3, 8, 1024, 64_000_000),
+            new CacheGroupStats(15, 2, 5, 512, 16_000_000)
         );
         DataFusionStats stats = new DataFusionStats(
             new NativeExecutorsStats(io, null, taskMonitors),

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DataFusionCacheClearIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DataFusionCacheClearIT.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests for {@code POST /_plugins/_analytics_backend_datafusion/cache/_clear}.
+ *
+ * <p>Tests verify:
+ * <ul>
+ *   <li>Clear all: no params — returns 200, {@code acknowledged=true}, non-empty {@code cleared_nodes}</li>
+ *   <li>Selective clear: {@code ?footer=true}, {@code ?column=true}, {@code ?offset=true} — each returns 200</li>
+ *   <li>Combined params: {@code ?column=true&offset=true} — returns 200</li>
+ *   <li>Unknown param: ignored (backward compat) — still returns 200</li>
+ * </ul>
+ *
+ * <p>The cache contents themselves are not observable via REST (stats endpoint is PR 1),
+ * so these tests verify only that the action completes successfully and returns a
+ * well-formed response.
+ */
+public class DataFusionCacheClearIT extends AnalyticsRestTestCase {
+
+    private static final String CLEAR_ENDPOINT = "/_plugins/_analytics_backend_datafusion/cache/_clear";
+
+    // ── clear all ────────────────────────────────────────────────────────────
+
+    public void testClearAllCachesReturns200WithAcknowledged() throws IOException {
+        Map<String, Object> body = clearCache("");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    // ── selective: single param ───────────────────────────────────────────────
+
+    public void testClearFooterCacheOnly() throws IOException {
+        Map<String, Object> body = clearCache("?footer=true");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    public void testClearColumnIndexCacheOnly() throws IOException {
+        Map<String, Object> body = clearCache("?column=true");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    public void testClearOffsetIndexCacheOnly() throws IOException {
+        Map<String, Object> body = clearCache("?offset=true");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    // ── selective: combined params ────────────────────────────────────────────
+
+    public void testClearColumnAndOffsetTogether() throws IOException {
+        Map<String, Object> body = clearCache("?column=true&offset=true");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    public void testClearAllThreeExplicitly() throws IOException {
+        Map<String, Object> body = clearCache("?footer=true&column=true&offset=true");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    // ── idempotency ───────────────────────────────────────────────────────────
+
+    public void testClearIsIdempotent() throws IOException {
+        // Second clear of an already-empty cache must still return 200.
+        clearCache("");
+        Map<String, Object> body = clearCache("");
+        assertEquals(true, body.get("acknowledged"));
+        assertClearedNodes(body);
+    }
+
+    // ── response shape ────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    public void testResponseIncludesNodesAndClusterName() throws IOException {
+        Request request = new Request("POST", CLEAR_ENDPOINT);
+        Response response = client().performRequest(request);
+        Map<String, Object> body = assertOkAndParse(response, "cache/_clear");
+
+        // NodesResponseRestListener wraps with _nodes + cluster_name
+        assertNotNull("_nodes header present", body.get("_nodes"));
+        assertNotNull("cluster_name present", body.get("cluster_name"));
+
+        Map<String, Object> nodesHeader = (Map<String, Object>) body.get("_nodes");
+        int total = ((Number) nodesHeader.get("total")).intValue();
+        int successful = ((Number) nodesHeader.get("successful")).intValue();
+        assertTrue("at least one node total", total >= 1);
+        assertTrue("all nodes successful", successful == total);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private void assertClearedNodes(Map<String, Object> body) {
+        List<Object> clearedNodes = (List<Object>) body.get("cleared_nodes");
+        assertNotNull("cleared_nodes present", clearedNodes);
+        assertFalse("at least one node cleared", clearedNodes.isEmpty());
+    }
+
+    private Map<String, Object> clearCache(String queryParams) throws IOException {
+        Request request = new Request("POST", CLEAR_ENDPOINT + queryParams);
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "cache/_clear" + queryParams);
+    }
+}

--- a/server/src/main/java/org/opensearch/node/resource/tracker/ResourceTrackerSettings.java
+++ b/server/src/main/java/org/opensearch/node/resource/tracker/ResourceTrackerSettings.java
@@ -143,12 +143,14 @@ public class ResourceTrackerSettings {
         if (ram <= 0 || heap <= 0 || heap >= ram) {
             return "0b";
         }
-        // 79% of off-heap (RAM - heap) leaves ~21% headroom for unmanaged native consumers:
-        // Lucene mmap, Liquid cache, OS page cache, sidecar processes. Matches the partitioning
+        // 80% of off-heap (RAM - heap) leaves ~20% headroom for unmanaged native consumers:
+        // Lucene mmap, Liquid cache, OS page cache, sidecar processes. Raised from 79% to 80%
+        // to accommodate the DataFusion parquet cache budget (1% of off-heap carved from
+        // unmanaged headroom + 2% from the DataFusion operator pool). Matches the partitioning
         // model in PR #21732. Operators with predominantly analytics workloads can raise this
         // toward 100%; search-heavy workloads needing more page cache should lower it.
         long offHeap = ram - heap;
-        return Long.toString(offHeap * 79 / 100) + "b";
+        return Long.toString(offHeap * 80 / 100) + "b";
     }
 
     /**

--- a/server/src/test/java/org/opensearch/node/resource/tracker/NodeResourceUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/node/resource/tracker/NodeResourceUsageTrackerTests.java
@@ -176,12 +176,12 @@ public class NodeResourceUsageTrackerTests extends OpenSearchSingleNodeTestCase 
         long ram = 8L * 1024 * 1024 * 1024;
         assertEquals("heap >= ram → unconfigured", "0b", ResourceTrackerSettings.deriveNativeMemoryLimitDefault(ram, ram));
         assertEquals("heap > ram → unconfigured", "0b", ResourceTrackerSettings.deriveNativeMemoryLimitDefault(ram, ram + 1));
-        // Happy path: 64 GB / 16 GB heap → 79% of (RAM - heap) = 79% of 48 GB.
+        // Happy path: 64 GB / 16 GB heap → 80% of (RAM - heap) = 79% of 48 GB.
         long sixtyFourGB = 64L * 1024 * 1024 * 1024;
         long sixteenGB = 16L * 1024 * 1024 * 1024;
-        long expected = (sixtyFourGB - sixteenGB) * 79 / 100;
+        long expected = (sixtyFourGB - sixteenGB) * 80 / 100;
         assertEquals(
-            "happy path → 79% of (ram - heap)",
+            "happy path → 80% of (ram - heap)",
             expected + "b",
             ResourceTrackerSettings.deriveNativeMemoryLimitDefault(sixtyFourGB, sixteenGB)
         );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

#### Dynamic settings for cache limits
  
Adjusts the native memory partitioning to carve out a dedicated 3% budget for DataFusion's parquet metadata caches:
  
```
  node.native_memory.limit = 80% of off-heap  (was 79%, +1% from unmanaged headroom)
    ├── 71% → datafusion.memory_pool_limit_bytes   (operator pool, was 74%)
    ├──  3% → datafusion.metadata_index_cache.total_size_bytes  (new)
    │     ├── 48% → footer metadata cache  (parquet footers + row-group stats)
    │     ├── 34% → offset index cache     (projection-driven page offsets)
    │     └── 13% → column index cache     (predicate-driven page min/max)
    |    └── 5% → file stats cache     (predicate-driven page min/max)
    ├──  8% → Arrow ingest pool
    ├──  5% → Arrow flight pool
    ├──  5% → Arrow query pool
    ├──  5% → Parquet write pool
    └──  3% → Parquet merge pool
    = 100%
```
  
  The 3% is funded by reducing the datafusion pool from 74→71% and expanding node.native_memory.limit from 79→80% of off-heap. Percentages within the cache budget must sum to ≤100 (unused headroom is accepted, matching Arrow's sum(max) ≤ budget model).  
Cluster setting updates get rejected if the new sum exceeds 100.

```
Total RAM:    64 GB
  JVM heap:     16 GB
  Off-heap:     48 GB

  OLD:
    node.native_memory.limit = 79% × 48 = 37.92 GB
    Unmanaged                = 21% × 48 = 10.08 GB
    DataFusion: 74% × 37.92 = 28.06 GB

  NEW:
    node.native_memory.limit = 80% × 48 = 38.40 GB  (+0.48 GB, 1% of off-heap from unmanaged)
    Unmanaged                = 20% × 48 =  9.60 GB (-0.48 GB)
    DataFusion: 71% × 38.40 = 27.26 GB  (-0.80 GB)

    71% → DataFusion pool  = 27.26 GB
    3%  → cache total      =  1.15 GB
    8%  → Arrow ingest     =  3.07 GB
    5%  → Arrow flight     =  1.92 GB
    5%  → Arrow query      =  1.92 GB
    5%  → Parquet write    =  1.92 GB
    3%  → Parquet merge    =  1.15 GB
    = 100%

  Unmanaged: 20% × 48 = 9.60 GB
  Total: 38.40 + 9.60 = 48 GB

```
  
  **Dynamic settings**
  
  - `datafusion.metadata_index_cache.total_size_bytes` — total cache budget (default: 3% of node.native_memory.limit, falls back to 500 MB)
  - `datafusion.cache.footer_metadata_percent` — default 48%
  - `datafusion.cache.offset_index_percent` — default 34%
  - `datafusion.cache.column_index_percent` — default 13%
  -  `datafusion.cache.statistics_percent`- default 5%

**Reasoning behind the split :** 
- Parquet footer is the must have for every query , so allocating higher memory there. 

- Offset index needs memory in cache for both predicate + projection columns along with 1st column for stats, so it's the second most expensive.

- Column index is only for predicate columns and with RG scoping as well , its way cheaper
  
  All are NodeScope + Dynamic. Changing the total or any percent triggers recomputePageCacheLimits which validates the sum and pushes updated byte limits to native. Startup wiring in
  CacheUtils.createCacheConfig pushes limits on node start.
  

#### Cache stats
  
  CacheStats now reports four independent groups (was three, previously had a single combined scoped_page_index_cache):
  
  "cache_stats": {
    "metadata_cache":    { "hit_count": ..., "miss_count": ..., ... },
    "statistics_cache":  { ... },
    "column_index_cache": { ... },
    "offset_index_cache": { ... }
  }
  
  StatsLayout grows from 80→85 longs (640→680 bytes) to accommodate the split.
  
  #### Cache clear REST API
  
  POST /_plugins/_analytics_backend_datafusion/cache/_clear              → clears all caches
  POST /_plugins/_analytics_backend_datafusion/cache/_clear?footer=true  → footer metadata only
  POST /_plugins/_analytics_backend_datafusion/cache/_clear?column=true  → column index only
  POST /_plugins/_analytics_backend_datafusion/cache/_clear?offset=true  → offset index only
  POST /_plugins/_analytics_backend_datafusion/cache/_clear?offset=true&offset=true  → offset index and column index
  
  Multiple params may be combined. Mirrors OpenSearch's /_cache/clear?query=true pattern. Broadcasts to all nodes via TransportNodesAction so every node's process-global caches are cleared, not just the receiving node.
  
 **Rust FFI stubs (ffm.rs)**
  
  Three new #[no_mangle] exports wired to Java via NativeBridge:
  - df_set_column_index_cache_limit — no-op stub (TODO: wire to cache::page_index::set_column_index_cache_limit in PR 1)
  - df_set_offset_index_cache_limit — no-op stub 
  - df_clear_scoped_page_index_cache — no-op stub
  
 
#### Follow-ups
  
  1. PR 1 (Rust cache implementation) — replace the three FFI stubs with real implementations calling into crate::cache::page_index. Also wires stats.rs to surface actual hit/miss/entry/bytes counters through
  the 85-field stats buffer.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
