### PR TITLE
Bug fix to throw 400 instead of 500

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -224,7 +224,9 @@ public class OpenSearchFilterRule extends RelOptRule {
                         viableSet.retainAll(registry.filterBackendsForField(function, storageInfo));
                     }
                     if (viableSet.isEmpty()) {
-                        throw new IllegalStateException(
+                        // No viable alternatives is a client error (IllegalArgumentException -> HTTP 400) so the actionable
+                        // message is surfaced to the caller instead of being redacted as a 500.
+                        throw new IllegalArgumentException(
                             "No backend can evaluate filter predicate ["
                                 + predicate.getKind()
                                 + "] on literal-named fields "

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -449,6 +449,10 @@ public class FilterRuleTests extends BasePlannerRulesTests {
      * rejection. The query still fails — no backend supports {@code query_string} on a {@code long}
      * field — but via the capability-viability path, not the friendly type-rejection. The distinct
      * error proves the lenient gate skipped {@code rejectNonTextFieldsForTextFunction}.
+     *
+     * <p>The viability failure is a query-level (client) error, so it surfaces as an
+     * {@link IllegalArgumentException} (HTTP 400 with the actionable message preserved) rather
+     * than an {@link IllegalStateException} (which would be redacted as a 500).
      */
     public void testLenientTrueSuppressesEagerRejectionViaExtractor() {
         FieldReferences refs = new FieldReferences(List.of("severityNumber"), List.of(), true);
@@ -457,7 +461,7 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
         PlannerContext context = buildContext("parquet", Map.of("severityNumber", Map.of("type", "long")), backendsWithExtractor(refs));
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> runPlanner(filter, context));
         assertTrue(
             "Should fail via viability, not eager rejection: " + exception.getMessage(),
             exception.getMessage().contains("No backend can evaluate")

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeForceMergeIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeForceMergeIT.java
@@ -97,6 +97,7 @@ public class CompositeForceMergeIT extends OpenSearchIntegTestCase {
         assertEquals(docsPerCycle * cycles, getTotalDocCount());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/22307")
     public void testForceMergeWithMaxNumSegmentsGreaterThanOne() throws Exception {
         client().admin()
             .indices()


### PR DESCRIPTION
### Description
When no viable backend is present, it should be thrown as 400 error so that the meaningful error can be propagated to the client. Currently it is getting redacted since it is thrown as 500

### Related Issues
CI build failure is broken currently with the following error:
```
Suite: Test class org.opensearch.analytics.qa.TextRelevanceValidationIT
  2> REPRODUCE WITH: ./gradlew ':sandbox:qa:analytics-engine-rest:integTest' --tests 'org.opensearch.analytics.qa.TextRelevanceValidationIT.testQueryStringLenientTrueStillCannotRouteNumericField' -Dtests.seed=DCAB753B7BD422EF -Dtests.security.manager=false -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=es-Latn-ES -Dtests.timezone=Iceland -Druntime.java=25
  2> java.lang.AssertionError: Expected response body to contain [No backend can evaluate] but was: {
      "error": {
        "reason": "There was internal problem at backend",
        "details": "Internal error [task_id=31523]",
][o.o.a.q.TextRelevanceValidationIT] [testQueryStringWildcardFieldPatternIsNotRejected] initializing REST clients against [http://[::1]:46583, http://127.0.0.1:36115/, http://[::1]:41679, http://127.0.0.1:37299/]
        "type": "RuntimeException"
      },
      "status": 500
    }
        at __randomizedtesting.SeedInfo.seed([DCAB753B7BD422EF:D4B6224BEC71D321]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.opensearch.analytics.qa.TextRelevanceValidationIT.assertErrorContains(TextRelevanceValidationIT.java:264)
        at
```

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
