### PR TITLE
Add analytics.query.max_plan_depth dynamic cluster setting

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -100,6 +100,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
     private volatile long perQueryBufferLimit;
     private volatile int maxShardsPerQuery;
     private volatile int maxConcurrentShardRequestsPerNode;
+    private volatile int maxPlanDepth;
     private volatile boolean preferMetadataDriver;
     private final PlannerSettings plannerSettings;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
@@ -152,6 +153,8 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
                 AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE,
                 v -> maxConcurrentShardRequestsPerNode = v
             );
+        this.maxPlanDepth = AnalyticsQuerySettings.MAX_PLAN_DEPTH.get(clusterService.getSettings());
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AnalyticsQuerySettings.MAX_PLAN_DEPTH, v -> maxPlanDepth = v);
         this.preferMetadataDriver = AnalyticsPlugin.PREFER_METADATA_DRIVER.get(clusterService.getSettings());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsPlugin.PREFER_METADATA_DRIVER, v -> preferMetadataDriver = v);
@@ -182,7 +185,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // permissions before any planning work begins. The AnalyticsQueryRequest
         // implements IndicesRequest.Replaceable, exposing target indices extracted
         // from the RelNode's TableScan nodes.
-        String[] indices = RelNodeUtils.extractIndices(logicalFragment);
+        String[] indices = RelNodeUtils.extractIndices(logicalFragment, maxPlanDepth);
         AnalyticsQueryRequest request = new AnalyticsQueryRequest(logicalFragment, queryCtx, indices);
         applyParentTask(request, queryCtx);
         client.execute(
@@ -197,7 +200,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // Route through the framework action (profile=true) just like execute(), so a profiling
         // query runs under the framework-provided, cancellable task rather than detached on
         // searchExecutor. The SecurityFilter also evaluates index permissions on this path.
-        String[] indices = RelNodeUtils.extractIndices(logicalFragment);
+        String[] indices = RelNodeUtils.extractIndices(logicalFragment, maxPlanDepth);
         AnalyticsQueryRequest request = new AnalyticsQueryRequest(logicalFragment, queryCtx, indices, true);
         applyParentTask(request, queryCtx);
         client.execute(

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -202,31 +202,36 @@ public class RelNodeUtils {
     }
 
     /** Maximum recursion depth when walking a RelNode tree to extract indices. */
-    static final int MAX_EXTRACT_INDICES_DEPTH = 15;
+    static final int DEFAULT_MAX_PLAN_DEPTH = 15;
 
     /**
      * Extracts all index names referenced by {@link org.apache.calcite.rel.core.TableScan}
-     * nodes in the plan. Walks the tree up to {@link #MAX_EXTRACT_INDICES_DEPTH} levels to
+     * nodes in the plan. Walks the tree up to {@code maxDepth} levels to
      * guard against pathologically deep plans constructed from complex user queries.
      *
      * @param plan the root of the RelNode tree
      * @return array of distinct index names in encounter order
      * @throws IllegalArgumentException if the plan exceeds the maximum depth
      */
-    public static String[] extractIndices(RelNode plan) {
+    public static String[] extractIndices(RelNode plan, int maxDepth) {
         java.util.Set<String> indices = new java.util.LinkedHashSet<>();
-        if (!collectIndices(plan, indices, 0)) {
+        if (!collectIndices(plan, indices, 0, maxDepth)) {
             throw new IllegalArgumentException(
                 "Query plan exceeds maximum depth ("
-                    + MAX_EXTRACT_INDICES_DEPTH
+                    + maxDepth
                     + ") for index extraction. Simplify the query by reducing nested joins or subqueries."
             );
         }
         return indices.toArray(String[]::new);
     }
 
-    private static boolean collectIndices(RelNode node, java.util.Set<String> indices, int depth) {
-        if (depth >= MAX_EXTRACT_INDICES_DEPTH) {
+    /** Overload using the default depth. */
+    public static String[] extractIndices(RelNode plan) {
+        return extractIndices(plan, DEFAULT_MAX_PLAN_DEPTH);
+    }
+
+    private static boolean collectIndices(RelNode node, java.util.Set<String> indices, int depth, int maxDepth) {
+        if (depth >= maxDepth) {
             return false;
         }
         if (node instanceof TableScan scan) {
@@ -242,7 +247,7 @@ public class RelNodeUtils {
             }
         }
         for (RelNode input : node.getInputs()) {
-            if (!collectIndices(input, indices, depth + 1)) {
+            if (!collectIndices(input, indices, depth + 1, maxDepth)) {
                 return false;
             }
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -80,8 +80,21 @@ public final class AnalyticsQuerySettings {
         Setting.Property.Dynamic
     );
 
+    /**
+     * Maximum depth of the Calcite RelNode tree allowed during query planning.
+     * Queries exceeding this depth (e.g. deeply nested JOINs or subqueries) are
+     * rejected with a 400 before execution begins.
+     */
+    public static final Setting<Integer> MAX_PLAN_DEPTH = Setting.intSetting(
+        "analytics.query.max_plan_depth",
+        15,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     public static List<Setting<?>> all() {
-        return List.of(DELEGATION_BLOCKED_PREDICATES, MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
+        return List.of(DELEGATION_BLOCKED_PREDICATES, MAX_SHARDS_PER_QUERY, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE, MAX_PLAN_DEPTH);
     }
 
     private AnalyticsQuerySettings() {}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
@@ -24,7 +24,7 @@ import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
-import static org.opensearch.analytics.planner.RelNodeUtils.MAX_EXTRACT_INDICES_DEPTH;
+import static org.opensearch.analytics.planner.RelNodeUtils.DEFAULT_MAX_PLAN_DEPTH;
 
 /**
  * Unit tests for {@link RelNodeUtils#extractIndices(RelNode)}.
@@ -136,7 +136,7 @@ public class RelNodeUtilsTests extends OpenSearchTestCase {
         RelBuilder b = builder();
         RelNode node = b.scan("deep_index").build();
         // Wrap in LogicalFilter nodes directly to avoid RelBuilder optimizations.
-        for (int i = 0; i < MAX_EXTRACT_INDICES_DEPTH + 5; i++) {
+        for (int i = 0; i < DEFAULT_MAX_PLAN_DEPTH + 5; i++) {
             RexBuilder rex = node.getCluster().getRexBuilder();
             RexNode condition = rex.makeCall(
                 SqlStdOperatorTable.GREATER_THAN,
@@ -145,7 +145,7 @@ public class RelNodeUtilsTests extends OpenSearchTestCase {
             );
             node = LogicalFilter.create(node, condition);
         }
-        // The plan exceeds MAX_EXTRACT_INDICES_DEPTH — should throw rather than silently skip
+        // The plan exceeds DEFAULT_MAX_PLAN_DEPTH — should throw rather than silently skip
         RelNode deepPlan = node;
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RelNodeUtils.extractIndices(deepPlan));
         assertTrue(e.getMessage().contains("maximum depth"));

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MaxPlanDepthSettingIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/MaxPlanDepthSettingIT.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Integration test for the {@code analytics.query.max_plan_depth} dynamic cluster setting.
+ * Verifies that queries succeeding at the default depth are rejected when the limit is lowered.
+ */
+public class MaxPlanDepthSettingIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static boolean dataProvisioned = false;
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testQuerySucceedsAtDefaultDepthThenRejectedWhenLowered() throws Exception {
+        ensureDataProvisioned();
+        // A simple aggregation query produces a plan with depth > 1
+        String query = "source=" + DATASET.indexName + " | stats avg(num0) by str0";
+
+        // Should succeed at the default depth (15)
+        Request ok = new Request("POST", "/_analytics/ppl");
+        ok.setJsonEntity("{\"query\": \"" + query + "\"}");
+        Response response = client().performRequest(ok);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        // Lower the max plan depth to 1 — any non-trivial query will be rejected
+        setMaxPlanDepth(1);
+        try {
+            Request rejected = new Request("POST", "/_analytics/ppl");
+            rejected.setJsonEntity("{\"query\": \"" + query + "\"}");
+            try {
+                client().performRequest(rejected);
+                fail("Expected 400 for query exceeding max_plan_depth=1");
+            } catch (ResponseException e) {
+                assertEquals("should be 400", 400, e.getResponse().getStatusLine().getStatusCode());
+                String body = new String(e.getResponse().getEntity().getContent().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                assertTrue("error mentions depth: " + body, body.contains("maximum depth"));
+            }
+        } finally {
+            // Restore default so other tests are not affected
+            resetMaxPlanDepth();
+        }
+    }
+
+    private void setMaxPlanDepth(int depth) throws IOException {
+        Request req = new Request("PUT", "/_cluster/settings");
+        req.setJsonEntity("{\"transient\": {\"analytics.query.max_plan_depth\": " + depth + "}}");
+        client().performRequest(req);
+    }
+
+    private void resetMaxPlanDepth() throws IOException {
+        Request req = new Request("PUT", "/_cluster/settings");
+        req.setJsonEntity("{\"transient\": {\"analytics.query.max_plan_depth\": null}}");
+        client().performRequest(req);
+    }
+}


### PR DESCRIPTION
### Description

Converts the hardcoded plan depth limit (15) into a dynamic cluster setting that operators can tune at runtime.

### Setting

```
analytics.query.max_plan_depth
```

- **Default:** 15
- **Min:** 1
- **Scope:** NodeScope, Dynamic
- **Update:** `PUT /_cluster/settings {"transient": {"analytics.query.max_plan_depth": 20}}`

### Behavior

Queries with Calcite RelNode trees deeper than this limit are rejected with HTTP 400 before execution begins:
```
Query plan exceeds maximum depth (15) for index extraction. Simplify the query by reducing nested joins or subqueries.
```

### Testing

- Unit test: `RelNodeUtilsTests.testDepthGuardThrowsOnExcessiveDepth`
- Integration test: `MaxPlanDepthSettingIT` — verifies a query succeeds at default depth, then is rejected after lowering the setting to 1