### PR TITLE
Fix character range in TCHAR_PATTERN regex

### DIFF
--- a/server/src/main/java/org/opensearch/rest/RestRequest.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequest.java
@@ -81,7 +81,7 @@ import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
 public class RestRequest implements ToXContent.Params {
 
     // tchar pattern as defined by RFC7230 section 3.2.6
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-z0-9!#$%&'*+\\-.\\^_`|~]+");
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+\\-.\\^_`|~]+");
 
     private static final AtomicLong requestIdGenerator = new AtomicLong();
 

--- a/server/src/test/java/org/opensearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestRequestTests.java
@@ -225,7 +225,17 @@ public class RestRequestTests extends OpenSearchTestCase {
     }
 
     public void testMalformedContentTypeHeader() {
-        final String type = randomFrom("text", "text/:ain; charset=utf-8", "text/plain\";charset=utf-8", ":", "/", "t:/plain");
+        final String type = randomFrom(
+            "text",
+            "text/:ain; charset=utf-8",
+            "text/plain\";charset=utf-8",
+            ":",
+            "/",
+            "t:/plain",
+            "text/plain[",
+            "text/plain]",
+            "text\\plain"
+        );
         final RestRequest.ContentTypeHeaderException e = expectThrows(RestRequest.ContentTypeHeaderException.class, () -> {
             final Map<String, List<String>> headers = Collections.singletonMap("Content-Type", Collections.singletonList(type));
             contentRestRequest("", Collections.emptyMap(), headers);


### PR DESCRIPTION
### Description
Corrects a typo in the TCHAR_PATTERN regular expression range inside RestRequest.java.
Changing A-z to A-Z prevents the parser from incorrectly matching extra characters like `[`, `\`, `]` which are outside the RFC 7230 definition of tchar in the Content-Type header.
After reviewing the RFC spec and debugging some header parser edge cases, I noticed this broad range was causing incorrect media type matching.
Verification shows that HTTP routing and parsing tests run without any issues.

### Related Issues
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).