### PR TITLE
Remove Thread#stop from forbidden APIs

### DIFF
--- a/buildSrc/src/main/resources/forbidden/jdk-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/jdk-signatures.txt
@@ -86,11 +86,6 @@ java.lang.reflect.AccessibleObject#setAccessible(java.lang.reflect.AccessibleObj
 @defaultMessage this method needs special permission
 java.lang.Thread#getAllStackTraces()
 
-@defaultMessage Stopping threads explicitly leads to inconsistent states. Use interrupt() instead.
-java.lang.Thread#stop()
-# uncomment when https://github.com/elastic/elasticsearch/issues/31715 is fixed
-# java.lang.Thread#stop(java.lang.Throwable)
-
 @defaultMessage Please do not terminate the application
 java.lang.System#exit(int)
 java.lang.Runtime#exit(int)


### PR DESCRIPTION
Thread#stop has been removed in JDK-26 and forbidden APIs fails if attempting to build with that version unless this is removed.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
