### PR TITLE
[Sandbox] Narrow scan for sort+limit queries whose output is a subset of sort/filter columns

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchLateMaterializationRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchLateMaterializationRewriter.java
@@ -151,12 +151,44 @@ public final class OpenSearchLateMaterializationRewriter {
             anchorCtx.anchor
         );
 
-        // Skip predicate: aboveAnchorPhysicalFields - belowAnchorPhysicalFields must be non-empty.
+        // Columns the query actually touches = sort keys + below-filter cols (belowAnchor)
+        // ∪ output/display cols (aboveAnchor). The narrowed Scan need only carry these.
+        Set<String> neededPhysicalFields = new HashSet<>(belowAnchorPhysicalFields);
+        neededPhysicalFields.addAll(aboveAnchorPhysicalFields);
+        int totalScanCols = belowChain.scan.getRowType().getFieldCount();
+
+        // Skip predicate.
+        //
+        // Previously this declined QTF whenever aboveAnchorPhysicalFields ⊆ belowAnchorPhysicalFields,
+        // on the premise that "the non-QTF path reads the same physical fields anyway, so QTF saves
+        // no I/O." That premise does not hold: when the sole output column is (a subset of) the sort
+        // key, projection pushdown does not narrow the parquet scan, so the non-QTF plan reads EVERY
+        // column. For example `... | sort EventTime | head 10 | fields EventTime` materialized all
+        // ~100 columns to answer a one-column query. Declining QTF there is a latency cliff.
+        //
+        // Fire QTF whenever the query touches fewer columns than the full scan, so the narrowed Scan
+        // reads only `neededPhysicalFields`:
+        // - hasFetchOnly (above ⊄ below): classic late-materialization — heavy display columns are
+        // deferred to a per-survivor fetch.
+        // - !hasFetchOnly (above ⊆ below): no fetch-only columns, but the narrowed Scan still avoids
+        // materializing every column for all N rows. The wrapper's fetch re-reads only the K
+        // survivors of already-needed (cheap) columns — negligible beside the columns it skips.
+        // Decline only when the query already needs every column (narrowing would be a no-op).
         boolean hasFetchOnly = aboveAnchorPhysicalFields.stream().anyMatch(name -> !belowAnchorPhysicalFields.contains(name));
