### PR TITLE
Reducing the ingestion/write memory limit by 50% of original value

### DIFF
--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
@@ -11,6 +11,7 @@ package org.opensearch.arrow.allocator;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
 import org.opensearch.arrow.spi.PoolGroup;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
@@ -125,19 +126,19 @@ public class ArrowBasePlugin extends Plugin implements ExtensiblePlugin, ActionP
         Setting.Property.Dynamic
     );
 
-    /** Minimum guaranteed bytes for the ingest pool. Default is 2% of budget. */
+    /** Minimum guaranteed bytes for the ingest pool. Default is 2% of budget on warm nodes, 4% otherwise. */
     public static final Setting<Long> INGEST_MIN_SETTING = new Setting<>(
         NativeAllocatorPoolConfig.SETTING_INGEST_MIN,
-        s -> derivePoolMinDefault(s, 2),
+        s -> derivePoolMinDefault(s, DiscoveryNode.isWarmNode(s) ? 2 : 4),
         s -> parseNonNegativeLong(s, NativeAllocatorPoolConfig.SETTING_INGEST_MIN),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
-    /** Maximum bytes the ingest pool can burst to. Default is 4% of budget. */
+    /** Maximum bytes the ingest pool can burst to. Default is 4% of budget on warm nodes, 8% otherwise. */
     public static final Setting<Long> INGEST_MAX_SETTING = new Setting<>(
         NativeAllocatorPoolConfig.SETTING_INGEST_MAX,
-        s -> derivePoolMaxDefault(s, 4),
+        s -> derivePoolMaxDefault(s, DiscoveryNode.isWarmNode(s) ? 4 : 8),
         s -> parseNonNegativeLong(s, NativeAllocatorPoolConfig.SETTING_INGEST_MAX),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
@@ -125,19 +125,19 @@ public class ArrowBasePlugin extends Plugin implements ExtensiblePlugin, ActionP
         Setting.Property.Dynamic
     );
 
-    /** Minimum guaranteed bytes for the ingest pool. Default is 4% of budget. */
+    /** Minimum guaranteed bytes for the ingest pool. Default is 2% of budget. */
     public static final Setting<Long> INGEST_MIN_SETTING = new Setting<>(
         NativeAllocatorPoolConfig.SETTING_INGEST_MIN,
-        s -> derivePoolMinDefault(s, 4),
+        s -> derivePoolMinDefault(s, 2),
         s -> parseNonNegativeLong(s, NativeAllocatorPoolConfig.SETTING_INGEST_MIN),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
 
-    /** Maximum bytes the ingest pool can burst to. Default is 8% of budget. */
+    /** Maximum bytes the ingest pool can burst to. Default is 4% of budget. */
     public static final Setting<Long> INGEST_MAX_SETTING = new Setting<>(
         NativeAllocatorPoolConfig.SETTING_INGEST_MAX,
-        s -> derivePoolMaxDefault(s, 8),
+        s -> derivePoolMaxDefault(s, 4),
         s -> parseNonNegativeLong(s, NativeAllocatorPoolConfig.SETTING_INGEST_MAX),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
+++ b/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
@@ -28,12 +28,13 @@ public class ArrowBasePluginTests extends OpenSearchTestCase {
     }
 
     public void testFlightAndIngestMinDerivedFromBudget() {
-        // With node.native_memory.limit set, mins derive as percentages
+        // With node.native_memory.limit set, mins derive as percentages. No warm role here, so
+        // ingest uses the non-warm default.
         Settings s = Settings.builder().put("node.native_memory.limit", "1gb").build();
         long budget = 1024L * 1024 * 1024;
-        // flight min = 2% of budget, ingest min = 2% of budget
+        // flight min = 2% of budget, ingest min = 4% of budget (non-warm)
         assertEquals(Long.valueOf(budget * 2 / 100), ArrowBasePlugin.FLIGHT_MIN_SETTING.get(s));
-        assertEquals(Long.valueOf(budget * 2 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
+        assertEquals(Long.valueOf(budget * 4 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
     }
 
     public void testPoolMaxDefaultsAreLongMaxValueWhenAcUnset() {
@@ -47,14 +48,24 @@ public class ArrowBasePluginTests extends OpenSearchTestCase {
         Settings s = Settings.builder().put("node.native_memory.limit", "10gb").build();
         long limit = 10L * 1024 * 1024 * 1024;
         assertEquals(Long.valueOf(limit * 5 / 100), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(limit * 4 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
+        // No warm role, so ingest uses the non-warm default (8%).
+        assertEquals(Long.valueOf(limit * 8 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
         assertEquals(Long.valueOf(limit * 5 / 100), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
+    }
+
+    public void testIngestPoolDefaultsAreReducedOnWarmNodes() {
+        // Warm nodes shrink the ingest pool (min 2%, max 4%) to free budget for the metadata cache.
+        Settings s = Settings.builder().put("node.native_memory.limit", "10gb").putList("node.roles", "warm").build();
+        long limit = 10L * 1024 * 1024 * 1024;
+        assertEquals(Long.valueOf(limit * 2 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
+        assertEquals(Long.valueOf(limit * 4 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
     }
 
     public void testPoolMaxDefaultsIgnoreBufferPercent() {
         Settings s = Settings.builder().put("node.native_memory.limit", "1000b").put("node.native_memory.buffer_percent", 20).build();
         assertEquals(Long.valueOf(50L), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(40L), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
+        // No warm role, so ingest uses the non-warm default (8% of 1000 = 80).
+        assertEquals(Long.valueOf(80L), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
         assertEquals(Long.valueOf(50L), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
     }
 

--- a/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
+++ b/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
@@ -31,9 +31,9 @@ public class ArrowBasePluginTests extends OpenSearchTestCase {
         // With node.native_memory.limit set, mins derive as percentages
         Settings s = Settings.builder().put("node.native_memory.limit", "1gb").build();
         long budget = 1024L * 1024 * 1024;
-        // flight min = 2% of budget, ingest min = 4% of budget
+        // flight min = 2% of budget, ingest min = 2% of budget
         assertEquals(Long.valueOf(budget * 2 / 100), ArrowBasePlugin.FLIGHT_MIN_SETTING.get(s));
-        assertEquals(Long.valueOf(budget * 4 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
+        assertEquals(Long.valueOf(budget * 2 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
     }
 
     public void testPoolMaxDefaultsAreLongMaxValueWhenAcUnset() {
@@ -47,14 +47,14 @@ public class ArrowBasePluginTests extends OpenSearchTestCase {
         Settings s = Settings.builder().put("node.native_memory.limit", "10gb").build();
         long limit = 10L * 1024 * 1024 * 1024;
         assertEquals(Long.valueOf(limit * 5 / 100), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(limit * 8 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
+        assertEquals(Long.valueOf(limit * 4 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
         assertEquals(Long.valueOf(limit * 5 / 100), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
     }
 
     public void testPoolMaxDefaultsIgnoreBufferPercent() {
         Settings s = Settings.builder().put("node.native_memory.limit", "1000b").put("node.native_memory.buffer_percent", 20).build();
         assertEquals(Long.valueOf(50L), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(80L), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
+        assertEquals(Long.valueOf(40L), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
         assertEquals(Long.valueOf(50L), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -24,14 +24,14 @@ import java.util.Locale;
  * <pre>
  * node.native_memory.limit = 80% of off-heap
  *   ├── 71% → datafusion.memory_pool_limit_bytes  (operator pool)
- *   ├──  3% → datafusion.metadata_index_cache.total_size   (all metadata caches (footer + page indexes), this class)
+ *   ├──  9% → datafusion.metadata_index_cache.total_size   (all metadata caches (footer + page indexes), this class)
  *   │     ├── 50% → metadata cache   (footer metadata, Rust jemalloc)
  *   │     ├── 35% → offset index     (projection-driven, Rust jemalloc)
  *   │     └── 15% → column index     (predicate-driven, Rust jemalloc)
- *   ├──  8% → Arrow ingest pool
+ *   ├──  4% → Arrow ingest pool
  *   ├──  5% → Arrow flight pool
  *   ├──  5% → Arrow query pool
- *   ├──  5% → Parquet write pool
+ *   ├──  3% → Parquet write pool
  *   └──  3% → Parquet merge pool
  *   = 100%
  * </pre>
@@ -39,7 +39,7 @@ import java.util.Locale;
  * <p>The three sub-cache percentages must sum to &lt;= 100 (unused headroom is accepted). Changing any one without adjusting
  * the others is rejected at validation time.
  *
- * <p>The statistics cache is sized independently (not part of the 3% total) because it
+ * <p>The statistics cache is sized independently (not part of the 9% total) because it
  * holds file-level row-group statistics, not page-level indexes — a different working set
  * with different eviction characteristics.
  */
@@ -103,13 +103,13 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
-    // Page-cache total budget (3% of node.native_memory.limit)
+    // Page-cache total budget (9% (for warm)/3% (for other node types) of node.native_memory.limit)
 
     public static final String METADATA_INDEX_CACHE_TOTAL_SIZE_KEY = "datafusion.metadata_index_cache.total_size";
 
     /**
      * Total byte budget for all three metadata caches (footer metadata, ColumnIndex,
-     * OffsetIndex). Defaults to 3% of {@code node.native_memory.limit}; falls back to
+     * OffsetIndex). Defaults to 9% of {@code node.native_memory.limit}; falls back to
      * 500 MB when AC is unconfigured.
      */
     public static final Setting<ByteSizeValue> METADATA_INDEX_CACHE_TOTAL_SIZE = new Setting<>(
@@ -220,7 +220,7 @@ public class CacheSettings {
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /**
-     * Default total page-cache budget: 3% of {@code node.native_memory.limit}.
+     * Default total page-cache budget: 9% of {@code node.native_memory.limit}.
      * Falls back to 500 MB when AC is unconfigured (limit == 0).
      */
     static String deriveMetadataIndexCacheTotalDefault(Settings settings) {
@@ -228,7 +228,7 @@ public class CacheSettings {
         if (nativeLimit.getBytes() <= 0) {
             return (500L * 1024 * 1024) + "b";
         }
-        long total = Math.max(nativeLimit.getBytes() * 3 / 100, 0L);
+        long total = Math.max(nativeLimit.getBytes() * 9 / 100, 0L);
         return total + "b";
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheSettings.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.be.datafusion.cache;
 
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeUnit;
@@ -25,15 +26,16 @@ import java.util.Locale;
  * node.native_memory.limit = 80% of off-heap
  *   ├── 71% → datafusion.memory_pool_limit_bytes  (operator pool)
  *   ├──  9% → datafusion.metadata_index_cache.total_size   (all metadata caches (footer + page indexes), this class)
+ *   │     │       (9% on warm nodes; 3% on all other node types)
  *   │     ├── 50% → metadata cache   (footer metadata, Rust jemalloc)
  *   │     ├── 35% → offset index     (projection-driven, Rust jemalloc)
  *   │     └── 15% → column index     (predicate-driven, Rust jemalloc)
- *   ├──  4% → Arrow ingest pool
+ *   ├──  4% → Arrow ingest pool                            (4% on warm nodes; 8% on all other node types)
  *   ├──  5% → Arrow flight pool
  *   ├──  5% → Arrow query pool
- *   ├──  3% → Parquet write pool
+ *   ├──  3% → Parquet write pool                           (3% on warm nodes; 5% on all other node types)
  *   └──  3% → Parquet merge pool
- *   = 100%
+ *   = 100% (warm node)
  * </pre>
  *
  * <p>The three sub-cache percentages must sum to &lt;= 100 (unused headroom is accepted). Changing any one without adjusting
@@ -103,14 +105,14 @@ public class CacheSettings {
         Setting.Property.Dynamic
     );
 
-    // Page-cache total budget (9% (for warm)/3% (for other node types) of node.native_memory.limit)
+    // Page-cache total budget (9% of node.native_memory.limit on warm nodes, 3% otherwise)
 
     public static final String METADATA_INDEX_CACHE_TOTAL_SIZE_KEY = "datafusion.metadata_index_cache.total_size";
 
     /**
      * Total byte budget for all three metadata caches (footer metadata, ColumnIndex,
-     * OffsetIndex). Defaults to 9% of {@code node.native_memory.limit}; falls back to
-     * 500 MB when AC is unconfigured.
+     * OffsetIndex). Defaults to 9% of {@code node.native_memory.limit} on warm nodes
+     * (3% on all other node types); falls back to 500 MB when AC is unconfigured.
      */
     public static final Setting<ByteSizeValue> METADATA_INDEX_CACHE_TOTAL_SIZE = new Setting<>(
         METADATA_INDEX_CACHE_TOTAL_SIZE_KEY,
@@ -220,15 +222,17 @@ public class CacheSettings {
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /**
-     * Default total page-cache budget: 9% of {@code node.native_memory.limit}.
-     * Falls back to 500 MB when AC is unconfigured (limit == 0).
+     * Default total page-cache budget: 9% of {@code node.native_memory.limit} on warm nodes,
+     * 3% on all other node types. Falls back to 500 MB when AC is unconfigured (limit == 0).
      */
     static String deriveMetadataIndexCacheTotalDefault(Settings settings) {
         ByteSizeValue nativeLimit = ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
         if (nativeLimit.getBytes() <= 0) {
             return (500L * 1024 * 1024) + "b";
         }
-        long total = Math.max(nativeLimit.getBytes() * 9 / 100, 0L);
+        // Warm nodes dedicate a larger share (9%) to metadata caches; other node types retain the 3% default.
+        int percent = DiscoveryNode.isWarmNode(settings) ? 9 : 3;
+        long total = Math.max(nativeLimit.getBytes() * percent / 100, 0L);
         return total + "b";
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/cache/CacheSettingsPercentValidationTests.java
@@ -72,7 +72,7 @@ public class CacheSettingsPercentValidationTests extends OpenSearchTestCase {
     // ── computeCacheSizes ─────────────────────────────────────────────────────
 
     public void testComputeSizesDefaultSplit() {
-        long total = 1_150_000_000L; // ~1.15 GB (3% of 38.4 GB native limit on r6g.2xlarge)
+        long total = 1_150_000_000L; // ~1.15 GB sample metadata-index cache total budget
         long[] sizes = CacheSettings.computeCacheSizes(48, 34, 13, 5, total);
         assertEquals(4, sizes.length);
         assertEquals(total * 48 / 100, sizes[0]); // footer ~552 MB

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -185,7 +185,7 @@ public final class ParquetSettings {
         Setting.Property.Dynamic
     );
 
-    /** Minimum guaranteed bytes for the native write pool. Default is half of write max (2% of budget). */
+    /** Minimum guaranteed bytes for the native write pool. Default is 2% of budget. */
     public static final Setting<Long> WRITE_POOL_MIN = new Setting<>(
         "parquet.native.pool.write.min",
         s -> derivePoolMinDefault(s, 2),
@@ -200,10 +200,10 @@ public final class ParquetSettings {
         Setting.Property.Dynamic
     );
 
-    /** Maximum bytes the native write pool can burst to. Default is 5% of node.native_memory.limit. */
+    /** Maximum bytes the native write pool can burst to. Default is 3% of node.native_memory.limit. */
     public static final Setting<Long> WRITE_POOL_MAX = new Setting<>(
         "parquet.native.pool.write.max",
-        s -> derivePoolMaxDefault(s, 5),
+        s -> derivePoolMaxDefault(s, 3),
         s -> {
             long v = Long.parseLong(s);
             if (v < 0) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -14,6 +14,7 @@ import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeUnit;
@@ -200,10 +201,10 @@ public final class ParquetSettings {
         Setting.Property.Dynamic
     );
 
-    /** Maximum bytes the native write pool can burst to. Default is 3% of node.native_memory.limit. */
+    /** Maximum bytes the native write pool can burst to. Default is 3% of budget on warm nodes, 5% otherwise. */
     public static final Setting<Long> WRITE_POOL_MAX = new Setting<>(
         "parquet.native.pool.write.max",
-        s -> derivePoolMaxDefault(s, 3),
+        s -> derivePoolMaxDefault(s, DiscoveryNode.isWarmNode(s) ? 3 : 5),
         s -> {
             long v = Long.parseLong(s);
             if (v < 0) {


### PR DESCRIPTION
### Description
Originally, Arrow ingest pool had 8% and Parquet write pool had 5% of the `node.native_memory.limit` setting. Since warm nodes would not get more write traffic, we are reducing both the above limits by 50% and dedicate that additional size to `datafusion.metadata_index_cache.total_size` which would increase from 3% to 9%.
Refer #22257 for the original size limits

### Related Issues
None

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
