### PR TITLE
Extend CONCAT test coverage to scalar-function operands

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -255,7 +255,7 @@ impl LocalSession {
 mod tests {
     use super::*;
 
-    use arrow_array::{Int64Array, RecordBatch};
+    use arrow_array::{Array, Int64Array, RecordBatch, StringArray};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_substrait::logical_plan::producer::to_substrait_plan;
@@ -282,6 +282,24 @@ mod tests {
             vec![Arc::new(Int64Array::from(values.to_vec()))],
         )
         .expect("batch builds")
+    }
+
+    fn two_string_schema(a: &str, b: &str) -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new(a, DataType::Utf8, false),
+            Field::new(b, DataType::Utf8, false),
+        ]))
+    }
+
+    fn two_string_batch(schema: &SchemaRef, col_a: &[&str], col_b: &[&str]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![
+                Arc::new(StringArray::from(col_a.to_vec())),
+                Arc::new(StringArray::from(col_b.to_vec())),
+            ],
+        )
+        .expect("string batch builds")
     }
 
     #[tokio::test]
@@ -418,6 +436,73 @@ mod tests {
             }
         }
         assert_eq!(total, 45);
+    }
+
+    /// `concat(substring(a, ...), '|', substring(b, ...))` over a WHERE filter —
+    /// the outer operands are scalar-function calls and the middle operand is a
+    /// string literal. Round-trips through SQL → Substrait → `from_substrait_plan`
+    /// and asserts one concatenated row per input.
+    #[tokio::test]
+    async fn execute_substrait_concat_substring_literal_substring() {
+        let env = test_runtime_env();
+        let mut session = LocalSession::new(&env);
+        let schema = two_string_schema("url", "referer");
+
+        // Two rows, both non-empty so they survive the WHERE filter.
+        let batch = two_string_batch(
+            &schema,
+            &["http://alpha", "http://bravo"],
+            &["https://gamma", "https://delta"],
+        );
+        session
+            .register_memtable("input-0", Arc::clone(&schema), vec![batch])
+            .expect("register memtable");
+
+        let sql = "SELECT concat(substring(url, 1, 7), '|', substring(referer, 1, 8)) AS r \
+                   FROM \"input-0\" WHERE url <> '' AND referer <> ''";
+
+        let substrait_bytes = {
+            let env = test_runtime_env();
+            let mut producer = LocalSession::new(&env);
+            producer
+                .register_memtable("input-0", Arc::clone(&schema), vec![])
+                .expect("producer register");
+            let df = producer.ctx.sql(sql).await.expect("concat sql parses");
+            let plan = df.logical_plan().clone();
+            let substrait = to_substrait_plan(&plan, &producer.ctx.state()).expect("to_substrait");
+            let mut buf = Vec::new();
+            substrait.encode(&mut buf).expect("encode");
+            buf
+        };
+
+        let (mut stream, _plan) = session
+            .execute_substrait(&substrait_bytes)
+            .await
+            .expect("execute");
+
+        let mut results: Vec<String> = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.expect("batch ok");
+            // DataFusion's string functions may return Utf8/LargeUtf8/Utf8View depending on
+            // version; cast to Utf8 so the assertion is independent of the concrete string type.
+            let col = datafusion::arrow::compute::cast(batch.column(0), &DataType::Utf8)
+                .expect("cast concat output to Utf8");
+            let col = col.as_any().downcast_ref::<StringArray>().expect("utf8 col");
+            for i in 0..col.len() {
+                results.push(col.value(i).to_string());
+            }
+        }
+
+        // Each row joins the two substring results with the middle '|' literal.
+        results.sort();
+        assert_eq!(
+            results,
+            vec![
+                "http://|https://".to_string(),
+                "http://|https://".to_string(),
+            ],
+            "concat(substring, '|', substring) must yield one '|'-joined row per input"
+        );
     }
 
     #[tokio::test]

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConcatVariadicAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ConcatVariadicAdapterTests.java
@@ -18,6 +18,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -120,5 +121,49 @@ public class ConcatVariadicAdapterTests extends OpenSearchTestCase {
         RexNode adapted = adapter.adapt(original, List.of(), cluster);
 
         assertSame("all-VARCHAR call must pass through unchanged", original, adapted);
+    }
+
+    public void testAdaptCastsCharLiteralBetweenScalarFunctionOperands() {
+        // CONCAT(SUBSTRING(f0,1,3), charLiteral, SUBSTRING(f1,1,3)): the outer operands are
+        // scalar-function calls (RexCall), only the middle FixedChar literal needs casting.
+        RexNode substr0 = substringCall(0);
+        RexNode charLiteral = rexBuilder.makeInputRef(charType, 2);
+        RexNode substr1 = substringCall(1);
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, substr0, charLiteral, substr1);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame("operator identity must be preserved", original.getOperator(), adapted.getOperator());
+        for (int i = 0; i < adapted.getOperands().size(); i++) {
+            assertEquals(
+                "operand " + i + " must be VARCHAR after normalisation",
+                SqlTypeName.VARCHAR,
+                adapted.getOperands().get(i).getType().getSqlTypeName()
+            );
+        }
+        // The two scalar-function operands were already VARCHAR, so they must pass through by
+        // reference — only the middle literal is rewritten.
+        assertSame("VARCHAR substring operand 0 must pass through unchanged", substr0, adapted.getOperands().get(0));
+        assertSame("VARCHAR substring operand 2 must pass through unchanged", substr1, adapted.getOperands().get(2));
+        assertNotSame("CHAR literal operand must be rewritten to a VARCHAR cast", charLiteral, adapted.getOperands().get(1));
+    }
+
+    public void testAdaptTwoScalarFunctionOperandsIsNoOp() {
+        // CONCAT(SUBSTRING(f0,1,3), SUBSTRING(f1,1,3)): two VARCHAR-typed scalar-function operands,
+        // nothing to cast, so the original call passes through by reference.
+        RexCall original = (RexCall) rexBuilder.makeCall(SqlLibraryOperators.CONCAT_FUNCTION, substringCall(0), substringCall(1));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame("all-VARCHAR scalar-fn operand call must pass through unchanged", original, adapted);
+    }
+
+    /** {@code SUBSTRING(field#idx, 1, 3)} typed VARCHAR — a RexCall operand for concat. */
+    private RexCall substringCall(int fieldIndex) {
+        RexNode field = rexBuilder.makeInputRef(varcharType, fieldIndex);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RexNode start = rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, intType);
+        RexNode len = rexBuilder.makeExactLiteral(java.math.BigDecimal.valueOf(3), intType);
+        return (RexCall) rexBuilder.makeCall(varcharType, SqlStdOperatorTable.SUBSTRING, List.of(field, start, len));
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConcatVariadicIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ConcatVariadicIT.java
@@ -19,6 +19,16 @@ import java.util.Map;
  * VARCHAR / FixedChar operand list (the natural shape when fields and short string
  * literals appear together) trips isthmus' consistency check. The adapter pre-casts
  * every non-VARCHAR operand to VARCHAR so substrait emits a uniform-typed call.
