### PR TITLE
refactor: Eliminate deep clone of BoolNode and extract prune_tree_config into match arms

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -262,12 +262,24 @@ fn collect_predicate_exprs(tree: &BoolNode, out: &mut Vec<Arc<dyn PhysicalExpr>>
     }
 }
 
+/// Collect leaf predicate exprs from the extraction tree in a single traversal.
+fn collect_leaf_exprs(extraction: Option<&ExtractionResult>) -> Vec<Arc<dyn PhysicalExpr>> {
+    let Some(e) = extraction else { return vec![] };
+    let mut exprs = Vec::new();
+    collect_predicate_exprs(&e.tree, &mut exprs);
+    exprs
+}
+
 fn collect_predicate_column_indices(extraction: Option<&ExtractionResult>) -> Vec<usize> {
     let Some(e) = extraction else { return vec![] };
     let mut exprs = Vec::new();
     collect_predicate_exprs(&e.tree, &mut exprs);
+    collect_predicate_column_indices_from_exprs(&exprs)
+}
+
+fn collect_predicate_column_indices_from_exprs(exprs: &[Arc<dyn PhysicalExpr>]) -> Vec<usize> {
     let mut indices = HashSet::new();
-    for expr in &exprs {
+    for expr in exprs {
         let _ = expr.apply(|node| {
             if let Some(col) = node.downcast_ref::<Column>() {
                 indices.insert(col.index());
@@ -325,6 +337,26 @@ fn collect_plan_column_names(plan: &datafusion::logical_expr::LogicalPlan) -> Ve
         Ok(TreeNodeRecursion::Continue)
     });
     names.into_iter().collect()
+}
+
+/// Build the `prune_tree_config` tuple from a BoolNode tree and schema.
+/// Builds per-leaf PruningPredicates from pre-collected leaf exprs.
+fn build_prune_tree_config(
+    tree: &Arc<BoolNode>,
+    schema: &SchemaRef,
+    leaf_exprs: &[Arc<dyn PhysicalExpr>],
+) -> Option<(Arc<BoolNode>, Arc<HashMap<usize, Arc<PruningPredicate>>>, SchemaRef)> {
+    let leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = leaf_exprs
+        .iter()
+        .filter_map(|expr| {
+            build_pruning_predicate(expr, Arc::clone(schema))
+                .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
+        })
+        .collect();
+    if leaf_predicates.is_empty() {
+        return None;
+    }
+    Some((Arc::clone(tree), Arc::new(leaf_predicates), Arc::clone(schema)))
 }
 
 /// For a tree classified as `SingleCollector`, walk it to find the single
@@ -955,23 +987,9 @@ async unsafe fn execute_indexed_with_context_inner(
         FilterClass::Tree => None,
     };
 
-    let mut prune_tree_config = extraction.as_ref().and_then(|e| {
-        let mut leaf_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
-        collect_predicate_exprs(&e.tree, &mut leaf_exprs);
-        let leaf_predicates: HashMap<usize, Arc<PruningPredicate>> = leaf_exprs
-            .iter()
-            .filter_map(|expr| {
-                build_pruning_predicate(expr, schema.clone())
-                    .map(|pp| (Arc::as_ptr(expr) as *const () as usize, pp))
-            })
-            .collect();
-        if leaf_predicates.is_empty() {
-            return None;
-        }
-        Some((Arc::new(e.tree.clone()), Arc::new(leaf_predicates), schema.clone()))
-    });
+    let leaf_exprs = collect_leaf_exprs(extraction.as_ref());
 
-    let predicate_columns = collect_predicate_column_indices(extraction.as_ref());
+    let predicate_columns = collect_predicate_column_indices_from_exprs(&leaf_exprs);
 
     // Augment each segment's footer-only metadata with a scoped page index so
     // the indexed PagePruner can page-prune. Both predicate (→ ColumnIndex) and
@@ -1007,7 +1025,7 @@ async unsafe fn execute_indexed_with_context_inner(
         }
     }
 
-    let factory: EvaluatorFactory = match classification {
+    let (factory, prune_tree_config): (EvaluatorFactory, _) = match classification {
         FilterClass::None => {
             // Predicate-only scan: page-pruned universe, residual applied in
             // on_batch_mask. Also covers an unfoldable constant (e.g. mktime('...') >
@@ -1015,6 +1033,9 @@ async unsafe fn execute_indexed_with_context_inner(
             // residual (pushdown is Exact, so DataFusion drops the FilterExec).
             // Previously errored here when emit_row_ids was false (indexed path only).
             let schema_for_pruner = schema.clone();
+            let prune_tree_config = extraction
+                .as_ref()
+                .and_then(|e| build_prune_tree_config(&e.tree, &schema_for_pruner, &leaf_exprs));
             let residual_expr: Option<Arc<dyn PhysicalExpr>> = extraction.as_ref().and_then(|e| {
                 residual_bool_to_physical_expr(&e.tree)
             });
@@ -1022,7 +1043,7 @@ async unsafe fn execute_indexed_with_context_inner(
                 .as_ref()
                 .and_then(|expr| build_pruning_predicate(expr, Arc::clone(&schema_for_pruner)));
 
-            Arc::new(
+            (Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     let pruner = Arc::new(PagePruner::new(
                         &schema_for_pruner,
@@ -1041,7 +1062,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         ));
                     Ok(eval)
                 },
-            )
+            ), prune_tree_config)
         }
         FilterClass::SingleCollector => {
             let extraction = extraction.as_ref().ok_or_else(|| {
@@ -1050,6 +1071,7 @@ async unsafe fn execute_indexed_with_context_inner(
                 )
             })?;
             let schema_for_pruner = schema.clone();
+            let prune_tree_config = build_prune_tree_config(&extraction.tree, &schema_for_pruner, &leaf_exprs);
 
             // Correctness-delegated provider (eager). `None` when the query has only
             // performance-delegated leaves and no Collector at all.
@@ -1101,7 +1123,7 @@ async unsafe fn execute_indexed_with_context_inner(
             let call_strategy = CollectorCallStrategy::PageRangeSplit;
             let bloom_store = Arc::clone(&store);
             let bloom_schema = schema.clone();
-            Arc::new(
+            (Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     let collector_opt: Option<Arc<dyn RowGroupDocsCollector>> = match &correctness_provider {
                         Some(provider) => {
@@ -1160,7 +1182,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         ));
                     Ok(eval)
                 },
-            )
+            ), prune_tree_config)
         }
         FilterClass::Tree => {
             let extraction = extraction.ok_or_else(|| {
@@ -1172,7 +1194,7 @@ async unsafe fn execute_indexed_with_context_inner(
             // same-kind connectives. Flatten after push_not_down so the
             // connective changes from De Morgan (e.g. NOT(AND(...)) -> OR(NOT...))
             // get absorbed into the surrounding Or if applicable.
-            let tree = extraction.tree.push_not_down().flatten();
+            let tree = Arc::try_unwrap(extraction.tree).unwrap().push_not_down().flatten();
             // One provider per Collector leaf (DFS order).
             let leaf_ids = tree.collector_leaves();
             let mut providers: Vec<Arc<ProviderHandle>> = Vec::with_capacity(leaf_ids.len());
@@ -1211,13 +1233,13 @@ async unsafe fn execute_indexed_with_context_inner(
             // Build prune_tree_config from the normalized tree. This ensures
             // StatsPruneTree children indices align with ResolvedNode children
             // (same push_not_down + flatten normalization applied above).
-            prune_tree_config = if pruning_predicates.is_empty() {
+            let prune_tree_config = if pruning_predicates.is_empty() {
                 None
             } else {
                 Some((Arc::clone(&tree), Arc::clone(&pruning_predicates), schema_for_pruner.clone()))
             };
 
-            Arc::new(
+            (Arc::new(
                 move |segment: &SegmentFileInfo, chunk, stream_metrics: &StreamMetrics, stats_prune_tree: Option<&Arc<StatsPruneTree>>| {
                     // Build one collector per Collector leaf for this chunk.
                     let mut per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> =
@@ -1267,7 +1289,7 @@ async unsafe fn execute_indexed_with_context_inner(
                     });
                     Ok(eval)
                 },
-            )
+            ), prune_tree_config)
         }
     };
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/substrait_to_tree.rs
@@ -85,7 +85,7 @@ pub enum FilterClass {
 /// now that `Predicate` leaves carry `Arc<dyn PhysicalExpr>` directly.
 #[derive(Debug)]
 pub struct ExtractionResult {
-    pub tree: BoolNode,
+    pub tree: Arc<BoolNode>,
 }
 
 /// Extract the scan-level filter from a logical plan, skipping HAVING/window
@@ -149,7 +149,7 @@ pub fn expr_to_bool_tree(
     } else {
         tree
     };
-    Ok(ExtractionResult { tree })
+    Ok(ExtractionResult { tree: Arc::new(tree) })
 }
 
 fn convert_expr(
@@ -515,7 +515,7 @@ mod tests {
     fn simple_predicate() {
         let expr = col("price").gt(lit(100i32));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Predicate(_)));
+        assert!(matches!(*r.tree, BoolNode::Predicate(_)));
     }
 
     #[test]
@@ -527,35 +527,35 @@ mod tests {
             Box::new(col("price")),
         ));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Predicate(_)));
+        assert!(matches!(*r.tree, BoolNode::Predicate(_)));
     }
 
     #[test]
     fn and_of_predicates() {
         let expr = col("price").gt(lit(100i32)).and(col("qty").lt(lit(50i32)));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::And(_)));
+        assert!(matches!(*r.tree, BoolNode::And(_)));
     }
 
     #[test]
     fn not_predicate() {
         let expr = Expr::Not(Box::new(col("active").eq(lit(true))));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Not(_)));
