### PR TITLE
feat(block-cache): Add range containment check in FoyerCache::get()

### DIFF
--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -697,6 +697,135 @@ impl FoyerCache {
         let raw = if let Some(pos) = key.find(SEPARATOR) { &key[..pos] } else { key };
         raw.trim_start_matches('/')
     }
+
+    /// Attempt to serve a range request from cached superset entries.
+    ///
+    /// Scans the key_index for the same file path and looks for:
+    /// 1. A single cached entry that fully contains the requested range (containment).
+    /// 2. Multiple cached entries that together cover the requested range (stitching).
+    ///
+    /// Returns `Some(Bytes)` on success, `None` if the range cannot be served from cache.
+    async fn try_range_containment(&self, key: &CacheKey) -> Option<Bytes> {
+        use crate::range_cache::parse_range;
+
+        let (req_start, req_end) = parse_range(key.as_str())?;
+        if req_start >= req_end {
+            return None;
+        }
+        let idx_key = Self::index_key(key.as_str()).to_string();
+
+        // Get the set of cached keys for this file path.
+        let entry = self.key_index.get(&idx_key)?;
+        let cached_keys: &std::collections::HashSet<String> = entry.value();
+        if cached_keys.is_empty() {
+            return None;
+        }
+
+        // Collect all cached ranges for this file, sorted by start.
+        let mut ranges: Vec<(u64, u64, &String)> = Vec::new();
+        for k in cached_keys.iter() {
+            if let Some((s, e)) = parse_range(k) {
+                if e > req_start && s < req_end {
+                    // This range overlaps with the requested range.
+                    ranges.push((s, e, k));
+                }
+            }
+        }
+
+        if ranges.is_empty() {
+            native_bridge_common::log_debug!(
+                "[block-cache] get containment: key='{}' no overlapping ranges in key_index for path='{}'",
+                key.as_str(), idx_key
+            );
+            return None;
+        }
+
+        // Sort by start offset for stitching.
+        ranges.sort_by_key(|&(s, _, _)| s);
+
+        native_bridge_common::log_debug!(
+            "[block-cache] get containment: key='{}' needed={}..{} found {} candidate(s): [{}]",
+            key.as_str(), req_start, req_end, ranges.len(),
+            ranges.iter().map(|(s, e, _)| format!("{}..{}", s, e)).collect::<Vec<_>>().join(", ")
+        );
+
+        // Check if we can cover [req_start, req_end) with these ranges (no gaps).
+        let mut coverage = req_start;
+        let mut covering: Vec<(u64, u64, &String)> = Vec::new();
+        for &(s, e, k) in &ranges {
+            if s > coverage {
+                // Gap — can't stitch.
+                native_bridge_common::log_debug!(
+                    "[block-cache] get containment FAIL (gap at {}): key='{}' needed={}..{} found {} candidate(s)",
+                    coverage, key.as_str(), req_start, req_end, ranges.len()
+                );
+                return None;
+            }
+            covering.push((s, e, k));
+            if e >= coverage {
+                coverage = e;
+            }
+            if coverage >= req_end {
+                break;
+            }
+        }
+
+        if coverage < req_end {
+            native_bridge_common::log_debug!(
+                "[block-cache] get containment FAIL (short): key='{}' needed={}..{} covered_to={}",
+                key.as_str(), req_start, req_end, coverage
+            );
+            return None;
+        }
+
+        // We have full coverage. Fetch data from each covering entry and assemble.
+        let needed_len = (req_end - req_start) as usize;
+        let mut buf = Vec::with_capacity(needed_len);
+        let mut pos = req_start;
+
+        for (s, e, k) in &covering {
+            if pos >= req_end {
+                break;
+            }
+            match self.inner.get(&k.to_string()).await {
+                Ok(Some(entry)) => {
+                    let data = entry.value();
+                    // Slice: we need bytes [pos..min(req_end, e)] from this entry.
+                    // The entry covers [s..e], so offset within entry = pos - s.
+                    let slice_start = (pos - s) as usize;
+                    let slice_end = ((req_end.min(*e)) - s) as usize;
+                    if slice_end <= data.len() && slice_start < slice_end {
+                        buf.extend_from_slice(&data[slice_start..slice_end]);
+                        pos = req_end.min(*e);
+                    } else {
+                        // Data size mismatch (entry was evicted and re-cached with different size?).
+                        native_bridge_common::log_debug!(
+                            "[block-cache] get containment FAIL (data mismatch): cached_key='{}' data_len={} slice={}..{}",
+                            k, data.len(), slice_start, slice_end
+                        );
+                        return None;
+                    }
+                }
+                _ => {
+                    // Entry was evicted between key_index check and disk read.
+                    native_bridge_common::log_debug!(
+                        "[block-cache] get containment FAIL (evicted): cached_key='{}'", k
+                    );
+                    return None;
+                }
+            }
+        }
+
+        if buf.len() == needed_len {
+            native_bridge_common::log_debug!(
+                "[block-cache] get HIT (containment): key='{}' served from {} cached range(s)",
+                key.as_str(), covering.len()
+            );
+            Some(Bytes::from(buf))
+        } else {
+            None
+        }
+    }
 }
 
 impl BlockCache for FoyerCache {
@@ -712,20 +841,28 @@ impl BlockCache for FoyerCache {
         // completes). Without the guard, a cancelled future would leave active_in_bytes elevated.
         let _active_guard = ActiveBytesGuard::new(&self.stats.active_in_bytes, range_len);
 
+        // Fast path: exact key lookup.
         match self.inner.get(&key.as_str().to_string()).await {
             Ok(Some(e)) => {
                 let size = e.value().len() as i64;
                 self.stats.hit_count.fetch_add(1, Ordering::Relaxed);
                 self.stats.hit_bytes.fetch_add(size, Ordering::Relaxed);
-                Some(Bytes::copy_from_slice(e.value()))
+                return Some(Bytes::copy_from_slice(e.value()));
             }
-            _ => {
-                self.stats.miss_count.fetch_add(1, Ordering::Relaxed);
-                self.stats.miss_bytes.fetch_add(range_len, Ordering::Relaxed);
-                None
-            }
+            _ => {}
         }
-        // _active_guard dropped here — fetch_sub runs regardless of hit/miss/cancellation
+
+        // Slow path: check if any cached range(s) for this file contain/cover the requested range.
+        if let Some(result) = self.try_range_containment(key).await {
+            let size = result.len() as i64;
+            self.stats.hit_count.fetch_add(1, Ordering::Relaxed);
+            self.stats.hit_bytes.fetch_add(size, Ordering::Relaxed);
+            return Some(result);
+        }
+
+        self.stats.miss_count.fetch_add(1, Ordering::Relaxed);
+        self.stats.miss_bytes.fetch_add(range_len, Ordering::Relaxed);
+        None
         })
     }
 

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/range_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/range_cache.rs
@@ -127,6 +127,17 @@ pub(crate) fn key_byte_size(raw_key: &str) -> i64 {
     0
 }
 
