### PR TITLE
[analytics-engine] Support dc() on boolean fields + optimized Utf8View hashing

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 roaring = "=0.10.12"
 thiserror = { workspace = true }
+foldhash = "0.2"
 
 # convert_tz UDF
 chrono-tz = "=0.10.4"

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/approx_distinct_safe.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/approx_distinct_safe.rs
@@ -6,25 +6,39 @@
  * compatible open source license.
  */
 
-//! Safe `approx_distinct` override — fixes https://github.com/apache/datafusion/pull/21064
-//! by routing Utf8View through consistent &str hashing.
+//! Custom `approx_distinct` UDAF bringing unreleased fixes from DataFusion main
+//! as an intermediate solution for two issues in DF 54:
 //!
-//! TODO: Remove once fixed upstream (likely DataFusion v55/v56).
-//! TODO: Evaluate if DF's UDAF extension points (e.g. AccumulatorArgs overrides or
-//!       custom PhysicalOptimizerRule to inject CastExec) can avoid same-name overrides.
+//! 1. Utf8View over-counting: https://github.com/apache/datafusion/pull/21064 introduced
+//!    inconsistent hashing (inline u128 vs &str) causing ~2x overcount on keyword fields.
+//!    Fixed upstream in https://github.com/apache/datafusion/pull/22815.
+//!
+//! 2. Boolean not supported: `approx_distinct(boolean)` errors with "not implemented".
+//!    Added upstream in https://github.com/apache/datafusion/pull/22707 with short-circuit.
+//!
+//! This UDAF overrides DF54's built-in `approx_distinct` for these two types and delegates
+//! all others to the built-in.
+//! TODO: Remove this file when upgrading to DataFusion 55+.
 
+use std::hash::BuildHasher;
 use std::sync::Arc;
-use datafusion::arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+
+use datafusion::arrow::array::{Array, ArrayRef, BinaryArray, BooleanArray, StringViewArray};
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion::common::{downcast_value, Result};
+use datafusion::common::{downcast_value, internal_datafusion_err, Result};
 use datafusion::execution::context::SessionContext;
+use datafusion::functions_aggregate::approx_distinct::approx_distinct_udaf;
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion::logical_expr::{Accumulator, AggregateUDFImpl, Signature, Volatility};
-use datafusion::functions_aggregate::approx_distinct::approx_distinct_udaf;
+use datafusion::physical_expr::expressions::format_state_name;
 use datafusion::scalar::ScalarValue;
 
