### PR TITLE
Cache parquet-to-arrow schema per segment to avoid repeated derivation

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use arrow::datatypes::SchemaRef;
 use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
 use datafusion::parquet::file::metadata::ParquetMetaData;
-use parquet::arrow::parquet_to_arrow_schema;
 
 /// Map the query's predicate-column names to **this file's** parquet leaf
 /// indices, resolving against the file's OWN schema so the indices are correct
@@ -45,23 +44,10 @@ pub fn resolve_predicate_parquet_columns(
     _arrow_schema: &SchemaRef,
     metadata: &ParquetMetaData,
     predicate_column_names: &[String],
+    file_schema: &SchemaRef,
 ) -> Vec<usize> {
     let parquet_schema = metadata.file_metadata().schema_descr();
-    // Per-file arrow schema: 1:1 with this file's parquet leaves, so a column's
-    // arrow position maps to its true leaf. (The passed `_arrow_schema` is the
-    // union table schema and is intentionally NOT used for index resolution —
-    // see the doc comment.)
-    let file_arrow_schema = match parquet_to_arrow_schema(
-        parquet_schema,
-        metadata.file_metadata().key_value_metadata(),
-    ) {
-        Ok(s) => Arc::new(s),
-        // If we can't derive the file schema (malformed footer, unsupported type),
-        // return empty. Empty is the safe conservative choice:  the caller skips the
-        // scoped load and falls back to footer-only.
-        Err(_) => return vec![],
-    };
-    resolve_with_schema(&file_arrow_schema, metadata, predicate_column_names)
+    resolve_with_schema(file_schema, metadata, predicate_column_names)
 }
 
 /// Resolve TWO name-sets (e.g. predicate columns and projection columns) against
@@ -76,22 +62,12 @@ pub fn resolve_predicate_parquet_columns_pair(
     metadata: &ParquetMetaData,
     predicate_col_names: &[String],
     projection_col_names: &[String],
+    file_schema: &SchemaRef,
 ) -> (Vec<usize>, Vec<usize>) {
-    let parquet_schema = metadata.file_metadata().schema_descr();
-    match parquet_to_arrow_schema(
-        parquet_schema,
-        metadata.file_metadata().key_value_metadata(),
-    ) {
-        Ok(s) => {
-            let file_arrow_schema = Arc::new(s);
-            (
-                resolve_with_schema(&file_arrow_schema, metadata, predicate_col_names),
-                resolve_with_schema(&file_arrow_schema, metadata, projection_col_names),
-            )
-        }
-        // Can't derive the file schema — return empty for both sets.
-        Err(_) => (vec![], vec![]),
-    }
+    (
+        resolve_with_schema(file_schema, metadata, predicate_col_names),
+        resolve_with_schema(file_schema, metadata, projection_col_names),
+    )
 }
 
 /// Resolve predicate column names → parquet leaf indices against a specific arrow

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
@@ -685,6 +685,7 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path as ObjPath;
     use object_store::{ObjectStoreExt, PutPayload};
+    use parquet::arrow::parquet_to_arrow_schema;
 
     use super::super::SCOPED_CACHE_TEST_GUARD as CACHE_TEST_GUARD;
 
