### PR TITLE
[gRPC] Handle null FieldValue and aggregation missing values

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/bucket/terms/TermsAggregationBuilderConverter.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/bucket/terms/TermsAggregationBuilderConverter.java
@@ -78,7 +78,7 @@ public class TermsAggregationBuilderConverter implements AggregationBuilderProto
         // common fields for ValuesSourceAggregation
         ValuesSourceProtoFields valuesSourceFields = ValuesSourceProtoFields.builder()
             .field(terms.hasField() ? terms.getField() : null)
-            .missing(terms.hasMissing() ? FieldValueProtoUtils.fromProto(terms.getMissing()) : null)
+            .missing(terms.hasMissing() ? FieldValueProtoUtils.fromProto(terms.getMissing(), false) : null)
             .valueType(terms.hasValueType() ? terms.getValueType() : null)
             .format(terms.hasFormat() ? terms.getFormat() : null)
             .script(terms.hasScript() ? ScriptProtoUtils.parseFromProtoRequest(terms.getScript()) : null)

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MaxAggregationProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MaxAggregationProtoUtils.java
@@ -43,7 +43,7 @@ public class MaxAggregationProtoUtils {
 
         ValuesSourceProtoFields fields = ValuesSourceProtoFields.builder()
             .field(maxAggProto.hasField() ? maxAggProto.getField() : null)
-            .missing(maxAggProto.hasMissing() ? FieldValueProtoUtils.fromProto(maxAggProto.getMissing()) : null)
+            .missing(maxAggProto.hasMissing() ? FieldValueProtoUtils.fromProto(maxAggProto.getMissing(), false) : null)
             .valueType(maxAggProto.hasValueType() ? maxAggProto.getValueType() : null)
             .format(maxAggProto.hasFormat() ? maxAggProto.getFormat() : null)
             .script(maxAggProto.hasScript() ? ScriptProtoUtils.parseFromProtoRequest(maxAggProto.getScript()) : null)

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MinAggregationProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MinAggregationProtoUtils.java
@@ -43,7 +43,7 @@ public class MinAggregationProtoUtils {
 
         ValuesSourceProtoFields fields = ValuesSourceProtoFields.builder()
             .field(minAggProto.hasField() ? minAggProto.getField() : null)
-            .missing(minAggProto.hasMissing() ? FieldValueProtoUtils.fromProto(minAggProto.getMissing()) : null)
+            .missing(minAggProto.hasMissing() ? FieldValueProtoUtils.fromProto(minAggProto.getMissing(), false) : null)
             .valueType(minAggProto.hasValueType() ? minAggProto.getValueType() : null)
             .format(minAggProto.hasFormat() ? minAggProto.getFormat() : null)
             .script(minAggProto.hasScript() ? ScriptProtoUtils.parseFromProtoRequest(minAggProto.getScript()) : null)

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/common/FieldValueProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/common/FieldValueProtoUtils.java
@@ -9,6 +9,7 @@ package org.opensearch.transport.grpc.proto.response.common;
 
 import org.opensearch.common.Numbers;
 import org.opensearch.protobufs.FieldValue;
+import org.opensearch.protobufs.NullValue;
 
 import java.math.BigInteger;
 
@@ -51,11 +52,8 @@ public class FieldValueProtoUtils {
      * @throws IllegalArgumentException if the Java object type cannot be converted
      */
     public static void toProto(Object javaObject, FieldValue.Builder fieldValueBuilder) {
-        if (javaObject == null) {
-            throw new IllegalArgumentException("Cannot convert null to FieldValue");
-        }
-
         switch (javaObject) {
+            case null -> fieldValueBuilder.setNullValue(NullValue.NULL_VALUE_NULL);
             case String s -> fieldValueBuilder.setString(s);
             case Integer i -> {
                 org.opensearch.protobufs.GeneralNumber.Builder num = org.opensearch.protobufs.GeneralNumber.newBuilder();

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/bucket/terms/TermsAggregationBuilderConverterTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/bucket/terms/TermsAggregationBuilderConverterTests.java
@@ -8,6 +8,7 @@
 package org.opensearch.transport.grpc.proto.request.search.aggregation.bucket.terms;
 
 import org.opensearch.protobufs.AggregationContainer;
+import org.opensearch.protobufs.FieldValue;
 import org.opensearch.protobufs.InlineScript;
 import org.opensearch.protobufs.Script;
 import org.opensearch.protobufs.SortOrder;
@@ -93,6 +94,16 @@ public class TermsAggregationBuilderConverterTests extends OpenSearchTestCase {
         assertEquals("map", t.executionHint());
         assertEquals(SubAggCollectionMode.BREADTH_FIRST, t.collectMode());
         assertNotNull(t.includeExclude());
+    }
+
+    public void testStringMissingValue() {
+        AggregationContainer container = buildContainer(
+            TermsAggregationFields.newBuilder().setField("status").setMissing(FieldValue.newBuilder().setString("unknown").build()).build()
+        );
+
+        TermsAggregationBuilder builder = (TermsAggregationBuilder) converter.fromProto("by_status", container);
+
+        assertEquals("unknown", builder.missing());
     }
 
     public void testOrderVariants() {

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MaxAggregationProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MaxAggregationProtoUtilsTests.java
@@ -46,6 +46,17 @@ public class MaxAggregationProtoUtilsTests extends OpenSearchTestCase {
         assertEquals(0.0, result.missing());
     }
 
+    public void testFromProtoWithStringMissingValue() {
+        MaxAggregation proto = MaxAggregation.newBuilder()
+            .setField("status")
+            .setMissing(FieldValue.newBuilder().setString("unknown").build())
+            .build();
+
+        MaxAggregationBuilder result = MaxAggregationProtoUtils.fromProto("max_status", proto);
+
+        assertEquals("unknown", result.missing());
+    }
+
     public void testFromProtoWithoutFieldOrScript() {
         MaxAggregation proto = MaxAggregation.newBuilder().build();
 

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MinAggregationProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/search/aggregation/metrics/MinAggregationProtoUtilsTests.java
@@ -46,6 +46,17 @@ public class MinAggregationProtoUtilsTests extends OpenSearchTestCase {
         assertEquals(0.0, result.missing());
     }
 
+    public void testFromProtoWithStringMissingValue() {
+        MinAggregation proto = MinAggregation.newBuilder()
+            .setField("status")
+            .setMissing(FieldValue.newBuilder().setString("unknown").build())
+            .build();
+
+        MinAggregationBuilder result = MinAggregationProtoUtils.fromProto("min_status", proto);
+
+        assertEquals("unknown", result.missing());
+    }
+
     public void testFromProtoWithoutFieldOrScript() {
         MinAggregation proto = MinAggregation.newBuilder().build();
 

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/common/FieldValueProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/common/FieldValueProtoUtilsTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.transport.grpc.proto.response.common;
 
 import org.opensearch.protobufs.FieldValue;
+import org.opensearch.protobufs.NullValue;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.math.BigInteger;
@@ -16,6 +17,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class FieldValueProtoUtilsTests extends OpenSearchTestCase {
+
+    public void testToProtoWithNull() {
+        FieldValue fieldValue = FieldValueProtoUtils.toProto(null);
+
+        assertNotNull("FieldValue should not be null", fieldValue);
+        assertTrue("FieldValue should have null value", fieldValue.hasNullValue());
+        assertEquals("Null value should match proto enum", NullValue.NULL_VALUE_NULL, fieldValue.getNullValue());
+    }
 
     public void testToProtoWithInteger() {
         Integer intValue = 42;

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/search/SearchHitProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/response/search/SearchHitProtoUtilsTests.java
@@ -17,6 +17,8 @@ import org.opensearch.core.common.text.Text;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.protobufs.HitsMetadataHitsInner;
+import org.opensearch.protobufs.NullValue;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchShardTarget;
@@ -137,6 +139,32 @@ public class SearchHitProtoUtilsTests extends OpenSearchTestCase {
         assertFalse("SeqNo should not be set", hit.hasXSeqNo());
         assertFalse("PrimaryTerm should not be set", hit.hasXPrimaryTerm());
         assertFalse("Source should not be set", hit.hasXSource());
+    }
+
+    public void testToProtoWithNullSortValue() throws IOException {
+        SearchHit searchHit = new SearchHit(1);
+        searchHit.sortValues(new Object[] { "first", null }, new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW });
+
+        HitsMetadataHitsInner hit = SearchHitProtoUtils.toProto(searchHit);
+
+        assertNotNull("Hit should not be null", hit);
+        assertEquals("Should have 2 sort values", 2, hit.getSortCount());
+        assertTrue("First sort value should be a string", hit.getSort(0).hasString());
+        assertEquals("First sort value should match", "first", hit.getSort(0).getString());
+        assertTrue("Second sort value should be null", hit.getSort(1).hasNullValue());
+        assertEquals("Null sort value should match proto enum", NullValue.NULL_VALUE_NULL, hit.getSort(1).getNullValue());
+    }
+
+    public void testToProtoWithOnlyNullSortValue() throws IOException {
+        SearchHit searchHit = new SearchHit(1);
+        searchHit.sortValues(new Object[] { null }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        HitsMetadataHitsInner hit = SearchHitProtoUtils.toProto(searchHit);
+
+        assertNotNull("Hit should not be null", hit);
+        assertEquals("Should have 1 sort value", 1, hit.getSortCount());
+        assertTrue("Sort value should be null", hit.getSort(0).hasNullValue());
+        assertEquals("Null sort value should match proto enum", NullValue.NULL_VALUE_NULL, hit.getSort(0).getNullValue());
     }
 
     public void testToProtoWithDocumentFields() throws IOException {


### PR DESCRIPTION
## Summary

Handle two gRPC `FieldValue` correctness gaps:

- map Java `null` to `NullValue.NULL_VALUE_NULL` in response serialization so search hits can return missing sort values
- preserve string `missing` values as plain strings for `min`, `max`, and `terms` aggregations on the request path instead of converting them to `BytesRef`

This keeps gRPC behavior aligned with the REST API for null sort values and aggregation `missing` string values.

## Testing

```bash
JAVA_HOME=/opt/jvm/jdk-21 PATH=/opt/jvm/jdk-21/bin:$PATH ./gradlew :modules:transport-grpc:test \
  --tests org.opensearch.transport.grpc.proto.response.common.FieldValueProtoUtilsTests \
  --tests org.opensearch.transport.grpc.proto.response.search.SearchHitProtoUtilsTests \
  --tests org.opensearch.transport.grpc.proto.request.search.aggregation.metrics.MinAggregationProtoUtilsTests \
  --tests org.opensearch.transport.grpc.proto.request.search.aggregation.metrics.MaxAggregationProtoUtilsTests \
  --tests org.opensearch.transport.grpc.proto.request.search.aggregation.bucket.terms.TermsAggregationBuilderConverterTests
```

```bash
# Manual local validation against 127.0.0.1:9200 and 127.0.0.1:9400
# - sort response returns NULL_VALUE_NULL for missing sort fields
# - terms aggregation missing string returns bucket key "unknown" over gRPC, matching HTTP
# - term/match/fuzzy null request values are rejected by both gRPC and HTTP
```
