### PR TITLE
[DFAE] Acknowledge all docs during composite-engine primary relocation

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -86,6 +86,7 @@ import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.DocsStats;
+import org.opensearch.index.shard.RemoteStoreRefreshListener;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.DefaultTranslogDeletionPolicy;
 import org.opensearch.index.translog.InternalTranslogManager;
@@ -946,6 +947,9 @@ public class DataFormatAwareEngine implements Indexer {
             ensureOpen();
             ensureNoTragicException();
             refreshLock.lock();
+
+            // refresh only if new segments have been created or force param is true
+            notifyRefreshListenersBefore();
             try (GatedCloseable<CatalogSnapshot> catalogSnapshot = catalogSnapshotManager.acquireSnapshot()) {
                 if (store.tryIncRef()) {
                     try {
@@ -1059,8 +1063,6 @@ public class DataFormatAwareEngine implements Indexer {
                             .noneMatch(ns -> existingSegments.stream().anyMatch(es -> es.generation() == ns.generation()))
                             : "new segment generation collides with an existing segment generation";
 
-                        // refresh only if new segments have been created or force param is true
-                        notifyRefreshListenersBefore();
                         if (refreshed) {
                             final long engineRefreshStartNanos = System.nanoTime();
                             long nextGen = newSegments.size() > 1 ? writerGenerationCounter.incrementAndGet() : RefreshInput.NO_GENERATION;
@@ -1095,7 +1097,6 @@ public class DataFormatAwareEngine implements Indexer {
                         } else if ("flush".equals(source)) {
                             catalogSnapshotManager.bumpGeneration();
                         }
-                        notifyRefreshListenersAfter(refreshed);
                     } finally {
                         store.decRef();
                     }
@@ -1106,6 +1107,7 @@ public class DataFormatAwareEngine implements Indexer {
                     }
                 }
             } finally {
+                notifyRefreshListenersAfter(refreshed);
                 versionMap.afterRefresh(refreshed);
                 IOUtils.close(toClose);
                 refreshLock.unlock();
@@ -2107,9 +2109,20 @@ public class DataFormatAwareEngine implements Indexer {
             refreshLock.lock();
         }
         try (GatedCloseable<CatalogSnapshot> oldSnapshotRef = catalogSnapshotManager.acquireSnapshot()) {
-            notifyRefreshListenersBefore();
+            // A merge only swaps segments in the catalog; it does not advance the checkpoint, so
+            // checkpoint-publishing listeners must not be notified. We invoke only the
+            // RemoteStoreRefreshListener so the merged segments get uploaded to the remote store.
+            for (ReferenceManager.RefreshListener refreshListener : refreshListeners) {
+                if (refreshListener instanceof RemoteStoreRefreshListener) {
+                    refreshListener.beforeRefresh();
+                }
+            }
             catalogSnapshotManager.applyMergeResults(mergeResult, oneMerge);
-            notifyRefreshListenersAfter(true);
+            for (ReferenceManager.RefreshListener refreshListener : refreshListeners) {
+                if (refreshListener instanceof RemoteStoreRefreshListener) {
+                    refreshListener.afterRefresh(true);
+                }
+            }
         } catch (Exception ex) {
             try {
                 logger.error(() -> new ParameterizedMessage("Merge failed while registering merged files in Snapshot"), ex);

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -2160,8 +2160,9 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     /**
      * Covers {@code DataFormatAwareEngine.applyMergeChanges}: a forceMerge over two
      * previously-refreshed segments must (1) replace the source segments in the catalog
-     * with a single merged segment, (2) invoke beforeRefresh/afterRefresh exactly once
-     * each on registered refresh listeners while holding the refresh lock, and
+     * with a single merged segment, (2) restrict its beforeRefresh/afterRefresh
+     * notifications to {@code RemoteStoreRefreshListener} instances only, so a plain
+     * refresh listener that fires on real refreshes is NOT invoked by the merge, and
      * (3) release the refresh lock on exit so a subsequent {@code refresh()} proceeds.
      *
      * <p>The system-property gate on {@code MERGE_ENABLED_PROPERTY} applies only to
@@ -2169,7 +2170,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
      * straight to {@code MergeScheduler.forceMerge} and does not consult it, so this
      * test drives the merge end-to-end without touching system properties.
      */
-    public void testApplyMergeChangesUpdatesCatalogAndNotifiesListeners() throws Exception {
+    public void testApplyMergeChangesUpdatesCatalogAndSkipsNonRemoteStoreListeners() throws Exception {
         AtomicInteger beforeCalls = new AtomicInteger();
         AtomicInteger afterCalls = new AtomicInteger();
         // Records call order: 'B' for beforeRefresh, 'A' for afterRefresh.
@@ -2233,12 +2234,17 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
                 }
             }, 10, java.util.concurrent.TimeUnit.SECONDS);
 
-            // applyMergeChanges must have invoked the listeners exactly once each, in order.
-            assertThat("beforeRefresh must fire exactly once for the merge", beforeCalls.get() - beforeAfterSeed, equalTo(1));
-            assertThat("afterRefresh must fire exactly once for the merge", afterCalls.get() - afterAfterSeed, equalTo(1));
+            // applyMergeChanges must notify only RemoteStoreRefreshListener instances. The plain
+            // listener registered here is not one, so the merge must NOT invoke it.
+            assertThat(
+                "merge must not invoke beforeRefresh on a non-remote-store listener",
+                beforeCalls.get() - beforeAfterSeed,
+                equalTo(0)
+            );
+            assertThat("merge must not invoke afterRefresh on a non-remote-store listener", afterCalls.get() - afterAfterSeed, equalTo(0));
             synchronized (callOrder) {
-                // Seed cycles contribute "BABA"; the merge must append exactly "BA".
-                assertThat("call order must be before-then-after for every cycle", callOrder.toString(), equalTo("BABABA"));
+                // Seed cycles contribute "BABA"; the merge must append nothing for this listener.
+                assertThat("merge must not append before/after for a non-remote-store listener", callOrder.toString(), equalTo("BABA"));
             }
 
             // Sanity: the refreshLock must have been released. A follow-up refresh must


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

  During a primary relocation on the data-format-aware (composite) engine, the
  source could publish a refresh checkpoint that was **ahead of the documents
  actually materialized** into its segments. The relocation target committed that
  inflated checkpoint as its recovery anchor, and on promotion the translog replay
  floor (`checkpoint + 1`) sat above the un-materialized band, so those documents
  were never replayed → silent doc loss (~one bulk batch per relocation).
  
  #### Root cause: `notifyRefreshListenersBefore()/After()` were positioned (and were
  fired during merges) such that `lastRefreshedCheckpoint` could advance past the
  segments that a refresh had actually materialized.
  
####  Fix:
  - Call `notifyRefreshListenersBefore()` at the start of `refresh()` and
    `notifyRefreshListenersAfter(refreshed)` in the outer `finally`, so the
    published checkpoint reflects only materialized segments.
  - In `applyMergeChanges`, notify **only** `RemoteStoreRefreshListener` (so merged
    segments are still uploaded to the remote store) and **not** the
    checkpoint-publishing listeners — a merge swaps segments without advancing the
    checkpoint.
  
  ### Testing
  - Updated `DataFormatAwareEngineTests` to assert the merge path no longer invokes
    non-`RemoteStoreRefreshListener` listeners.
  - Validated on a staging composite domain: 2M-doc ingest with a primary
    relocation mid-ingest now lands at the exact acked count (no loss).
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
