### PR TITLE
Normalize remote store translog metadata keys case-insensitively

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -293,14 +293,34 @@ public class TranslogTransferManager {
         } else {
             // Download translog.tlog file with object metadata from remote to local FS
             Map<String, String> metadata = downloadToFS(translogFilename, location, primaryTerm, true);
+            Map<String, String> normalizedMetadata = normalizeMetadata(metadata);
             try {
-                assert metadata != null && !metadata.isEmpty() && metadata.containsKey(CHECKPOINT_FILE_DATA_KEY);
-                recoverCkpFileUsingMetadata(metadata, location, generation, translogFilename);
+                assert normalizedMetadata != null
+                    && !normalizedMetadata.isEmpty()
+                    && normalizedMetadata.containsKey(CHECKPOINT_FILE_DATA_KEY);
+                recoverCkpFileUsingMetadata(normalizedMetadata, location, generation, translogFilename);
             } catch (Exception e) {
                 throw new IOException("Failed to recover checkpoint file from remote", e);
             }
         }
         return true;
+    }
+
+    private Map<String, String> normalizeMetadata(Map<String, String> metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        Map<String, String> normalizedMetadata = new HashMap<>();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (entry.getKey() != null) {
+                String key = entry.getKey().toLowerCase(java.util.Locale.ROOT);
+                if (key.startsWith("x-amz-meta-")) {
+                    key = key.substring("x-amz-meta-".length());
+                }
+                normalizedMetadata.put(key, entry.getValue());
+            }
+        }
+        return normalizedMetadata;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -819,6 +819,37 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         assertTlogCkpDownloadStatsWithMetadata();
     }
 
+    public void testDownloadTranslogWithPrefixedMetadata() throws IOException {
+        isTranslogMetadataEnabled = true;
+        translogTransferManager = new TranslogTransferManager(
+            shardId,
+            transferService,
+            remoteBaseTransferPath.add(TRANSLOG.getName()),
+            remoteBaseTransferPath.add(METADATA.getName()),
+            tracker,
+            remoteTranslogTransferTracker,
+            DefaultRemoteStoreSettings.INSTANCE,
+            isTranslogMetadataEnabled
+        );
+        Path location = createTempDir();
+        assertFalse(Files.exists(location.resolve("translog-23.tlog")));
+        assertFalse(Files.exists(location.resolve("translog-23.ckp")));
+        Map<String, String> metadata = new HashMap<>();
+        String ckpDataString = Base64.getEncoder().encodeToString(ckpBytes);
+        metadata.put("X-Amz-Meta-Ckp-Data", ckpDataString);
+        when(transferService.downloadBlobWithMetadata(any(BlobPath.class), eq("translog-23.tlog"))).thenAnswer(invocation -> {
+            Thread.sleep(delayForBlobDownload);
+            return new InputStreamWithMetadata(new ByteArrayInputStream(tlogBytes), metadata);
+        });
+        translogTransferManager.downloadTranslog("12", "23", location);
+        verify(transferService, times(0)).downloadBlob(any(BlobPath.class), eq("translog-23.tlog"));
+        verify(transferService, times(0)).downloadBlob(any(BlobPath.class), eq("translog-23.ckp"));
+        verify(transferService, times(1)).downloadBlobWithMetadata(any(BlobPath.class), eq("translog-23.tlog"));
+        assertTrue(Files.exists(location.resolve("translog-23.tlog")));
+        assertTrue(Files.exists(location.resolve("translog-23.ckp")));
+        assertTlogCkpDownloadStatsWithMetadata();
+    }
+
     private void mockDownloadBlobWithMetadataResponse() throws IOException {
         Map<String, String> metadata = new HashMap<>();
         String ckpDataString = Base64.getEncoder().encodeToString(ckpBytes);


### PR DESCRIPTION
Resolves #21486

### Description
S3-compatible backend storage engines (e.g. Ceph RGW) return custom user metadata keys prefixed with `x-amz-meta-` (or with varying casing, e.g. `X-Amz-Meta-Ckp-Data` / `x-amz-meta-ckp-data`) instead of stripping the prefix. This caused the assertion `metadata.containsKey(CHECKPOINT_FILE_DATA_KEY)` (looking for exactly `"ckp-data"`) to fail and throw an `IllegalStateException` during translog recovery.

This PR implements a normalization method to lowercase the keys and strip the `x-amz-meta-` prefix from the metadata map before processing, ensuring recovery succeeds correctly on all S3-compatible backends.