### PR TITLE
Fix multi index resolution on analytics engine

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -35,6 +35,7 @@ import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.planner.rel.OpenSearchUnion;
 import org.opensearch.analytics.planner.rel.OpenSearchValues;
 import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.core.common.Strings;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -230,7 +231,15 @@ public class RelNodeUtils {
         }
         if (node instanceof TableScan scan) {
             java.util.List<String> names = scan.getTable().getQualifiedName();
-            indices.add(names.get(names.size() - 1));
+            String tableName = names.get(names.size() - 1);
+            // PPL multi-source queries (source=a,b) produce a single TableScan with a
+            // comma-delimited table name. Split so each index is evaluated independently
+            // by the security filter — same logic as IndexResolution.
+            for (String idx : Strings.splitStringByCommaToArray(tableName)) {
+                if (!idx.isEmpty()) {
+                    indices.add(idx);
+                }
+            }
         }
         for (RelNode input : node.getInputs()) {
             if (!collectIndices(input, indices, depth + 1)) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
@@ -151,6 +151,74 @@ public class RelNodeUtilsTests extends OpenSearchTestCase {
         assertTrue(e.getMessage().contains("maximum depth"));
     }
 
+    // --- Multi-index comma-separated table name tests (FGAC bypass fix) ---
+
+    public void testCommaDelimitedIndicesSplit() {
+        RelBuilder b = builderWithTable("logs-2024-01,secrets-2024-01");
+        RelNode plan = b.scan("logs-2024-01,secrets-2024-01").build();
+        assertArrayEquals(new String[] { "logs-2024-01", "secrets-2024-01" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testCommaDelimitedThreeIndices() {
+        RelBuilder b = builderWithTable("a,b,c");
+        RelNode plan = b.scan("a,b,c").build();
+        assertArrayEquals(new String[] { "a", "b", "c" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    public void testDoubleCommaProducesEmptyStringFiltered() {
+        RelBuilder b = builderWithTable("index1,,index2");
+        RelNode plan = b.scan("index1,,index2").build();
+        // Strings.splitStringByCommaToArray trims and skips empty tokens
+        String[] result = RelNodeUtils.extractIndices(plan);
+        for (String idx : result) {
+            assertFalse("Should not contain empty string", idx.isEmpty());
+        }
+        assertTrue("Should contain index1", java.util.Arrays.asList(result).contains("index1"));
+        assertTrue("Should contain index2", java.util.Arrays.asList(result).contains("index2"));
+    }
+
+    public void testLeadingComma() {
+        RelBuilder b = builderWithTable(",index1");
+        RelNode plan = b.scan(",index1").build();
+        String[] result = RelNodeUtils.extractIndices(plan);
+        for (String idx : result) {
+            assertFalse("Should not contain empty string", idx.isEmpty());
+        }
+        assertTrue("Should contain index1", java.util.Arrays.asList(result).contains("index1"));
+    }
+
+    public void testDoubleLeadingComma() {
+        RelBuilder b = builderWithTable(",,index1");
+        RelNode plan = b.scan(",,index1").build();
+        String[] result = RelNodeUtils.extractIndices(plan);
+        for (String idx : result) {
+            assertFalse("Should not contain empty string", idx.isEmpty());
+        }
+        assertTrue("Should contain index1", java.util.Arrays.asList(result).contains("index1"));
+    }
+
+    public void testTrailingComma() {
+        RelBuilder b = builderWithTable("index1,");
+        RelNode plan = b.scan("index1,").build();
+        String[] result = RelNodeUtils.extractIndices(plan);
+        for (String idx : result) {
+            assertFalse("Should not contain empty string", idx.isEmpty());
+        }
+        assertTrue("Should contain index1", java.util.Arrays.asList(result).contains("index1"));
+    }
+
+    public void testSingleIndexNoComma() {
+        RelBuilder b = builderWithTable("plain_index");
+        RelNode plan = b.scan("plain_index").build();
+        assertArrayEquals(new String[] { "plain_index" }, RelNodeUtils.extractIndices(plan));
+    }
+
+    private RelBuilder builderWithTable(String tableName) {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add(tableName, new MockTable());
+        return RelBuilder.create(Frameworks.newConfigBuilder().defaultSchema(schema).build());
+    }
+
     /** Minimal table implementation for RelBuilder schema registration. */
     private static class MockTable extends AbstractTable {
         @Override


### PR DESCRIPTION
### Description

`RelNodeUtils.extractIndices()` returned comma-delimited table names as a single array element (e.g. `["idx1,idx2"]`). The security filter's `IndexNameExpressionResolver` tried to resolve this as one index name, was unable to, and resolved no concrete indices.

Due to the default setting of [strict expand open](https://github.com/opensearch-project/OpenSearch/blob/main/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java#L97) on analytics query request [index resolution errors are not fatal](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java#L329).

### Fix

Split comma-delimited table names in `collectIndices()` using `Strings.splitStringByCommaToArray()` (same utility used by `IndexResolution` in the planner). Each index is now a separate entry in the `String[]` array, so security evaluates permissions on each independently.