### PR TITLE
Move single doc validation to mapper parsing rather than indexing

### DIFF
--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -19,7 +19,6 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.nativebridge.spi.ArrowExport;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.NativeParquetWriter;
@@ -35,9 +34,6 @@ import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -189,14 +185,11 @@ public class VSRManager implements AutoCloseable {
      * Transfers collected fields from the document input into the active VSR
      * using the ArrowFieldRegistry to resolve typed vector writes.
      * <p>
-     * Enforces single-value semantics: if the same {@link MappedFieldType} instance
-     * appears more than once in the document's field list, a {@link MapperParsingException}
-     * is thrown. Identity equality (reference {@code ==}) is used because the mapper
-     * service reuses field type instances — the same instance appearing twice indicates
-     * a multi-value field, which columnar formats do not support.
+     * Single-value semantics are enforced at the {@link ParquetDocumentInput} layer:
+     * if an array field produces multiple values for the same field type, only the
+     * last value is retained (last-value-wins).
      *
      * @param doc the document input containing field-value pairs
-     * @throws MapperParsingException if a field appears more than once in the document
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
         if (pendingWrite != null && pendingWrite.isDone()) {
@@ -216,14 +209,8 @@ public class VSRManager implements AutoCloseable {
             );
         }
         ManagedVSR activeVSR = managedVSR.get();
-        Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
         for (FieldValuePair pair : doc.getFinalInput()) {
             MappedFieldType fieldType = pair.getFieldType();
-            if (dedup.add(fieldType) == false) {
-                throw new MapperParsingException(
-                    "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
-                );
-            }
             ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
             if (parquetField == null) {
                 // Defense-in-depth: schema reconciliation is supposed to happen in

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -40,7 +40,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,7 +54,6 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-
         if (dedup.add(fieldType) == false) {
             throw new MapperParsingException(
                 "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -15,11 +15,14 @@ import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.engine.exec.PrimaryTermFieldType;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -37,6 +40,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
+    Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -49,6 +53,12 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             // nothing to support on this format for this field.
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
+        }
+
+        if (dedup.add(fieldType) == false) {
+            throw new MapperParsingException(
+                "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
+            );
         }
         collectedFields.add(new FieldValuePair(fieldType, value));
     }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -22,7 +22,6 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.KeywordFieldMapper;
-import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetBaseTests;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -583,29 +582,6 @@ public class VSRManagerTests extends ParquetBaseTests {
         ParquetFileMetadata metadata = manager.flush();
         assertNotNull(metadata);
         assertEquals(totalDocs, metadata.numRows());
-    }
-
-    public void testRejectsDuplicateFieldInSingleDocument() throws Exception {
-        List<Field> fields = new ArrayList<>();
-        fields.addAll(metadataFields());
-        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
-        schema = new Schema(fields);
-
-        String filePath = createTempDir().resolve("dedup.parquet").toString();
-        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
-
-        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
-        assignTestCapabilities(valField, PARQUET_FORMAT);
-
-        ParquetDocumentInput doc = new ParquetDocumentInput();
-        populateMetadataFields(doc);
-        doc.addField(valField, 10);
-        doc.addField(valField, 20); // same field instance — multi-value
-
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
-        MapperParsingException e = expectThrows(MapperParsingException.class, () -> manager.addDocument(doc));
-        assertTrue(e.getMessage().contains("Cannot accept multiple values for field: [val]"));
-        manager.close();
     }
 
     public void testAllowsDistinctFieldsInSingleDocument() throws Exception {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -81,6 +81,8 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         populateMetadataFields(input);
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        assignTestCapabilities(valField, PARQUET_FORMAT);
+
         input.addField(valField, 10);
         expectThrows(MapperParsingException.class, () -> input.addField(valField, 20));
     }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -12,6 +12,7 @@ import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetBaseTests;
 import org.opensearch.parquet.engine.ParquetDataFormat;
@@ -73,5 +74,14 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
 
         input.close();
         assertTrue(input.getFinalInput().isEmpty());
+    }
+
+    public void testRejectsDuplicateFieldInSingleDocument() throws Exception {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+
+        NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+        input.addField(valField, 10);
+        expectThrows(MapperParsingException.class, () -> input.addField(valField, 20));
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Move single doc validation to mapper parsing rather than indexing

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
