### PR TITLE
Compile native Rust benchmarks during check

### DIFF
--- a/sandbox/libs/dataformat-native/build.gradle
+++ b/sandbox/libs/dataformat-native/build.gradle
@@ -60,21 +60,20 @@ def buildType = project.hasProperty('rustDebug') ? 'debug' : 'release'
 def rustWorkspaceDir = file("${projectDir}/rust")
 def nativeLibFile = file("${rustWorkspaceDir}/target/${buildType}/${libPrefix}${nativeLibName}${libExtension}")
 
+def cargoExecutable = 'cargo'
+def possibleCargoPaths = [
+    System.getenv('HOME') + '/.cargo/bin/cargo',
+    '/usr/local/bin/cargo',
+    'cargo'
+]
+for (String path : possibleCargoPaths) {
+    if (new File(path).exists()) { cargoExecutable = path; break }
+}
+
 task buildRustLibrary(type: Exec) {
     description = 'Build the unified Rust native library from the Cargo workspace'
     group = 'build'
     workingDir rustWorkspaceDir
-
-    def cargoExecutable = 'cargo'
-    def possibleCargoPaths = [
-        System.getenv('HOME') + '/.cargo/bin/cargo',
-        '/usr/local/bin/cargo',
-        'cargo'
-    ]
-    for (String path : possibleCargoPaths) {
-        if (new File(path).exists()) { cargoExecutable = path; break }
-    }
-
     def cargoArgs = [cargoExecutable, 'build', '-p', 'opensearch-native-lib']
     if (buildType == 'release') { cargoArgs.add('--release') }
     commandLine cargoArgs
@@ -95,6 +94,51 @@ task buildRustLibrary(type: Exec) {
     outputs.file nativeLibFile
 }
 
+task cargoBenchCheckDataFusion(type: Exec) {
+    description = 'Compile opensearch-datafusion Rust benchmarks without running them'
+    group = 'verification'
+    workingDir rustWorkspaceDir
+    def cargoArgs = [cargoExecutable, 'bench', '-p', 'opensearch-datafusion']
+    if (buildType == 'debug') { cargoArgs.addAll(['--profile', 'dev']) }
+    cargoArgs.add('--no-run')
+    commandLine cargoArgs
+
+    inputs.files fileTree("${projectDir}/../../plugins/analytics-backend-datafusion/rust/src")
+    inputs.files fileTree("${projectDir}/../../plugins/analytics-backend-datafusion/rust/benches")
+    inputs.file "${projectDir}/../../plugins/analytics-backend-datafusion/rust/Cargo.toml"
+    inputs.files fileTree("${rustWorkspaceDir}/common/src")
+    inputs.files fileTree("${rustWorkspaceDir}/lib/src")
+    inputs.file "${rustWorkspaceDir}/Cargo.toml"
+    inputs.file "${rustWorkspaceDir}/Cargo.lock"
+    outputs.file "${rustWorkspaceDir}/target/${buildType}/gradle-cargoBenchCheckDataFusion.stamp"
+    doLast {
+        file("${rustWorkspaceDir}/target/${buildType}").mkdirs()
+        file("${rustWorkspaceDir}/target/${buildType}/gradle-cargoBenchCheckDataFusion.stamp").text = new Date().toString()
+    }
+}
+
+task cargoBenchCheckParquet(type: Exec) {
+    description = 'Compile opensearch-parquet-format Rust benchmarks without running them'
+    group = 'verification'
+    workingDir rustWorkspaceDir
+    def cargoArgs = [cargoExecutable, 'bench', '-p', 'opensearch-parquet-format']
+    if (buildType == 'debug') { cargoArgs.addAll(['--profile', 'dev']) }
+    cargoArgs.add('--no-run')
+    commandLine cargoArgs
+
+    inputs.files fileTree("${projectDir}/../../plugins/parquet-data-format/src/main/rust/src")
+    inputs.files fileTree("${projectDir}/../../plugins/parquet-data-format/src/main/rust/benches")
+    inputs.file "${projectDir}/../../plugins/parquet-data-format/src/main/rust/Cargo.toml"
+    inputs.files fileTree("${rustWorkspaceDir}/common/src")
+    inputs.file "${rustWorkspaceDir}/Cargo.toml"
+    inputs.file "${rustWorkspaceDir}/Cargo.lock"
+    outputs.file "${rustWorkspaceDir}/target/${buildType}/gradle-cargoBenchCheckParquet.stamp"
+    doLast {
+        file("${rustWorkspaceDir}/target/${buildType}").mkdirs()
+        file("${rustWorkspaceDir}/target/${buildType}/gradle-cargoBenchCheckParquet.stamp").text = new Date().toString()
+    }
+}
+
 // External override: reuse a prebuilt .dylib from another worktree, a blessed shared copy,
 // or a CI-provided binary. Set OPENSEARCH_NATIVE_LIB (env) or -PnativeLibOverride to an
 // absolute .dylib/.so/.dll path; buildRustLibrary is skipped and nativeLibPath resolves to
@@ -106,6 +150,8 @@ ext.nativeLibPath = resolvedNativeLib
 buildRustLibrary.onlyIf { nativeLibOverride == null }
 
 assemble.dependsOn buildRustLibrary
+check.dependsOn cargoBenchCheckDataFusion
+check.dependsOn cargoBenchCheckParquet
 
 test {
     systemProperty 'tests.security.manager', 'false'

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/cross_rt_throughput_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/cross_rt_throughput_bench.rs
@@ -44,7 +44,7 @@ fn test_batch(rows: usize) -> RecordBatch {
 fn make_executor() -> DedicatedExecutor {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(4).enable_all();
-    DedicatedExecutor::new("bench-cpu", builder)
+    DedicatedExecutor::new("bench-cpu", builder, 4)
 }
 
 /// Benchmark: push N batches through CrossRtStream and consume them.
@@ -86,8 +86,7 @@ fn bench_cross_rt_throughput(c: &mut Criterion) {
                             stream::iter(batches),
                         ));
 
-                        let cross =
-                            CrossRtStream::new_with_df_error_stream(inner, exec.clone());
+                        let cross = CrossRtStream::new_with_df_error_stream(inner, exec.clone());
                         let wrapped = RecordBatchStreamAdapter::new(cross.schema(), cross);
                         tokio::pin!(wrapped);
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/query_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/query_bench.rs
@@ -7,6 +7,7 @@ use futures::TryStreamExt;
 use object_store::local::LocalFileSystem;
 use object_store::{ObjectStore, ObjectStoreExt};
 use opensearch_datafusion::api::DataFusionRuntime;
+use opensearch_datafusion::datafusion_query_config::{DatafusionQueryConfig, InternalSearch};
 use opensearch_datafusion::query_executor;
 use opensearch_datafusion::runtime_manager::RuntimeManager;
 use std::sync::Arc;
@@ -51,7 +52,7 @@ fn setup() -> (RuntimeManager, DataFusionRuntime, tempfile::TempDir) {
     (mgr, df_runtime, tmp)
 }
 
-fn get_substrait(mgr: &RuntimeManager, df: &DataFusionRuntime, dir: &str, sql: &str) -> Vec<u8> {
+fn get_substrait(mgr: &RuntimeManager, _df: &DataFusionRuntime, dir: &str, sql: &str) -> Vec<u8> {
     use datafusion::datasource::file_format::parquet::ParquetFormat;
     use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
     use datafusion_substrait::logical_plan::producer::to_substrait_plan;
@@ -93,43 +94,48 @@ fn bench_execute_query(c: &mut Criterion) {
         let plan = get_substrait(&mgr, &df_runtime, dir, "SELECT id, value FROM t");
         let url = ListingTableUrl::parse(dir).unwrap();
 
-        c.bench_with_input(
-            BenchmarkId::new("execute_query", rows),
-            &rows,
-            |b, _| {
-                b.to_async(mgr.io_runtime.as_ref()).iter(|| {
-                    let url = url.clone();
-                    let metas = metas.clone();
-                    let plan = plan.clone();
-                    let exec = mgr.cpu_executor();
-                    async {
-                        let ptr = query_executor::execute_query(
-                            url,
-                            metas,
-                            "t".into(),
-                            plan,
-                            &df_runtime,
-                            exec,
-                            None,
-                            &opensearch_datafusion::datafusion_query_config::DatafusionQueryConfig::test_default(),
-                            0,
-                            Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
-                        ).await.unwrap();
-                        // Consume and free the stream
-                        let mut stream = unsafe {
-                            Box::from_raw(ptr as *mut datafusion::physical_plan::stream::RecordBatchStreamAdapter<
-                                opensearch_datafusion::cross_rt_stream::CrossRtStream,
-                            >)
-                        };
-                        let mut count = 0u64;
-                        while let Some(batch) = stream.try_next().await.unwrap() {
-                            count += batch.num_rows() as u64;
-                        }
-                        count
+        c.bench_with_input(BenchmarkId::new("execute_query", rows), &rows, |b, _| {
+            b.to_async(mgr.io_runtime.as_ref()).iter(|| {
+                let url = url.clone();
+                let metas = metas.clone();
+                let plan = plan.clone();
+                let exec = mgr.cpu_executor();
+                async {
+                    let ptr = query_executor::execute_query(
+                        url,
+                        metas,
+                        "t".into(),
+                        plan,
+                        &df_runtime,
+                        exec,
+                        None,
+                        &DatafusionQueryConfig::test_default(),
+                        0,
+                        Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                        None,
+                        &[],
+                        &[],
+                        InternalSearch::Off,
+                    )
+                    .await
+                    .unwrap();
+                    // Consume and free the stream
+                    let mut stream = unsafe {
+                        Box::from_raw(
+                            ptr
+                                as *mut datafusion::physical_plan::stream::RecordBatchStreamAdapter<
+                                    opensearch_datafusion::cross_rt_stream::CrossRtStream,
+                                >,
+                        )
+                    };
+                    let mut count = 0u64;
+                    while let Some(batch) = stream.try_next().await.unwrap() {
+                        count += batch.num_rows() as u64;
                     }
-                });
-            },
-        );
+                    count
+                }
+            });
+        });
     }
     mgr.cpu_executor.shutdown();
     std::mem::forget(mgr);
@@ -158,10 +164,13 @@ fn bench_stream_next(c: &mut Criterion) {
                     &df_runtime,
                     exec,
                     None,
-                    &opensearch_datafusion::datafusion_query_config::DatafusionQueryConfig::test_default(
-                    ),
+                    &DatafusionQueryConfig::test_default(),
                     0,
                     Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                    None,
+                    &[],
+                    &[],
+                    InternalSearch::Off,
                 )
                 .await
                 .unwrap();
@@ -208,10 +217,13 @@ fn bench_aggregation(c: &mut Criterion) {
                     &df_runtime,
                     exec,
                     None,
-                    &opensearch_datafusion::datafusion_query_config::DatafusionQueryConfig::test_default(
-                    ),
+                    &DatafusionQueryConfig::test_default(),
                     0,
                     Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                    None,
+                    &[],
+                    &[],
+                    InternalSearch::Off,
                 )
                 .await
                 .unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/row_id_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/row_id_bench.rs
@@ -22,8 +22,7 @@ use futures::TryStreamExt;
 use object_store::local::LocalFileSystem;
 use object_store::{ObjectStore, ObjectStoreExt};
 use opensearch_datafusion::api::DataFusionRuntime;
-use opensearch_datafusion::datafusion_query_config::DatafusionQueryConfig;
-use opensearch_datafusion::memory::DynamicLimitPool;
+use opensearch_datafusion::datafusion_query_config::{DatafusionQueryConfig, InternalSearch};
 use opensearch_datafusion::query_executor;
 use opensearch_datafusion::runtime_manager::RuntimeManager;
 use std::sync::Arc;
@@ -46,17 +45,12 @@ fn bench_file() -> String {
 }
 
 fn setup() -> (RuntimeManager, DataFusionRuntime) {
-    let mgr = RuntimeManager::new(4);
+    let mgr = RuntimeManager::new(4, 1.5, 1.5);
     let runtime_env = RuntimeEnvBuilder::new()
         .with_memory_pool(Arc::new(GreedyMemoryPool::new(2 * 1024 * 1024 * 1024)))
         .build()
         .unwrap();
-    let (_, handle) = DynamicLimitPool::new(2 * 1024 * 1024 * 1024);
-    let df_runtime = DataFusionRuntime {
-        runtime_env,
-        custom_cache_manager: None,
-        dynamic_limit_handle: handle,
-    };
+    let df_runtime = DataFusionRuntime::new_for_bench(runtime_env);
     (mgr, df_runtime)
 }
 
@@ -113,6 +107,7 @@ fn bench_clickbench(c: &mut Criterion) {
     use opensearch_datafusion::indexed_table::table_provider::{
         IndexedTableConfig, IndexedTableProvider, SegmentFileInfo,
     };
+    use parquet::file::metadata::PageIndexPolicy;
 
     let (mgr, df_runtime) = setup();
     let file = bench_file();
@@ -123,8 +118,11 @@ fn bench_clickbench(c: &mut Criterion) {
     let path = std::path::Path::new(&file);
     let size = std::fs::metadata(path).unwrap().len();
     let fh = std::fs::File::open(path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&fh, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &fh,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Required),
+    )
+    .unwrap();
     let parquet_schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -148,6 +146,8 @@ fn bench_clickbench(c: &mut Criterion) {
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
         global_base: 0,
+        sort_min: None,
+        sort_max: None,
     };
 
     // Schema with ___row_id appended (virtual column)
@@ -208,14 +208,19 @@ fn bench_clickbench(c: &mut Criterion) {
                         &config,
                         0,
                         Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                        None,
+                        &[],
+                        &[],
+                        InternalSearch::Off,
                     )
                     .await
                     .unwrap();
                     let mut stream = unsafe {
                         Box::from_raw(
-                            ptr as *mut datafusion::physical_plan::stream::RecordBatchStreamAdapter<
-                                opensearch_datafusion::cross_rt_stream::CrossRtStream,
-                            >,
+                            ptr
+                                as *mut datafusion::physical_plan::stream::RecordBatchStreamAdapter<
+                                    opensearch_datafusion::cross_rt_stream::CrossRtStream,
+                                >,
                         )
                     };
                     let mut rows = 0u64;
@@ -263,7 +268,7 @@ fn bench_clickbench(c: &mut Criterion) {
                         let factory: opensearch_datafusion::indexed_table::table_provider::EvaluatorFactory = {
                             let tree = Arc::clone(&tree);
                             let schema = schema.clone();
-                            Arc::new(move |seg, _chunk, _sm| {
+                            Arc::new(move |seg, _chunk, _sm, stats_prune_tree| {
                                 let resolved = tree.resolve(&[])?;
                                 let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata)));
                                 let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -281,6 +286,8 @@ fn bench_clickbench(c: &mut Criterion) {
                                         opensearch_datafusion::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(_sm),
                                     ),
                                     collector_strategy: opensearch_datafusion::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                                    stats_prune_tree: stats_prune_tree.cloned(),
+                                    rg_index_to_pos: std::collections::HashMap::new(),
                                 });
                                 Ok(eval)
                             })
@@ -302,6 +309,10 @@ fn bench_clickbench(c: &mut Criterion) {
                             }),
                             predicate_columns: vec![search_phrase_idx],
                             emit_row_ids: true,
+                            prune_tree_config: None,
+                            sort_fields: vec![],
+                            sort_orders: vec![],
+                            cancellation_token: None,
                         }));
 
                         let ctx = datafusion::prelude::SessionContext::new();
@@ -353,7 +364,7 @@ fn bench_clickbench(c: &mut Criterion) {
                         let factory: opensearch_datafusion::indexed_table::table_provider::EvaluatorFactory = {
                             let tree = Arc::clone(&tree);
                             let schema = schema.clone();
-                            Arc::new(move |seg, _chunk, _sm| {
+                            Arc::new(move |seg, _chunk, _sm, stats_prune_tree| {
                                 let resolved = tree.resolve(&[])?;
                                 let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata)));
                                 let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
@@ -371,6 +382,8 @@ fn bench_clickbench(c: &mut Criterion) {
                                         opensearch_datafusion::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(_sm),
                                     ),
                                     collector_strategy: opensearch_datafusion::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                                    stats_prune_tree: stats_prune_tree.cloned(),
+                                    rg_index_to_pos: std::collections::HashMap::new(),
                                 });
                                 Ok(eval)
                             })