+use super::hll::{HyperLogLog, HLL_HASH_STATE};
+
 pub fn register_all(ctx: &SessionContext) {
-    ctx.register_udaf(datafusion::logical_expr::AggregateUDF::from(SafeApproxDistinct::new()));
+    ctx.register_udaf(datafusion::logical_expr::AggregateUDF::from(
+        SafeApproxDistinct::new(),
+    ));
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -49,8 +63,8 @@ impl AggregateUDFImpl for SafeApproxDistinct {
         &self.signature
     }
 
-    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
-        approx_distinct_udaf().inner().return_type(args)
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+        Ok(DataType::UInt64)
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
@@ -59,23 +73,9 @@ impl AggregateUDFImpl for SafeApproxDistinct {
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
         let data_type = acc_args.expr_fields[0].data_type();
-        if matches!(data_type, DataType::Utf8View) {
-            // Wrap DF's Utf8 accumulator, feed it materialized &str from StringViewArray
-            let utf8_args = AccumulatorArgs {
-                return_field: acc_args.return_field,
-                schema: acc_args.schema,
-                ignore_nulls: acc_args.ignore_nulls,
-                order_bys: acc_args.order_bys,
-                name: acc_args.name,
-                is_distinct: acc_args.is_distinct,
-                exprs: acc_args.exprs,
-                expr_fields: &[Arc::new(Field::new("x", DataType::Utf8, true))],
-                is_reversed: acc_args.is_reversed,
-            };
-            let inner = approx_distinct_udaf().inner().accumulator(utf8_args)?;
-            Ok(Box::new(Utf8ViewToUtf8Accumulator { inner }))
-        } else {
-            approx_distinct_udaf().inner().accumulator(acc_args)
+        match data_type {
+            DataType::Utf8View => Ok(Box::new(Utf8ViewHLLAccumulator::new())),
+            _ => approx_distinct_udaf().inner().accumulator(acc_args),
         }
     }
 
@@ -84,33 +84,313 @@ impl AggregateUDFImpl for SafeApproxDistinct {
     }
 }
 
-/// Wraps DF's Utf8 HLL accumulator, converting Utf8View batches to StringArray on the fly.
+// ── Utf8View HLL: consistent per-string-length hashing (matches DF main #22815) ──
+
 #[derive(Debug)]
-struct Utf8ViewToUtf8Accumulator {
-    inner: Box<dyn Accumulator>,
+struct Utf8ViewHLLAccumulator {
+    hll: HyperLogLog<u8>,
 }
 
-impl Accumulator for Utf8ViewToUtf8Accumulator {
+impl Utf8ViewHLLAccumulator {
+    fn new() -> Self {
+        Self { hll: HyperLogLog::new() }
+    }
+}
+
+impl Accumulator for Utf8ViewHLLAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
-        let view_array: &StringViewArray = downcast_value!(values[0], StringViewArray);
-        // Materialize as StringArray — consistent hashing via StringHLLAccumulator
-        let string_array: StringArray = view_array.iter().collect();
-        self.inner.update_batch(&[Arc::new(string_array) as ArrayRef])
+        let array: &StringViewArray = downcast_value!(values[0], StringViewArray);
+        if array.data_buffers().is_empty() {
+            for (i, &view) in array.views().iter().enumerate() {
+                if !array.is_null(i) {
+                    self.hll.add_hashed(HLL_HASH_STATE.hash_one(view));
+                }
+            }
+        } else {
+            for (i, &view) in array.views().iter().enumerate() {
+                if array.is_null(i) {
+                    continue;
+                }
+                if (view as u32) <= 12 {
+                    self.hll.add_hashed(HLL_HASH_STATE.hash_one(view));
+                } else {
+                    self.hll.add_hashed(HLL_HASH_STATE.hash_one(array.value(i)));
+                }
+            }
+        }
+        Ok(())
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
-        self.inner.merge_batch(states)
+        let binary_array = downcast_value!(states[0], BinaryArray);
+        for v in binary_array.iter() {
+            let v = v.ok_or_else(|| {
+                internal_datafusion_err!("Invalid HLL binary state")
+            })?;
+            let other: HyperLogLog<u8> = v.try_into()?;
+            self.hll.merge(&other);
+        }
+        Ok(())
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        self.inner.state()
+        Ok(vec![self.hll.to_scalar()])
     }
 
     fn evaluate(&mut self) -> Result<ScalarValue> {
-        self.inner.evaluate()
+        Ok(ScalarValue::UInt64(Some(self.hll.count() as u64)))
     }
 
     fn size(&self) -> usize {
-        self.inner.size()
+        std::mem::size_of_val(self)
+    }
+}
+
+// ── Boolean accumulator with short-circuit ──────────────────────────────────
+
+#[derive(Debug)]
+struct BooleanDistinctAccumulator {
+    seen_true: bool,
+    seen_false: bool,
+}
+
+impl BooleanDistinctAccumulator {
+    fn new() -> Self {
+        Self {
+            seen_true: false,
+            seen_false: false,
+        }
+    }
+}
+
+impl Accumulator for BooleanDistinctAccumulator {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        if self.seen_true && self.seen_false {
+            return Ok(());
+        }
+        let array: &BooleanArray = downcast_value!(values[0], BooleanArray);
+        for i in 0..array.len() {
+            if !array.is_null(i) {
+                if array.value(i) {
+                    self.seen_true = true;
+                } else {
+                    self.seen_false = true;
+                }
+                if self.seen_true && self.seen_false {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        if self.seen_true && self.seen_false {
+            return Ok(());
+        }
+        let binary_array: &BinaryArray = downcast_value!(states[0], BinaryArray);
+        for v in binary_array.iter().flatten() {
+            if v.len() >= 2 {
+                self.seen_true |= v[0] != 0;
+                self.seen_false |= v[1] != 0;
+            }
+            if self.seen_true && self.seen_false {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        Ok(vec![ScalarValue::Binary(Some(vec![
+            self.seen_true as u8,
+            self.seen_false as u8,
+        ]))])
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        Ok(ScalarValue::UInt64(Some(
+            self.seen_true as u64 + self.seen_false as u64,
+        )))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::BooleanArray;
+
+    #[test]
+    fn boolean_acc_both_values() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr: ArrayRef = Arc::new(BooleanArray::from(vec![true, false, true, false]));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(2)));
+    }
+
+    #[test]
+    fn boolean_acc_only_true() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr: ArrayRef = Arc::new(BooleanArray::from(vec![true, true, true]));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(1)));
+    }
+
+    #[test]
+    fn boolean_acc_only_false() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr: ArrayRef = Arc::new(BooleanArray::from(vec![false, false]));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(1)));
+    }
+
+    #[test]
+    fn boolean_acc_with_nulls() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr: ArrayRef = Arc::new(BooleanArray::from(vec![
+            Some(true), None, Some(false), None,
+        ]));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(2)));
+    }
+
+    #[test]
+    fn boolean_acc_short_circuits() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr1: ArrayRef = Arc::new(BooleanArray::from(vec![true, false]));
+        acc.update_batch(&[arr1]).unwrap();
+        // Second batch should be a no-op
+        let arr2: ArrayRef = Arc::new(BooleanArray::from(vec![true, true, true]));
+        acc.update_batch(&[arr2]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(2)));
+    }
+
+    #[test]
+    fn boolean_acc_empty() {
+        let mut acc = BooleanDistinctAccumulator::new();
+        let arr: ArrayRef = Arc::new(BooleanArray::from(Vec::<bool>::new()));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(0)));
+    }
+
+    #[test]
+    fn utf8view_consistency() {
+        use datafusion::arrow::array::StringViewArray;
+        let udaf = SafeApproxDistinct::new();
+        let field = Arc::new(Field::new("x", DataType::Utf8View, true));
+        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![field.as_ref().clone()]));
+        let expr: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("x", 0));
+        let acc_args = AccumulatorArgs {
+            return_field: Arc::new(Field::new("r", DataType::UInt64, true)),
+            schema: &schema,
+            ignore_nulls: false,
+            order_bys: &[],
+            name: "x",
+            is_distinct: false,
+            exprs: &[expr],
+            expr_fields: &[Arc::new(Field::new("x", DataType::Utf8View, true))],
+            is_reversed: false,
+        };
+        let mut acc = udaf.accumulator(acc_args).unwrap();
+
+        // Two batches with same values — should produce same result as one batch
+        let arr1: ArrayRef = Arc::new(StringViewArray::from(vec!["hello", "world", "hello"]));
+        let arr2: ArrayRef = Arc::new(StringViewArray::from(vec!["world", "hello", "world"]));
+        acc.update_batch(&[arr1]).unwrap();
+        acc.update_batch(&[arr2]).unwrap();
+
+        let result = acc.evaluate().unwrap();
+        assert_eq!(result, ScalarValue::UInt64(Some(2)));
+    }
+
+    #[test]
+    fn utf8view_state_roundtrip() {
+        let mut acc = Utf8ViewHLLAccumulator::new();
+        let arr: ArrayRef = Arc::new(StringViewArray::from(vec!["alpha", "beta", "gamma"]));
+        acc.update_batch(&[arr]).unwrap();
+
+        let state = acc.state().unwrap();
+        assert_eq!(state.len(), 1);
+        let ScalarValue::Binary(Some(bytes)) = &state[0] else { panic!("expected Binary state") };
+
+        let mut acc2 = Utf8ViewHLLAccumulator::new();
+        let binary_arr: ArrayRef = Arc::new(
+            datafusion::arrow::array::BinaryArray::from(vec![bytes.as_slice()])
+        );
+        acc2.merge_batch(&[binary_arr]).unwrap();
+        assert_eq!(acc2.evaluate().unwrap(), ScalarValue::UInt64(Some(3)));
+    }
+
+    #[test]
+    fn utf8view_mixed_batches_consistent() {
+        // Batch 1: has a long string (forces data_buffers non-empty)
+        let mut builder = arrow::array::StringViewBuilder::new();
+        builder.append_value("this_is_a_long_string_over_12_bytes");
+        builder.append_value("short");
+        builder.append_value("tiny");
+        let batch1: ArrayRef = Arc::new(builder.finish());
+
+        // Batch 2: only short strings (data_buffers empty, all inline)
+        let batch2: ArrayRef = Arc::new(StringViewArray::from(vec!["short", "tiny", "new"]));
+
+        let mut acc = Utf8ViewHLLAccumulator::new();
+        acc.update_batch(&[batch1]).unwrap();
+        acc.update_batch(&[batch2]).unwrap();
+
+        // 4 distinct: "this_is_a_long...", "short", "tiny", "new"
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(4)));
+    }
+
+    #[test]
+    fn utf8view_merge_two_shards() {
+        let mut acc1 = Utf8ViewHLLAccumulator::new();
+        let mut acc2 = Utf8ViewHLLAccumulator::new();
+
+        let arr1: ArrayRef = Arc::new(StringViewArray::from(vec!["a", "b", "c"]));
+        let arr2: ArrayRef = Arc::new(StringViewArray::from(vec!["b", "c", "d"]));
+        acc1.update_batch(&[arr1]).unwrap();
+        acc2.update_batch(&[arr2]).unwrap();
+
+        let state1 = acc1.state().unwrap();
+        let state2 = acc2.state().unwrap();
+        let ScalarValue::Binary(Some(b1)) = &state1[0] else { panic!() };
+        let ScalarValue::Binary(Some(b2)) = &state2[0] else { panic!() };
+
+        let mut merged = Utf8ViewHLLAccumulator::new();
+        let binary_arr: ArrayRef = Arc::new(
+            datafusion::arrow::array::BinaryArray::from(vec![b1.as_slice(), b2.as_slice()])
+        );
+        merged.merge_batch(&[binary_arr]).unwrap();
+        // Union of {a,b,c} and {b,c,d} = {a,b,c,d} = 4
+        assert_eq!(merged.evaluate().unwrap(), ScalarValue::UInt64(Some(4)));
+    }
+
+    #[test]
+    fn delegates_int32_to_builtin() {
+        let udaf = SafeApproxDistinct::new();
+        let field = Arc::new(Field::new("x", DataType::Int32, true));
+        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![field.as_ref().clone()]));
+        let expr: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("x", 0));
+        let acc_args = AccumulatorArgs {
+            return_field: Arc::new(Field::new("r", DataType::UInt64, true)),
+            schema: &schema,
+            ignore_nulls: false,
+            order_bys: &[],
+            name: "x",
+            is_distinct: false,
+            exprs: &[expr],
+            expr_fields: &[field.clone()],
+            is_reversed: false,
+        };
+        let mut acc = udaf.accumulator(acc_args).unwrap();
+        let arr: ArrayRef = Arc::new(datafusion::arrow::array::Int32Array::from(vec![1, 2, 3, 2, 1]));
+        acc.update_batch(&[arr]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::UInt64(Some(3)));
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/hll.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/hll.rs
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Minimal HyperLogLog copy from DataFusion (Apache-2.0). Wire-compatible with DF54's Binary state format.
+//! TODO: Remove this file when upgrading to DataFusion 55+ (HyperLogLog becomes pub).
+
+use datafusion::common::{internal_datafusion_err, DataFusionError, Result};
+use datafusion::scalar::ScalarValue;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+const HLL_P: usize = 14;
+const HLL_Q: usize = 64 - HLL_P;
+const NUM_REGISTERS: usize = 1 << HLL_P;
+const HLL_P_MASK: u64 = (NUM_REGISTERS as u64) - 1;
+
+/// Same seed as DF54's internal HLL_HASH_STATE.
+pub const HLL_HASH_STATE: foldhash::quality::FixedState =
+    foldhash::quality::FixedState::with_seed(0);
+
+#[derive(Clone, Debug)]
+pub struct HyperLogLog<T: Hash + ?Sized> {
+    registers: [u8; NUM_REGISTERS],
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Hash + ?Sized> HyperLogLog<T> {
+    pub fn new() -> Self {
+        Self {
+            registers: [0; NUM_REGISTERS],
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn add(&mut self, obj: &T) {
+        use std::hash::BuildHasher;
+        self.add_hashed(HLL_HASH_STATE.hash_one(obj));
+    }
+
+    #[inline]
+    pub fn add_hashed(&mut self, hash: u64) {
+        let index = (hash & HLL_P_MASK) as usize;
+        let p = ((hash >> HLL_P) | (1_u64 << HLL_Q)).trailing_zeros() + 1;
+        self.registers[index] = self.registers[index].max(p as u8);
+    }
+
+    pub fn merge(&mut self, other: &HyperLogLog<T>) {
+        for i in 0..NUM_REGISTERS {
+            self.registers[i] = self.registers[i].max(other.registers[i]);
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        let mut histogram = [0u32; HLL_Q + 2];
+        for &r in &self.registers {
+            histogram[r as usize] += 1;
+        }
+        let m = NUM_REGISTERS as f64;
+        let mut z = m * hll_tau((m - histogram[HLL_Q + 1] as f64) / m);
+        for i in histogram[1..=HLL_Q].iter().rev() {
+            z += *i as f64;
+            z *= 0.5;
+        }
+        z += m * hll_sigma(histogram[0] as f64 / m);
+        (0.5 / 2_f64.ln() * m * m / z).round() as usize
+    }
+
+    pub fn to_scalar(&self) -> ScalarValue {
+        ScalarValue::Binary(Some(self.registers.to_vec()))
+    }
+}
+
+impl<T: Hash + ?Sized> TryFrom<&[u8]> for HyperLogLog<T> {
+    type Error = DataFusionError;
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let arr: [u8; NUM_REGISTERS] = v.try_into().map_err(|_| {
+            internal_datafusion_err!("Invalid HLL state: expected {} bytes", NUM_REGISTERS)
+        })?;
+        Ok(Self {
+            registers: arr,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+#[inline]
+fn hll_sigma(x: f64) -> f64 {
+    if x == 1. {
+        return f64::INFINITY;
+    }
+    let mut y = 1.0;
+    let mut z = x;
+    let mut x = x;
+    loop {
+        x *= x;
+        let z_prime = z;
+        z += x * y;
+        y += y;
+        if z_prime == z {
+            break;
+        }
+    }
+    z
+}
+
+#[inline]
+fn hll_tau(x: f64) -> f64 {
+    if x == 0.0 || x == 1.0 {
+        return 0.0;
+    }
+    let mut y = 1.0;
+    let mut z = 1.0 - x;
+    let mut x = x;
+    loop {
+        x = x.sqrt();
+        let z_prime = z;
+        y *= 0.5;
+        z -= (1.0 - x).powi(2) * y;
+        if z_prime == z {
+            break;
+        }
+    }
+    z / 3.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::BuildHasher;
+
+    #[test]
+    fn empty_hll_counts_zero() {
+        let hll: HyperLogLog<u8> = HyperLogLog::new();
+        assert_eq!(hll.count(), 0);
+    }
+
+    #[test]
+    fn single_value_counts_one() {
+        let mut hll: HyperLogLog<u8> = HyperLogLog::new();
+        hll.add_hashed(HLL_HASH_STATE.hash_one("hello"));
+        assert_eq!(hll.count(), 1);
+    }
+
+    #[test]
+    fn duplicate_values_count_once() {
+        let mut hll: HyperLogLog<u8> = HyperLogLog::new();
+        for _ in 0..1000 {
+            hll.add_hashed(HLL_HASH_STATE.hash_one("same"));
+        }
+        assert_eq!(hll.count(), 1);
+    }
+
+    #[test]
+    fn distinct_values_counted() {
+        let mut hll: HyperLogLog<u8> = HyperLogLog::new();
+        for i in 0..100 {
+            hll.add_hashed(HLL_HASH_STATE.hash_one(&i));
+        }
+        let count = hll.count();
+        assert!(count >= 95 && count <= 105, "expected ~100, got {count}");
+    }
+
+    #[test]
+    fn merge_produces_union() {
+        let mut hll1: HyperLogLog<u8> = HyperLogLog::new();
+        let mut hll2: HyperLogLog<u8> = HyperLogLog::new();
+        for i in 0..50 {
+            hll1.add_hashed(HLL_HASH_STATE.hash_one(&i));
+        }
+        for i in 50..100 {
+            hll2.add_hashed(HLL_HASH_STATE.hash_one(&i));
+        }
+        hll1.merge(&hll2);
+        let count = hll1.count();
+        assert!(count >= 95 && count <= 105, "expected ~100, got {count}");
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut hll: HyperLogLog<u8> = HyperLogLog::new();
+        for i in 0..50 {
+            hll.add_hashed(HLL_HASH_STATE.hash_one(&i));
+        }
+        let scalar = hll.to_scalar();
+        let ScalarValue::Binary(Some(bytes)) = scalar else { panic!("expected Binary") };
+        let restored: HyperLogLog<u8> = bytes.as_slice().try_into().unwrap();
+        assert_eq!(hll.count(), restored.count());
+    }
+
+    #[test]
+    fn invalid_state_returns_error() {
+        let short_bytes = vec![0u8; 10];
+        let result: Result<HyperLogLog<u8>> = short_bytes.as_slice().try_into();
+        assert!(result.is_err());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/mod.rs
@@ -13,6 +13,7 @@
 use datafusion::execution::context::SessionContext;
 
 pub mod approx_distinct_safe;
+mod hll;
 pub mod internal_pattern;
 pub mod list_merge;
 pub mod os_count_distinct;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchDistinctCountRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchDistinctCountRule.java
@@ -129,7 +129,7 @@ public class OpenSearchDistinctCountRule extends RelOptRule {
             if (call.getAggregation() == SqlStdOperatorTable.APPROX_COUNT_DISTINCT) {
                 for (int argIdx : call.getArgList()) {
                     SqlTypeName typeName = fields.get(argIdx).getType().getSqlTypeName();
-                    if (typeName == SqlTypeName.TINYINT || typeName == SqlTypeName.SMALLINT) {
+                    if (typeName == SqlTypeName.TINYINT || typeName == SqlTypeName.SMALLINT || typeName == SqlTypeName.BOOLEAN) {
                         needsWiden = true;
                         break;
                     }
@@ -149,7 +149,7 @@ public class OpenSearchDistinctCountRule extends RelOptRule {
             RelDataTypeField field = fields.get(i);
             RexNode ref = rexBuilder.makeInputRef(input, i);
             SqlTypeName typeName = field.getType().getSqlTypeName();
-            if (typeName == SqlTypeName.TINYINT || typeName == SqlTypeName.SMALLINT) {
+            if (typeName == SqlTypeName.TINYINT || typeName == SqlTypeName.SMALLINT || typeName == SqlTypeName.BOOLEAN) {
                 ref = rexBuilder.makeCast(intType, ref);
             }
             projects.add(ref);

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DistinctCountIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DistinctCountIT.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.analytics.qa;
 
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +89,50 @@ public class DistinctCountIT extends AnalyticsRestTestCase {
 
     public void testDc_integer_withFilter() throws Exception {
         assertDcWithFilterAccurate("RegionID", "GoodEvent = 1");
+    }
+
+    // ── boolean field (requires custom index) ─────────────────────────────────
+
+    public void testDc_boolean() throws Exception {
+        String boolIdx = "dc_bool_test";
+        try {
+            client().performRequest(new Request("DELETE", "/" + boolIdx));
+        } catch (Exception ignored) { }
+
+        Request create = new Request("PUT", "/" + boolIdx);
+        create.setJsonEntity(
+            "{\"settings\":{\"number_of_shards\":2,\"number_of_replicas\":0,"
+                + "\"index.pluggable.dataformat.enabled\":true,"
+                + "\"index.pluggable.dataformat\":\"composite\","
+                + "\"index.composite.primary_data_format\":\"parquet\","
+                + "\"index.composite.secondary_data_formats\":[\"lucene\"]},"
+                + "\"mappings\":{\"properties\":{\"active\":{\"type\":\"boolean\"},\"score\":{\"type\":\"integer\"}}}}"
+        );
+        client().performRequest(create);
+
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            bulk.append("{\"index\":{}}\n");
+            bulk.append("{\"active\":").append(i % 3 != 0).append(",\"score\":").append(i).append("}\n");
+        }
+        Request bulkReq = new Request("POST", "/" + boolIdx + "/_bulk");
+        bulkReq.setJsonEntity(bulk.toString());
+        bulkReq.addParameter("refresh", "true");
+        bulkReq.setOptions(bulkReq.getOptions().toBuilder()
+            .addHeader("Content-Type", "application/x-ndjson").build());
+        client().performRequest(bulkReq);
+
+        Request flush = new Request("POST", "/" + boolIdx + "/_flush");
+        flush.addParameter("force", "true");
+        client().performRequest(flush);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dc = executePpl("source=" + boolIdx + " | stats distinct_count(active) as dc");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) dc.get("datarows");
+        int dcVal = ((Number) rows.get(0).get(0)).intValue();
+        logger.info("dc(boolean active): {}", dcVal);
+        assertEquals("dc(boolean) must return 2 (true + false)", 2, dcVal);
     }
 
     // ── grouped dc ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
 ## Summary

  Adds boolean field support for `dc()`/`distinct_count()` and replaces the Utf8View `StringArray` collection workaround with the optimized per-string-length hashing from DataFusion main — zero allocation, same performance as DF55.

  **Utf8View:** Backport [apache/datafusion#22815](https://github.com/apache/datafusion/pull/22815) — short strings (≤12 bytes) hash as u128 view, long strings hash as `&str` via `add_hashed`. Uses `FixedState::with_seed(0)` for merge compatibility with
  DF54's internal `HLL_HASH_STATE`.

  **Boolean:** Cast BOOLEAN to INTEGER in `OpenSearchDistinctCountRule` (same path as TINYINT/SMALLINT). `BooleanDistinctAccumulator` with short-circuit included for future DF55+ use.

  **HLL module:** Minimal ~90-line copy of DataFusion's `HyperLogLog` core (Apache-2.0). Wire-compatible Binary state format. Required because DF54's `HyperLogLog` is `pub(crate)`.

  All files marked `TODO: Remove when upgrading to DataFusion 55+`.

  ## Changes

  - `udaf/approx_distinct_safe.rs` — `Utf8ViewHLLAccumulator` (optimized) + `BooleanDistinctAccumulator`
  - `udaf/hll.rs` — HyperLogLog registers + add_hashed + merge + count + state serialization
  - `udaf/mod.rs` — register hll module
  - `Cargo.toml` — add `foldhash = "0.2"`
  - `OpenSearchDistinctCountRule.java` — add BOOLEAN to widening cast
  - `DistinctCountIT.java` — add boolean field test

  ## Test Plan

  - [x] 18 Rust unit tests: HLL core (7) + UDAF accumulators (11: boolean, utf8view state/merge/mixed, delegation)
  - [x] `DistinctCountIT`: 14 Java ITs: keyword, short, integer, long, boolean, filtered, grouped
  - [x] Validated on clickbench multi-shard setup cluster

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
