### PR TITLE
Fix analytics-engine SearchStatsContributor undercounting by shard fan-out factor

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -260,11 +260,26 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     @Override
     public SearchStats contributeSearchStats() {
-        AnalyticsStats.LatencyStats elapsed = statsCollector.snapshot().queries().elapsedMs();
-        if (elapsed.count() == 0) {
+        // Contribute per-shard fragment task counts so the node-level search counters
+        // exposed via _nodes/stats match Lucene's per-shard accounting (one increment
+        // per shard query phase, not per user query).
+        //
+        // The queries.elapsed_ms bucket counts 1-per-query, which undercounts the
+        // rate by the shard fan-out factor and drops most queries' latency (the
+        // start/end window in AnalyticsStatsCollector#recordExecution is commonly
+        // 0 when stage timestamps aren't populated). The SHARD_FRAGMENT stage
+        // bucket counts 1-per-(query, node-hosting-shards), still missing the
+        // per-shard granularity Lucene reports. fragments.total walks each
+        // SHARD_FRAGMENT execution's per-shard StageTasks, giving per-shard
+        // counts matching Lucene's onPreQueryPhase semantics.
+        AnalyticsStats snapshot = statsCollector.snapshot();
+        AnalyticsStats.Fragments fragments = snapshot.fragments();
+        if (fragments == null || fragments.total() == 0) {
             return null;
         }
-        SearchStats.Stats stats = new SearchStats.Stats.Builder().queryCount(elapsed.count()).queryTimeInMillis(elapsed.sumMs()).build();
+        SearchStats.Stats stats = new SearchStats.Stats.Builder().queryCount(fragments.total())
+            .queryTimeInMillis(fragments.elapsedMs().sumMs())
+            .build();
         return new SearchStats(stats, 0, null);
     }
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchStatsContributorIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/SearchStatsContributorIT.java
@@ -25,42 +25,91 @@ import java.util.Map;
 public class SearchStatsContributorIT extends AnalyticsRestTestCase {
 
     private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    /**
+     * Multi-shard index so the test can distinguish the per-query contributor
+     * (queryCount delta ≈ N) from the per-shard Lucene-equivalent contributor
+     * (queryCount delta ≈ N × shards). Catches the regression class where the
+     * contributor counts 1-per-query and silently under-reports search rate
+     * by the shard fan-out factor to downstream consumers of node stats.
+     */
+    private static final int NUMBER_OF_SHARDS = 3;
     private static boolean dataProvisioned = false;
 
     private void ensureDataProvisioned() throws IOException {
         if (dataProvisioned == false) {
-            DatasetProvisioner.provision(client(), DATASET);
+            DatasetProvisioner.provision(client(), DATASET, NUMBER_OF_SHARDS);
             dataProvisioned = true;
         }
     }
 
-    public void testQueryTotalIncrementsAfterAnalyticsQueries() throws IOException {
+    /**
+     * Guards the 1-per-query bug: cluster-wide query_total must grow with the
+     * shard fan-out factor. A 1-per-query contributor would produce delta ≈ N
+     * (instead of N × shards), under-reporting search rate by the shard fan-out
+     * factor to downstream consumers of node stats.
+     */
+    public void testQueryTotalScalesWithShardFanOut() throws IOException {
         ensureDataProvisioned();
 
-        long baselineQueryTotal = getQueryTotalAcrossNodes();
-        long baselineQueryTimeMs = getQueryTimeAcrossNodes();
+        long before = getQueryTotalAcrossNodes();
+        fireQueries();
+        long after = getQueryTotalAcrossNodes();
 
-        // Fire a handful of analytics-engine PPL queries — varied shapes so the contributor
-        // sees both real elapsed time and a non-trivial count.
+        long delta = after - before;
+        long minExpected = (long) TOTAL_QUERIES * NUMBER_OF_SHARDS / 2;
+        assertTrue(
+            "search.query_total must grow with shard fan-out (fired " + TOTAL_QUERIES
+                + " on " + NUMBER_OF_SHARDS + "-shard index, expected ≥ " + minExpected
+                + ", observed delta=" + delta + ")",
+            delta >= minExpected
+        );
+    }
+
+    /**
+     * Guards the latency-aggregation bug: query_time_in_millis must move when
+     * real PPL work runs. A delta of 0 means the contributor's time source
+     * dropped every recording (e.g. an all-or-nothing window that collapsed).
+     */
+    public void testQueryTimeIncrementsAfterAnalyticsQueries() throws IOException {
+        ensureDataProvisioned();
+
+        long before = getQueryTimeAcrossNodes();
+        fireQueries();
+        long after = getQueryTimeAcrossNodes();
+
+        long delta = after - before;
+        assertTrue("search.query_time_in_millis must grow > 0 after PPL work, observed delta=" + delta, delta > 0);
+    }
+
+    /**
+     * Minimum-viable check: every fired query must contribute at least once to
+     * cluster-wide query_total. Catches regressions where the contributor stops
+     * firing entirely (e.g. returns null, or filters out all stages).
+     */
+    public void testQueryTotalIncrementsAtLeastOncePerQuery() throws IOException {
+        ensureDataProvisioned();
+
+        long before = getQueryTotalAcrossNodes();
+        fireQueries();
+        long after = getQueryTotalAcrossNodes();
+
+        long delta = after - before;
+        assertTrue(
+            "search.query_total must grow by at least one per query (fired " + TOTAL_QUERIES
+                + ", observed delta=" + delta + ")",
+            delta >= TOTAL_QUERIES
+        );
+    }
+
+    private static final int TOTAL_QUERIES = 15;
+
+    private void fireQueries() throws IOException {
+        // Varied shapes so the contributor sees both real elapsed time and a non-trivial count.
         for (int i = 0; i < 5; i++) {
             executePpl("source=" + DATASET.indexName + " | fields str0");
             executePpl("source=" + DATASET.indexName + " | where num0 > 0 | fields str0, num0");
             executePpl("source=" + DATASET.indexName + " | stats avg(num0)");
         }
-
-        long afterQueryTotal = getQueryTotalAcrossNodes();
-        long afterQueryTimeMs = getQueryTimeAcrossNodes();
-
-        long countDelta = afterQueryTotal - baselineQueryTotal;
-        assertTrue(
-            "search.query_total must increment by at least 1 after analytics queries, delta=" + countDelta,
-            countDelta >= 1
-        );
-        // query_time_in_millis is a sum so it should grow strictly monotonically with count;
-        // any single query that took 0ms is unlikely with non-trivial work, but the contract
-        // we care about is "the field is being populated", so >= 0 is enough.
-        long timeDelta = afterQueryTimeMs - baselineQueryTimeMs;
-        assertTrue("search.query_time_in_millis must not regress, delta=" + timeDelta, timeDelta >= 0);
     }
 
     private long getQueryTotalAcrossNodes() throws IOException {


### PR DESCRIPTION
## Description

`SearchStatsContributor` (added in #21796) reports 1-per-query via `queries.elapsed_ms.count`, but Lucene's `ShardSearchStats` counts per shard: `onPreQueryPhase` / `onQueryPhase` fire on each shard's data node, so a query touching N shards contributes ~N to cluster-wide `search.query_total`. The analytics contributor's 1-per-query reporting means downstream consumers of node search stats see traffic under-reported by the shard fan-out factor (~50x on a 50-shard index, ~8x on 8 shards).

Secondary: `query_time_in_millis` reports near-zero because the collector's per-query elapsed is `latestStageEnd - earliestStageStart` and skips recording when either timestamp is 0.

## Fix

Contribute from `fragments.total` and `fragments.elapsedMs` instead of the per-query bucket. `fragments` is the per-shard-task counter inside SHARD_FRAGMENT executions, matching Lucene's per-shard semantics for both count and time.

## Tests

Split `SearchStatsContributorIT` into three:

- `testQueryTotalScalesWithShardFanOut`: 3-shard index, asserts delta >= N*shards/2. Catches the 1-per-query bug.
- `testQueryTimeIncrementsAfterAnalyticsQueries`: asserts time delta > 0. Catches the all-or-nothing-window bug.
- `testQueryTotalIncrementsAtLeastOncePerQuery`: asserts delta >= N. Catches a regression where the contributor stops firing entirely.

## Empirical confirmation

Reproduced on a 27-node OpenSearch 3.5 cluster running the analytics engine:

| Index shards | Queries fired | Observed cluster-wide count delta | Expected (Lucene parity) |
|---:|---:|---:|---:|
| 50 | 50 | **36** | 2,500 |
| 8 | 100 | **66** | 800 |

Per-node breakdown for the 50-shard run: only 3 of 27 nodes incremented (the coordinators), 24 data nodes serving shards stayed at 0.

## Check List

- [x] New functionality covered by tests
- [x] Empirical confirmation on a live cluster
- [x] Signed off