### PR TITLE
Fixed DataFormatAwareDFASnapshotBlockingITs

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareDFASnapshotBlockingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareDFASnapshotBlockingIT.java
@@ -96,6 +96,7 @@ public class DataFormatAwareDFASnapshotBlockingIT extends DataFormatAwareReadonl
             .put("index.pluggable.dataformat.enabled", true)
             .put("index.pluggable.dataformat", "composite")
             .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
             .build();
         client().admin().indices().prepareCreate(indexName).setSettings(hot).get();
         ensureGreen(indexName);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flaky DFA snapshot IT: add Lucene secondary format to hot index
  
  DataFormatAwareDFASnapshotBlockingIT was failing with "timed out waiting for green state." The createHotDFAIndex helper created a composite index with
  primary_data_format=parquet and no secondary format. Parquet alone can't provide the FULL_TEXT_SEARCH capability that the internal _field_names field
  requires, so shard recovery failed (MapperParsingException) and the index never went green.
  
  Fix: add secondary_data_formats=[lucene], matching the base class dfaIndexSettings() and every other DFA test.
  
  Testing: All 3 tests pass with the original failing seed D3A2B9F9FDBA80FC (tests=3, failures=0, errors=0); compile + Spotless pass.
  
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
