### PR TITLE
[analytics-engine] Disable skip_partial_aggregation for multi-shard queries

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -200,6 +200,9 @@ pub async unsafe fn create_session_context(
 
     let mut config = SessionConfig::new();
     config.options_mut().execution.parquet.pushdown_filters = query_config.listing_table_pushdown_filters;
+    if has_partial_aggregate {
+        config.options_mut().execution.skip_partial_aggregation_probe_ratio_threshold = 1.0;
+    }
     config.options_mut().execution.target_partitions = effective_partitions;
     config.options_mut().execution.batch_size = effective_batch_size;
     // When the index has `index.sort.field`, ask DataFusion to use the sort-aware
@@ -826,5 +829,31 @@ mod tests {
         assert!(Arc::ptr_eq(&got_a, &store_a), "env_a must resolve to its own store");
         assert!(Arc::ptr_eq(&got_b, &store_b), "env_b must resolve to its own store");
         assert!(!Arc::ptr_eq(&got_a, &got_b), "per-query stores must be independent across queries");
+    }
+
+    #[test]
+    fn test_skip_partial_agg_disabled_when_has_partial_aggregate() {
+        // When has_partial_aggregate=true, skip_partial must be disabled (threshold=1.0)
+        let mut config = SessionConfig::new();
+        let has_partial = true;
+        if has_partial {
+            config.options_mut().execution.skip_partial_aggregation_probe_ratio_threshold = 1.0;
+        }
+        assert_eq!(
+            config.options().execution.skip_partial_aggregation_probe_ratio_threshold,
+            1.0,
+            "skip_partial must be disabled (1.0) for multi-shard"
+        );
+    }
+
+    #[test]
+    fn test_skip_partial_agg_default_when_single_shard() {
+        // When has_partial_aggregate=false, skip_partial retains DF default (0.8)
+        let config = SessionConfig::new();
+        assert_eq!(
+            config.options().execution.skip_partial_aggregation_probe_ratio_threshold,
+            0.8,
+            "single-shard must retain DF default threshold"
+        );
     }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PartialAggregateModeIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PartialAggregateModeIT.java
@@ -138,4 +138,38 @@ public class PartialAggregateModeIT extends AnalyticsRestTestCase {
         req.setJsonEntity("{\"transient\":{\"analytics.shard_bucket_oversampling_factor\":" + factor + "}}");
         client().performRequest(req);
     }
+
+    /** Regression guard: TopK with high-cardinality group keys must produce valid counts. */
+    @SuppressWarnings("unchecked")
+    public void testTopK_highCardinalityGroupBy_correctness() throws Exception {
+        ensureProvisioned();
+        setConcurrentSearchMode("all", 4);
+        setOversampling(2.0);
+
+        String idx = CLICKBENCH.indexName;
+
+        Map<String, Object> total = executePpl("source=" + idx + " | stats count()");
+        long totalCount = ((Number) ((List<List<Object>>) total.get("datarows")).get(0).get(0)).longValue();
+
+        Map<String, Object> topk = executePpl(
+            "source=" + idx + " | stats count() as cnt by RegionID | sort - cnt | head 5"
+        );
+        List<List<Object>> rows = (List<List<Object>>) topk.get("datarows");
+        assertNotNull(rows);
+        assertFalse("TopK must return rows", rows.isEmpty());
+
+        long sumTopK = rows.stream().mapToLong(r -> ((Number) r.get(0)).longValue()).sum();
+        assertTrue(
+            "Sum of top-K counts (" + sumTopK + ") must not exceed total (" + totalCount + ")",
+            sumTopK <= totalCount
+        );
+
+        for (List<Object> row : rows) {
+            long cnt = ((Number) row.get(0)).longValue();
+            assertTrue("Each group count must be > 0", cnt > 0);
+        }
+
+        setConcurrentSearchMode("none", 0);
+        setOversampling(0.0);
+    }
 }


### PR DESCRIPTION
 ## Summary

  Set `skip_partial_aggregation_probe_ratio_threshold=1.0` when `has_partial_aggregate=true` (multi-shard). Prevents DataFusion from bypassing partial aggregation on high-cardinality group keys, which combined with TopK produces wrong results (raw rows with count=1 picked arbitrarily).

Clickbench q19 and q31 give correct results now on high cardinality workloads.

  ## Test Plan

  - [x] 2 Rust UTs: config set correctly for multi-shard vs single-shard
  - [x] Regression guard IT: TopK high-cardinality group-by correctness
  - [x] Full IT suite + coordinator IT: 0 regressions
  - [x] Validated on different benchmark clusters 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
