### PR TITLE
Add indexing throttle on merge pressure for DataFormatAwareEngine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -500,7 +500,13 @@ public class DataFormatAwareEngine implements Indexer {
                         refreshLock.unlock();
                     }
                 }
-            }, shardId, engineConfig.getIndexSettings(), engineConfig.getThreadPool());
+            },
+                this::activateThrottling,
+                this::deactivateThrottling,
+                shardId,
+                engineConfig.getIndexSettings(),
+                engineConfig.getThreadPool()
+            );
             success = true;
             logger.trace("created new DataFormatBasedEngine");
         } catch (IOException | TranslogCorruptedException e) {

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -48,8 +48,11 @@ public class MergeScheduler {
     private final MergeHandler mergeHandler;
     private final BiConsumer<MergeResult, OneMerge> applyMergeChanges;
     private final Runnable onMergeFailureCleanup;
+    private final Runnable activateThrottling;
+    private final Runnable deactivateThrottling;
     private final ThreadPool threadPool;
     private final AtomicInteger activeMerges = new AtomicInteger(0);
+    private final AtomicBoolean isThrottling = new AtomicBoolean(false);
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
     private final Semaphore forceMergeLock = new Semaphore(1);
     private final AtomicBoolean frozen = new AtomicBoolean(false);
@@ -75,6 +78,8 @@ public class MergeScheduler {
      * @param mergeHandler          the handler that selects and executes merges
      * @param applyMergeChanges     callback to apply merge results (e.g., update the catalog)
      * @param onMergeFailureCleanup callback invoked when a merge fails and cleanup is performed
+     * @param activateThrottling    callback to activate indexing throttle when merge pressure is high
+     * @param deactivateThrottling  callback to deactivate indexing throttle when merge pressure subsides
      * @param shardId               the shard this scheduler is associated with
      * @param indexSettings         the index settings providing merge scheduler configuration
      * @param threadPool            the OpenSearch thread pool for executing merge tasks
@@ -83,6 +88,8 @@ public class MergeScheduler {
         MergeHandler mergeHandler,
         BiConsumer<MergeResult, OneMerge> applyMergeChanges,
         Runnable onMergeFailureCleanup,
+        Runnable activateThrottling,
+        Runnable deactivateThrottling,
         ShardId shardId,
         IndexSettings indexSettings,
         ThreadPool threadPool
@@ -90,6 +97,8 @@ public class MergeScheduler {
         this.mergeHandler = mergeHandler;
         this.applyMergeChanges = applyMergeChanges;
         this.onMergeFailureCleanup = onMergeFailureCleanup;
+        this.activateThrottling = activateThrottling;
+        this.deactivateThrottling = deactivateThrottling;
         this.threadPool = threadPool;
         logger = Loggers.getLogger(getClass(), shardId);
         this.indexSettings = indexSettings;
@@ -138,6 +147,7 @@ public class MergeScheduler {
         if (!isFrozen()) {
             mergeHandler.findAndRegisterMerges();
         }
+        evaluateThrottle();
         executeMerge();
     }
 
@@ -343,6 +353,7 @@ public class MergeScheduler {
                 // uncaught exception on the merge thread pool.
             } finally {
                 activeMerges.decrementAndGet();
+                evaluateThrottle();
                 // Fire all drain listeners if all merges completed and none pending
                 if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
                     List<Runnable> listeners = List.copyOf(onDrainedListeners);
@@ -392,6 +403,29 @@ public class MergeScheduler {
             throw e instanceof IOException ? (IOException) e : new IOException(e);
         } finally {
             mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
+        }
+    }
+
+    private synchronized void evaluateThrottle() {
+        int numMergesInFlight = activeMerges.get() + mergeHandler.getPendingMergeCount();
+        if (numMergesInFlight > maxMergeCount) {
+            if (isThrottling.getAndSet(true) == false) {
+                logger.info("now throttling indexing: numMergesInFlight={}, maxMergeCount={}", numMergesInFlight, maxMergeCount);
+                try {
+                    activateThrottling.run();
+                } catch (Exception e) {
+                    logger.warn("exception in activateThrottling callback", e);
+                }
+            }
+        } else if (numMergesInFlight < maxMergeCount) {
+            if (isThrottling.getAndSet(false)) {
+                logger.info("stop throttling indexing: numMergesInFlight={}, maxMergeCount={}", numMergesInFlight, maxMergeCount);
+                try {
+                    deactivateThrottling.run();
+                } catch (Exception e) {
+                    logger.warn("exception in deactivateThrottling callback", e);
+                }
+            }
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
@@ -67,7 +67,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
         scheduler.onDrained(() -> listenerCalled.set(true));
@@ -84,7 +93,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
         scheduler.onDrained(() -> listenerCalled.set(true));
@@ -101,7 +119,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         AtomicInteger callCount = new AtomicInteger(0);
 
@@ -177,7 +204,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         CountDownLatch latch = new CountDownLatch(3);
         AtomicInteger callCount = new AtomicInteger(0);
@@ -223,7 +259,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         // First call to hasPendingMerges returns true (first check fails, goes to add),
         // second call returns false (double-check succeeds, fires the listener)
@@ -248,7 +293,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         // Register listeners individually via the double-check path.
         // Each onDrained call is independent — if one listener throws during its own
@@ -285,7 +339,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         assertTrue("hasPendingMerges should delegate to handler when handler reports true", scheduler.hasPendingMerges());
 
@@ -302,7 +365,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         assertEquals("Active merge count should be 0 initially", 0, scheduler.getActiveMergeCount());
     }
@@ -336,7 +408,16 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        MergeScheduler scheduler = new MergeScheduler(
+            mockHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            testShardId,
+            indexSettings,
+            threadPool
+        );
 
         // Register an onDrained listener BEFORE triggering merges.
         // Reset hasPendingMerges stub for the full flow:
@@ -416,7 +497,7 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
         when(mockHandler.hasPendingMerges()).thenReturn(false);
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
-        return new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+        return new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, () -> {}, () -> {}, testShardId, indexSettings, threadPool);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerTests.java
@@ -15,6 +15,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.MergeSchedulerConfig;
 import org.opensearch.index.engine.dataformat.MergeResult;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.test.IndexSettingsModule;
@@ -25,7 +26,9 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -67,7 +70,16 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
     }
 
     private MergeScheduler newScheduler(MergeHandler mergeHandler, IndexModule.TieringState tieringState) {
-        return new MergeScheduler(mergeHandler, (result, merge) -> {}, () -> {}, shardId, indexSettings(tieringState), threadPool);
+        return new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> {},
+            () -> {},
+            () -> {},
+            () -> {},
+            shardId,
+            indexSettings(tieringState),
+            threadPool
+        );
     }
 
     public void testFreezeBlocksTriggerMerges() {
@@ -157,6 +169,8 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
             mergeHandler,
             (result, merge) -> { schedulerRef.get().shutdown(); },
             () -> {},
+            () -> {},
+            () -> {},
             shardId,
             indexSettings(IndexModule.TieringState.HOT),
             threadPool
@@ -173,5 +187,83 @@ public class MergeSchedulerTests extends OpenSearchTestCase {
 
         verify(mergeHandler).doMerge(merge1);
         verify(mergeHandler, never()).doMerge(merge2);
+    }
+
+    public void testThrottlingActivatesWhenMergesExceedMaxCount() throws Exception {
+        AtomicInteger activateCount = new AtomicInteger();
+        AtomicInteger deactivateCount = new AtomicInteger();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+                .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "2")
+                .build()
+        );
+
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+        OneMerge merge1 = mock(OneMerge.class);
+        OneMerge merge2 = mock(OneMerge.class);
+        OneMerge merge3 = mock(OneMerge.class);
+        when(merge1.getSegmentsToMerge()).thenReturn(List.of());
+        when(merge2.getSegmentsToMerge()).thenReturn(List.of());
+        when(merge3.getSegmentsToMerge()).thenReturn(List.of());
+
+        when(mergeHandler.getPendingMergeCount()).thenReturn(3, 3, 2, 1, 0);
+        when(mergeHandler.hasPendingMerges()).thenReturn(true, true, true, false);
+        when(mergeHandler.getNextMerge()).thenReturn(merge1).thenReturn(merge2).thenReturn(merge3).thenReturn(null);
+        when(mergeHandler.doMerge(any())).thenReturn(new MergeResult(Map.of()));
+
+        MergeScheduler scheduler = new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> {},
+            () -> {},
+            activateCount::incrementAndGet,
+            deactivateCount::incrementAndGet,
+            shardId,
+            idxSettings,
+            threadPool
+        );
+
+        scheduler.triggerMerges();
+        assertBusy(() -> assertTrue("throttle should have activated", activateCount.get() > 0));
+        assertBusy(() -> assertTrue("throttle should have deactivated", deactivateCount.get() > 0));
+    }
+
+    public void testThrottlingNotActivatedWhenMergesWithinLimit() throws Exception {
+        AtomicInteger activateCount = new AtomicInteger();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING.getKey(), "1")
+                .put(MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING.getKey(), "6")
+                .build()
+        );
+
+        MergeHandler mergeHandler = mock(MergeHandler.class);
+        OneMerge merge1 = mock(OneMerge.class);
+        when(merge1.getSegmentsToMerge()).thenReturn(List.of());
+        when(mergeHandler.getPendingMergeCount()).thenReturn(1, 0);
+        when(mergeHandler.hasPendingMerges()).thenReturn(true, false);
+        when(mergeHandler.getNextMerge()).thenReturn(merge1).thenReturn(null);
+        when(mergeHandler.doMerge(any())).thenReturn(new MergeResult(Map.of()));
+
+        MergeScheduler scheduler = new MergeScheduler(
+            mergeHandler,
+            (result, merge) -> {},
+            () -> {},
+            activateCount::incrementAndGet,
+            () -> {},
+            shardId,
+            idxSettings,
+            threadPool
+        );
+
+        scheduler.triggerMerges();
+        Thread.sleep(200);
+        assertEquals("throttle should not activate when merges within limit", 0, activateCount.get());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeTests.java
@@ -180,6 +180,8 @@ public class MergeTests extends OpenSearchTestCase {
             createNoopHandler(emptySnapshotSupplier()),
             (mergeResult, oneMerge) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             idxSettings,
             mockThreadPool()
@@ -402,6 +404,8 @@ public class MergeTests extends OpenSearchTestCase {
             createNoopHandler(emptySnapshotSupplier()),
             (mr, om) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             idxSettings,
             mockThreadPool()
@@ -430,6 +434,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> captured.set(mr),
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -455,6 +461,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -479,7 +487,7 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(handler, (mr, om) -> {
             captured.set(mr);
             latch.countDown();
-        }, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        }, () -> {}, () -> {}, () -> {}, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
 
         onForceMergeThread(() -> scheduler.forceMerge(1));
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -521,6 +529,8 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
+            () -> {},
+            () -> {},
             () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
@@ -584,6 +594,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> {},
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -605,6 +617,8 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
+            () -> {},
+            () -> {},
             () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
@@ -634,6 +648,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             (mr, om) -> {},
             () -> cleanupCalled.set(true),
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -666,6 +682,8 @@ public class MergeTests extends OpenSearchTestCase {
             handler,
             applyCallback,
             () -> {},
+            () -> {},
+            () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),
             mockThreadPool()
@@ -678,7 +696,14 @@ public class MergeTests extends OpenSearchTestCase {
     public void testForceMergeWithNoSegmentsIsNoop() throws Exception {
         MergeScheduler scheduler = new MergeScheduler(createNoopHandler(emptySnapshotSupplier()), (mr, om) -> {
             fail("applyMergeChanges should not be called");
-        }, () -> { fail("onMergeFailureCleanup should not be called"); }, SHARD_ID, mergeSchedulerSettings(), mockThreadPool());
+        },
+            () -> { fail("onMergeFailureCleanup should not be called"); },
+            () -> {},
+            () -> {},
+            SHARD_ID,
+            mergeSchedulerSettings(),
+            mockThreadPool()
+        );
 
         onForceMergeThread(() -> scheduler.forceMerge(1));
     }
@@ -695,6 +720,8 @@ public class MergeTests extends OpenSearchTestCase {
         MergeScheduler scheduler = new MergeScheduler(
             handler,
             (mr, om) -> {},
+            () -> {},
+            () -> {},
             () -> {},
             SHARD_ID,
             mergeSchedulerSettings(),


### PR DESCRIPTION
When outstanding merges (active + pending) exceed maxMergeCount, the MergeScheduler now activates indexing throttle via the engine's existing IndexingThrottler, serializing write threads to a single thread until merge pressure subsides. This mirrors the behavior already present in InternalEngine's EngineMergeScheduler.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