@@ -900,7 +901,7 @@ mod tests {
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
 
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         assert_eq!(cols, vec![0]);
 
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
@@ -930,10 +931,10 @@ mod tests {
         let fo = footer_only(&bytes);
         let names_a = vec!["price".to_string()];
         let names_b = vec!["qty".to_string(), "price".to_string()];
-        let mut single_a = resolve_predicate_parquet_columns(&schema, &fo, &names_a);
-        let mut single_b = resolve_predicate_parquet_columns(&schema, &fo, &names_b);
+        let mut single_a = resolve_predicate_parquet_columns(&schema, &fo, &names_a, &schema);
+        let mut single_b = resolve_predicate_parquet_columns(&schema, &fo, &names_b, &schema);
         let (mut pair_a, mut pair_b) =
-            resolve_predicate_parquet_columns_pair(&schema, &fo, &names_a, &names_b);
+            resolve_predicate_parquet_columns_pair(&schema, &fo, &names_a, &names_b, &schema);
         single_a.sort_unstable();
         single_b.sort_unstable();
         pair_a.sort_unstable();
@@ -991,15 +992,15 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
             .await
             .unwrap();
         let full = full_index(&bytes);
         let pp =
             build_pruning_predicate(&pred("price", 0, Operator::GtEq, 20), schema.clone()).unwrap();
-        let s = PagePruner::new(&schema, Arc::clone(&aug)).prune_rg(&pp, 0, None);
-        let f = PagePruner::new(&schema, full).prune_rg(&pp, 0, None);
+        let s = PagePruner::new(&schema, Arc::clone(&aug), schema.clone()).prune_rg(&pp, 0, None);
+        let f = PagePruner::new(&schema, full, schema.clone()).prune_rg(&pp, 0, None);
         assert_eq!(s.as_ref().map(kept), f.as_ref().map(kept));
         assert_eq!(s.as_ref().map(kept), Some(16));
     }
@@ -1060,7 +1061,19 @@ mod tests {
 
         // Must resolve to the file's TRUE leaf for `price` = 1, NOT the union
         // position 0 (which is `extra` in this file).
-        let cols = resolve_predicate_parquet_columns(&union_schema, &fo, &["price".to_string()]);
+        let file_own_schema: SchemaRef = Arc::new(
+            parquet::arrow::parquet_to_arrow_schema(
+                fo.file_metadata().schema_descr(),
+                fo.file_metadata().key_value_metadata(),
+            )
+            .unwrap(),
+        );
+        let cols = resolve_predicate_parquet_columns(
+            &union_schema,
+            &fo,
+            &["price".to_string()],
+            &file_own_schema,
+        );
         assert_eq!(
             cols,
             vec![1],
@@ -1081,8 +1094,9 @@ mod tests {
         let pp =
             build_pruning_predicate(&pred("price", 1, Operator::GtEq, 20), file_schema.clone())
                 .unwrap();
-        let s = PagePruner::new(&file_schema, Arc::clone(&aug)).prune_rg(&pp, 0, None);
-        let f = PagePruner::new(&file_schema, full).prune_rg(&pp, 0, None);
+        let s = PagePruner::new(&file_schema, Arc::clone(&aug), file_schema.clone())
+            .prune_rg(&pp, 0, None);
+        let f = PagePruner::new(&file_schema, full, file_schema.clone()).prune_rg(&pp, 0, None);
         assert_eq!(
             s.as_ref().map(kept),
             f.as_ref().map(kept),
@@ -1117,7 +1131,7 @@ mod tests {
 
         // Scope the page index to `price` ONLY (mimics the predicate-scoped indexed
         // path). `qty` therefore gets the one-page placeholder + NONE ColumnIndex.
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         assert_eq!(cols, vec![0]);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
             .await
@@ -1132,10 +1146,10 @@ mod tests {
             Arc::new(BinaryExpr::new(price_ge, Operator::And, qty_le));
         let pp = build_pruning_predicate(&residual, schema.clone()).unwrap();
 
-        let s_kept = PagePruner::new(&schema, Arc::clone(&aug))
+        let s_kept = PagePruner::new(&schema, Arc::clone(&aug), schema.clone())
             .prune_rg(&pp, 0, None)
             .map(|s| kept(&s));
-        let f_kept = PagePruner::new(&schema, full)
+        let f_kept = PagePruner::new(&schema, full, schema.clone())
             .prune_rg(&pp, 0, None)
             .map(|s| kept(&s));
         // Superset invariant: scoped must keep AT LEAST what full keeps (never
@@ -1162,7 +1176,7 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
             .await
             .unwrap();
@@ -1187,7 +1201,7 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
             .await
@@ -1230,8 +1244,9 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
-        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+        let c_price =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &c_price, &[])
             .await
@@ -1266,11 +1281,13 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let c_price =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         let c_both = resolve_predicate_parquet_columns(
             &schema,
             &fo,
             &["price".to_string(), "qty".to_string()],
+            &schema,
         );
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &c_price, &[])
@@ -1306,7 +1323,7 @@ mod tests {
         let fo = footer_only(&bytes);
         // Both predicates are on `price` (col 0) — only the literal differs, which
         // never enters the cache key.
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
             .await
@@ -1331,8 +1348,9 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
-        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+        let c_price =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &c_price, &[])
             .await
@@ -1367,8 +1385,9 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let c_price = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
-        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()]);
+        let c_price =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
+        let c_qty = resolve_predicate_parquet_columns(&schema, &fo, &["qty".to_string()], &schema);
 
         // Measure one CI cell (predicate `price` = col0 at the single RG), then set
         // a budget of ~1.5 cells so a second distinct cell forces an eviction.
@@ -1416,7 +1435,7 @@ mod tests {
         let (bytes, schema) = four_rg_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()], &schema);
 
         // Cold: 4 RGs × 1 predicate col → 4 CI misses, 4 CI entries.
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[])
@@ -1450,11 +1469,19 @@ mod tests {
         let (bytes, schema) = wide4_parquet(); // n0,n1,s0,s1 — 1 RG
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let c_n0 = resolve_predicate_parquet_columns(&schema, &fo, &["n0".to_string()]);
-        let c_n0_n1 =
-            resolve_predicate_parquet_columns(&schema, &fo, &["n0".to_string(), "n1".to_string()]);
-        let c_n1_s0 =
-            resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string(), "s0".to_string()]);
+        let c_n0 = resolve_predicate_parquet_columns(&schema, &fo, &["n0".to_string()], &schema);
+        let c_n0_n1 = resolve_predicate_parquet_columns(
+            &schema,
+            &fo,
+            &["n0".to_string(), "n1".to_string()],
+            &schema,
+        );
+        let c_n1_s0 = resolve_predicate_parquet_columns(
+            &schema,
+            &fo,
+            &["n1".to_string(), "s0".to_string()],
+            &schema,
+        );
 
         // {n0}: 1 new cell.
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &c_n0, &[])
@@ -1493,7 +1520,8 @@ mod tests {
         let (bytes, schema) = wide4_parquet(); // n0=0,n1=1,s0=2,s1=3 — 1 RG
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()], &schema);
 
         // Project s0 (col 2): offset cols = {0, 1(n1), 2(s0)} → 3 new cells.
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[2])
@@ -1526,7 +1554,8 @@ mod tests {
         let (bytes, schema) = wide4_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()], &schema);
         assert_eq!(pred_cols, vec![1]);
 
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[2])
@@ -1570,7 +1599,8 @@ mod tests {
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
         // Scope to n1 (pred) + s0 (proj). Col 3 (s1) is scoped out → placeholder.
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()], &schema);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[2])
             .await
             .unwrap();
@@ -1621,7 +1651,8 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[1])
             .await
             .unwrap();
@@ -1641,7 +1672,8 @@ mod tests {
         let (bytes, schema) = wide4_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["n1".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[])
             .await
@@ -1671,7 +1703,8 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
 
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &[])
             .await
@@ -1698,8 +1731,10 @@ mod tests {
         let (bytes, schema) = four_rg_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let pred_cols = resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()]);
-        let proj_cols = resolve_predicate_parquet_columns(&schema, &fo, &["val".to_string()]);
+        let pred_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()], &schema);
+        let proj_cols =
+            resolve_predicate_parquet_columns(&schema, &fo, &["val".to_string()], &schema);
 
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &pred_cols, &proj_cols)
             .await