+        assert!(matches!(*r.tree, BoolNode::Not(_)));
     }
 
     #[test]
     fn in_list_expression_is_accepted() {
         let expr = col("price").in_list(vec![lit(5i32), lit(10i32), lit(15i32)], false);
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Predicate(_)));
+        assert!(matches!(*r.tree, BoolNode::Predicate(_)));
     }
 
     #[test]
     fn is_null_expression_is_accepted() {
         let expr = Expr::IsNull(Box::new(col("price")));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Predicate(_)));
+        assert!(matches!(*r.tree, BoolNode::Predicate(_)));
     }
 
     #[test]
@@ -565,9 +565,9 @@ mod tests {
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
         // BETWEEN may desugar into And internally or stay as-is; either
         // shape is accepted so long as the result is boolean-valued.
-        match r.tree {
+        match *r.tree {
             BoolNode::Predicate(_) | BoolNode::And(_) => {}
-            other => panic!("expected Predicate or And, got {:?}", other),
+            ref other => panic!("expected Predicate or And, got {:?}", other),
         }
     }
 
@@ -576,7 +576,7 @@ mod tests {
         // (price + 10) > 100 — our old converter would reject this.
         let expr = (col("price") + lit(10i32)).gt(lit(100i32));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::Predicate(_)));
+        assert!(matches!(*r.tree, BoolNode::Predicate(_)));
     }
 
     #[test]