-        if (!hasFetchOnly) {
-            LOGGER.debug("[QTF] aboveAnchorPhysicalFields ⊆ belowAnchorPhysicalFields; QTF would not save any I/O — skipping");
+        boolean narrowsScan = neededPhysicalFields.size() < totalScanCols;
+        if (!hasFetchOnly && !narrowsScan) {
+            LOGGER.debug("[QTF] query needs all {} scan columns; narrowing would be a no-op — skipping", totalScanCols);
             return null;
         }
+        LOGGER.debug(
+            "[QTF] narrowing scan from {} cols to {} needed cols {} (hasFetchOnly={}); below={} above={}",
+            totalScanCols,
+            neededPhysicalFields.size(),
+            neededPhysicalFields,
+            hasFetchOnly,
+            belowAnchorPhysicalFields,
+            aboveAnchorPhysicalFields
+        );
 
         return new Detection(
             anchorCtx.anchor,

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/LateMaterializationPlanShapeTests.java
@@ -440,17 +440,32 @@ public class LateMaterializationPlanShapeTests extends BasePlannerRulesTests {
         assertQtfDeclined("SELECT URL FROM hits LIMIT 10", 2);
     }
 
-    public void testQtfDeclined_skipPredicate_sortColIsOnlyProjection() {
+    public void testQtfFires_sortColIsOnlyProjection() {
         // SELECT EventDate FROM hits ORDER BY EventDate LIMIT 10
-        // AboveAnchor = {EventDate}; BelowAnchor = {EventDate}; FetchOnly = {} → skip.
-        // Refetching EventDate by row id when it already rode through the reduce would be a wash.
-        assertQtfDeclined("SELECT EventDate FROM hits ORDER BY EventDate LIMIT 10", 2);
+        // AboveAnchor = {EventDate}; BelowAnchor = {EventDate}; FetchOnly = {}.
+        // No fetch-only column, BUT the query needs only 1 of the table's columns, so the narrowed
+        // Scan still avoids materializing every column for all rows — QTF fires (degenerate case).
+        // Previously declined, which left the non-QTF path reading the full row (latency cliff).
+        assertQtfFired(
+            "SELECT EventDate FROM hits ORDER BY EventDate LIMIT 10",
+            2,
+            Expect.scanCols("EventDate"),
+            Expect.aboveAnchorPhysicalFields("EventDate"),
+            Expect.wrapperOutput("EventDate")
+        );
     }
 
-    public void testQtfDeclined_skipPredicate_filterColIsOnlyProjection() {
+    public void testQtfFires_filterColIsOnlyProjection() {
         // SELECT CounterID FROM hits WHERE CounterID = 5 ORDER BY EventDate LIMIT 10
-        // AboveAnchor = {CounterID}; BelowAnchor = {CounterID, EventDate}; FetchOnly = {} → skip.
-        assertQtfDeclined("SELECT CounterID FROM hits WHERE CounterID = 5 ORDER BY EventDate LIMIT 10", 2);
+        // AboveAnchor = {CounterID}; BelowAnchor = {CounterID, EventDate}; FetchOnly = {}.
+        // Above ⊆ below, but the query needs only 2 columns → narrowed Scan still helps → QTF fires.
+        assertQtfFired(
+            "SELECT CounterID FROM hits WHERE CounterID = 5 ORDER BY EventDate LIMIT 10",
+            2,
+            Expect.scanCols("CounterID", "EventDate"),
+            Expect.aboveAnchorPhysicalFields("CounterID"),
+            Expect.wrapperOutput("CounterID")
+        );
     }
 
     public void testQtfDeclined_aggregateBelowSort() {


### PR DESCRIPTION
### Description

PPL queries of the shape `... | sort <col> | head <k> | fields <cols>` could read **every column** in the table even when only a few columns are needed, when the projected (output) columns were a subset of the sort/filter columns.

The analytics engine has a late-materialization rewrite that narrows the scan to only the columns a query needs (sort keys + filter columns below the sort, plus the display columns above it). It was **declining** to fire whenever the set of output columns was already contained in the set of sort/filter columns, on the assumption that in that case the ordinary (non-rewritten) plan would read the same narrow set of columns anyway — so the rewrite would save nothing.

That assumption does not hold. When the sole output column is the sort key (or a subset of the sort/filter columns), the column projection is **not** pushed down into the scan, so the non-rewritten plan reads the full row — all columns — to answer what is effectively a one- or two-column query. Declining the rewrite in this case is a latency cliff.

### Approach

- **Before:** fire the rewrite only when there is at least one output column that is *not* already a sort/filter column. Otherwise decline — and fall back to a plan that reads all columns.
- **After:** fire the rewrite whenever the query touches **fewer columns than the full table**, so the scan is narrowed to exactly the needed columns. Decline only in the genuine no-op case where the query needs every column.

This keeps the existing behavior for the common case (output columns are a superset of sort/filter columns) and additionally covers the degenerate case (output ⊆ sort/filter), where the narrowed scan now avoids materializing every column for every row. When there are no extra display columns to defer, the rewrite degenerates to "narrow scan + re-fetch the same few needed columns for the K survivors" — negligible next to the columns it stops reading for all rows.

### Shard physical plans (before → after)

Captured on the data node. The key change is the scan's `projection`: before, it lists every column; after, it carries only the columns the query needs (the sort-key column indices drop from their position among all columns, e.g. `@16`, to `@0`).

**q25** — `where SearchPhrase != '' | sort EventTime | fields SearchPhrase | head 10`

Before:
```
SortPreservingMergeExec: [EventTime@16 ASC], fetch=10
  SortExec: TopK(fetch=10), expr=[EventTime@16 ASC], preserve_partitioning=[true]
    FilterExec: SearchPhrase@74 != 
      DataSourceExec: file_groups={4 groups: [...17 parquet files...]},
        projection=[AdvEngineID, Age, BrowserCountry, BrowserLanguage, CLID, ClientEventTime,
          ClientIP, ClientTimeZone, CodeVersion, ConnectTiming, CookieEnable, CounterClass,
          CounterID, DNSTiming, DontCountHits, EventDate, EventTime, FUniqID, FetchTiming,
          FlashMajor, FlashMinor, FlashMinor2, FromTag, GoodEvent, HID, HTTPError, HasGCLID,
          HistoryLength, HitColor, IPNetworkID, Income, Interests, IsArtifical, IsDownload,
          IsEvent, IsLink, IsMobile, IsNotBounce, IsOldCounter, IsParameter, IsRefresh,
          JavaEnable, JavascriptEnable, LocalEventTime, MobilePhone, MobilePhoneModel, NetMajor,
          NetMinor, OS, OpenerName, OpenstatAdID, OpenstatCampaignID, OpenstatServiceName,
          OpenstatSourceID, OriginalURL, PageCharset, ParamCurrency, ParamCurrencyID,
          ParamOrderID, ParamPrice, Params, Referer, RefererCategoryID, RefererHash,
          RefererRegionID, RegionID, RemoteIP, ResolutionDepth, ResolutionHeight, ResolutionWidth,
          ResponseEndTiming, ResponseStartTiming, Robotness, SearchEngineID, SearchPhrase,
          SendTiming, Sex, SilverlightVersion1, SilverlightVersion2, SilverlightVersion3,
          SilverlightVersion4, SocialSourceNetworkID, SocialSourcePage, Title, TraficSourceID,
          URL, URLCategoryID, URLHash, URLRegionID, UTMCampaign, UTMContent, UTMMedium, UTMSource,
          UTMTerm, UserAgent, UserAgentMajor, UserAgentMinor, UserID, WatchID, WindowClientHeight,
          WindowClientWidth, WindowName, WithHash],
        file_type=parquet, predicate=SearchPhrase@63 !=  AND DynamicFilter [ empty ],
        pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1),
        required_guarantees=[SearchPhrase not in ()]
```

After:
```
SortPreservingMergeExec: [EventTime@0 ASC], fetch=10
  SortExec: TopK(fetch=10), expr=[EventTime@0 ASC], preserve_partitioning=[true]
    <scan narrowed to [SearchPhrase, EventTime]>
```

**q27** — `where SearchPhrase != '' | sort EventTime, SearchPhrase | fields SearchPhrase | head 10`

Before:
```
SortPreservingMergeExec: [EventTime@16 ASC, SearchPhrase@74 ASC], fetch=10
  SortExec: TopK(fetch=10), expr=[EventTime@16 ASC, SearchPhrase@74 ASC], preserve_partitioning=[true]
    FilterExec: SearchPhrase@74 != 
      DataSourceExec: file_groups={4 groups: [...17 parquet files...]},
        projection=[AdvEngineID, Age, BrowserCountry, ... (all ~100 columns, same list as q25) ... WithHash],
        file_type=parquet, predicate=SearchPhrase@63 !=  AND DynamicFilter [ empty ],
        pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1),
        required_guarantees=[SearchPhrase not in ()]
```

After:
```
SortPreservingMergeExec: [EventTime@0 ASC, SearchPhrase@1 ASC], fetch=10
  SortExec: TopK(fetch=10), expr=[EventTime@0 ASC, SearchPhrase@1 ASC], preserve_partitioning=[true]
    <scan narrowed to [EventTime, SearchPhrase]>
```

### Benchmark

ClickBench dataset (~100M rows, ~100 columns), single shard per node. Times are warm, two runs each. To isolate the effect of **this change**, all other query-acceleration paths were disabled for the measurement, so the numbers reflect the projection-narrowing alone.

| ClickBench query | PPL | Before | After |
|---|---|---:|---:|
| (probe) | `sort EventTime \| head 10 \| fields EventTime` | ~11.3 s | ~0.23 s |
| q25 | `where SearchPhrase != '' \| sort EventTime \| fields SearchPhrase \| head 10` | ~13.1 s | ~0.59 s |
| q27 | `where SearchPhrase != '' \| sort EventTime, SearchPhrase \| fields SearchPhrase \| head 10` | ~12.5 s | ~0.60 s |

The first row is a synthetic single-column probe (output column == sole sort key) — the clearest case of the degenerate shape this PR fixes. q25 and q27 are standard ClickBench queries that exhibit the same pattern (output column is a subset of the sort/filter columns).

Queries that already projected a superset of the sort/filter columns are unaffected (the rewrite already fired for them).

### Testing

- `LateMaterializationPlanShapeTests` — the two cases that previously asserted the rewrite was declined (output = sole sort key; output ⊆ sort+filter) are converted to assert the narrowed-scan plan. Full suite (26 tests) passes.
- `spotlessJavaCheck` clean.

### Check List
- [x] Functionality includes unit tests.
- [x] Commits are signed per the DCO using `--signoff`.
