### PR TITLE
Fix duplicate documents after primary relocation on the composite engine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -484,10 +484,8 @@ public class DataFormatAwareEngine implements Indexer {
                 }
             );
 
-            // Restore version map and checkpoint tracker after crash recovery.
-            if (localCheckpointTracker.getPersistedCheckpoint() < localCheckpointTracker.getMaxSeqNo()) {
-                restoreVersionMapAndCheckpointTracker();
-            }
+            // Restore version map and checkpoint tracker after recovery.
+            restoreVersionMapAndCheckpointTracker();
 
             // Merge failure cleanup: cleans up unreferenced files and acts as a safety net
             // for refreshLock. The preMergeCommitHook acquires refreshLock on the merge thread;


### PR DESCRIPTION
… open

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
  On the data-format-aware (composite) engine, the recovered segments can contain
  documents whose sequence numbers are **above** the persisted local checkpoint at
  engine open (recovery/promotion). `restoreVersionMapAndCheckpointTracker()` exists
  to reconcile this case: it marks those seqnos processed/persisted and repopulates
  the version map, so the subsequent translog replay recognizes them as already
  applied and does not re-apply them.
  
  That reconciliation was gated by
  `persistedCheckpoint < localCheckpointTracker.getMaxSeqNo()`. For this engine the
  recovered `maxSeqNo` equals the persisted checkpoint at open, so the condition was
  effectively never true and the reconciliation was always skipped. As a result,
  documents above the checkpoint were re-applied during translog replay; because the
  composite engine is append-only (no update/delete by `_id`), each re-applied op
  produced a **duplicate row** — observed as an inflated doc count (e.g. +1 per
  primary relocation) with `docs.deleted = 0`.
  
  ### Fix
  Remove the gate and always invoke `restoreVersionMapAndCheckpointTracker()` on
  engine open. When there are no documents above the persisted checkpoint it is a
  no-op (`getDocsAboveSeqNo` returns empty), so the change is safe for normal opens
  and only does work when there is state to reconcile.
  

#### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
