### PR TITLE
[FIX] Detect delegation using Bottom-most filter over scan for Single Shard

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -36,6 +36,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchUnion;
 import org.opensearch.analytics.planner.rel.OpenSearchValues;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -163,6 +164,24 @@ public class RelNodeUtils {
             return findNode(node.getInputs().getFirst(), type);
         }
         return null;
+    }
+
+    /**
+     * Finds all nodes of the given type reachable from {@code node} (walks the full tree, all inputs).
+     * Unlike {@link #findNode} (which returns only the topmost match via the first-input chain), this
+     * sees every match — e.g. a WHERE filter below an Aggregate AND a HAVING filter above it, which
+     * do not merge (FILTER_MERGE does not cross the Aggregate). Order is pre-order (topmost first).
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends RelNode> List<T> findAllNodes(RelNode node, Class<T> type) {
+        List<T> out = new ArrayList<>();
+        if (type.isInstance(node)) {
+            out.add((T) node);
+        }
+        for (RelNode input : node.getInputs()) {
+            out.addAll(findAllNodes(input, type));
+        }
+        return out;
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -113,7 +113,11 @@ public class FragmentConversionDriver {
             // Derive filter tree shape BEFORE stripping (annotations must be intact). The deriver
             // mirrors the combiner's post-combine shape so the data node's classification matches
             // the tree it actually receives.
-            OpenSearchFilter filter = RelNodeUtils.findNode(plan.resolvedFragment(), OpenSearchFilter.class);
+            // Pushdown+merge rules leave delegated annotations only in the bottommost (WHERE) filter;
+            // a HAVING stays in a separate un-delegated filter above the Aggregate. Pick the WHERE,
+            // not findNode's topmost (HAVING → NO_DELEGATION → collector skipped → over-count).
+            List<OpenSearchFilter> filters = RelNodeUtils.findAllNodes(plan.resolvedFragment(), OpenSearchFilter.class);
+            OpenSearchFilter filter = filters.isEmpty() ? null : filters.getLast();
             FilterTreeShape treeShape = filter != null
                 ? FilterTreeShapeDeriver.derive(filter, plan.backendId())
                 : FilterTreeShape.NO_DELEGATION;

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -1279,6 +1279,76 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             .orElseThrow()).getTreeShape();
     }
 
+    // ---- HAVING regression: delegated WHERE under an Aggregate with a HAVING filter above ----
+
+    /**
+     * HAVING produces two stacked filters that don't merge across the Aggregate: a native HAVING
+     * (count=1) above and the delegated WHERE (match_phrase) below. The derived FilterTreeShape
+     * (which the data node reads as its classification) must reflect the WHERE's delegation
+     * (CONJUNCTIVE), not the topmost HAVING (NO_DELEGATION). Regression: picking the topmost filter
+     * yielded NO_DELEGATION → data node skipped the Lucene collector → full scan / over-count.
+     */
+    public void testHavingFilterAboveDelegatedWhere_derivesConjunctive() {
+        StagePlan plan = runHaving(matchPhrase("hello"));
+        assertEquals("delegated WHERE under HAVING must still ship one expression", 1, plan.delegatedExpressions().size());
+        assertEquals("treeShape must come from the WHERE (CONJUNCTIVE), not the HAVING (NO_DELEGATION)",
+            FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
+    }
+
+    /** Builds Filter(count=1)[HAVING] over Aggregate(group=message, count(*)) over Filter(where)[scan]. */
+    private StagePlan runHaving(RexNode whereCondition) {
+        RecordingConvertor dfConvertor = new RecordingConvertor();
+        RecordingSerializer serializer = new RecordingSerializer();
+        MockDataFusionBackend df = new MockDataFusionBackend() {
+            @Override
+            protected Set<DelegationType> supportedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public FragmentConvertor getFragmentConvertor() {
+                return dfConvertor;
+            }
+        };
+        MockLuceneBackend lucene = new MockLuceneBackend() {
+            @Override
+            protected Set<DelegationType> acceptedDelegations() {
+                return Set.of(DelegationType.FILTER);
+            }
+
+            @Override
+            public Map<ScalarFunction, DelegatedPredicateSerializer> delegatedPredicateSerializers() {
+                Map<ScalarFunction, DelegatedPredicateSerializer> map = new HashMap<>(super.delegatedPredicateSerializers());
+                map.put(ScalarFunction.MATCH_PHRASE, serializer);
+                return map;
+            }
+        };
+        List<AnalyticsSearchBackendPlugin> backends = List.of(df, lucene);
+        Map<String, Map<String, Object>> fields = Map.of(
+            "message", Map.of("type", "keyword", "index", true),
+            "amount", Map.of("type", "integer", "index", false),
+            "count", Map.of("type", "integer", "index", false)
+        );
+        // Single shard: no exchange split, so HAVING + Aggregate + WHERE stay in ONE fragment — the
+        // shape the bug needs (multi-shard forks HAVING into a separate reduce stage, hiding it).
+        PlannerContext context = buildContext("parquet", 1, fields, backends);
+        RelNode scan = stubScan(
+            mockTable(
+                "test_index",
+                new String[] { "message", "amount", "count" },
+                new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.INTEGER, SqlTypeName.INTEGER }
+            )
+        );
+        LogicalFilter where = LogicalFilter.create(scan, whereCondition);
+        LogicalAggregate aggregate = makeAggregate(where, ImmutableBitSet.of(0), countStarCall(where));
+        LogicalFilter having = LogicalFilter.create(aggregate, makeEquals(1, SqlTypeName.BIGINT, 1));
+        RelNode cboOutput = runPlanner(having, context);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        PlanForker.forkAll(dag, context.getCapabilityRegistry());
+        FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
+        return leafStage(dag).getPlanAlternatives().getFirst();
+    }
+
     // ---- Combining tests (OR/NOT/mixed) ----
 
     /** match_phrase AND fuzzy OR amount=200 → OR(AND(lucene,lucene), native) — combined, INTERLEAVED. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -1291,8 +1291,11 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
     public void testHavingFilterAboveDelegatedWhere_derivesConjunctive() {
         StagePlan plan = runHaving(matchPhrase("hello"));
         assertEquals("delegated WHERE under HAVING must still ship one expression", 1, plan.delegatedExpressions().size());
-        assertEquals("treeShape must come from the WHERE (CONJUNCTIVE), not the HAVING (NO_DELEGATION)",
-            FilterTreeShape.CONJUNCTIVE, treeShapeOf(plan));
+        assertEquals(
+            "treeShape must come from the WHERE (CONJUNCTIVE), not the HAVING (NO_DELEGATION)",
+            FilterTreeShape.CONJUNCTIVE,
+            treeShapeOf(plan)
+        );
     }
 
     /** Builds Filter(count=1)[HAVING] over Aggregate(group=message, count(*)) over Filter(where)[scan]. */
