### PR TITLE
[Fix] [DFAE] Sync translog while relocating remote-backed data format aware primary shard

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1050,10 +1050,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 forceRefreshes.close();
 
                 boolean syncTranslog = (isRemoteTranslogEnabled() || this.isMigratingToRemote())
-                    && Durability.ASYNC == indexSettings.getTranslogDurability();
-                // Since all the index permits are acquired at this point, the translog buffer will not change.
-                // It is safe to perform sync of translogs now as this will ensure for remote-backed indexes, the
-                // translogs has been uploaded to the remote store.
+                    && (Durability.ASYNC == indexSettings.getTranslogDurability() || indexSettings.isPluggableDataFormatEnabled());
+                // Force a final, blocking translog upload to remote for ALL remote-backed indexes before draining
+                // uploads below. This must run for REQUEST durability too, not just ASYNC: with REQUEST the freshest
+                // acked ops may still be in the buffered upload path and not yet on remote. If we drained without
+                // this sync, the pending upload would hit the drained syncPermit, no-op (TLOG-SKIP), and those acked
+                // ops would never reach remote, silently lost on handoff since the target recovers from remote.
                 if (syncTranslog) {
                     maybeSync();
                 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
  
  During primary relocation of a remote-store-backed index, acknowledged writes can be
  **silently lost** when `index.translog.durability=request` (the default).
  
  `IndexShard.relocated()` only performed a final translog upload (`maybeSync()`) when durability was `ASYNC`:
  
  ```java
  boolean syncTranslog = (isRemoteTranslogEnabled() || this.isMigratingToRemote())
      && Durability.ASYNC == indexSettings.getTranslogDurability();
```
  
  It then calls drainSync(), which acquires the single syncPermit and pauses all further uploads. For REQUEST durability the final maybeSync() was skipped, so the freshest acked ops — still in the buffered upload path — had not yet reached remote. When their queued upload finally ran, prepareAndUpload() could not acquire the drained permit, no-op'd (TLOG-SKIP), and returned false. That false is swallowed  up the write path and the ops were already acked to the client. Because the relocation target recovers from the remote store, those ops had no path to the new primary and  were permanently lost.
  
  Fix
  
  Run the pre-drain maybeSync() for all remote-backed indexes, not just ASYNC durability. maybeSync() is a synchronous, blocking upload that rolls the current generation and uploads up to the local checkpoint, bypassing the async buffer. It completes and releases the syncPermit before drainSync() runs, guaranteeing the  remote store reaches the source's local checkpoint before handoff.
  ```java
  boolean syncTranslog = (isRemoteTranslogEnabled() || this.isMigratingToRemote());
  ```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