+/// Parse the `(start, end)` byte range from a raw cache key: `"path\x1Fstart-end"`.
+/// Returns `None` for non-range keys or malformed suffixes.
+pub(crate) fn parse_range(raw_key: &str) -> Option<(u64, u64)> {
+    let sep_pos = raw_key.find(SEPARATOR)?;
+    let range_part = &raw_key[sep_pos + SEPARATOR.len_utf8()..];
+    let dash_pos = range_part.find('-')?;
+    let start = range_part[..dash_pos].parse::<u64>().ok()?;
+    let end = range_part[dash_pos + 1..].parse::<u64>().ok()?;
+    Some((start, end))
+}
+
 // ── key_byte_size unit tests ──────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -2577,3 +2577,148 @@ fn recovery_stale_snapshot_keys_cleaned_by_sweep() {
     assert!(!cache.key_index.contains_key("data/stale.parquet"),
         "stale key must be gone after sweep");
 }
+
+// ── Range containment + stitching tests ───────────────────────────────────────
+
+#[test]
+fn get_subrange_hits_from_cached_superset() {
+    let (cache, _dir) = test_cache();
+
+    // Cache bytes 0..1000
+    let data: Vec<u8> = (0..1000u16).map(|i| (i % 256) as u8).collect();
+    put_range(&cache, "/data/file.parquet", 0, 1000, &data);
+
+    // Request bytes 0..500 — should hit via containment
+    let key = range_cache_key("/data/file.parquet", 0, 500);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some(), "subrange 0..500 should hit from cached 0..1000");
+    assert_eq!(result.unwrap().as_ref(), &data[0..500]);
+}
+
+#[test]
+fn get_middle_subrange_hits_from_cached_superset() {
+    let (cache, _dir) = test_cache();
+
+    let data: Vec<u8> = (0..1000u16).map(|i| (i % 256) as u8).collect();
+    put_range(&cache, "/data/file.parquet", 0, 1000, &data);
+
+    // Request bytes 200..700 — middle slice
+    let key = range_cache_key("/data/file.parquet", 200, 700);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some(), "subrange 200..700 should hit from cached 0..1000");
+    assert_eq!(result.unwrap().as_ref(), &data[200..700]);
+}
+
+#[test]
+fn get_exact_range_still_works() {
+    let (cache, _dir) = test_cache();
+
+    let data = b"hello world";
+    put_range(&cache, "/data/file.parquet", 100, 111, data);
+
+    // Exact match should still use the fast path
+    let key = range_cache_key("/data/file.parquet", 100, 111);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().as_ref(), b"hello world");
+}
+
+#[test]
+fn get_miss_when_no_superset_exists() {
+    let (cache, _dir) = test_cache();
+
+    // Cache 0..500
+    let data = vec![0u8; 500];
+    put_range(&cache, "/data/file.parquet", 0, 500, &data);
+
+    // Request 0..1000 — not fully contained
+    let key = range_cache_key("/data/file.parquet", 0, 1000);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_none(), "0..1000 is not contained in 0..500");
+}
+
+#[test]
+fn get_stitches_from_two_adjacent_ranges() {
+    let (cache, _dir) = test_cache();
+
+    // Cache two adjacent ranges: 0..500 and 500..1000
+    let data1: Vec<u8> = (0..500u16).map(|i| (i % 256) as u8).collect();
+    let data2: Vec<u8> = (500..1000u16).map(|i| (i % 256) as u8).collect();
+    put_range(&cache, "/data/file.parquet", 0, 500, &data1);
+    put_range(&cache, "/data/file.parquet", 500, 1000, &data2);
+
+    // Request 0..1000 — should stitch from both
+    let key = range_cache_key("/data/file.parquet", 0, 1000);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some(), "0..1000 should be stitchable from 0..500 + 500..1000");
+    let expected: Vec<u8> = (0..1000u16).map(|i| (i % 256) as u8).collect();
+    assert_eq!(result.unwrap().as_ref(), expected.as_slice());
+}
+
+#[test]
+fn get_stitches_from_overlapping_ranges() {
+    let (cache, _dir) = test_cache();
+
+    // Cache overlapping ranges: 0..600 and 400..1000
+    let data1: Vec<u8> = (0..600u16).map(|i| (i % 256) as u8).collect();
+    let data2: Vec<u8> = (400..1000u16).map(|i| (i % 256) as u8).collect();
+    put_range(&cache, "/data/file.parquet", 0, 600, &data1);
+    put_range(&cache, "/data/file.parquet", 400, 1000, &data2);
+
+    // Request 0..1000 — should stitch (first covers 0..600, second covers 600..1000)
+    let key = range_cache_key("/data/file.parquet", 0, 1000);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some(), "0..1000 should be stitchable from 0..600 + 400..1000");
+    let bytes = result.unwrap();
+    assert_eq!(bytes.len(), 1000);
+    // First 600 bytes come from data1
+    let expected_first: Vec<u8> = (0..600u16).map(|i| (i % 256) as u8).collect();
+    assert_eq!(&bytes[0..600], expected_first.as_slice());
+    // Last 400 bytes come from data2 (offset 200..600 within data2)
+    let expected_last: Vec<u8> = (600..1000u16).map(|i| (i % 256) as u8).collect();
+    assert_eq!(&bytes[600..1000], expected_last.as_slice());
+}
+
+#[test]
+fn get_fails_with_gap_between_ranges() {
+    let (cache, _dir) = test_cache();
+
+    // Cache 0..400 and 600..1000 — gap at 400..600
+    let data1 = vec![1u8; 400];
+    let data2 = vec![2u8; 400];
+    put_range(&cache, "/data/file.parquet", 0, 400, &data1);
+    put_range(&cache, "/data/file.parquet", 600, 1000, &data2);
+
+    // Request 0..1000 — gap means miss
+    let key = range_cache_key("/data/file.parquet", 0, 1000);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_none(), "0..1000 cannot be served with gap at 400..600");
+}
+
+#[test]
+fn get_subrange_from_different_file_does_not_hit() {
+    let (cache, _dir) = test_cache();
+
+    let data = vec![0u8; 1000];
+    put_range(&cache, "/data/a.parquet", 0, 1000, &data);
+
+    // Request same range but different file
+    let key = range_cache_key("/data/b.parquet", 0, 500);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_none(), "different file path should not hit");
+}
+
+#[test]
+fn get_containment_works_with_non_zero_start() {
+    let (cache, _dir) = test_cache();
+
+    // Cache 1000..2000
+    let data: Vec<u8> = (0..1000u16).map(|i| (i % 256) as u8).collect();
+    put_range(&cache, "/data/file.parquet", 1000, 2000, &data);
+
+    // Request 1200..1800 — subrange of 1000..2000
+    let key = range_cache_key("/data/file.parquet", 1200, 1800);
+    let result = block_on(cache.get(&key));
+    assert!(result.is_some(), "1200..1800 should hit from 1000..2000");
+    assert_eq!(result.unwrap().as_ref(), &data[200..800]);
+}


### PR DESCRIPTION
### Description
When an exact cache key misses, scan the key_index for cached ranges that fully contain (or can be stitched to cover) the requested range. This avoids redundant remote fetches when a superset of data is already cached — common in Parquet workloads where column chunks are read with varying sub-ranges across queries.

- Add parse_range() helper to range_cache.rs
- Add try_range_containment() to FoyerCache with coverage/stitching logic
- Add 9 unit tests for containment, stitching, gaps, cross-file isolation
- All containment logs at DEBUG level for production

### Testing

https://quip-amazon.com/QtX4ACyc51ut/PR-22271-Test-Report

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [Yes] Functionality includes testing.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