@@ -1325,9 +1328,12 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         };
         List<AnalyticsSearchBackendPlugin> backends = List.of(df, lucene);
         Map<String, Map<String, Object>> fields = Map.of(
-            "message", Map.of("type", "keyword", "index", true),
-            "amount", Map.of("type", "integer", "index", false),
-            "count", Map.of("type", "integer", "index", false)
+            "message",
+            Map.of("type", "keyword", "index", true),
+            "amount",
+            Map.of("type", "integer", "index", false),
+            "count",
+            Map.of("type", "integer", "index", false)
         );
         // Single shard: no exchange split, so HAVING + Aggregate + WHERE stay in ONE fragment — the
         // shape the bug needs (multi-shard forks HAVING into a separate reduce stage, hiding it).


### PR DESCRIPTION
## What
  Fix over-counting in single-shard aggregation queries that combine a delegated `WHERE` (e.g. `match(...)`) with a `HAVING` clause (`... | stats count() by X | where cnt > N`).

  ## Why
  On a single shard, `WHERE` and `HAVING` end up as two stacked `OpenSearchFilter` nodes in one fragment — they don't merge because `FILTER_MERGE` can't cross the `Aggregate` between them. `FragmentConversionDriver` derived the fragment's `FilterTreeShape` from `findNode`, which returns the *topmost* filter — the `HAVING` (no delegation). That yielded `NO_DELEGATION`, so the data node skipped the Lucene collector and full-scanned, making every row pass the predicate and inflating counts (e.g. a `match` query that should return 16 returned 30+; on the 100M cluster a region went 144K → 18M). Reported via 3 PPL `match() + stats ... | where cnt > N` queries.

  ## How
  Derive the tree shape from the *bottommost* `OpenSearchFilter` (the scan-level `WHERE` that carries the delegated annotations) instead of the topmost. Added `RelNodeUtils.findAllNodes` (full-tree walk) and pick `.getLast()`. The bottommost is the genuine `WHERE` because pushdown + `FILTER_MERGE` already collapse all stacked `WHERE` filters, leaving only the un-mergeable `HAVING`-over-`WHERE` pair across the `Aggregate`. Joins are unaffected: a join's exchange always separates `WHERE` (shard fragment) from `HAVING` (reduce fragment), so each fragment has a single filter regardless of shard count.

  ## Follow-ups
  - Single-shard self-joins still insert a `SINGLETON` `OpenSearchExchangeReducer` and split into two stages — likely an unnecessary gather. Worth a separate look.