@@ -392,6 +405,10 @@ fn bench_clickbench(c: &mut Criterion) {
                             }),
                             predicate_columns: vec![search_phrase_idx],
                             emit_row_ids: false,
+                            prune_tree_config: None,
+                            sort_fields: vec![],
+                            sort_orders: vec![],
+                            cancellation_token: None,
                         }));
 
                         let ctx = datafusion::prelude::SessionContext::new();


### PR DESCRIPTION
### Description
Adds Gradle verification coverage for native Rust benchmark targets so `check` compiles them without running performance benchmarks.

The native bridge build already compiles `opensearch-native-lib`, but `cargo build -p opensearch-native-lib` does not compile benchmark targets. That allowed files under `benches/` to drift when Rust APIs changed without being caught by CI.

This change:

- Adds `cargoBenchCheckDataFusion` and `cargoBenchCheckParquet` in `sandbox/libs:dataformat-native`.
- Runs `cargo bench -p ... --no-run` for `opensearch-datafusion` and `opensearch-parquet-format`.
- Wires both tasks into `check`, keeping Gradle as the single build/check orchestration layer used locally and by CI.
- Uses one task per Rust crate with benchmarks, because Cargo discovers benchmark targets at the package level and these are the only workspace crates with benchmark targets today.
- Declares Rust source, benchmark, manifest, and lockfile inputs plus per-build-type stamp outputs, preserving Gradle incremental behavior and avoiding debug/release stamp reuse.
- Uses Cargo's `dev` profile when `-PrustDebug` is set, matching the sandbox workflow's debug Rust mode while keeping this verification step focused on compilation.
- Updates existing DataFusion benchmark sources to match current internal APIs while preserving their benchmark scenarios.

