### PR TITLE
Fix statistics cache limit silently reset to 20MB default

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
@@ -463,11 +463,7 @@ impl FileStatisticsCache for CustomStatisticsCache {
         self.size_limit.load(Ordering::Relaxed)
     }
 
-    fn update_cache_limit(&self, limit: usize) {
-        // Best-effort: update_size_limit also triggers eviction; ignore its Result
-        // since the trait method is infallible.
-        let _ = self.update_size_limit(limit);
-    }
+    fn update_cache_limit(&self, _limit: usize) {}
 
     fn list_entries(&self) -> std::collections::HashMap<TableScopedPath, FileStatisticsCacheEntry> {
         std::collections::HashMap::new()
@@ -769,5 +765,19 @@ mod tests {
 
         for handle in handles { handle.join().unwrap(); }
         assert!(cache.len() > 0);
+    }
+
+    #[test]
+    fn test_update_cache_limit_trait_is_noop() {
+        use datafusion::execution::cache::cache_manager::FileStatisticsCache;
+
+        let cache = CustomStatisticsCache::new(PolicyType::Lru, 50 * 1024 * 1024, 0.8);
+        assert_eq!(cache.cache_limit(), 50 * 1024 * 1024);
+
+        FileStatisticsCache::update_cache_limit(&cache, 20 * 1024 * 1024);
+        assert_eq!(cache.cache_limit(), 50 * 1024 * 1024);
+
+        cache.update_size_limit(30 * 1024 * 1024).unwrap();
+        assert_eq!(cache.cache_limit(), 30 * 1024 * 1024);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -1102,6 +1102,40 @@ pub unsafe extern "C" fn df_cache_manager_contains_by_type(
     })
 }
 
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn df_cache_manager_update_size_limit(
+    runtime_ptr: i64,
+    cache_type_ptr: *const u8,
+    cache_type_len: i64,
+    new_limit: i64,
+) -> i64 {
+    if runtime_ptr == 0 {
+        return Err("df_cache_manager_update_size_limit: null runtime pointer".to_string());
+    }
+    if new_limit < 0 {
+        return Err(format!("df_cache_manager_update_size_limit: negative limit {}", new_limit));
+    }
+    let cache_type = str_from_raw(cache_type_ptr, cache_type_len)
+        .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+    let manager = runtime.custom_cache_manager.as_ref().ok_or_else(|| {
+        "df_cache_manager_update_size_limit: no cache manager configured".to_string()
+    })?;
+    match cache_type {
+        cache::CACHE_TYPE_METADATA => {
+            manager.update_metadata_cache_limit(new_limit as usize);
+            Ok(0)
+        }
+        cache::CACHE_TYPE_STATS => {
+            manager.update_statistics_cache_limit(new_limit as usize)
+                .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+            Ok(0)
+        }
+        _ => Err(format!("df_cache_manager_update_size_limit: unsupported cache type: {}", cache_type)),
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn df_close_session_context(ptr: i64) {
     crate::session_context::close_session_context(ptr);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -19,7 +19,9 @@ import org.opensearch.arrow.spi.PoolGroup;
 import org.opensearch.be.datafusion.action.stats.DataFusionStatsActionType;
 import org.opensearch.be.datafusion.action.stats.RestDataFusionStatsAction;
 import org.opensearch.be.datafusion.action.stats.TransportDataFusionStatsAction;
+import org.opensearch.be.datafusion.cache.CacheManager;
 import org.opensearch.be.datafusion.cache.CacheSettings;
+import org.opensearch.be.datafusion.cache.CacheUtils;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -874,19 +876,22 @@ public class DataFusionPlugin extends Plugin
         long oiLimit = total * oiPct / 100;
         long statsLimit = total * statsPct / 100;
         logger.info(
-            "Updating cache limits: footer_metadata={} bytes (node restart required), "
-                + "column_index={} bytes, offset_index={} bytes, statistics={} bytes (node restart required)",
+            "Updating cache limits: footer_metadata={} bytes, " + "column_index={} bytes, offset_index={} bytes, statistics={} bytes",
             metaLimit,
             ciLimit,
             oiLimit,
             statsLimit
         );
-        // CI and OI limits take effect immediately via FFI.
-        // Footer metadata and statistics cache limits require a node restart
-        // (no runtime FFI to update the Java-side DefaultFilesMetadataCache limits).
-        // TODO: add df_update_metadata_cache_limit FFI to make them dynamic.
         NativeBridge.setColumnIndexCacheLimit(ciLimit);
         NativeBridge.setOffsetIndexCacheLimit(oiLimit);
+        DataFusionService service = dataFusionService;
+        if (service != null) {
+            CacheManager cm = service.getCacheManager();
+            if (cm != null) {
+                cm.updateSizeLimit(CacheUtils.CacheType.METADATA, metaLimit);
+                cm.updateSizeLimit(CacheUtils.CacheType.STATISTICS, statsLimit);
+            }
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeRequest.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodeRequest.java
@@ -20,11 +20,13 @@ public class ClearCacheNodeRequest extends TransportRequest {
     private boolean footer;
     private boolean column;
     private boolean offset;
+    private boolean statistics;
 
-    public ClearCacheNodeRequest(boolean footer, boolean column, boolean offset) {
+    public ClearCacheNodeRequest(boolean footer, boolean column, boolean offset, boolean statistics) {
         this.footer = footer;
         this.column = column;
         this.offset = offset;
+        this.statistics = statistics;
     }
 
     public ClearCacheNodeRequest(StreamInput in) throws IOException {
@@ -32,6 +34,7 @@ public class ClearCacheNodeRequest extends TransportRequest {
         this.footer = in.readBoolean();
         this.column = in.readBoolean();
         this.offset = in.readBoolean();
+        this.statistics = in.readBoolean();
     }
 
     @Override
@@ -40,6 +43,7 @@ public class ClearCacheNodeRequest extends TransportRequest {
         out.writeBoolean(footer);
         out.writeBoolean(column);
         out.writeBoolean(offset);
+        out.writeBoolean(statistics);
     }
 
     public boolean isFooter() {
@@ -54,7 +58,11 @@ public class ClearCacheNodeRequest extends TransportRequest {
         return offset;
     }
 
+    public boolean isStatistics() {
+        return statistics;
+    }
+
     public boolean isClearAll() {
-        return !footer && !column && !offset;
+        return !footer && !column && !offset && !statistics;
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesRequest.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/ClearCacheNodesRequest.java
@@ -27,6 +27,7 @@ public class ClearCacheNodesRequest extends BaseNodesRequest<ClearCacheNodesRequ
     private boolean footer;
     private boolean column;
     private boolean offset;
+    private boolean statistics;
 
     /** Clears ALL caches on the target nodes (no params given). */
     public ClearCacheNodesRequest(String... nodesIds) {
@@ -38,6 +39,7 @@ public class ClearCacheNodesRequest extends BaseNodesRequest<ClearCacheNodesRequ
         this.footer = in.readBoolean();
         this.column = in.readBoolean();
         this.offset = in.readBoolean();
+        this.statistics = in.readBoolean();
     }
 
     @Override
@@ -46,6 +48,7 @@ public class ClearCacheNodesRequest extends BaseNodesRequest<ClearCacheNodesRequ
         out.writeBoolean(footer);
         out.writeBoolean(column);
         out.writeBoolean(offset);
+        out.writeBoolean(statistics);
     }
 
     /** Whether to clear the footer metadata cache. */
@@ -75,8 +78,16 @@ public class ClearCacheNodesRequest extends BaseNodesRequest<ClearCacheNodesRequ
         this.offset = offset;
     }
 
+    public boolean isStatistics() {
+        return statistics;
+    }
+
+    public void setStatistics(boolean statistics) {
+        this.statistics = statistics;
+    }
+
     /** True when no specific flag is set — means clear everything. */
     public boolean isClearAll() {
-        return !footer && !column && !offset;
+        return !footer && !column && !offset && !statistics;
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/RestClearCacheAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/RestClearCacheAction.java
@@ -27,6 +27,7 @@ import static org.opensearch.rest.RestRequest.Method.POST;
  * POST /_plugins/_analytics_backend_datafusion/cache/_clear?footer=true  → footer metadata only
  * POST /_plugins/_analytics_backend_datafusion/cache/_clear?column=true  → column index only
  * POST /_plugins/_analytics_backend_datafusion/cache/_clear?offset=true  → offset index only
+ * POST /_plugins/_analytics_backend_datafusion/cache/_clear?statistics=true  → statistics only
  * </pre>
  *
  * <p>Multiple params may be combined. When no param is set, all caches are cleared.
@@ -54,6 +55,7 @@ public class RestClearCacheAction extends BaseRestHandler {
         nodesRequest.setFooter(request.paramAsBoolean("footer", false));
         nodesRequest.setColumn(request.paramAsBoolean("column", false));
         nodesRequest.setOffset(request.paramAsBoolean("offset", false));
+        nodesRequest.setStatistics(request.paramAsBoolean("statistics", false));
         return channel -> client.execute(ClearCacheActionType.INSTANCE, nodesRequest, new NodesResponseRestListener<>(channel));
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/stats/TransportClearCacheAction.java
@@ -73,7 +73,7 @@ public class TransportClearCacheAction extends TransportNodesAction<
 
     @Override
     protected ClearCacheNodeRequest newNodeRequest(ClearCacheNodesRequest request) {
-        return new ClearCacheNodeRequest(request.isFooter(), request.isColumn(), request.isOffset());
+        return new ClearCacheNodeRequest(request.isFooter(), request.isColumn(), request.isOffset(), request.isStatistics());
     }
 
     @Override
@@ -93,6 +93,7 @@ public class TransportClearCacheAction extends TransportNodesAction<
                 if (request.isFooter()) cacheManager.clearCacheForCacheType(CacheUtils.CacheType.METADATA);
                 if (request.isColumn()) cacheManager.clearCacheForCacheType(CacheUtils.CacheType.COLUMN_INDEX);
                 if (request.isOffset()) cacheManager.clearCacheForCacheType(CacheUtils.CacheType.OFFSET_INDEX);
+                if (request.isStatistics()) cacheManager.clearCacheForCacheType(CacheUtils.CacheType.STATISTICS);
             }
         }
         return new ClearCacheNodeResponse(clusterService.localNode());

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheManager.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/cache/CacheManager.java
@@ -88,10 +88,10 @@ public class CacheManager {
 
     public void updateSizeLimit(CacheUtils.CacheType cacheType, long sizeLimit) {
         try {
-            // TODO: Add updateSizeLimitForCacheType FFM function when needed
-            logger.warn("updateSizeLimit not yet implemented for FFM bridge");
+            NativeBridge.cacheManagerUpdateSizeLimit(runtimeHandle.get(), cacheType.getCacheTypeName(), sizeLimit);
+            logger.info("Updated {} cache size limit to {} bytes", cacheType.getCacheTypeName(), sizeLimit);
         } catch (Exception e) {
-            logger.error("Error updating size limit", e);
+            logger.error("Error updating cache size limit", e);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -131,6 +131,7 @@ public final class NativeBridge {
     private static final MethodHandle CACHE_MANAGER_GET_MEMORY_BY_TYPE;
     private static final MethodHandle CACHE_MANAGER_GET_TOTAL_MEMORY;
     private static final MethodHandle CACHE_MANAGER_CONTAINS_BY_TYPE;
+    private static final MethodHandle CACHE_MANAGER_UPDATE_SIZE_LIMIT;
     private static final MethodHandle CREATE_SESSION_CONTEXT;
     private static final MethodHandle CREATE_SESSION_CONTEXT_INDEXED;
     private static final MethodHandle CLOSE_SESSION_CONTEXT;
@@ -509,6 +510,17 @@ public final class NativeBridge {
                 ValueLayout.ADDRESS,
                 ValueLayout.JAVA_LONG,
                 ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG
+            )
+        );
+
+        CACHE_MANAGER_UPDATE_SIZE_LIMIT = linker.downcallHandle(
+            lib.find("df_cache_manager_update_size_limit").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
                 ValueLayout.JAVA_LONG
             )
         );
@@ -1661,6 +1673,13 @@ public final class NativeBridge {
             var file = call.str(filePath);
             long result = call.invoke(CACHE_MANAGER_CONTAINS_BY_TYPE, runtimePtr, type.segment(), type.len(), file.segment(), file.len());
             return result != 0;
+        }
+    }
+
+    public static void cacheManagerUpdateSizeLimit(long runtimePtr, String cacheType, long newLimit) {
+        try (var call = new NativeCall()) {
+            var type = call.str(cacheType);
+            call.invoke(CACHE_MANAGER_UPDATE_SIZE_LIMIT, runtimePtr, type.segment(), type.len(), newLimit);
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/ClearCacheRequestTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/ClearCacheRequestTests.java
@@ -27,6 +27,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertFalse(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertTrue("no flags set → isClearAll()", req.isClearAll());
     }
 
@@ -36,6 +37,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertTrue(req.isFooter());
         assertFalse(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertFalse("footer=true → not clear-all", req.isClearAll());
     }
 
@@ -45,6 +47,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertTrue(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
@@ -54,6 +57,17 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertFalse(req.isColumn());
         assertTrue(req.isOffset());
+        assertFalse(req.isStatistics());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testSetStatisticsOnlyIsNotClearAll() {
+        ClearCacheNodesRequest req = new ClearCacheNodesRequest();
+        req.setStatistics(true);
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertTrue(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
@@ -62,7 +76,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         req.setFooter(true);
         req.setColumn(true);
         req.setOffset(true);
-        // isClearAll() is false when any flag is explicitly set — caller chose specific caches
+        req.setStatistics(true);
         assertFalse(req.isClearAll());
     }
 
@@ -71,6 +85,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         original.setFooter(true);
         original.setColumn(false);
         original.setOffset(true);
+        original.setStatistics(true);
 
         BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
@@ -80,23 +95,33 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertEquals(original.isFooter(), deserialized.isFooter());
         assertEquals(original.isColumn(), deserialized.isColumn());
         assertEquals(original.isOffset(), deserialized.isOffset());
+        assertEquals(original.isStatistics(), deserialized.isStatistics());
         assertEquals(original.isClearAll(), deserialized.isClearAll());
     }
 
     // ── ClearCacheNodeRequest ─────────────────────────────────────────────────
 
     public void testNodeRequestIsClearAllWhenNoFlagsSet() {
-        ClearCacheNodeRequest req = new ClearCacheNodeRequest(false, false, false);
+        ClearCacheNodeRequest req = new ClearCacheNodeRequest(false, false, false, false);
         assertTrue(req.isClearAll());
     }
 
     public void testNodeRequestIsNotClearAllWhenFlagSet() {
-        ClearCacheNodeRequest req = new ClearCacheNodeRequest(true, false, false);
+        ClearCacheNodeRequest req = new ClearCacheNodeRequest(true, false, false, false);
+        assertFalse(req.isClearAll());
+    }
+
+    public void testNodeRequestStatisticsFlag() {
+        ClearCacheNodeRequest req = new ClearCacheNodeRequest(false, false, false, true);
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertTrue(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
     public void testNodeRequestRoundTrip() throws IOException {
-        ClearCacheNodeRequest original = new ClearCacheNodeRequest(false, true, true);
+        ClearCacheNodeRequest original = new ClearCacheNodeRequest(false, true, true, true);
 
         BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
@@ -106,6 +131,7 @@ public class ClearCacheRequestTests extends OpenSearchTestCase {
         assertFalse(deserialized.isFooter());
         assertTrue(deserialized.isColumn());
         assertTrue(deserialized.isOffset());
+        assertTrue(deserialized.isStatistics());
         assertFalse(deserialized.isClearAll());
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/RestClearCacheActionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/action/stats/RestClearCacheActionTests.java
@@ -59,6 +59,7 @@ public class RestClearCacheActionTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertFalse(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertTrue("no params → isClearAll()", req.isClearAll());
     }
 
@@ -67,6 +68,7 @@ public class RestClearCacheActionTests extends OpenSearchTestCase {
         assertTrue(req.isFooter());
         assertFalse(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
@@ -75,6 +77,7 @@ public class RestClearCacheActionTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertTrue(req.isColumn());
         assertFalse(req.isOffset());
+        assertFalse(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
@@ -83,6 +86,16 @@ public class RestClearCacheActionTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertFalse(req.isColumn());
         assertTrue(req.isOffset());
+        assertFalse(req.isStatistics());
+        assertFalse(req.isClearAll());
+    }
+
+    public void testStatisticsParamSetsStatisticsFlag() throws Exception {
+        ClearCacheNodesRequest req = captureRequest(Map.of("statistics", "true"));
+        assertFalse(req.isFooter());
+        assertFalse(req.isColumn());
+        assertFalse(req.isOffset());
+        assertTrue(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 
@@ -91,6 +104,7 @@ public class RestClearCacheActionTests extends OpenSearchTestCase {
         assertFalse(req.isFooter());
         assertTrue(req.isColumn());
         assertTrue(req.isOffset());
+        assertFalse(req.isStatistics());
         assertFalse(req.isClearAll());
     }
 


### PR DESCRIPTION
## Summary

- **Statistics cache limit fix**: DataFusion calls `FileStatisticsCache::update_cache_limit(20MB)` on every `CacheManager` rebuild (runtime init + per-query config rebuild). This silently overrides the user-configured limit. Fixed by making the trait method a no-op — our configured limit is only changed via our own `update_size_limit()` path.
- **Dynamic cache limit updates**: Wires the full Java→FFM→Rust path for runtime cache limit changes. New `df_cache_manager_update_size_limit` FFM export + `NativeBridge.cacheManagerUpdateSizeLimit()`. The plugin's grouped settings consumer (`recomputePageCacheLimits`) now pushes metadata + statistics limits dynamically (previously only CI/OI were dynamic; metadata/statistics required a node restart).
- **Statistics cache clear API**: Adds a `statistics` flag to the plugin's clear-cache REST endpoint so it can be selectively cleared: `POST /_plugins/_analytics_backend_datafusion/cache/_clear?statistics=true`.

## Test plan

- [ ] Verify `statistics_cache.size_limit_bytes` in stats API matches the configured percent budget (not 20MB)
- [ ] Verify `POST /_plugins/_analytics_backend_datafusion/cache/_clear?statistics=true` clears only statistics cache entries
- [ ] Verify dynamic settings update (`PUT _cluster/settings` changing `datafusion.cache.statistics_percent`) propagates the new limit to the native cache without restart
- [ ] Run existing unit tests (`ClearCacheRequestTests`, `RestClearCacheActionTests`)