### PR TITLE
Adding metadata cache ratio setting for warm

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -21,6 +21,7 @@ import org.opensearch.be.datafusion.action.stats.RestDataFusionStatsAction;
 import org.opensearch.be.datafusion.action.stats.TransportDataFusionStatsAction;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
@@ -445,6 +446,7 @@ public class DataFusionPlugin extends Plugin
             .spillDirectory(spillDir)
             .datanodeMultiplier(DatafusionSettings.CONCURRENCY_DATANODE_MULTIPLIER.get(settings))
             .clusterSettings(clusterService.getClusterSettings())
+            .warmNode(DiscoveryNode.isWarmNode(settings))
             .build();
         dataFusionService.start();
         logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
@@ -49,6 +49,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
     private final double datanodeMultiplier;
     private final double coordinatorMultiplier;
     private final ClusterSettings clusterSettings;
+    private final boolean warmNode;
 
     /** Handle to the native DataFusion global runtime (memory pool + cache). */
     private volatile NativeRuntimeHandle runtimeHandle;
@@ -64,6 +65,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
         this.datanodeMultiplier = builder.datanodeMultiplier;
         this.coordinatorMultiplier = builder.coordinatorMultiplier;
         this.clusterSettings = builder.clusterSettings;
+        this.warmNode = builder.warmNode;
     }
 
     /** Creates a new builder. */
@@ -93,7 +95,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
         long cacheManagerPtr = 0L;
         NativeCacheManagerHandle cacheHandle = null;
         if (clusterSettings != null) {
-            cacheHandle = CacheUtils.createCacheConfig(clusterSettings);
+            cacheHandle = CacheUtils.createCacheConfig(clusterSettings, warmNode);
             cacheManagerPtr = cacheHandle.getPointer();
         }
 
