### PR TITLE
Remove duplicate versionMap after refresh call.

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -1112,7 +1112,6 @@ public class DataFormatAwareEngine implements Indexer {
                 }
             } finally {
                 notifyRefreshListenersAfter(refreshed);
-                versionMap.afterRefresh(refreshed);
                 IOUtils.close(toClose);
                 refreshLock.unlock();
             }


### PR DESCRIPTION
### Description

`DataFormatAwareEngine` registers `versionMap` as a `RefreshListener` in its constructor, so `notifyRefreshListenersAfter(refreshed)` already drives `versionMap.afterRefresh(refreshed)` as part of the listener fan-out. The `refresh()` method then called `versionMap.afterRefresh(refreshed)` a second time inline in the `finally` block, double-invoking `afterRefresh` on every successful refresh.

This change removes the redundant inline `versionMap.afterRefresh(refreshed)` call, leaving the single invocation that flows through the standard refresh-listener notification path. This matches `InternalEngine`, where the version map's `afterRefresh` is driven solely through the registered listener rather than being called directly.

No behavior change beyond eliminating the duplicate call; the version map is still advanced exactly once per refresh via the listener.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).