### PR TITLE
Surface circuit breaker as HTTP 429 when it self-cancels the query

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/QueryExecution.java
@@ -13,10 +13,12 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.analytics.exec.stage.DataProducer;
 import org.opensearch.analytics.exec.stage.StageExecution;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.tasks.CancellableTask;
 
@@ -170,12 +172,24 @@ public class QueryExecution {
     }
 
     /**
-     * Live parent-task cancellation wins — keeps the user-facing message accurate over the
-     * downstream FAILED cause. Otherwise propagate the captured stage failure (synthetic
-     * fallback for CANCELLED with no upstream cause).
+     * Determines the exception to report for a non-SUCCEEDED terminal.
+     *
+     * <p>Live parent-task cancellation still wins — the user-facing "query cancelled" message stays
+     * accurate for genuine top-down cancels. The one exception is a breaker masquerading as a cancel:
+     * a memory-gate trip ({@link CircuitBreakingException}) fails the (reduce) stage and then cancels
+     * the parent task via the sibling/child cancel sweep, so {@code isCancelled()} is already true by
+     * the time we report. Returning {@link TaskCancelledException} there would mask the real cause as
+     * HTTP 500; instead we peek at the captured root failure and, if a breaker is hiding in its cause
+     * chain, surface it unwrapped so {@code status()} yields 429. A genuine cancel records no stage
+     * failure ({@code getFailure()} is {@code null}), so the peek finds nothing and behavior is
+     * unchanged. The non-cancel path is byte-for-byte the original: captured failure, else synthetic.
      */
     private Exception terminalCause(State terminal) {
         if (config.parentTask() instanceof CancellableTask ct && ct.isCancelled()) {
+            Throwable breaker = ExceptionsHelper.unwrap(graph.rootExecution().getFailure(), CircuitBreakingException.class);
+            if (breaker != null) {
+                return (CircuitBreakingException) breaker;
+            }
             return new TaskCancelledException("query cancelled");
         }
         StageExecution rootExec = graph.rootExecution();

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/QueryExecutionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/QueryExecutionTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics.exec;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.opensearch.OpenSearchException;
 import org.opensearch.analytics.backend.ExchangeSource;
 import org.opensearch.analytics.exec.stage.DataProducer;
 import org.opensearch.analytics.exec.stage.StageExecution;
@@ -21,12 +22,17 @@ import org.opensearch.analytics.planner.dag.Stage;
 import org.opensearch.analytics.planner.dag.StageExecutionType;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.core.common.breaker.CircuitBreakingException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.core.tasks.TaskId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -184,12 +190,139 @@ public class QueryExecutionTests extends OpenSearchTestCase {
         assertSame("original stage failure must reach the listener even when terminal sink close throws", rootCause, onFailure.get());
     }
 
+    public void testBareBreakerMasqueradingAsCancelSurfacesAs429() {
+        // The exact shape reproduced live on 91-d: the breaker is the root stage's captured failure
+        // (DatafusionReduceSink.reduce → onTaskTerminal → captureFailure), and the same trip then
+        // cancels the parent task via the child cancel sweep so isCancelled() is already true.
+        // terminalCause must surface the breaker (HTTP 429), not mask it as TaskCancelledException (500).
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        builder.registerFactory(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AnalyticsQueryTask task = newTask();
+        task.cancel("circuit breaker sweep cancelled the parent task");
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        newQueryExecution(rootStage, ActionListener.wrap(r -> fail("unexpected success"), onFailure::set), task);
+
+        CircuitBreakingException breaker = new CircuitBreakingException(
+            "[analytics_backend_datafusion] Failed to allocate 64 bytes (limit: 7101482993)",
+            64,
+            7101482993L,
+            CircuitBreaker.Durability.TRANSIENT
+        );
+        root.failWith(breaker);
+
+        Exception surfaced = onFailure.get();
+        assertSame("breaker must be surfaced, not masked by the self-cancel", breaker, surfaced);
+        assertEquals("breaker maps to HTTP 429", RestStatus.TOO_MANY_REQUESTS, ((OpenSearchException) surfaced).status());
+    }
+
+    public void testWrappedBreakerUnderCancelStillUnwrapsTo429() {
+        // Defends the cause-walk: even if the breaker arrives nested (e.g. a CompletionException from
+        // an async→sync future.join() bridge) under a cancelled parent task, it must still be unwrapped.
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        builder.registerFactory(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AnalyticsQueryTask task = newTask();
+        task.cancel("circuit breaker sweep cancelled the parent task");
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        newQueryExecution(rootStage, ActionListener.wrap(r -> fail("unexpected success"), onFailure::set), task);
+
+        CircuitBreakingException breaker = new CircuitBreakingException(
+            "[analytics_backend_datafusion] Failed to allocate 327680 bytes (limit: 4194304)",
+            327680,
+            4194304,
+            CircuitBreaker.Durability.TRANSIENT
+        );
+        root.failWith(new CompletionException(breaker));
+
+        Exception surfaced = onFailure.get();
+        assertSame("nested breaker must be unwrapped, not masked by cancellation", breaker, surfaced);
+        assertEquals("breaker maps to HTTP 429", RestStatus.TOO_MANY_REQUESTS, ((OpenSearchException) surfaced).status());
+    }
+
+    public void testBareBreakerFailureSurfacesAs429() {
+        // A breaker captured directly as the root failure (parent task NOT cancelled) is surfaced as-is
+        // via the unchanged non-cancel path.
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        builder.registerFactory(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        newQueryExecution(rootStage, ActionListener.wrap(r -> fail("unexpected success"), onFailure::set));
+
+        CircuitBreakingException breaker = new CircuitBreakingException("Failed to allocate", CircuitBreaker.Durability.TRANSIENT);
+        root.failWith(breaker);
+
+        Exception surfaced = onFailure.get();
+        assertSame(breaker, surfaced);
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, ((OpenSearchException) surfaced).status());
+    }
+
+    public void testGenuineCancelWithNoStageFailureStaysTaskCancelled() {
+        // No stage recorded a failure (getFailure()==null) and the parent task is cancelled: this is a
+        // real top-down cancel and must remain a TaskCancelledException (HTTP 500) — proving the fix
+        // does not turn genuine cancellations into 429.
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        builder.registerFactory(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AnalyticsQueryTask task = newTask();
+        task.cancel("user aborted the request");
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        QueryExecution qe = newQueryExecution(rootStage, ActionListener.wrap(r -> fail("unexpected success"), onFailure::set), task);
+        qe.cancelAll("user aborted the request");
+
+        Exception surfaced = onFailure.get();
+        assertTrue("genuine cancel must stay TaskCancelledException", surfaced instanceof TaskCancelledException);
+        assertEquals("cancellation maps to HTTP 500", RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchException) surfaced).status());
+    }
+
+    public void testNonBreakerFailureWithCancelledParentStaysTaskCancelled() {
+        // A non-breaker stage failure that also cancelled the parent task keeps the original cancel-first
+        // behavior: the peek finds no breaker, so we report TaskCancelledException (HTTP 500). Option B
+        // only diverts the breaker case; every other cancelled path is unchanged.
+        Stage rootStage = stageWithId(0);
+        TestRootExecution root = new TestRootExecution(rootStage, new CountingCloseSink());
+        builder.registerFactory(StageExecutionType.LOCAL_PASSTHROUGH, (stage, s, cfg) -> root);
+
+        AnalyticsQueryTask task = newTask();
+        task.cancel("sibling sweep cancelled the parent task");
+
+        AtomicReference<Exception> onFailure = new AtomicReference<>();
+        newQueryExecution(rootStage, ActionListener.wrap(r -> fail("unexpected success"), onFailure::set), task);
+
+        root.failWith(new RuntimeException("non-memory stage failure"));
+
+        Exception surfaced = onFailure.get();
+        assertTrue("non-breaker failure under a cancel stays TaskCancelledException", surfaced instanceof TaskCancelledException);
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────
 
     private QueryExecution newQueryExecution(Stage rootStage, ActionListener<Iterable<VectorSchemaRoot>> listener) {
         QueryContext ctx = queryCtx(rootStage);
         ExecutionGraph graph = ExecutionGraph.build(ctx, builder, StageExecution::start);
         return new QueryExecution(ctx, graph, StageExecution::start, listener);
+    }
+
+    private QueryExecution newQueryExecution(
+        Stage rootStage,
+        ActionListener<Iterable<VectorSchemaRoot>> listener,
+        AnalyticsQueryTask task
+    ) {
+        QueryDAG dag = new QueryDAG("q-test", rootStage);
+        QueryContext ctx = QueryContext.forTest(dag, task);
+        ExecutionGraph graph = ExecutionGraph.build(ctx, builder, StageExecution::start);
+        return new QueryExecution(ctx, graph, StageExecution::start, listener);
+    }
+
+    private static AnalyticsQueryTask newTask() {
+        return new AnalyticsQueryTask(1L, "transport", "analytics_query", "q-test", TaskId.EMPTY_TASK_ID, java.util.Map.of(), null);
     }
 
     private static Stage stageWithId(int id) {


### PR DESCRIPTION
### Description

A circuit breaker (`CircuitBreakingException`, HTTP 429) that trips on the **reduce** stage is currently reported to the client as **HTTP 500** instead of 429.

**Root cause.** When the memory gate trips on the reduce stage, the stage transitions to `FAILED`, which cancels its child stages, and `AbstractStageExecution.cancel` propagates the cancel to the parent task (`parentTask.cancel()`). By the time `QueryExecution.terminalCause` builds the error to report, the parent task is already cancelled. The original ordering checked `isCancelled()` **first**, so it returned a synthetic `TaskCancelledException` (HTTP 500) and discarded the real breaker (HTTP 429).

This was confirmed on a live cluster from the logged exception stack and an adjacent same-`taskId` breaker log line on the same thread:

```
DatafusionReduceSink.reduce -> CircuitBreakingException[Failed to allocate 64 bytes]
ReduceStageExecution stage 1 terminal=FAILED, firing cancellable.cancel()
... -> QueryExecution.cancelAll -> terminalCause(QueryExecution.java:179)
   -> TaskCancelledException: query cancelled
POST /_plugins/_ppl - 500 INTERNAL_SERVER_ERROR
```

**Fix.** `terminalCause` keeps the cancel-first ordering, but inside the cancelled branch it now peeks at the captured root failure: if a `CircuitBreakingException` is in its cause chain, it is surfaced unwrapped so `status()` yields 429. A genuine top-down cancel records no stage failure (`getFailure() == null`), so the peek finds nothing and behavior is unchanged. The non-cancel path is byte-for-byte the original.

`ExceptionsHelper.unwrap` (cause-only, no suppressed) is used to avoid a multi-shard suppressed-sibling false positive.

**Tests.** `QueryExecutionTests` adds:
- bare breaker masquerading as a cancel → 429 (the reproduced shape)
- nested breaker under a cancel → still unwrapped to 429
- genuine cancel with no stage failure → stays `TaskCancelledException` (500)
- non-breaker failure under a cancel → stays `TaskCancelledException` (500)

### Related Issues
<!-- N/A -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
