### PR TITLE
Exclude system indices from remote cluster state

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -803,17 +803,7 @@ public class GatewayMetaState implements Closeable {
         }
 
         private boolean verifyManifestAndClusterState(ClusterMetadataManifest manifest, ClusterState clusterState) {
-            assert manifest != null : "ClusterMetadataManifest is null";
-            assert clusterState != null : "ClusterState is null";
-            assert clusterState.metadata().indices().size() == manifest.getIndices().size()
-                : "Number of indices in last accepted state and manifest are different";
-            manifest.getIndices().stream().forEach(md -> {
-                assert clusterState.metadata().indices().containsKey(md.getIndexName())
-                    : "Last accepted state does not contain the index : " + md.getIndexName();
-                assert clusterState.metadata().indices().get(md.getIndexName()).getIndexUUID().equals(md.getIndexUUID())
-                    : "Last accepted state and manifest do not have same UUID for index : " + md.getIndexName();
-            });
-            return true;
+            return remoteClusterStateService.verifyManifestMatchesClusterState(manifest, clusterState);
         }
 
         private boolean shouldWriteFullClusterState(ClusterState clusterState) {

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateIndexFilter.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateIndexFilter.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedIndexMetadata;
+import org.opensearch.indices.SystemIndices;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Excludes system indices from remote cluster state publication and restore. System index documents are stored on
+ * local disk; publishing only their {@link IndexMetadata} to remote cluster state causes unrecoverable ghost indices
+ * after nodes restart with empty local storage.
+ *
+ * @opensearch.internal
+ */
+class RemoteClusterStateIndexFilter {
+
+    private final SystemIndices systemIndices;
+
+    RemoteClusterStateIndexFilter(SystemIndices systemIndices) {
+        this.systemIndices = systemIndices;
+    }
+
+    boolean includeIndex(String indexName) {
+        return systemIndices.isSystemIndex(indexName) == false;
+    }
+
+    List<IndexMetadata> filterIndexMetadata(Collection<IndexMetadata> indices) {
+        return indices.stream().filter(indexMetadata -> includeIndex(indexMetadata.getIndex().getName())).collect(Collectors.toList());
+    }
+
+    List<UploadedIndexMetadata> filterUploadedIndexMetadata(List<UploadedIndexMetadata> indices) {
+        if (indices.isEmpty()) {
+            return indices;
+        }
+        return indices.stream()
+            .filter(uploadedIndexMetadata -> includeIndex(uploadedIndexMetadata.getIndexName()))
+            .collect(Collectors.toList());
+    }
+
+    List<IndexRoutingTable> filterIndexRoutingTables(List<IndexRoutingTable> indexRoutingTables) {
+        if (indexRoutingTables == null || indexRoutingTables.isEmpty()) {
+            return indexRoutingTables;
+        }
+        return indexRoutingTables.stream()
+            .filter(indexRoutingTable -> includeIndex(indexRoutingTable.getIndex().getName()))
+            .collect(Collectors.toList());
+    }
+
+    void removeSystemIndicesFromUploadedMetadataMap(Map<String, UploadedIndexMetadata> uploadedIndexMetadataByName) {
+        uploadedIndexMetadataByName.keySet().removeIf(indexName -> includeIndex(indexName) == false);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -62,6 +62,7 @@ import org.opensearch.gateway.remote.model.RemoteTemplatesMetadata;
 import org.opensearch.gateway.remote.model.RemoteTransientSettingsMetadata;
 import org.opensearch.gateway.remote.routingtable.RemoteRoutingTableDiff;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.SystemIndices;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
@@ -241,6 +242,7 @@ public class RemoteClusterStateService implements Closeable {
     private RemoteManifestManager remoteManifestManager;
     private ClusterSettings clusterSettings;
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final RemoteClusterStateIndexFilter indexFilter;
     private final String CLUSTER_STATE_UPLOAD_TIME_LOG_STRING = "writing cluster state for version [{}] took [{}ms]";
     private final String METADATA_UPDATE_LOG_STRING = "wrote metadata for [{}] indices and skipped [{}] unchanged "
         + "indices, coordination metadata updated : [{}], settings metadata updated : [{}], templates metadata "
@@ -271,7 +273,8 @@ public class RemoteClusterStateService implements Closeable {
         ThreadPool threadPool,
         List<IndexMetadataUploadListener> indexMetadataUploadListeners,
         NamedWriteableRegistry namedWriteableRegistry,
-        LongSupplier applicationDurationMsSupplier
+        LongSupplier applicationDurationMsSupplier,
+        SystemIndices systemIndices
     ) {
         assert isRemoteClusterStateConfigured(settings) : "Remote cluster state is not configured";
         this.nodeId = nodeId;
@@ -280,6 +283,7 @@ public class RemoteClusterStateService implements Closeable {
         this.relativeTimeNanosSupplier = relativeTimeNanosSupplier;
         this.applicationDurationMsSupplier = applicationDurationMsSupplier;
         this.threadpool = threadPool;
+        this.indexFilter = new RemoteClusterStateIndexFilter(systemIndices);
         clusterSettings = clusterService.getClusterSettings();
         this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
         clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
@@ -328,7 +332,7 @@ public class RemoteClusterStateService implements Closeable {
         boolean publicationEnabled = isPublicationEnabled.get();
         UploadedMetadataResults uploadedMetadataResults = writeMetadataInParallel(
             clusterState,
-            new ArrayList<>(clusterState.metadata().indices().values()),
+            indexFilter.filterIndexMetadata(clusterState.metadata().indices().values()),
             emptyMap(),
             RemoteGlobalMetadataManager.filterCustoms(clusterState.metadata().customs(), publicationEnabled),
             true,
@@ -339,7 +343,7 @@ public class RemoteClusterStateService implements Closeable {
             publicationEnabled,
             publicationEnabled ? clusterState.customs() : Collections.emptyMap(),
             publicationEnabled,
-            remoteRoutingTableService.getIndicesRouting(clusterState.getRoutingTable()),
+            indexFilter.filterIndexRoutingTables(remoteRoutingTableService.getIndicesRouting(clusterState.getRoutingTable())),
             null
         );
 
@@ -382,6 +386,25 @@ public class RemoteClusterStateService implements Closeable {
             );
         }
         return manifestDetails;
+    }
+
+    /**
+     * Verifies that the uploaded manifest matches the cluster state after excluding system indices from remote publication.
+     */
+    @InternalApi
+    public boolean verifyManifestMatchesClusterState(ClusterMetadataManifest manifest, ClusterState clusterState) {
+        assert manifest != null : "ClusterMetadataManifest is null";
+        assert clusterState != null : "ClusterState is null";
+        List<IndexMetadata> indicesInManifest = indexFilter.filterIndexMetadata(clusterState.metadata().indices().values());
+        assert indicesInManifest.size() == manifest.getIndices().size()
+            : "Number of indices in last accepted state and manifest are different";
+        manifest.getIndices().forEach(md -> {
+            assert clusterState.metadata().indices().containsKey(md.getIndexName()) : "Last accepted state does not contain the index : "
+                + md.getIndexName();
+            assert clusterState.metadata().indices().get(md.getIndexName()).getIndexUUID().equals(md.getIndexUUID())
+                : "Last accepted state and manifest do not have same UUID for index : " + md.getIndexName();
+        });
+        return true;
     }
 
     /**
@@ -429,12 +452,17 @@ public class RemoteClusterStateService implements Closeable {
         final Map<String, ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndexMetadata = previousManifest.getIndices()
             .stream()
             .collect(Collectors.toMap(UploadedIndexMetadata::getIndexName, Function.identity()));
+        indexFilter.removeSystemIndicesFromUploadedMetadataMap(allUploadedIndexMetadata);
 
         List<IndexMetadata> toUpload = new ArrayList<>();
         // We prepare a map that contains the previous index metadata for the indexes for which version has changed.
         Map<String, IndexMetadata> prevIndexMetadataByName = new HashMap<>();
         for (final IndexMetadata indexMetadata : clusterState.metadata().indices().values()) {
             String indexName = indexMetadata.getIndex().getName();
+            if (indexFilter.includeIndex(indexName) == false) {
+                indicesToBeDeletedFromRemote.remove(indexName);
+                continue;
+            }
             final IndexMetadata prevIndexMetadata = indicesToBeDeletedFromRemote.get(indexName);
             Long previousVersion = prevIndexMetadata != null ? prevIndexMetadata.getVersion() : null;
             if (previousVersion == null || indexMetadata.getVersion() != previousVersion) {
@@ -467,6 +495,8 @@ public class RemoteClusterStateService implements Closeable {
             routingTableDiff.provideDiff().getUpserts().forEach((k, v) -> indicesRoutingToUpload.add(v));
             deletedIndicesRouting.addAll(routingTableDiff.provideDiff().getDeletes());
         }
+        indicesRoutingToUpload.removeIf(indexRoutingTable -> indexFilter.includeIndex(indexRoutingTable.getIndex().getName()) == false);
+        deletedIndicesRouting.removeIf(indexName -> indexFilter.includeIndex(indexName) == false);
 
         UploadedMetadataResults uploadedMetadataResults;
         // For migration case from codec V0 or V1 to V2, we have added null check on metadata attribute files,
@@ -1587,7 +1617,7 @@ public class RemoteClusterStateService implements Closeable {
                     manifest,
                     manifest.getClusterUUID(),
                     localNodeId,
-                    manifest.getIndices(),
+                    indexFilter.filterUploadedIndexMetadata(manifest.getIndices()),
                     manifest.getCustomMetadataMap(),
                     manifest.getCoordinationMetadata() != null,
                     manifest.getSettingsMetadata() != null,
@@ -1595,7 +1625,7 @@ public class RemoteClusterStateService implements Closeable {
                     manifest.getTemplatesMetadata() != null,
                     includeEphemeral && manifest.getDiscoveryNodesMetadata() != null,
                     includeEphemeral && manifest.getClusterBlocksMetadata() != null,
-                    includeEphemeral ? manifest.getIndicesRouting() : emptyList(),
+                    includeEphemeral ? indexFilter.filterUploadedIndexMetadata(manifest.getIndicesRouting()) : emptyList(),
                     includeEphemeral && manifest.getHashesOfConsistentSettings() != null,
                     includeEphemeral ? manifest.getClusterStateCustomMap() : emptyMap(),
                     false,
@@ -1613,7 +1643,7 @@ public class RemoteClusterStateService implements Closeable {
                     manifest,
                     manifest.getClusterUUID(),
                     localNodeId,
-                    manifest.getIndices(),
+                    indexFilter.filterUploadedIndexMetadata(manifest.getIndices()),
                     // for manifest codec V1, we don't have the following objects to read, so not passing anything
                     emptyMap(),
                     false,
@@ -1654,14 +1684,16 @@ public class RemoteClusterStateService implements Closeable {
             ClusterStateDiffManifest diff = manifest.getDiffManifest();
             boolean includeEphemeral = true;
 
-            List<UploadedIndexMetadata> updatedIndices = diff.getIndicesUpdated().stream().map(idx -> {
-                Optional<UploadedIndexMetadata> uploadedIndexMetadataOptional = manifest.getIndices()
-                    .stream()
-                    .filter(idx2 -> idx2.getIndexName().equals(idx))
-                    .findFirst();
-                assert uploadedIndexMetadataOptional.isPresent() == true;
-                return uploadedIndexMetadataOptional.get();
-            }).collect(Collectors.toList());
+            List<UploadedIndexMetadata> updatedIndices = indexFilter.filterUploadedIndexMetadata(
+                diff.getIndicesUpdated().stream().map(idx -> {
+                    Optional<UploadedIndexMetadata> uploadedIndexMetadataOptional = manifest.getIndices()
+                        .stream()
+                        .filter(idx2 -> idx2.getIndexName().equals(idx))
+                        .findFirst();
+                    assert uploadedIndexMetadataOptional.isPresent() == true;
+                    return uploadedIndexMetadataOptional.get();
+                }).collect(Collectors.toList())
+            );
 
             Map<String, UploadedMetadataAttribute> updatedCustomMetadata = new HashMap<>();
             if (diff.getCustomMetadataUpdated() != null) {
@@ -1679,9 +1711,11 @@ public class RemoteClusterStateService implements Closeable {
             List<UploadedIndexMetadata> updatedIndexRouting = new ArrayList<>();
             if (manifest.getCodecVersion() == CODEC_V2 || manifest.getCodecVersion() == CODEC_V3) {
                 updatedIndexRouting.addAll(
-                    remoteRoutingTableService.getUpdatedIndexRoutingTableMetadata(
-                        diff.getIndicesRoutingUpdated(),
-                        manifest.getIndicesRouting()
+                    indexFilter.filterUploadedIndexMetadata(
+                        remoteRoutingTableService.getUpdatedIndexRoutingTableMetadata(
+                            diff.getIndicesRoutingUpdated(),
+                            manifest.getIndicesRouting()
+                        )
                     )
                 );
             }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -923,7 +923,8 @@ public class Node implements Closeable {
                     List.of(remoteIndexPathUploader),
                     namedWriteableRegistry,
                     // Supplier for current cluster state application duration in ms (0 if idle)
-                    () -> clusterService.getClusterApplierService().getCurrentApplicationDurationMs()
+                    () -> clusterService.getClusterApplierService().getCurrentApplicationDurationMs(),
+                    systemIndices
                 );
                 remoteClusterStateCleanupManager = remoteClusterStateService.getCleanupManager();
             } else {

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -74,6 +74,7 @@ import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.index.recovery.RemoteStoreRestoreService.RemoteRestoreResult;
 import org.opensearch.index.remote.RemoteIndexPathUploader;
 import org.opensearch.indices.DefaultRemoteStoreSettings;
+import org.opensearch.indices.SystemIndices;
 import org.opensearch.node.Node;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.fs.FsRepository;
@@ -152,6 +153,12 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
         nodeEnvironment.close();
         IOUtils.close(gateway);
         super.tearDown();
+    }
+
+    private static RemoteClusterStateService mockRemoteClusterStateService() {
+        RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        when(remoteClusterStateService.verifyManifestMatchesClusterState(any(), any())).thenReturn(true);
+        return remoteClusterStateService;
     }
 
     private CoordinationState.PersistedState newGatewayPersistedState() throws IOException {
@@ -525,7 +532,8 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
                             )
                         ),
                         writableRegistry(),
-                        () -> 0L
+                        () -> 0L,
+                        new SystemIndices(Collections.emptyMap())
                     );
                 } else {
                     return null;
@@ -757,7 +765,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     }
 
     public void testRemotePersistedState() throws IOException {
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final ClusterMetadataManifest manifest = ClusterMetadataManifest.builder().clusterTerm(1L).stateVersion(5L).build();
         final String previousClusterUUID = "prev-cluster-uuid";
         Mockito.when(remoteClusterStateService.writeFullMetadata(Mockito.any(), Mockito.any()))
@@ -814,7 +822,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     }
 
     public void testRemotePersistedStateWithDifferentNodeConfiguration() throws IOException {
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final String previousClusterUUID = "prev-cluster-uuid";
         final ClusterMetadataManifest manifest = ClusterMetadataManifest.builder()
             .clusterTerm(1L)
@@ -864,7 +872,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     }
 
     public void testRemotePersistentState_FollowerNode() throws IOException {
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final ClusterMetadataManifest manifest = ClusterMetadataManifest.builder()
             .clusterTerm(1L)
             .stateVersion(5L)
@@ -929,7 +937,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     }
 
     public void testRemotePersistedStateNotCommitted() throws IOException {
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final String previousClusterUUID = "prev-cluster-uuid";
         final ClusterMetadataManifest manifest = ClusterMetadataManifest.builder()
             .previousClusterUUID(previousClusterUUID)
@@ -969,7 +977,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     }
 
     public void testRemotePersistedStateExceptionOnFullStateUpload() throws IOException {
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final String previousClusterUUID = "prev-cluster-uuid";
         Mockito.doThrow(IOException.class).when(remoteClusterStateService).writeFullMetadata(Mockito.any(), Mockito.any());
 
@@ -987,7 +995,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
 
     public void testRemotePersistedStateFailureStats() throws IOException {
         RemoteUploadStats remoteStateStats = new RemoteUploadStats();
-        final RemoteClusterStateService remoteClusterStateService = Mockito.mock(RemoteClusterStateService.class);
+        final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
         final String previousClusterUUID = "prev-cluster-uuid";
         Mockito.doThrow(IOException.class).when(remoteClusterStateService).writeFullMetadata(Mockito.any(), Mockito.any());
         when(remoteClusterStateService.getUploadStats()).thenReturn(remoteStateStats);
@@ -1012,7 +1020,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     public void testGatewayForRemoteState() throws IOException {
         MockGatewayMetaState gateway = null;
         try {
-            RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster")).thenReturn("test-cluster-uuid");
             RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
             when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenReturn(
@@ -1058,7 +1066,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     public void testGatewayForRemoteStateForInitialBootstrap() throws IOException {
         MockGatewayMetaState gateway = null;
         try {
-            final RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote(clusterName.value())).thenReturn(ClusterState.UNKNOWN_UUID);
 
             final RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
@@ -1087,7 +1095,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     public void testGatewayForRemoteStateForNodeReplacement() throws IOException {
         MockGatewayMetaState gateway = null;
         try {
-            final RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster")).thenReturn("test-cluster-uuid");
             final ClusterState previousState = createClusterState(
                 randomNonNegativeLong(),
@@ -1135,7 +1143,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     public void testGatewayForRemoteStateForNodeReboot() throws IOException {
         MockGatewayMetaState gateway = null;
         try {
-            final RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             final RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
             final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
             final IndexMetadata indexMetadata = IndexMetadata.builder("test-index1")
@@ -1176,7 +1184,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
     public void testGatewayForRemoteStateForInitialBootstrapBlocksApplied() throws IOException {
         MockGatewayMetaState gateway = null;
         try {
-            final RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            final RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote(clusterName.value())).thenReturn("test-cluster-uuid");
 
             final IndexMetadata indexMetadata = IndexMetadata.builder("test-index1")
@@ -1241,7 +1249,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
         MockGatewayMetaState gateway = null;
         MockGatewayMetaState gatewayMetaStateSpy = null;
         try {
-            RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster")).thenReturn("test-cluster-uuid");
             RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
             when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenThrow(
@@ -1267,7 +1275,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
         MockGatewayMetaState gateway = null;
         final MockGatewayMetaState gatewayMetaStateSpy;
         try {
-            RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
+            RemoteClusterStateService remoteClusterStateService = mockRemoteClusterStateService();
             when(remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster")).thenReturn("test-cluster-uuid");
             RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
             when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenThrow(

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateIndexFilterTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateIndexFilterTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedIndexMetadata;
+import org.opensearch.indices.SystemIndexDescriptor;
+import org.opensearch.indices.SystemIndices;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RemoteClusterStateIndexFilterTests extends OpenSearchTestCase {
+
+    private static final String SYSTEM_INDEX = ".test-system-index";
+    private static final String USER_INDEX = "user-index";
+
+    private final RemoteClusterStateIndexFilter indexFilter = new RemoteClusterStateIndexFilter(
+        new SystemIndices(Map.of("test-plugin", List.of(new SystemIndexDescriptor(SYSTEM_INDEX, "test system index"))))
+    );
+
+    public void testIncludeIndex() {
+        assertTrue(indexFilter.includeIndex(USER_INDEX));
+        assertFalse(indexFilter.includeIndex(SYSTEM_INDEX));
+    }
+
+    public void testFilterIndexMetadata() {
+        IndexMetadata systemIndexMetadata = indexMetadata(SYSTEM_INDEX, "uuid-1");
+        IndexMetadata userIndexMetadata = indexMetadata(USER_INDEX, "uuid-2");
+        List<IndexMetadata> filtered = indexFilter.filterIndexMetadata(List.of(systemIndexMetadata, userIndexMetadata));
+        assertEquals(1, filtered.size());
+        assertEquals(USER_INDEX, filtered.get(0).getIndex().getName());
+    }
+
+    public void testFilterUploadedIndexMetadata() {
+        UploadedIndexMetadata systemIndex = new UploadedIndexMetadata(SYSTEM_INDEX, "uuid-1", "system-file");
+        UploadedIndexMetadata userIndex = new UploadedIndexMetadata(USER_INDEX, "uuid-2", "user-file");
+        List<UploadedIndexMetadata> filtered = indexFilter.filterUploadedIndexMetadata(List.of(systemIndex, userIndex));
+        assertEquals(1, filtered.size());
+        assertEquals(USER_INDEX, filtered.get(0).getIndexName());
+    }
+
+    public void testRemoveSystemIndicesFromUploadedMetadataMap() {
+        Map<String, UploadedIndexMetadata> uploaded = new HashMap<>();
+        uploaded.put(SYSTEM_INDEX, new UploadedIndexMetadata(SYSTEM_INDEX, "uuid-1", "system-file"));
+        uploaded.put(USER_INDEX, new UploadedIndexMetadata(USER_INDEX, "uuid-2", "user-file"));
+        indexFilter.removeSystemIndicesFromUploadedMetadataMap(uploaded);
+        assertEquals(1, uploaded.size());
+        assertTrue(uploaded.containsKey(USER_INDEX));
+    }
+
+    public void testEmptySystemIndicesRegistryIncludesAllIndices() {
+        RemoteClusterStateIndexFilter noSystemIndicesFilter = new RemoteClusterStateIndexFilter(new SystemIndices(Collections.emptyMap()));
+        assertTrue(noSystemIndicesFilter.includeIndex(SYSTEM_INDEX));
+        assertTrue(noSystemIndicesFilter.includeIndex(USER_INDEX));
+    }
+
+    private static IndexMetadata indexMetadata(String indexName, String indexUUID) {
+        return new IndexMetadata.Builder(indexName).settings(
+            org.opensearch.common.settings.Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
+                .build()
+        ).numberOfShards(1).numberOfReplicas(0).build();
+    }
+
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -66,6 +66,8 @@ import org.opensearch.index.remote.RemoteIndexPathUploader;
 import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.indices.IndicesModule;
+import org.opensearch.indices.SystemIndexDescriptor;
+import org.opensearch.indices.SystemIndices;
 import org.opensearch.repositories.FilterRepository;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -264,7 +266,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             namedWriteableRegistry,
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
     }
 
@@ -307,7 +310,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                     )
                 ),
                 writableRegistry(),
-                () -> 0L
+                () -> 0L,
+                new SystemIndices(Collections.emptyMap())
             )
         );
     }
@@ -363,6 +367,45 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         assertThat(manifest.getClusterStateCustomMap().size(), is(0));
     }
 
+    public void testWriteFullMetadataExcludesSystemIndices() throws IOException {
+        final String systemIndexName = ".test-system-index";
+        remoteClusterStateService.close();
+        remoteClusterStateService = new RemoteClusterStateService(
+            "test-node-id",
+            repositoriesServiceSupplier,
+            settings,
+            clusterService,
+            () -> 0L,
+            threadPool,
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    settings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
+            namedWriteableRegistry,
+            () -> 0L,
+            new SystemIndices(Map.of("test-plugin", List.of(new SystemIndexDescriptor(systemIndexName, "test system index"))))
+        );
+        final ClusterState clusterStateWithUserIndex = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        final IndexMetadata systemIndexMetadata = generateClusterStateWithOneIndex(systemIndexName, 1, 0, true).build()
+            .metadata()
+            .index(systemIndexName);
+        final ClusterState clusterState = ClusterState.builder(clusterStateWithUserIndex)
+            .metadata(Metadata.builder(clusterStateWithUserIndex.metadata()).put(systemIndexMetadata, true).build())
+            .build();
+        mockBlobStoreObjects();
+        remoteClusterStateService.start();
+        final ClusterMetadataManifest manifest = remoteClusterStateService.writeFullMetadata(clusterState, "prev-cluster-uuid")
+            .getClusterMetadataManifest();
+        assertThat(manifest.getIndices().size(), is(1));
+        assertThat(manifest.getIndices().get(0).getIndexName(), is("test-index"));
+        assertFalse(manifest.getIndices().stream().anyMatch(index -> index.getIndexName().equals(systemIndexName)));
+    }
+
     public void testWriteFullMetadataSuccessPublicationEnabled() throws IOException {
         // TODO Make the publication flag parameterized
         publicationEnabled = true;
@@ -386,7 +429,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             writableRegistry(),
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
         assertTrue(remoteClusterStateService.isRemotePublicationEnabled());
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager())
@@ -761,7 +805,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             writableRegistry(),
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
         assertTrue(remoteClusterStateService.isRemotePublicationEnabled());
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
@@ -2803,7 +2848,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             writableRegistry(),
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
         assertTrue(remoteClusterStateService.getRemoteRoutingTableService() instanceof InternalRemoteRoutingTableService);
     }
@@ -3076,7 +3122,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             writableRegistry(),
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
     }
 
@@ -3107,7 +3154,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 )
             ),
             writableRegistry(),
-            () -> 0L
+            () -> 0L,
+            new SystemIndices(Collections.emptyMap())
         );
     }
 


### PR DESCRIPTION
## Summary

Exclude system indices from remote cluster state **publish**, **restore**, and **manifest verification** using the existing `SystemIndices` registry.

Fixes #21043.

## Problem

Remote cluster state persists **index metadata only** — not index documents. System indices such as `.opendistro_security` store their configuration as documents on **local disk**.

When remote cluster state was enabled, system index metadata was uploaded alongside user indices. After a node restart with empty local storage (e.g. Kubernetes `emptyDir`), OpenSearch restored that metadata from remote while the on-disk documents were gone. Plugins like security then saw the index as already existing (`ResourceAlreadyExistsException`) and never finished initialization (`OpenSearch Security not initialized`).

## Solution

Introduce `RemoteClusterStateIndexFilter`, backed by `SystemIndices`, and apply it consistently across remote cluster state paths:

- **Full write** (`writeFullMetadata`): skip system index metadata and routing on upload
- **Incremental write** (`writeIncrementalMetadata`): skip system indices from upload/diff computation; strip them from the previous manifest map used for incremental updates
- **Restore** (`getClusterStateForManifest`, `getClusterStateUsingDiff`): filter system indices out of downloaded manifests before rebuilding cluster state
- **Manifest verification** (`verifyManifestMatchesClusterState`): compare manifest entries against the filtered set of cluster indices so publication succeeds when system indices are present locally

`GatewayMetaState.RemotePersistedState` delegates manifest checks to `RemoteClusterStateService`, and `Node` wires `SystemIndices` into the service constructor.

