### PR TITLE
memory accounting for searchTasks

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1709,7 +1709,11 @@ pub(crate) fn base_schema_for_table(plan: &substrait::proto::Plan, table_name: &
 // ---------------------------------------------------------------------------
 
 /// Creates a `LocalSession` bound to the given runtime's [`RuntimeEnv`]
-/// (memory pool, disk manager, and caches are shared).
+/// (disk manager and caches are shared). When `context_id != 0`, the session
+/// installs a per-query [`crate::query_tracker::QueryMemoryPool`] (wrapping the
+/// runtime's pool) into its `RuntimeEnv`, so every reduce allocation is
+/// attributed to `context_id` (the parent `AnalyticsQueryTask`) and surfaces to
+/// search backpressure. `context_id == 0` shares the runtime pool directly.
 ///
 /// Returns a heap-allocated pointer (as i64) to `LocalSession`. Caller must
 /// call `close_local_session` exactly once to free it.
@@ -1717,9 +1721,9 @@ pub(crate) fn base_schema_for_table(plan: &substrait::proto::Plan, table_name: &
 /// # Safety
 /// `runtime_ptr` must be a valid, non-zero pointer returned by
 /// `create_global_runtime`.
-pub unsafe fn create_local_session(runtime_ptr: i64) -> Result<i64, DataFusionError> {
+pub unsafe fn create_local_session(runtime_ptr: i64, context_id: i64) -> Result<i64, DataFusionError> {
     let runtime = &*(runtime_ptr as *const DataFusionRuntime);
-    let session = LocalSession::new(&runtime.runtime_env);
+    let session = LocalSession::new_tracked(&runtime.runtime_env, context_id);
     Ok(Box::into_raw(Box::new(session)) as i64)
 }
 
@@ -1803,10 +1807,15 @@ pub async unsafe fn execute_local_plan(
 ) -> Result<i64, DataFusionError> {
     let session = &*(session_ptr as *const LocalSession);
 
-    // Per-query memory tracking — wraps the session's global pool. A
-    // `context_id` of 0 disables tracking (pool is not consulted) and no
-    // cancellation token is registered in the global QUERY_REGISTRY.
-    let query_context = QueryTrackingContext::new(context_id, session.memory_pool(), query_tracker::QueryType::Coordinator);
+    // Per-query memory tracking. Reuse the per-query pool the session installed
+    // into its `RuntimeEnv` at creation time (via `create_local_session` with
+    // this same `context_id`), so the tracker counts the exact pool the reduce
+    // reserves against. Falls back to wrapping the global pool only when the
+    // session wasn't created with tracking (context_id 0 -> disabled).
+    let query_context = match session.query_pool() {
+        Some(pool) => QueryTrackingContext::from_query_pool(context_id, pool, query_tracker::QueryType::Coordinator),
+        None => QueryTrackingContext::new(context_id, session.memory_pool(), query_tracker::QueryType::Coordinator),
+    };
     let token = query_tracker::get_cancellation_token(context_id);
 
     // Race substrait planning + execution against the cancellation token so
@@ -1863,8 +1872,13 @@ pub unsafe fn execute_local_prepared_plan(
     // shared QUERY_REGISTRY — parity with execute_query + execute_local_plan,
     // so a `cancel_query(context_id)` call fires the token here too.
     // The token is held via the QueryStreamHandle's context and consulted by
-    // stream_next on each batch pull.
-    let query_context = QueryTrackingContext::new(context_id, session.memory_pool(), query_tracker::QueryType::Coordinator);
+    // stream_next on each batch pull. Reuse the session's per-query pool (built
+    // in create_local_session with this context_id) so reduce reservations are
+    // counted by this tracker rather than an unused wrapper.
+    let query_context = match session.query_pool() {
+        Some(pool) => QueryTrackingContext::from_query_pool(context_id, pool, query_tracker::QueryType::Coordinator),
+        None => QueryTrackingContext::new(context_id, session.memory_pool(), query_tracker::QueryType::Coordinator),
+    };
     let token = query_tracker::get_cancellation_token(context_id);
 
     // DataFusion's execute_stream is sync, but kicks off RepartitionExec /

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -597,8 +597,8 @@ unsafe fn write_out_buffer(
 
 #[ffm_safe]
 #[no_mangle]
-pub unsafe extern "C" fn df_create_local_session(runtime_ptr: i64) -> i64 {
-    api::create_local_session(runtime_ptr).map_err(|e| e.to_string())
+pub unsafe extern "C" fn df_create_local_session(runtime_ptr: i64, context_id: i64) -> i64 {
+    api::create_local_session(runtime_ptr, context_id).map_err(|e| e.to_string())
 }
 
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -44,6 +44,7 @@ use prost::Message;
 use substrait::proto::Plan;
 
 use crate::partition_stream::{channel, PartitionStreamSender, SingleReceiverPartition};
+use crate::query_tracker::QueryMemoryPool;
 
 /// Coordinator-reduce DataFusion session.
 ///
@@ -60,6 +61,13 @@ pub struct LocalSession {
     /// untracked memory (intermediate buffers, hash table overhead) in the shared
     /// pool so concurrent reduces trigger backpressure before OOM.
     _phantom_reservation: Option<datafusion::execution::memory_pool::MemoryReservation>,
+    /// Per-query memory pool installed into this session's `RuntimeEnv` when the
+    /// session was created with a non-zero `context_id`. `None` when tracking is
+    /// disabled. The bridge layer reuses this exact instance to seed the
+    /// [`crate::query_tracker::QueryTrackingContext`], so the registry reports
+    /// the bytes the reduce actually reserves (the operators reserve against the
+    /// pool in this `RuntimeEnv`).
+    query_pool: Option<Arc<QueryMemoryPool>>,
 }
 
 impl LocalSession {
@@ -68,8 +76,31 @@ impl LocalSession {
     /// The runtime's memory pool, disk manager, and caches are inherited —
     /// every batch consumed or produced by this session counts against the
     /// same limits as the shard-scan path.
+    ///
+    /// Equivalent to [`Self::new_tracked`] with `context_id == 0` (no per-query
+    /// tracking). Retained for tests and any caller without a task id.
     pub fn new(runtime_env: &RuntimeEnv) -> Self {
-        let runtime_env = Arc::new(runtime_env.clone());
+        Self::new_tracked(runtime_env, 0)
+    }
+
+    /// Builds a session that, when `context_id != 0`, installs a per-query
+    /// [`QueryMemoryPool`] (wrapping the runtime's pool) into its `RuntimeEnv`.
+    ///
+    /// All reduce allocations then reserve against that wrapper, so the
+    /// per-query tracker keyed by `context_id` (the parent `AnalyticsQueryTask`
+    /// id) reports the reduce's true native footprint to search backpressure.
+    /// When `context_id == 0`, the session shares the runtime pool directly and
+    /// no per-query pool is created.
+    pub fn new_tracked(runtime_env: &RuntimeEnv, context_id: i64) -> Self {
+        let mut env = runtime_env.clone();
+        let query_pool = if context_id != 0 {
+            let qp = Arc::new(QueryMemoryPool::new(Arc::clone(&runtime_env.memory_pool)));
+            env.memory_pool = Arc::clone(&qp) as Arc<dyn MemoryPool>;
+            Some(qp)
+        } else {
+            None
+        };
+        let runtime_env = Arc::new(env);
         let mut config = SessionConfig::new();
         config.options_mut().execution.target_partitions = crate::api::get_reduce_target_partitions();
         let state = SessionStateBuilder::new()
@@ -81,7 +112,15 @@ impl LocalSession {
         let ctx = SessionContext::new_with_state(state);
         crate::udf::register_all(&ctx);
         crate::udaf::register_all(&ctx);
-        Self { ctx, prepared_plan: None, _phantom_reservation: None }
+        Self { ctx, prepared_plan: None, _phantom_reservation: None, query_pool }
+    }
+
+    /// The per-query memory pool this session was built against, or `None` when
+    /// created without tracking (`context_id == 0`). The bridge layer reuses
+    /// this to construct the query-tracking context so the tracker and the
+    /// executing session share one counter.
+    pub fn query_pool(&self) -> Option<Arc<QueryMemoryPool>> {
+        self.query_pool.clone()
     }
 
     /// Returns the configured batch_size for this session.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -512,7 +512,27 @@ impl QueryTrackingContext {
         if context_id == 0 {
             return Self { tracker: None, phantom_reservation: None, phantom_corrector: None };
         }
-        let query_pool = Arc::new(QueryMemoryPool::new(global_pool));
+        Self::from_query_pool(context_id, Arc::new(QueryMemoryPool::new(global_pool)), query_type)
+    }
+
+    /// Create a query context that reports against an existing
+    /// [`QueryMemoryPool`] instead of wrapping a shared pool itself.
+    ///
+    /// Use this when the executing session already built its `RuntimeEnv`
+    /// against a per-query pool (the coordinator-reduce path): passing that
+    /// same `Arc<QueryMemoryPool>` here makes the registry tracker report the
+    /// bytes the session actually reserves. Wrapping a fresh pool instead (as
+    /// [`Self::new`] does) would leave the tracker reporting zero because the
+    /// session never reserves against it. If `context_id` is 0, tracking is
+    /// disabled.
+    pub fn from_query_pool(
+        context_id: i64,
+        query_pool: Arc<QueryMemoryPool>,
+        query_type: QueryType,
+    ) -> Self {
+        if context_id == 0 {
+            return Self { tracker: None, phantom_reservation: None, phantom_corrector: None };
+        }
         let tracker = Arc::new(QueryTracker {
             start_time: Instant::now(),
             context_id,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/AbstractDatafusionReduceSink.java
@@ -84,7 +84,7 @@ abstract class AbstractDatafusionReduceSink implements ReducingExchangeSink, Can
         this.ctx = ctx;
         this.runtimeHandle = runtimeHandle;
         this.preparedState = preparedState;
-        this.session = preparedState != null ? preparedState.session() : new DatafusionLocalSession(runtimeHandle.get());
+        this.session = preparedState != null ? preparedState.session() : new DatafusionLocalSession(runtimeHandle.get(), ctx.taskId());
         Map<Integer, byte[]> inputs = new LinkedHashMap<>(ctx.childInputs().size());
         for (ExchangeSinkContext.ChildInput child : ctx.childInputs()) {
             inputs.put(child.childStageId(), child.producerPlanBytes());

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionLocalSession.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionLocalSession.java
@@ -26,9 +26,12 @@ public final class DatafusionLocalSession extends NativeHandle {
      * Creates a new local session tied to the given global runtime pointer.
      *
      * @param runtimePtr pointer returned by {@link NativeBridge#createGlobalRuntime}
+     * @param contextId  the parent {@code AnalyticsQueryTask.getId()} used to attribute this
+     *                   reduce's native memory to the coordinator search task (0 disables
+     *                   per-query tracking)
      */
-    public DatafusionLocalSession(long runtimePtr) {
-        super(NativeBridge.createLocalSession(runtimePtr));
+    public DatafusionLocalSession(long runtimePtr, long contextId) {
+        super(NativeBridge.createLocalSession(runtimePtr, contextId));
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/FinalAggregateInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/FinalAggregateInstructionHandler.java
@@ -43,7 +43,7 @@ public class FinalAggregateInstructionHandler implements FragmentInstructionHand
     ) {
         ExchangeSinkContext ctx = (ExchangeSinkContext) commonContext;
 
-        DatafusionLocalSession session = new DatafusionLocalSession(runtimeHandle.get());
+        DatafusionLocalSession session = new DatafusionLocalSession(runtimeHandle.get(), ctx.taskId());
         List<DatafusionPartitionSender> senders = new ArrayList<>(ctx.childInputs().size());
         List<Schema> inputSchemas = new ArrayList<>(ctx.childInputs().size());
         try {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -304,10 +304,10 @@ public final class NativeBridge {
         );
 
         // ── Coordinator-reduce bindings ──
-        // i64 df_create_local_session(runtime_ptr)
+        // i64 df_create_local_session(runtime_ptr, context_id)
         CREATE_LOCAL_SESSION = linker.downcallHandle(
             lib.find("df_create_local_session").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
         );
 
         // void df_close_local_session(session_ptr)
@@ -1203,11 +1203,17 @@ public final class NativeBridge {
     /**
      * Creates a local DataFusion session tied to the given global runtime. Returns an opaque
      * native pointer freed by {@link #closeLocalSession}.
+     *
+     * @param runtimePtr pointer to the global runtime
+     * @param contextId  the parent {@code AnalyticsQueryTask.getId()} (0 disables per-query
+     *                   native-memory tracking). When non-zero, the session installs a per-query
+     *                   memory pool so reduce allocations are attributed to this id and become
+     *                   visible to search backpressure.
      */
-    public static long createLocalSession(long runtimePtr) {
+    public static long createLocalSession(long runtimePtr, long contextId) {
         NativeHandle.validatePointer(runtimePtr, "runtime");
         try (var call = new NativeCall()) {
-            return call.invoke(CREATE_LOCAL_SESSION, runtimePtr);
+            return call.invoke(CREATE_LOCAL_SESSION, runtimePtr, contextId);
         }
     }
 


### PR DESCRIPTION
### Description

Attributes the coordinator-reduce path's native (off-heap) memory to the
parent search task so it becomes visible to search backpressure.

Previously, `create_local_session` created a reduce session that shared the
runtime memory pool directly, and the per-query tracking context wrapped a
*fresh* pool that the session never reserved against — so the registry
reported ~0 bytes for reduce work and backpressure could not see it.

This change threads a `context_id` (the parent `AnalyticsQueryTask.getId()`)
through the session-creation path:

- `create_local_session(runtime_ptr, context_id)` now installs a per-query
  `QueryMemoryPool` (wrapping the runtime pool) into the session's
  `RuntimeEnv` when `context_id != 0`. All reduce allocations reserve against
  that wrapper.
- `LocalSession::new_tracked` builds the session against that pool and exposes
  it via `query_pool()`. `new` is retained as `new_tracked(.., 0)` for the
  untracked path.
- The bridge layer reuses that same `Arc<QueryMemoryPool>` to seed the query
  tracking context (`QueryTrackingContext::from_query_pool`), so the tracker
  keyed by `context_id` reports the bytes the reduce actually reserves.
- Java callers (`AbstractDatafusionReduceSink`, `FinalAggregateInstructionHandler`)
  and `DatafusionLocalSession` / `NativeBridge.createLocalSession` are updated
  to pass the task id.

A `context_id` of 0 preserves the previous behavior (no per-query tracking,
shared runtime pool).

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing
off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