+ *
+ * <p>Operand-shape coverage matters here: a concat operand can be a field reference
+ * ({@code RexInputRef}), a string literal ({@code RexLiteral}), or a nested scalar-function
+ * call ({@code RexCall}, e.g. {@code substring(...)}). These travel different conversion
+ * paths, so the tests below exercise concat over <em>scalar-function operands</em> in
+ * addition to the field/literal shapes — the natural form of queries like
+ * {@code concat(substring(url, 1, 10), '|', substring(referer, 1, 10))}.
+ *
+ * <p>Fixture row 0 ({@code key00}) of calcs: str0="FURNITURE", str1="CLAMP ON LAMPS",
+ * str2="one", str3="e".
  */
 public class ConcatVariadicIT extends AnalyticsRestTestCase {
 
@@ -49,6 +59,50 @@ public class ConcatVariadicIT extends AnalyticsRestTestCase {
         assertRowsEqual(
             "source=" + DATASET.indexName + " | eval r = concat(str2, '-', str3) | fields r | head 1",
             row("one-e")
+        );
+    }
+
+    public void testConcatSubstringLiteralSubstringWithFilter() throws IOException {
+        // 3-arg concat where the outer operands are SUBSTRING scalar-function calls (RexCall, not
+        // field refs) and the middle operand is a short string literal, above a WHERE filter on the
+        // same fields. Row 0 of calcs has str0=`FURNITURE` and str1=`CLAMP ON LAMPS`, so
+        // substring(_,1,3) yields `FUR` and `CLA` → `FUR|CLA`.
+        assertRowsEqual(
+            "source="
+                + DATASET.indexName
+                + " | where str0 != '' and str1 != ''"
+                + " | eval r = concat(substring(str0, 1, 3), '|', substring(str1, 1, 3))"
+                + " | fields r | head 1",
+            row("FUR|CLA")
+        );
+    }
+
+    public void testConcatTwoSubstringsNoLiteral() throws IOException {
+        // 2-arg concat of two SUBSTRING calls, no middle literal — every operand is an already
+        // VARCHAR-typed scalar call, so the variadic adapter makes no change. `FUR` + `CLA`.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | eval r = concat(substring(str0, 1, 3), substring(str1, 1, 3)) | fields r | head 1",
+            row("FURCLA")
+        );
+    }
+
+    public void testConcatUpperAndLowerScalarFns() throws IOException {
+        // concat of two different scalar-function operands, no literal: upper(str3)=`E`,
+        // lower(str0)=`furniture` → `Efurniture`. Confirms the adapter's no-op path holds when
+        // operands are RexCalls (not field refs) typed VARCHAR.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | eval r = concat(upper(str3), lower(str0)) | fields r | head 1",
+            row("Efurniture")
+        );
+    }
+
+    public void testConcatScalarFnLiteralScalarFnDistinctFns() throws IOException {
+        // 3-arg concat(scalarFn, literal, scalarFn) with two distinct functions around a FixedChar
+        // literal: left(str0,3)=`FUR`, right(str0,3)=`URE` → `FUR#URE`. Exercises the cast path on
+        // the middle literal while both outer operands are scalar-function calls.
+        assertRowsEqual(
+            "source=" + DATASET.indexName + " | eval r = concat(left(str0, 3), '#', right(str0, 3)) | fields r | head 1",
+            row("FUR#URE")
         );
     }
 