The benchmark source updates intentionally use neutral/default values for newly required API parameters:

- `DedicatedExecutor::new(..., 4)` matches the benchmark's existing 4 worker thread executor setup.
- New `execute_query` optional parameters are passed as `None`, empty slices, and `InternalSearch::Off`, so the existing query benchmark path remains unchanged.
- `DataFusionRuntime::new_for_bench(...)` uses the benchmark-specific runtime constructor instead of manually constructing runtime internals.
- New index/table fields are set to empty/default values, so sort metadata, prune config, and cancellation behavior are not enabled by this change.

Validation:

```bash
git diff --check
```

```bash
rustfmt --edition 2021 --check \
  sandbox/plugins/analytics-backend-datafusion/rust/benches/cross_rt_throughput_bench.rs \
  sandbox/plugins/analytics-backend-datafusion/rust/benches/query_bench.rs \
  sandbox/plugins/analytics-backend-datafusion/rust/benches/row_id_bench.rs
```

```bash
./gradlew :sandbox:libs:dataformat-native:check --dry-run \
  -Dsandbox.enabled=true \
  -PrustDebug
```

```bash
./gradlew \
  :sandbox:libs:dataformat-native:cargoBenchCheckParquet \
  :sandbox:libs:dataformat-native:cargoBenchCheckDataFusion \
  -Dsandbox.enabled=true \
  -PrustDebug \
  --rerun-tasks
```

### Related Issues
Resolves #21538

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. Not applicable; this does not change public APIs.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. Not applicable; this is a build validation change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