@@ -299,6 +301,7 @@ public class DataFusionService extends AbstractLifecycleComponent {
         private double datanodeMultiplier = 1.0;
         private double coordinatorMultiplier = 1.0;
         private ClusterSettings clusterSettings;
+        private boolean warmNode = false;
 
         private Builder() {}
 
@@ -356,6 +359,16 @@ public class DataFusionService extends AbstractLifecycleComponent {
          */
         public Builder clusterSettings(ClusterSettings clusterSettings) {
             this.clusterSettings = clusterSettings;
+            return this;
+        }
+
+        /**
+         * Sets whether the current node holds the warm role. When true, cache types with a
+         * warm-size multiplier (currently the metadata cache) are scaled up at startup.
+         * @param warmNode true if the node is a warm node
+         */
+        public Builder warmNode(boolean warmNode) {
+            this.warmNode = warmNode;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -293,6 +293,7 @@ public final class DatafusionSettings {
 
         // Cache settings — metadata and statistics cache configuration
         CacheSettings.METADATA_CACHE_SIZE_LIMIT,
+        CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER,
         CacheSettings.STATISTICS_CACHE_SIZE_LIMIT,
         CacheSettings.METADATA_CACHE_EVICTION_TYPE,
         CacheSettings.STATISTICS_CACHE_EVICTION_TYPE,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -36,6 +36,23 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
+    public static final String METADATA_CACHE_WARM_SIZE_MULTIPLIER_KEY = "datafusion.metadata.cache.size.warm_multiplier";
+
+    /**
+     * Multiplier applied to {@link #METADATA_CACHE_SIZE_LIMIT} on warm nodes, which must hold more
+     * metadata than hot nodes. Defaults to {@code 1.0} (no change). The minimum is {@code 1.0} since
+     * the multiplier is only intended to grow the cache. The effective limit is computed once at
+     * service startup; like the base size limit, runtime updates do not yet take effect until the
+     * node restarts (see {@code CacheManager#updateSizeLimit}).
+     */
+    public static final Setting<Double> METADATA_CACHE_WARM_SIZE_MULTIPLIER = Setting.doubleSetting(
+        METADATA_CACHE_WARM_SIZE_MULTIPLIER_KEY,
+        1.25,
+        1.0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     public static final Setting<String> METADATA_CACHE_EVICTION_TYPE = new Setting<String>(
         "datafusion.metadata.cache.eviction.type",
         "LRU",
@@ -71,6 +88,7 @@ public class CacheSettings {
     public static final List<Setting<?>> CACHE_SETTINGS = Arrays.asList(
         METADATA_CACHE_ENABLED,
         METADATA_CACHE_SIZE_LIMIT,
+        METADATA_CACHE_WARM_SIZE_MULTIPLIER,
         METADATA_CACHE_EVICTION_TYPE,
         STATISTICS_CACHE_ENABLED,
         STATISTICS_CACHE_SIZE_LIMIT,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheUtils.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.unit.ByteSizeValue;
 import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_ENABLED;
 import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_EVICTION_TYPE;
 import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_SIZE_LIMIT;
+import static org.opensearch.be.datafusion.cache.CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER;
 import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_ENABLED;
 import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_EVICTION_TYPE;
 import static org.opensearch.be.datafusion.cache.CacheSettings.STATISTICS_CACHE_SIZE_LIMIT;
@@ -36,25 +37,35 @@ public final class CacheUtils {
      * Cache type enumeration with associated settings.
      */
     public enum CacheType {
-        METADATA("METADATA", METADATA_CACHE_ENABLED, METADATA_CACHE_SIZE_LIMIT, METADATA_CACHE_EVICTION_TYPE),
+        METADATA(
+            "METADATA",
+            METADATA_CACHE_ENABLED,
+            METADATA_CACHE_SIZE_LIMIT,
+            METADATA_CACHE_EVICTION_TYPE,
+            METADATA_CACHE_WARM_SIZE_MULTIPLIER
+        ),
 
-        STATISTICS("STATISTICS", STATISTICS_CACHE_ENABLED, STATISTICS_CACHE_SIZE_LIMIT, STATISTICS_CACHE_EVICTION_TYPE);
+        STATISTICS("STATISTICS", STATISTICS_CACHE_ENABLED, STATISTICS_CACHE_SIZE_LIMIT, STATISTICS_CACHE_EVICTION_TYPE, null);
 
         private final String cacheTypeName;
         private final Setting<Boolean> enabledSetting;
         private final Setting<ByteSizeValue> sizeLimitSetting;
         private final Setting<String> evictionTypeSetting;
+        /** Multiplier applied to the size limit on warm nodes; {@code null} when the cache type has no warm scaling. */
+        private final Setting<Double> warmSizeMultiplierSetting;
 
         CacheType(
             String cacheTypeName,
             Setting<Boolean> enabledSetting,
             Setting<ByteSizeValue> sizeLimitSetting,
-            Setting<String> evictionTypeSetting
+            Setting<String> evictionTypeSetting,
+            Setting<Double> warmSizeMultiplierSetting
         ) {
             this.cacheTypeName = cacheTypeName;
             this.enabledSetting = enabledSetting;
             this.sizeLimitSetting = sizeLimitSetting;
             this.evictionTypeSetting = evictionTypeSetting;
+            this.warmSizeMultiplierSetting = warmSizeMultiplierSetting;
         }
 
         public boolean isEnabled(ClusterSettings clusterSettings) {
@@ -77,6 +88,28 @@ public final class CacheUtils {
             return clusterSettings.get(sizeLimitSetting);
         }
 
+        /**
+         * Returns the effective cache size limit in bytes, applying the warm-node multiplier when this
+         * cache type defines one and the node is a warm node. On non-warm nodes, or for cache types
+         * without a warm multiplier, the base size limit is returned unchanged.
+         *
+         * @param clusterSettings cluster settings holding the base size limit and warm multiplier
+         * @param isWarmNode      whether the current node holds the warm role
+         * @return effective size limit in bytes, clamped to {@link Long#MAX_VALUE} on overflow
+         */
+        public long getEffectiveSizeLimitBytes(ClusterSettings clusterSettings, boolean isWarmNode) {
+            long base = getSizeLimit(clusterSettings).getBytes();
+            if (isWarmNode == false || warmSizeMultiplierSetting == null) {
+                return base;
+            }
+            double multiplier = clusterSettings.get(warmSizeMultiplierSetting);
+            double scaled = base * multiplier;
+            if (scaled >= Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            return (long) scaled;
+        }
+
         public String getEvictionType(ClusterSettings clusterSettings) {
             return clusterSettings.get(evictionTypeSetting);
         }
@@ -90,9 +123,11 @@ public final class CacheUtils {
      * Creates and configures a CacheManagerConfig pointer with all enabled caches.
      *
      * @param clusterSettings OpenSearch cluster settings containing cache configuration
+     * @param isWarmNode      whether the current node holds the warm role; when true, cache types
+     *                        with a warm-size multiplier (currently the metadata cache) are scaled up
      */
-    public static NativeCacheManagerHandle createCacheConfig(ClusterSettings clusterSettings) {
-        logger.info("Initializing cache configuration");
+    public static NativeCacheManagerHandle createCacheConfig(ClusterSettings clusterSettings, boolean isWarmNode) {
+        logger.info("Initializing cache configuration (warmNode={})", isWarmNode);
 
         long cacheManagerPtr = NativeBridge.createCustomCacheManager();
         NativeCacheManagerHandle handle = new NativeCacheManagerHandle(cacheManagerPtr);
@@ -100,17 +135,19 @@ public final class CacheUtils {
         // Configure each enabled cache type
         for (CacheType type : CacheType.values()) {
             if (type.isEnabled(clusterSettings)) {
+                long effectiveSizeBytes = type.getEffectiveSizeLimitBytes(clusterSettings, isWarmNode);
                 logger.info(
-                    "Configuring {} cache: size={} bytes, eviction={}",
+                    "Configuring {} cache: baseSize={} bytes, effectiveSize={} bytes, eviction={}",
                     type.getCacheTypeName(),
                     type.getSizeLimit(clusterSettings).getBytes(),
+                    effectiveSizeBytes,
                     type.getEvictionType(clusterSettings)
                 );
 
                 NativeBridge.createCache(
                     handle.getPointer(),
                     type.cacheTypeName,
-                    type.getSizeLimit(clusterSettings).getBytes(),
+                    effectiveSizeBytes,
                     type.getEvictionType(clusterSettings)
                 );
             } else {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -167,6 +167,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     public void testPluginRegistersAllCacheSettings() {
         List<Setting<?>> settings = new DataFusionPlugin().getSettings();
         assertTrue(settings.contains(CacheSettings.METADATA_CACHE_SIZE_LIMIT));
+        assertTrue(settings.contains(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER));
         assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT));
         assertTrue(settings.contains(CacheSettings.METADATA_CACHE_EVICTION_TYPE));
         assertTrue(settings.contains(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE));
@@ -224,6 +225,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         Set<Setting<?>> all = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         all.add(CacheSettings.METADATA_CACHE_ENABLED);
         all.add(CacheSettings.METADATA_CACHE_SIZE_LIMIT);
+        all.add(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER);
         all.add(CacheSettings.METADATA_CACHE_EVICTION_TYPE);
         all.add(CacheSettings.STATISTICS_CACHE_ENABLED);
         all.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionCacheManagerTests.java
@@ -37,6 +37,7 @@ public class DatafusionCacheManagerTests extends OpenSearchTestCase {
         Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
         clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_ENABLED);
         clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_SIZE_LIMIT);
+        clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER);
         clusterSettingsToAdd.add(CacheSettings.METADATA_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_ENABLED);
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheUtilsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheUtilsTests.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.cache;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+/**
+ * Unit tests for {@link CacheUtils.CacheType} effective size computation, in particular the
+ * warm-node multiplier applied to the metadata cache.
+ */
+public class CacheUtilsTests extends OpenSearchTestCase {
+
+    private ClusterSettings clusterSettings(Settings settings) {
+        return new ClusterSettings(
+            settings,
+            Set.of(
+                CacheSettings.METADATA_CACHE_SIZE_LIMIT,
+                CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER,
+                CacheSettings.STATISTICS_CACHE_SIZE_LIMIT
+            )
+        );
+    }
+
+    public void testMetadataNonWarmNodeUsesBaseSize() {
+        ClusterSettings cs = clusterSettings(Settings.builder().put(CacheSettings.METADATA_CACHE_SIZE_LIMIT_KEY, "200mb").build());
+        long expected = new ByteSizeValue(200, ByteSizeUnit.MB).getBytes();
+        assertEquals(expected, CacheUtils.CacheType.METADATA.getEffectiveSizeLimitBytes(cs, false));
+    }
+
+    public void testMetadataWarmNodeAppliesMultiplier() {
+        ClusterSettings cs = clusterSettings(
+            Settings.builder()
+                .put(CacheSettings.METADATA_CACHE_SIZE_LIMIT_KEY, "200mb")
+                .put(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER_KEY, 2.5)
+                .build()
+        );
+        long base = new ByteSizeValue(200, ByteSizeUnit.MB).getBytes();
+        assertEquals((long) (base * 2.5), CacheUtils.CacheType.METADATA.getEffectiveSizeLimitBytes(cs, true));
+    }
+
+    public void testMetadataWarmNodeWithDefaultMultiplierIsNoOp() {
+        ClusterSettings cs = clusterSettings(Settings.builder().put(CacheSettings.METADATA_CACHE_SIZE_LIMIT_KEY, "200mb").build());
+        long base = new ByteSizeValue(200, ByteSizeUnit.MB).getBytes();
+        // Default multiplier is 1.0, so even on a warm node the size is unchanged.
+        assertEquals(base, CacheUtils.CacheType.METADATA.getEffectiveSizeLimitBytes(cs, true));
+    }
+
+    public void testStatisticsCacheIgnoresWarmMultiplier() {
+        ClusterSettings cs = clusterSettings(
+            Settings.builder()
+                .put(CacheSettings.STATISTICS_CACHE_SIZE_LIMIT_KEY, "80mb")
+                .put(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER_KEY, 4.0)
+                .build()
+        );
+        long base = new ByteSizeValue(80, ByteSizeUnit.MB).getBytes();
+        assertEquals(base, CacheUtils.CacheType.STATISTICS.getEffectiveSizeLimitBytes(cs, true));
+        assertEquals(base, CacheUtils.CacheType.STATISTICS.getEffectiveSizeLimitBytes(cs, false));
+    }
+
+    public void testWarmMultiplierClampsOnOverflow() {
+        ClusterSettings cs = clusterSettings(
+            Settings.builder()
+                .put(CacheSettings.METADATA_CACHE_SIZE_LIMIT_KEY, "5000pb")
+                .put(CacheSettings.METADATA_CACHE_WARM_SIZE_MULTIPLIER_KEY, 4.0)
+                .build()
+        );
+        // base * 4.0 exceeds Long.MAX_VALUE and must be clamped.
+        assertEquals(Long.MAX_VALUE, CacheUtils.CacheType.METADATA.getEffectiveSizeLimitBytes(cs, true));
+    }
+}


### PR DESCRIPTION
### Description
Adding a new setting `datafusion.metadata.cache.size.warm_multiplier` which will be a multiplication factor that would need to be applied for warm nodes. This is needed since the metadata cache size would be needing a higher value for warm nodes.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).