@@ -597,7 +597,7 @@ mod tests {
             vec![lit(ScalarValue::Int32(Some(42)))],
         ));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        match r.tree {
+        match *r.tree {
             BoolNode::Collector { annotation_id } => {
                 assert_eq!(annotation_id, 42);
             }
@@ -621,7 +621,7 @@ mod tests {
             Box::new(or_branch),
         ));
         let r = expr_to_bool_tree(&expr, &test_schema(), &test_state()).unwrap();
-        assert!(matches!(r.tree, BoolNode::And(_)));
+        assert!(matches!(*r.tree, BoolNode::And(_)));
     }
 
     // ── classify_filter ──────────────────────────────────────────────


### PR DESCRIPTION
Eliminate deep clone of BoolNode and extract prune_tree_config into match arms



<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Change ExtractionResult.tree from BoolNode to Arc<BoolNode> to avoid deep cloning the tree when building prune_tree_config. None and SingleCollector paths now use Arc::clone (O(1)), Tree path uses Arc::try_unwrap for zero-cost ownership transfer.

- Add build_prune_tree_config utility that encapsulates collect_predicate_exprs + per-leaf build_pruning_predicate, used by None and SingleCollector arms.

- Move prune_tree_config construction into each EvaluatorFactory match arm, removing the mut variable. Tree arm reuses its existing pruning_predicates directly.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
