### PR TITLE
Fix: OpenSearch process does not exit when startup fails due to StartupException

### DIFF
--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
@@ -159,6 +159,8 @@ class OpenSearch extends EnvironmentAwareCommand {
             init(daemonize, pidFile, quiet, env);
         } catch (NodeValidationException e) {
             throw new UserException(ExitCodes.CONFIG, e.getMessage());
+        } catch (StartupException e) {
+            throw new UserException(ExitCodes.CODE_ERROR, e.getMessage());
         }
     }
 

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
@@ -88,7 +88,17 @@ class OpenSearch extends EnvironmentAwareCommand {
 
         LogConfigurator.registerErrorListener();
         final OpenSearch opensearch = new OpenSearch();
-        int status = main(args, opensearch, Terminal.DEFAULT);
+        int status;
+        try {
+            status = main(args, opensearch, Terminal.DEFAULT);
+        } catch (StartupException e) {
+            // StartupException has custom printStackTrace formatting (truncates guice frames, etc.).
+            // Catch it here so the process exits rather than hanging, while preserving that output.
+            e.printStackTrace(System.err);
+            exit(ExitCodes.CODE_ERROR);
+            return;
+        }
+
         if (status != ExitCodes.OK) {
             final String basePath = System.getProperty("opensearch.logs.base_path");
             // It's possible to fail before logging has been configured, in which case there's no point
@@ -159,8 +169,6 @@ class OpenSearch extends EnvironmentAwareCommand {
             init(daemonize, pidFile, quiet, env);
         } catch (NodeValidationException e) {
             throw new UserException(ExitCodes.CONFIG, e.getMessage());
-        } catch (StartupException e) {
-            throw new UserException(ExitCodes.CODE_ERROR, e.getMessage(), e);
         }
     }
 

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
@@ -88,16 +88,7 @@ class OpenSearch extends EnvironmentAwareCommand {
 
         LogConfigurator.registerErrorListener();
         final OpenSearch opensearch = new OpenSearch();
-        int status;
-        try {
-            status = main(args, opensearch, Terminal.DEFAULT);
-        } catch (StartupException e) {
-            // StartupException has custom printStackTrace formatting (truncates guice frames, etc.).
-            // Catch it here so the process exits rather than hanging, while preserving that output.
-            e.printStackTrace(System.err);
-            exit(ExitCodes.CODE_ERROR);
-            return;
-        }
+        int status = main(args, opensearch, Terminal.DEFAULT);
 
         if (status != ExitCodes.OK) {
             final String basePath = System.getProperty("opensearch.logs.base_path");
@@ -132,7 +123,14 @@ class OpenSearch extends EnvironmentAwareCommand {
     }
 
     static int main(final String[] args, final OpenSearch opensearch, final Terminal terminal) throws Exception {
-        return opensearch.main(args, terminal);
+        try {
+            return opensearch.main(args, terminal);
+        } catch (StartupException e) {
+            // StartupException has custom printStackTrace formatting (truncates guice frames, etc.).
+            // Catch it here so the process exits rather than hanging, while preserving that output.
+            e.printStackTrace(terminal.getErrorWriter());
+            return ExitCodes.CODE_ERROR;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
@@ -160,7 +160,7 @@ class OpenSearch extends EnvironmentAwareCommand {
         } catch (NodeValidationException e) {
             throw new UserException(ExitCodes.CONFIG, e.getMessage());
         } catch (StartupException e) {
-            throw new UserException(ExitCodes.CODE_ERROR, e.getMessage());
+            throw new UserException(ExitCodes.CODE_ERROR, e.getMessage(), e);
         }
     }
 

--- a/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
@@ -234,7 +234,9 @@ public class OpenSearchCliTests extends OpenSearchCliTestCase {
             ExitCodes.CODE_ERROR,
             true,
             (output, error) -> assertThat(error, containsString(cause.getMessage())),
-            (foreground, pidFile, quiet, env) -> { throw new StartupException(cause); }
+            (foreground, pidFile, quiet, env) -> {
+                throw new StartupException(cause);
+            }
         );
     }
 

--- a/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
@@ -227,15 +227,17 @@ public class OpenSearchCliTests extends OpenSearchCliTestCase {
     }
 
     public void testStartupExceptionExitsWithCodeError() throws Exception {
-        // Verify that a StartupException thrown during bootstrap causes a non-OK exit rather than
-        // leaving the process hanging (the exception must be caught and converted to UserException).
+        // StartupException must escape execute() and propagate to main(String[]) where it is caught,
+        // printed via its custom formatter, and exit(CODE_ERROR) is called.
+        // Via the test harness (3-arg main), it surfaces as an uncaught StartupException.
         final RuntimeException cause = new RuntimeException("dummy startup failure");
-        runTest(
-            ExitCodes.CODE_ERROR,
-            true,
-            (output, error) -> assertThat(error, containsString("dummy startup failure")),
-            (foreground, pidFile, quiet, env) -> { throw new StartupException(cause); }
+        StartupException thrown = expectThrows(
+            StartupException.class,
+            () -> runTest(ExitCodes.OK, true, (output, error) -> {}, (foreground, pidFile, quiet, env) -> {
+                throw new StartupException(cause);
+            })
         );
+        assertSame(cause, thrown.getCause());
     }
 
 }

--- a/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
@@ -226,4 +226,16 @@ public class OpenSearchCliTests extends OpenSearchCliTestCase {
         );
     }
 
+    public void testStartupExceptionExitsWithCodeError() throws Exception {
+        // Verify that a StartupException thrown during bootstrap causes a non-OK exit rather than
+        // leaving the process hanging (the exception must be caught and converted to UserException).
+        final RuntimeException cause = new RuntimeException("dummy startup failure");
+        runTest(
+            ExitCodes.CODE_ERROR,
+            true,
+            (output, error) -> assertThat(error, containsString("dummy startup failure")),
+            (foreground, pidFile, quiet, env) -> { throw new StartupException(cause); }
+        );
+    }
+
 }

--- a/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/OpenSearchCliTests.java
@@ -227,17 +227,15 @@ public class OpenSearchCliTests extends OpenSearchCliTestCase {
     }
 
     public void testStartupExceptionExitsWithCodeError() throws Exception {
-        // StartupException must escape execute() and propagate to main(String[]) where it is caught,
-        // printed via its custom formatter, and exit(CODE_ERROR) is called.
-        // Via the test harness (3-arg main), it surfaces as an uncaught StartupException.
+        // StartupException is caught in the 3-arg main(), which prints it via its custom formatter
+        // and returns CODE_ERROR so that the 1-arg main() calls exit(CODE_ERROR).
         final RuntimeException cause = new RuntimeException("dummy startup failure");
-        StartupException thrown = expectThrows(
-            StartupException.class,
-            () -> runTest(ExitCodes.OK, true, (output, error) -> {}, (foreground, pidFile, quiet, env) -> {
-                throw new StartupException(cause);
-            })
+        runTest(
+            ExitCodes.CODE_ERROR,
+            true,
+            (output, error) -> assertThat(error, containsString(cause.getMessage())),
+            (foreground, pidFile, quiet, env) -> { throw new StartupException(cause); }
         );
-        assertSame(cause, thrown.getCause());
     }
 
 }


### PR DESCRIPTION
## Description

When a plugin or bootstrap component  can throws a `RuntimeException` during startup, `OpenSearch.init()` wraps it in a `StartupException` and rethrows it. `StartupException` was never caught in the call chain — it escaped `OpenSearch.main(String[])` entirely, bypassing the `exit(status)` call. 

This lefts the JVM process hanging indefinitely after startup failure.

## Resolves 
https://github.com/opensearch-project/OpenSearch/issues/22260

## Root Cause

`StartupException` is a `RuntimeException`. The CLI framework in `Command.main()` only handles `OptionException` and `UserException` — so `StartupException` propagates uncaught all the way through `main(String[], OpenSearch, Terminal)` and escapes `main(String[])`. When non-daemon threads are still alive (as they are during a partial bootstrap), the JVM does not terminate automatically, leaving the process hanging.

```java
// main(String[]) — StartupException escapes here, exit() is never reached
int status = main(args, opensearch, Terminal.DEFAULT);
if (status != ExitCodes.OK) {
    ...
    exit(status);  // never reached
}
```

## Fix

`StartupException` **designed** to escape to `main()` — its `printStackTrace()` override has a comment: *"This logic actually prints the exception to the console, its what is invoked by the JVM when we throw the exception from main()"*. The formatted output was already correct. The only missing piece was `exit()`.

Catch `StartupException` in `main(String[])` — the correct level where `System.err` is appropriate and process exit decisions belong — call `e.printStackTrace(System.err)` to preserve the existing custom-formatted output (which truncates guice frames, etc.), then `exit(CODE_ERROR)`:

```java
try {
    status = main(args, opensearch, Terminal.DEFAULT);
} catch (StartupException e) {
    e.printStackTrace(System.err);
    exit(ExitCodes.CODE_ERROR);
    return;
}
```


## Stack trace (reproducer)

```
org.opensearch.bootstrap.StartupException: java.lang.RuntimeException: java.lang.RuntimeException: dummy
    at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:173)
    at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:160)
    at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
    at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:146)
    at org.opensearch.cli.Command.main(Command.java:101)
    at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:126)
```

Signed-off-by: Aparajita Pandey <aparajita31pandey@gmail.com>