### PR DESCRIPTION
 ### Description

  The variadic CONCAT fix (#22123) and its tests only exercised concat operands that were **field references** (`RexInputRef`) or **string literals**. The shape — `concat(substring(a, …), '|', substring(b, …))`, where the outer operands are nested **scalar-function calls** (`RexCall`) around a middle string literal — was uncovered at every layer.

  This adds regression coverage for that shape across all three layers. Test-only; no production code changes.

  - **IT** `ConcatVariadicIT` (calcs, deterministic exact-value asserts): `concat(substring, '|', substring)`, 2-arg `concat(substring, substring)`, `concat(upper, lower)`, and `concat(left, '#', right)`.
  - **Unit** `ConcatVariadicAdapterTests`: adapter cases with `SUBSTRING` `RexCall` operands — only the middle CHAR literal is cast, the VARCHAR scalar-fn operands pass through by reference; plus the all-scalar-fn no-op path.
  - **Rust e2e** `local_executor`: SQL → Substrait → `from_substrait_plan` → execute round-trip for `concat(substring, '|', substring)` over a WHERE filter, asserting one `'|'`-joined row per input (the reported bug returned zero rows).

  ### Testing

  - `ConcatVariadicAdapterTests` — 7/7 pass
  - `local_executor` e2e — 1/1 pass
  - `ConcatVariadicIT` — 6/6 pass

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