@@ -1725,7 +1760,7 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
 
         // Warm: 1 CI cell (price,rg0) + 2 OI cells (col0, col1).
         let _ = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[0, 1])
@@ -1768,6 +1803,7 @@ mod tests {
             &schema,
             &footer_only(&bytes),
             &["price".to_string()],
+            &schema,
         );
 
         // Stage two identical files at different paths.
@@ -1829,7 +1865,7 @@ mod tests {
         let (bytes, schema) = four_rg_parquet(); // id, v — 4 RGs, multi-page
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["id".to_string()], &schema);
 
         // Whole CI region is a strict superset of the scoped `id`-only union.
         let region = whole_index_region(&fo, ci_extent).unwrap();
@@ -1860,8 +1896,10 @@ mod tests {
         let pp =
             build_pruning_predicate(&pred("id", 0, Operator::GtEq, 20), schema.clone()).unwrap();
         for rg in 0..4 {
-            let s = PagePruner::new(&schema, Arc::clone(&aug)).prune_rg(&pp, rg, None);
-            let f = PagePruner::new(&schema, Arc::clone(&full)).prune_rg(&pp, rg, None);
+            let s =
+                PagePruner::new(&schema, Arc::clone(&aug), schema.clone()).prune_rg(&pp, rg, None);
+            let f =
+                PagePruner::new(&schema, Arc::clone(&full), schema.clone()).prune_rg(&pp, rg, None);
             assert_eq!(
                 s.as_ref().map(kept),
                 f.as_ref().map(kept),
@@ -1885,7 +1923,7 @@ mod tests {
         let (bytes, schema) = two_col_parquet();
         let (store, loc) = stage(bytes.clone()).await;
         let fo = footer_only(&bytes);
-        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()]);
+        let cols = resolve_predicate_parquet_columns(&schema, &fo, &["price".to_string()], &schema);
         let aug = load_scoped_page_index_cols(&store, &loc, &fo, &cols, &[1])
             .await
             .unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -751,13 +751,15 @@ mod tests {
         );
         let file_meta = FileMetaData::new(0, 0, None, None, schema, None);
         let pq_meta = ParquetMetaData::new(file_meta, vec![]);
+        let metadata = std::sync::Arc::new(pq_meta);
         SegmentFileInfo {
             writer_generation: global_base as i64 + 1, // arbitrary, just to vary
             max_doc,
             object_path: object_store::path::Path::from(format!("seg-{}.parquet", global_base)),
             parquet_size: 0,
             row_groups: vec![],
-            metadata: std::sync::Arc::new(pq_meta),
+            arrow_schema: std::sync::Arc::new(datafusion::arrow::datatypes::Schema::empty()),
+            metadata,
             global_base,
             sort_min: None,
             sort_max: None,
@@ -1051,6 +1053,7 @@ async unsafe fn execute_indexed_with_context_inner(
                     &segment.metadata,
                     &predicate_column_names,
                     &projection_column_names,
+                    &segment.arrow_schema,
                 );
                 if parquet_cols.is_empty() && offset_cols.is_empty() {
                     continue;
@@ -1097,6 +1100,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         let pruner = Arc::new(PagePruner::new(
                             &schema_for_pruner,
                             Arc::clone(&segment.metadata),
+                            segment.arrow_schema.clone(),
                         ));
                         let rg_index_to_pos: HashMap<usize, usize> = chunk
                             .row_group_indices
@@ -1213,6 +1217,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         let pruner = Arc::new(PagePruner::new(
                             &schema_for_pruner,
                             Arc::clone(&segment.metadata),
+                            segment.arrow_schema.clone(),
                         ));
                         // Bloom-filter row-group pruning is always enabled on the indexed read path.
                         let bloom_config =
@@ -1347,6 +1352,7 @@ async unsafe fn execute_indexed_with_context_inner(
                         let pruner = Arc::new(PagePruner::new(
                             &schema_for_pruner,
                             Arc::clone(&segment.metadata),
+                            segment.arrow_schema.clone(),
                         ));
 
                         let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter.rs
@@ -112,6 +112,8 @@ pub struct DynamicRgPruner {
     filter: Arc<dyn PhysicalExpr>,
     /// Full (parquet) schema — used to build the `PruningPredicate`.
     full_schema: SchemaRef,
+    /// Per-segment arrow schema derived from parquet footer.
+    seg_arrow_schema: SchemaRef,
     /// Generation of the snapshot currently cached in `pruning_predicate`.
     /// `u64::MAX` means "nothing cached yet" (forces a build on first use).
     cached_generation: u64,
@@ -124,10 +126,15 @@ pub struct DynamicRgPruner {
 impl DynamicRgPruner {
     /// Build a pruner over `filter`. Returns `None` if `filter` is `None`
     /// (no dynamic filter was accepted), so the hot path can skip all work.
-    pub fn new(filter: Option<Arc<dyn PhysicalExpr>>, full_schema: SchemaRef) -> Option<Self> {
+    pub fn new(
+        filter: Option<Arc<dyn PhysicalExpr>>,
+        full_schema: SchemaRef,
+        seg_arrow_schema: SchemaRef,
+    ) -> Option<Self> {
         filter.map(|filter| Self {
             filter,
             full_schema,
+            seg_arrow_schema,
             cached_generation: u64::MAX,
             pruning_predicate: None,
         })
@@ -171,7 +178,7 @@ impl DynamicRgPruner {
             .clone()
             .map(|predicate| RgPruningContext {
                 predicate,
-                schema: Arc::clone(&self.full_schema),
+                seg_arrow_schema: self.seg_arrow_schema.clone(),
             })
     }
 
@@ -194,7 +201,8 @@ impl DynamicRgPruner {
 #[derive(Clone)]
 pub struct RgPruningContext {
     predicate: Arc<PruningPredicate>,
-    schema: SchemaRef,
+    /// Per-segment arrow schema derived from parquet footer.
+    seg_arrow_schema: SchemaRef,
 }
 
 impl RgPruningContext {
@@ -204,19 +212,11 @@ impl RgPruningContext {
         let Some(rg_meta) = metadata.row_groups().get(rg_idx) else {
             return false;
         };
-        // Resolve stats against the segment's OWN parquet schema, not the full table
-        // schema: StatisticsConverter maps name→parquet-column positionally, so the full
-        // schema reads the wrong/no column under dynamic-mapping schema drift.
         let descr = metadata.file_metadata().schema_descr();
-        let seg_schema = datafusion::parquet::arrow::parquet_to_arrow_schema(
-            descr,
-            metadata.file_metadata().key_value_metadata(),
-        )
-        .unwrap_or_else(|_| self.schema.as_ref().clone());
         let stats = SingleRowGroupStatistics {
             parquet_schema: descr,
             rg_meta,
-            arrow_schema: &seg_schema,
+            arrow_schema: &self.seg_arrow_schema,
         };
         // `prune` returns one bool per container (we have exactly one). `false`
         // means "provably cannot match" → safe to skip. Any error => keep.
@@ -280,9 +280,16 @@ mod tests {
         let zero: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(0))));
         let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(sev, Operator::GtEq, zero));
         let predicate = Arc::new(PruningPredicate::try_new(expr, table_schema.clone()).unwrap());
+        let file_arrow_schema = Arc::new(
+            datafusion::parquet::arrow::parquet_to_arrow_schema(
+                md.file_metadata().schema_descr(),
+                md.file_metadata().key_value_metadata(),
+            )
+            .unwrap(),
+        );
         let ctx = RgPruningContext {
             predicate,
-            schema: table_schema,
+            seg_arrow_schema: file_arrow_schema,
         };
 
         assert!(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -1183,7 +1183,11 @@ mod tests {
             ArrowReaderOptions::new().with_page_index(true),
         )
         .unwrap();
-        PagePruner::new(meta.schema(), meta.metadata().clone())
+        PagePruner::new(
+            meta.schema(),
+            meta.metadata().clone(),
+            meta.schema().clone(),
+        )
     }
 
     fn collector_leaf(idx: usize) -> ResolvedNode {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -748,7 +748,11 @@ mod tests {
             ArrowReaderOptions::new().with_page_index(true),
         )
         .unwrap();
-        Arc::new(PagePruner::new(meta.schema(), meta.metadata().clone()))
+        Arc::new(PagePruner::new(
+            meta.schema(),
+            meta.metadata().clone(),
+            meta.schema().clone(),
+        ))
     }
 
     /// Leaf source that returns empty bitmaps — enough to compose a

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
@@ -151,7 +151,11 @@ mod tests {
         let file = tmp.reopen().unwrap();
         let options = ArrowReaderOptions::new().with_page_index(true);
         let meta = ArrowReaderMetadata::load(&file, options).unwrap();
-        Arc::new(PagePruner::new(meta.schema(), meta.metadata().clone()))
+        Arc::new(PagePruner::new(
+            meta.schema(),
+            meta.metadata().clone(),
+            meta.schema().clone(),
+        ))
     }
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -708,7 +708,11 @@ mod tests {
         let file = tmp.reopen().unwrap();
         let options = ArrowReaderOptions::new().with_page_index(true);
         let meta = ArrowReaderMetadata::load(&file, options).unwrap();
-        let pruner = PagePruner::new(meta.schema(), meta.metadata().clone());
+        let pruner = PagePruner::new(
+            meta.schema(),
+            meta.metadata().clone(),
+            meta.schema().clone(),
+        );
         Arc::new(pruner)
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
@@ -59,13 +59,21 @@ use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistic
 pub struct PagePruner {
     schema: SchemaRef,
     metadata: Arc<ParquetMetaData>,
+    /// Per-segment arrow schema derived from parquet footer, used for
+    /// positional column resolution in statistics-based pruning.
+    seg_arrow_schema: SchemaRef,
 }
 
 impl PagePruner {
-    pub fn new(schema: &SchemaRef, metadata: Arc<ParquetMetaData>) -> Self {
+    pub fn new(
+        schema: &SchemaRef,
+        metadata: Arc<ParquetMetaData>,
+        seg_arrow_schema: SchemaRef,
+    ) -> Self {
         Self {
             schema: schema.clone(),
             metadata,
+            seg_arrow_schema,
         }
     }
 
@@ -119,13 +127,7 @@ impl PagePruner {
         // schema misaligns StatisticsConverter's positional column lookup under
         // dynamic-mapping schema drift.
         let descr = self.metadata.file_metadata().schema_descr();
-        let seg_arrow_schema = match datafusion::parquet::arrow::parquet_to_arrow_schema(
-            descr,
-            self.metadata.file_metadata().key_value_metadata(),
-        ) {
-            Ok(s) => Arc::new(s),
-            Err(_) => Arc::clone(&self.schema),
-        };
+        let seg_arrow_schema = Arc::clone(&self.seg_arrow_schema);
 
         for col in &columns {
             let converter = match StatisticsConverter::try_new(col.name(), &seg_arrow_schema, descr)
@@ -531,6 +533,7 @@ fn eval_leaf(
     metadata: &ParquetMetaData,
     schema: &SchemaRef,
     rg_indices: &[usize],
+    seg_arrow_schema: &SchemaRef,
 ) -> Vec<bool> {
     let num = rg_indices.len();
     if num == 0 {
@@ -546,13 +549,7 @@ fn eval_leaf(
     // no column when the segment's schema is narrower or reordered (dynamic-mapping
     // schema drift) — yielding null stats that prune RGs that actually match.
     let descr = metadata.file_metadata().schema_descr();
-    let seg_arrow_schema = match datafusion::parquet::arrow::parquet_to_arrow_schema(
-        descr,
-        metadata.file_metadata().key_value_metadata(),
-    ) {
-        Ok(s) => Arc::new(s),
-        Err(_) => Arc::clone(schema),
-    };
+    let seg_arrow_schema = Arc::clone(seg_arrow_schema);
     let arrow_schema = seg_arrow_schema.as_ref();
     let rg_metas: Vec<_> = rg_indices
         .iter()
@@ -685,6 +682,7 @@ impl StatsPruneTree {
         metadata: &ParquetMetaData,
         schema: &SchemaRef,
         rg_indices: &[usize],
+        seg_arrow_schema: &SchemaRef,
     ) -> Self {
         use super::bool_tree::BoolNode;
         let num = rg_indices.len();
@@ -693,7 +691,14 @@ impl StatsPruneTree {
                 let annotated_children: Vec<_> = children
                     .iter()
                     .map(|c| {
-                        Self::build_from_bool_node(c, leaf_predicates, metadata, schema, rg_indices)
+                        Self::build_from_bool_node(
+                            c,
+                            leaf_predicates,
+                            metadata,
+                            schema,
+                            rg_indices,
+                            seg_arrow_schema,
+                        )
                     })
                     .collect();
                 let mut rg_can_match = vec![true; num];
@@ -711,7 +716,14 @@ impl StatsPruneTree {
                 let annotated_children: Vec<_> = children
                     .iter()
                     .map(|c| {
-                        Self::build_from_bool_node(c, leaf_predicates, metadata, schema, rg_indices)
+                        Self::build_from_bool_node(
+                            c,
+                            leaf_predicates,
+                            metadata,
+                            schema,
+                            rg_indices,
+                            seg_arrow_schema,
+                        )
                     })
                     .collect();
                 let mut rg_can_match = vec![false; num];
@@ -732,6 +744,7 @@ impl StatsPruneTree {
                     metadata,
                     schema,
                     rg_indices,
+                    seg_arrow_schema,
                 );
                 // NOT is conservatively all-true: negating stats-based pruning is unsound
                 // because stats give a superset, and inverting a superset is a subset.
@@ -744,7 +757,7 @@ impl StatsPruneTree {
             BoolNode::Predicate(expr) => {
                 let key = Arc::as_ptr(expr) as *const () as usize;
                 let rg_can_match = match leaf_predicates.get(&key) {
-                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices),
+                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices, seg_arrow_schema),
                     None => vec![true; num],
                 };
                 Self {
@@ -755,7 +768,7 @@ impl StatsPruneTree {
             BoolNode::DelegationPossible { original_expr, .. } => {
                 let key = Arc::as_ptr(original_expr) as *const () as usize;
                 let rg_can_match = match leaf_predicates.get(&key) {
-                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices),
+                    Some(pp) => eval_leaf(pp, metadata, schema, rg_indices, seg_arrow_schema),
                     None => vec![true; num],
                 };
                 Self {
@@ -825,7 +838,7 @@ mod tests {
         )
         .unwrap();
         let arc_meta = meta.metadata().clone();
-        let pruner = PagePruner::new(&schema, Arc::clone(&arc_meta));
+        let pruner = PagePruner::new(&schema, Arc::clone(&arc_meta), schema.clone());
         (pruner, schema, arc_meta)
     }
 
@@ -1159,7 +1172,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(meta.metadata().num_row_groups(), 2);
-        let pruner = PagePruner::new(&schema, meta.metadata().clone());
+        let pruner = PagePruner::new(&schema, meta.metadata().clone(), schema.clone());
         // price > 50: RG0 (0..31) → nothing, RG1 (100..131) → all.
         let expr = bin(col("price", 0), Operator::Gt, lit_int(50));
         let pp = build_pruning_predicate(&expr, schema).unwrap();
@@ -1237,7 +1250,7 @@ mod tests {
             tag_pages
         );
 
-        let pruner = PagePruner::new(&schema, Arc::clone(&arc_meta));
+        let pruner = PagePruner::new(&schema, Arc::clone(&arc_meta), schema.clone());
 
         // `price > 100` is definitively false for all rows; every grid
         // cell inherits stats from the single price page (min=0, max=31)
@@ -1304,7 +1317,7 @@ mod tests {
             ArrowReaderOptions::new().with_page_index(true),
         )
         .unwrap();
-        let pruner = PagePruner::new(&schema, meta.metadata().clone());
+        let pruner = PagePruner::new(&schema, meta.metadata().clone(), schema.clone());
 
         // IS NOT NULL: page 1 (all-null) should be pruned → 24 rows kept.
         use datafusion::physical_expr::expressions::IsNotNullExpr;
@@ -1371,7 +1384,11 @@ mod tests {
             ArrowReaderOptions::new().with_page_index(true),
         )
         .unwrap();
-        let pruner = PagePruner::new(&predicate_schema, meta.metadata().clone());
+        let pruner = PagePruner::new(
+            &predicate_schema,
+            meta.metadata().clone(),
+            predicate_schema.clone(),
+        );
 
         // `price < 5 AND extra = 10`. Only page 0 (0..7) can contain
         // price < 5. The `extra = 10` clause evaluates to unknown for
@@ -1454,7 +1471,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(meta.metadata().num_row_groups(), 2);
-        let pruner = PagePruner::new(&schema, meta.metadata().clone());
+        let pruner = PagePruner::new(&schema, meta.metadata().clone(), schema.clone());
 
         // Verify page_row_counts returns a valid layout for each RG.
         let rc0 = pruner.page_row_counts(0).unwrap();
@@ -1568,6 +1585,7 @@ mod tests {
             &arc_meta,
             &schema,
             &rg_indices,
+            &schema,
         );
 
         // Verify bottom-up:
@@ -1676,8 +1694,15 @@ mod tests {
 
         let expr = bin(col("severity", 1), Operator::GtEq, lit_int(0));
         let pp = build_pruning_predicate(&expr, table_schema.clone()).unwrap();
+        let file_arrow_schema: SchemaRef = Arc::new(
+            datafusion::parquet::arrow::parquet_to_arrow_schema(
+                md.file_metadata().schema_descr(),
+                md.file_metadata().key_value_metadata(),
+            )
+            .unwrap(),
+        );
         assert_eq!(
-            eval_leaf(&pp, &md, &table_schema, &[0]),
+            eval_leaf(&pp, &md, &table_schema, &[0], &file_arrow_schema),
             vec![true],
             "severity >= 0 is always true; eval_leaf must not prune under schema drift"
         );
@@ -1744,6 +1769,7 @@ mod tests {
             &arc_meta,
             &schema,
             &rg_indices,
+            &schema,
         );
 
         // rg_can_match is 3 elements (one per chunk RG), relative indexing.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -129,6 +129,7 @@ pub async fn build_segments(
             object_path: meta.location.clone(),
             parquet_size: size,
             row_groups,
+            arrow_schema: file_schema,
             metadata: pq_meta,
             global_base,
             sort_min,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -400,6 +400,9 @@ pub struct IndexedExec {
     /// dispatching further row groups and `IndexedStream` stops draining.
     /// `None` disables cancellation checks.
     pub(crate) cancellation_token: Option<tokio_util::sync::CancellationToken>,
+    /// Cached per-segment arrow schema derived from parquet footer. Used by
+    /// page pruning and dynamic filter to avoid repeated `parquet_to_arrow_schema`.
+    pub(crate) seg_arrow_schema: SchemaRef,
 }
 
 impl fmt::Debug for IndexedExec {
@@ -497,6 +500,7 @@ impl ExecutionPlan for IndexedExec {
             self.emit_row_ids,
             self.row_id_output_index,
             self.dynamic_filter.clone(),
+            self.seg_arrow_schema.clone(),
         )))
     }
 }
@@ -599,11 +603,15 @@ impl IndexedStream {
         emit_row_ids: bool,
         row_id_output_index: Option<usize>,
         dynamic_filter: Option<Arc<dyn datafusion::physical_expr::PhysicalExpr>>,
+        seg_arrow_schema: SchemaRef,
     ) -> Self {
         let evaluator = Arc::clone(&index_reader.evaluator);
         let batch_coalescer = LimitedBatchCoalescer::new(schema.clone(), target_batch_size, None);
-        let dynamic_rg_pruner =
-            super::dynamic_filter::DynamicRgPruner::new(dynamic_filter, full_schema.clone());
+        let dynamic_rg_pruner = super::dynamic_filter::DynamicRgPruner::new(
+            dynamic_filter,
+            full_schema.clone(),
+            seg_arrow_schema,
+        );
         Self {
             schema,
             full_schema,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -81,6 +81,11 @@ pub struct SegmentFileInfo {
     pub parquet_size: u64,
     pub row_groups: Vec<RowGroupInfo>,
     pub metadata: Arc<ParquetMetaData>,
+    /// Arrow schema derived from this segment's parquet footer. Computed once
+    /// at `build_segments` time by `parquet_to_arrow_schema` and reused by
+    /// page pruning, dynamic filter pruning, and column schema resolution
+    /// instead of re-deriving from the footer on every access.
+    pub arrow_schema: SchemaRef,
     /// Cumulative row count from all preceding segments. Used to compute
     /// shard-global row IDs: `global_base + rg.first_row + position_in_rg`.
     pub global_base: u64,
@@ -666,6 +671,7 @@ impl ExecutionPlan for QueryShardExec {
                             &segment.metadata,
                             schema,
                             &rg_indices,
+                            &segment.arrow_schema,
                         ))
                     });
 
@@ -731,6 +737,7 @@ impl ExecutionPlan for QueryShardExec {
                 row_id_output_index: self.row_id_output_index,
                 dynamic_filter: dynamic_filter.clone(),
                 cancellation_token: self.config.cancellation_token.clone(),
+                seg_arrow_schema: segment.arrow_schema.clone(),
             };
             streams.push(exec.execute(0, Arc::clone(&context))?);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -73,6 +73,7 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -85,7 +86,11 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
         let residual = Arc::clone(&residual);
         Arc::new(
             move |segment: &SegmentFileInfo, _chunk, stream_metrics, _stats_prune_tree| {
-                let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+                let pruner = Arc::new(PagePruner::new(
+                    &schema,
+                    Arc::clone(&segment.metadata),
+                    schema.clone(),
+                ));
                 let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(PredicateOnlyEvaluator::new(
                     pruner,
                     None,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -125,6 +125,7 @@ async fn run_indexed(sql: &str) -> (Vec<i32>, Arc<dyn datafusion::physical_plan:
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -133,7 +134,11 @@ async fn run_indexed(sql: &str) -> (Vec<i32>, Arc<dyn datafusion::physical_plan:
     let factory: super::super::table_provider::EvaluatorFactory = {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let collector: Arc<dyn RowGroupDocsCollector> = Arc::new(MatchAllCollector);
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
                 crate::indexed_table::eval::single_collector::SingleCollectorEvaluator::new(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -412,7 +412,11 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_delegation_tree(
         let provider_locks = Arc::clone(&provider_locks);
         let schema = loaded.schema.clone();
         Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(Arc::clone(&correctness)),
                 pruner,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -105,6 +105,7 @@ pub(in crate::indexed_table::tests_e2e) fn load_segment(corpus: &Corpus) -> Load
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -244,7 +245,11 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
         let pruning_predicates = Arc::clone(&pruning_predicates);
         Arc::new(move |segment, chunk, stream_metrics, stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let rg_index_to_pos: HashMap<usize, usize> = chunk
                 .row_group_indices
                 .iter()
@@ -413,7 +418,11 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_single_collector(
         let residual_pp = residual_pp.clone();
         let residual_physical = residual_physical.clone();
         Arc::new(move |segment, _chunk, stream_metrics, _stats_prune_tree| {
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(Arc::clone(&collector)),
                 pruner,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -231,6 +231,7 @@ async fn run_tree_and_plan(
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -254,7 +255,11 @@ async fn run_tree_and_plan(
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -130,6 +130,7 @@ async fn run_two_segment_query(
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -152,7 +153,11 @@ async fn run_two_segment_query(
                 .unwrap_or_default();
             let collector: Arc<dyn RowGroupDocsCollector> =
                 Arc::new(PerSegmentCollector { matching });
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
                 crate::indexed_table::eval::single_collector::SingleCollectorEvaluator::new(
                     Some(collector), pruner, None, None, None, None,
@@ -335,6 +340,7 @@ async fn run_two_segment_query_witness(
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -361,7 +367,11 @@ async fn run_two_segment_query_witness(
                 in_flight: Arc::clone(&in_flight),
                 max_in_flight: Arc::clone(&max_in_flight),
             });
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
                 crate::indexed_table::eval::single_collector::SingleCollectorEvaluator::new(
                     Some(collector), pruner, None, None, None, None,
@@ -552,6 +562,7 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -570,7 +581,11 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
                 .unwrap_or_default();
             let collector: Arc<dyn RowGroupDocsCollector> =
                 Arc::new(PerSegmentCollector { matching });
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
                 crate::indexed_table::eval::single_collector::SingleCollectorEvaluator::new(
                     Some(collector), pruner, None, None, None, None,
@@ -1049,6 +1064,7 @@ async fn run_wide_segments(
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -1074,7 +1090,11 @@ async fn run_wide_segments(
                 })
                 .collect();
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(
                 crate::indexed_table::eval::TreeBitsetSource {
                     tree: Arc::new(resolved),
@@ -1392,6 +1412,7 @@ async fn run_wide_segments_with_stats_pruning(
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: 0,
             sort_min: None,
             sort_max: None,
@@ -1432,7 +1453,11 @@ async fn run_wide_segments_with_stats_pruning(
                 })
                 .collect();
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let rg_index_to_pos: HashMap<usize, usize> = chunk
                 .row_group_indices
                 .iter()
@@ -1688,6 +1713,7 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         &parquet_meta,
         &schema,
         &rg_indices,
+        &schema,
     );
 
     // Assert: rg_can_match for position 0 (RG2, prices 80-110) should be true (price>60 matches).
@@ -1715,6 +1741,7 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         &parquet_meta,
         &schema,
         &rg_indices_low,
+        &schema,
     );
     // RG0 (prices 0-30): price>60 → false → AND=false
     assert!(
@@ -1747,7 +1774,11 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
     let per_leaf: Vec<(i32, Arc<dyn RowGroupDocsCollector>)> =
         vec![(0, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>)];
     let resolved = tree_arc.resolve(&per_leaf).unwrap();
-    let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta)));
+    let pruner = Arc::new(PagePruner::new(
+        &schema,
+        Arc::clone(&parquet_meta),
+        schema.clone(),
+    ));
 
     let source = crate::indexed_table::eval::TreeBitsetSource {
         tree: Arc::new(resolved),
@@ -1803,7 +1834,11 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         leaves: Arc::new(
             crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::without_metrics(),
         ),
-        page_pruner: Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta))),
+        page_pruner: Arc::new(PagePruner::new(
+            &schema,
+            Arc::clone(&parquet_meta),
+            schema.clone(),
+        )),
         cost_predicate: 1,
         cost_collector: 10,
         max_collector_parallelism: 1,
@@ -1903,6 +1938,7 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
         &parquet_meta,
         &schema,
         &rg_indices,
+        &schema,
     );
     // Root OR should still be true (Collector1 child is always-true).
     assert!(
@@ -1940,7 +1976,11 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
         (1, Arc::new(AllDocs) as Arc<dyn RowGroupDocsCollector>),
     ];
     let resolved = Arc::new(tree).resolve(&per_leaf).unwrap();
-    let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&parquet_meta)));
+    let pruner = Arc::new(PagePruner::new(
+        &schema,
+        Arc::clone(&parquet_meta),
+        schema.clone(),
+    ));
     let rg_index_to_pos: HashMap<usize, usize> = rg_indices
         .iter()
         .enumerate()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -333,6 +333,7 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -350,7 +351,11 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -215,6 +215,7 @@ fn load_segment(tmp: &NamedTempFile) -> (SegmentFileInfo, SchemaRef) {
         object_path: object_store::path::Path::from(path.to_string_lossy().as_ref()),
         parquet_size: size,
         row_groups: rgs,
+        arrow_schema: schema.clone(),
         metadata: parquet_meta,
         global_base: 0,
         sort_min: None,
@@ -311,7 +312,11 @@ async fn run_bitmap_tree(tree: BoolNode) -> (Vec<i32>, Arc<dyn ExecutionPlan>) {
         let pp_map = Arc::clone(&pp_map);
         Arc::new(move |segment, _chunk, sm, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -353,7 +358,11 @@ async fn run_single_collector(
         let residual_pp = residual_pp.clone();
         let residual_expr = Arc::clone(&residual_expr);
         Arc::new(move |segment, _chunk, sm, _stats_prune_tree| {
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(SingleCollectorEvaluator::new(
                 Some(collector_for_tag(collector_tag)),
                 pruner,
@@ -1010,7 +1019,7 @@ fn fixture_eval_ctx() -> RgEvalContext {
 fn cost_ordering_predicates_sorted_by_selectivity() {
     let tmp = write_fixture();
     let (seg, schema) = load_segment(&tmp);
-    let pruner = PagePruner::new(&schema, seg.metadata);
+    let pruner = PagePruner::new(&schema, seg.metadata, schema.clone());
     let ctx = fixture_eval_ctx();
 
     let pred_narrow = binop(col_expr("price"), Operator::Lt, lit_i32(1024)); // 1/4 pages
@@ -1080,7 +1089,7 @@ fn cost_ordering_predicates_sorted_by_selectivity() {
 fn cost_ordering_nested_and_branches_selective_first() {
     let tmp = write_fixture();
     let (seg, schema) = load_segment(&tmp);
-    let pruner = PagePruner::new(&schema, seg.metadata);
+    let pruner = PagePruner::new(&schema, seg.metadata, schema.clone());
     let ctx = fixture_eval_ctx();
 
     let pred_narrow = binop(col_expr("price"), Operator::Lt, lit_i32(1024));
@@ -1139,7 +1148,7 @@ fn cost_ordering_nested_and_branches_selective_first() {
 fn cost_ordering_complex_tree_predicates_before_or_before_nothing() {
     let tmp = write_fixture();
     let (seg, schema) = load_segment(&tmp);
-    let pruner = PagePruner::new(&schema, seg.metadata);
+    let pruner = PagePruner::new(&schema, seg.metadata, schema.clone());
     let ctx = fixture_eval_ctx();
 
     let pred_ge_10k = binop(col_expr("price"), Operator::GtEq, lit_i32(10_000));

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -61,6 +61,7 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -80,7 +81,11 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -50,6 +50,7 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -69,7 +70,11 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -222,6 +227,7 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base,
         sort_min: None,
         sort_max: None,
@@ -241,7 +247,11 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -503,6 +513,7 @@ async fn test_row_id_with_data_columns() {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -523,7 +534,11 @@ async fn test_row_id_with_data_columns() {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -759,6 +774,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         parquet_size: size1,
         row_groups: rgs1,
         metadata: Arc::clone(&parquet_meta1),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -770,6 +786,7 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         parquet_size: size2,
         row_groups: rgs2,
         metadata: Arc::clone(&parquet_meta2),
+        arrow_schema: schema.clone(),
         global_base: 16,
         sort_min: None,
         sort_max: None,
@@ -789,7 +806,11 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -96,6 +96,7 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -107,7 +108,11 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&[])?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -286,7 +291,7 @@ fn page_pruner_prunes_existing_column_despite_missing_column() {
         ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
     // Schema handed to the pruner includes the missing column.
     let drift_schema = schema_with_missing();
-    let pruner = PagePruner::new(&drift_schema, meta.metadata().clone());
+    let pruner = PagePruner::new(&drift_schema, meta.metadata().clone(), drift_schema.clone());
 
     // Existing-column predicate: score < 100 (fixture has score = i % 1000
     // so ~10% of rows match, concentrated at the start of every 1000-row
@@ -408,6 +413,7 @@ async fn query_with_mismatched_schema(
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: meta.schema().clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -418,7 +424,11 @@ async fn query_with_mismatched_schema(
         let schema = table_schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&[])?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -153,6 +153,7 @@ fn build_segments(tmps: &[NamedTempFile], specs: &[SegSpec]) -> (Vec<SegmentFile
             parquet_size: size,
             row_groups: rgs,
             metadata: Arc::clone(&parquet_meta),
+            arrow_schema: meta.schema().clone(),
             global_base: cumulative,
             sort_min: None,
             sort_max: None,
@@ -188,7 +189,11 @@ async fn collect_row_ids(
                 .unwrap_or_default();
             let collector: Arc<dyn RowGroupDocsCollector> =
                 Arc::new(LocalOffsetCollector { matching });
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             // Single-collector tree.
             let tree = BoolNode::Collector { annotation_id: 0 };
             let tree = tree.push_not_down();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -406,6 +406,7 @@ async fn run_large(
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -423,7 +424,11 @@ async fn run_large(
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
@@ -867,6 +872,7 @@ async fn run_large_partitioned(
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: schema.clone(),
         global_base: 0,
         sort_min: None,
         sort_max: None,
@@ -884,7 +890,11 @@ async fn run_large_partitioned(
         let schema = schema.clone();
         Arc::new(move |segment, _chunk, _stream_metrics, _stats_prune_tree| {
             let resolved = tree.resolve(&per_leaf)?;
-            let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&segment.metadata)));
+            let pruner = Arc::new(PagePruner::new(
+                &schema,
+                Arc::clone(&segment.metadata),
+                schema.clone(),
+            ));
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
@@ -222,7 +222,7 @@ impl AsyncFileReader for ScopedPageIndexReader {
             // 1. Footer-only metadata (shared metadata-cache hit if pre-seeded).
             //    Use the listing's ObjectMeta rather than a `head()` — the cache
             //    validity check only needs size + last_modified, both already known.
-            let (_schema, _size, footer) = load_parquet_metadata_with_meta(
+            let (file_arrow_schema, _size, footer) = load_parquet_metadata_with_meta(
                 Arc::clone(&store),
                 &location,
                 object_meta,
@@ -240,6 +240,7 @@ impl AsyncFileReader for ScopedPageIndexReader {
                     &footer,
                     &predicate_names,
                     &projection_names,
+                    &file_arrow_schema,
                 );
                 if let Some(augmented) = load_scoped_page_index_cols(
                     &store,


### PR DESCRIPTION
Compute parquet_to_arrow_schema once per segment at build_segments time and store the result in SegmentFileInfo.arrow_schema. All downstream consumers (PagePruner, DynamicRgPruner, StatsPruneTree, column schema resolver) now use the cached SchemaRef directly instead of re-deriving from the parquet footer on every row-group or page-pruning call.

For a query over N segments with R row groups and P predicate leaves, this reduces parquet_to_arrow_schema calls from ~N*(2R+P+1)+1 to N+1.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
