### PR TITLE
Fix star tree aggs with concurrent search

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/startree/StarTreeConcurrentSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/startree/StarTreeConcurrentSearchIT.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.startree;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.search.SearchService;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.aggregations.metrics.Sum;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.index.query.QueryBuilders.termQuery;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Regression tests for <a href="https://github.com/opensearch-project/OpenSearch/issues/20646">#20646</a>:
+ * star-tree aggregations must return correct results with concurrent segment search and intra-segment
+ * partitioning enabled (partition slices use collectRange, whole-segment slices use precompute).
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1, numClientNodes = 0)
+public class StarTreeConcurrentSearchIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test_star_tree_concurrent";
+    private static final int BULK_ROUNDS = 5;
+    private static final int EXPECTED_A_DOCS = 250;
+    private static final int SEARCH_ITERATIONS = 30;
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true)
+            .put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE.getKey(), "all")
+            .put(SearchService.CONCURRENT_SEGMENT_SEARCH_PARTITION_STRATEGY.getKey(), "balanced")
+            .put(SearchService.CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY, 4)
+            .build();
+    }
+
+    public void testStarTreeAggregationsWithConcurrentSearch() throws Exception {
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.composite_index", true)
+                .put("index.append_only.enabled", true)
+                .put("index.refresh_interval", "-1")
+                .put("index.requests.cache.enable", false)
+                .put("index.search.star_tree_index.enabled", true)
+                .put("index.codec", "default")
+                .build(),
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("composite")
+                .startObject("st")
+                .field("type", "star_tree")
+                .startObject("config")
+                .startArray("ordered_dimensions")
+                .startObject()
+                .field("name", "d1")
+                .endObject()
+                .startObject()
+                .field("name", "d2")
+                .endObject()
+                .endArray()
+                .startArray("metrics")
+                .startObject()
+                .field("name", "m1")
+                .field("stats", new String[] { "sum" })
+                .endObject()
+                .endArray()
+                .endObject()
+                .endObject()
+                .endObject()
+                .startObject("properties")
+                .startObject("d1")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("d2")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("m1")
+                .field("type", "integer")
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString()
+        );
+        ensureGreen(INDEX_NAME);
+
+        final String[][] rows = {
+            { "A", "X", "1" },
+            { "A", "Y", "1" },
+            { "A", "X", "1" },
+            { "A", "Y", "1" },
+            { "A", "X", "1" },
+            { "B", "X", "1" },
+            { "B", "Y", "1" },
+            { "B", "X", "1" },
+            { "B", "Y", "1" },
+            { "B", "X", "1" } };
+
+        for (int round = 0; round < BULK_ROUNDS; round++) {
+            BulkRequestBuilder bulk = client().prepareBulk(INDEX_NAME);
+            for (int repeat = 0; repeat < 10; repeat++) {
+                for (String[] row : rows) {
+                    bulk.add(client().prepareIndex(INDEX_NAME).setSource("d1", row[0], "d2", row[1], "m1", Integer.parseInt(row[2])));
+                }
+            }
+            assertFalse(bulk.get().hasFailures());
+            refresh(INDEX_NAME);
+        }
+
+        // Star-tree structures are built during merge; keep multiple segments to mirror #20646 repro.
+        refresh(INDEX_NAME);
+        client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(5)).get();
+        refresh(INDEX_NAME);
+
+        for (int i = 0; i < SEARCH_ITERATIONS; i++) {
+            SearchResponse response = client().prepareSearch(INDEX_NAME)
+                .setQuery(termQuery("d1", "A"))
+                .setSize(0)
+                .addAggregation(
+                    org.opensearch.search.aggregations.AggregationBuilders.terms("by_d")
+                        .field("d1")
+                        .subAggregation(org.opensearch.search.aggregations.AggregationBuilders.sum("total").field("m1"))
+                )
+                .get();
+
+            Terms terms = response.getAggregations().get("by_d");
+            assertEquals(1, terms.getBuckets().size());
+            assertThat(terms.getBuckets().get(0).getDocCount(), equalTo((long) EXPECTED_A_DOCS));
+            Sum sum = terms.getBuckets().get(0).getAggregations().get("total");
+            assertEquals(EXPECTED_A_DOCS, sum.getValue(), 0.0);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -108,7 +108,6 @@ import org.opensearch.search.query.ReduceableSearchResult;
 import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.slice.SliceBuilder;
 import org.opensearch.search.sort.SortAndFormats;
-import org.opensearch.search.startree.StarTreeQueryHelper;
 import org.opensearch.search.streaming.FlushMode;
 import org.opensearch.search.suggest.SuggestionSearchContext;
 
@@ -1404,12 +1403,6 @@ final class DefaultSearchContext extends SearchContext {
     public void evaluateRequestShouldUseIntraSegmentSearch() {
         String partitionStrategy = getPartitionStrategy();
         if (CONCURRENT_SEGMENT_SEARCH_PARTITION_STRATEGY_SEGMENT.equals(partitionStrategy) || shouldUseConcurrentSearch() == false) {
-            requestShouldUseIntraSegmentSearch.set(false);
-            return;
-        }
-        // StarTree precomputes aggregations at index time - intra-segment adds no benefit
-        if (aggregations() != null && StarTreeQueryHelper.getSupportedStarTree(getQueryShardContext()) != null) {
-            logger.debug("partition strategy decision: StarTree detected, disabling intra-segment");
             requestShouldUseIntraSegmentSearch.set(false);
             return;
         }

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1767,6 +1767,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final CollapseContext collapseContext = source.collapse().build(queryShardContext);
             context.collapse(collapseContext);
         }
+        maybeInitializeStarTreeQueryContext(context, source, queryShardContext);
         context.evaluateRequestShouldUseConcurrentSearch();
         context.evaluateRequestShouldUseIntraSegmentSearch();
         if (source.profile()) {
@@ -1776,7 +1777,16 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             Profilers profilers = new Profilers(context.searcher(), context.shouldUseConcurrentSearch(), pluginProfileMetricsSupplier);
             context.setProfilers(profilers);
         }
+    }
 
+    /**
+     * Initializes star-tree query context before concurrent and intra-segment search are evaluated.
+     */
+    private static void maybeInitializeStarTreeQueryContext(
+        DefaultSearchContext context,
+        SearchSourceBuilder source,
+        QueryShardContext queryShardContext
+    ) {
         if (context.getStarTreeIndexEnabled() && StarTreeQueryHelper.isStarTreeSupported(context)) {
             StarTreeQueryContext starTreeQueryContext = new StarTreeQueryContext(context, source.query());
             boolean consolidated = starTreeQueryContext.consolidateAllFilters(context);

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregatorBase.java
@@ -203,7 +203,11 @@ public abstract class AggregatorBase extends Aggregator {
 
     @Override
     public final LeafBucketCollector getLeafCollector(LeafReaderContext ctx) throws IOException {
-        if (tryPrecomputeAggregationForLeaf(ctx)) {
+        // Segment precompute is only valid for sequential, whole-segment collection. Under concurrent search or
+        // intra-segment partitioning each slice owns a portion of work and must collect via doc-id ranges instead.
+        if (context.shouldUseConcurrentSearch() == false
+            && context.shouldUseIntraSegmentSearch() == false
+            && tryPrecomputeAggregationForLeaf(ctx)) {
             throw new CollectionTerminatedException();
         }
         preGetSubLeafCollectors(ctx);

--- a/server/src/main/java/org/opensearch/search/startree/StarTreeQueryHelper.java
+++ b/server/src/main/java/org/opensearch/search/startree/StarTreeQueryHelper.java
@@ -121,6 +121,13 @@ public class StarTreeQueryHelper {
      */
     public static FixedBitSet getStarTreeFilteredValues(SearchContext context, LeafReaderContext ctx, StarTreeValues starTreeValues)
         throws IOException {
+        if (context.shouldUseConcurrentSearch()) {
+            return StarTreeTraversalUtil.getStarTreeResult(
+                starTreeValues,
+                context.getQueryShardContext().getStarTreeQueryContext().getBaseQueryStarTreeFilter(),
+                context
+            );
+        }
         FixedBitSet result = context.getQueryShardContext().getStarTreeQueryContext().maybeGetCachedNodeIdsForSegment(ctx.ord);
         if (result == null) {
             result = StarTreeTraversalUtil.getStarTreeResult(
@@ -128,8 +135,8 @@ public class StarTreeQueryHelper {
                 context.getQueryShardContext().getStarTreeQueryContext().getBaseQueryStarTreeFilter(),
                 context
             );
+            context.getQueryShardContext().getStarTreeQueryContext().maybeSetCachedNodeIdsForSegment(ctx.ord, result);
         }
-        context.getQueryShardContext().getStarTreeQueryContext().maybeSetCachedNodeIdsForSegment(ctx.ord, result);
         return result;
     }
 

--- a/server/src/test/java/org/opensearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/opensearch/search/DefaultSearchContextTests.java
@@ -65,10 +65,12 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.cache.IndexCache;
 import org.opensearch.index.cache.query.QueryCache;
 import org.opensearch.index.engine.Engine;
+import org.opensearch.index.mapper.CompositeDataCubeFieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.ParsedQuery;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
@@ -88,6 +90,7 @@ import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.slice.SliceBuilder;
 import org.opensearch.search.sort.SortAndFormats;
+import org.opensearch.search.startree.StarTreeQueryContext;
 import org.opensearch.search.streaming.FlushModeResolver;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -110,6 +113,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.opensearch.index.IndexSettings.INDEX_SEARCH_THROTTLED;
+import static org.opensearch.index.mapper.CompositeMappedFieldType.CompositeFieldType.STAR_TREE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.any;
@@ -1268,6 +1272,44 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
             );
             context.evaluateRequestShouldUseConcurrentSearch();
             assertFalse(context.shouldUseConcurrentSearch());
+
+            // Case11: star-tree query must not disable concurrent segment search
+            when(mockAggregations.factories().allFactoriesSupportConcurrentSearch()).thenReturn(true);
+            clusterSettings.applySettings(
+                Settings.builder()
+                    .put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE.getKey(), "all")
+                    .put(SearchService.CONCURRENT_SEGMENT_SEARCH_PARTITION_STRATEGY.getKey(), "balanced")
+                    .build()
+            );
+            CompositeDataCubeFieldType compositeFieldType = mock(CompositeDataCubeFieldType.class);
+            when(compositeFieldType.name()).thenReturn("st");
+            when(compositeFieldType.getCompositeIndexType()).thenReturn(STAR_TREE);
+            StarTreeQueryContext starTreeQueryContext = new StarTreeQueryContext(compositeFieldType, new MatchAllQueryBuilder(), -1);
+            when(queryShardContext.getStarTreeQueryContext()).thenReturn(starTreeQueryContext);
+
+            context = new DefaultSearchContext(
+                readerContext,
+                shardSearchRequest,
+                target,
+                clusterService,
+                bigArrays,
+                null,
+                null,
+                null,
+                false,
+                Version.CURRENT,
+                false,
+                executor,
+                null,
+                Collections.emptyList()
+            );
+            context.aggregations(mockAggregations);
+            context.evaluateRequestShouldUseConcurrentSearch();
+            if (executor == null) {
+                assertFalse(context.shouldUseConcurrentSearch());
+            } else {
+                assertTrue(context.shouldUseConcurrentSearch());
+            }
 
             // shutdown the threadpool
             threadPool.shutdown();

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
@@ -35,6 +35,7 @@ package org.opensearch.search.aggregations;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -81,6 +82,43 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
         @Override
         public InternalAggregation buildEmptyAggregation() {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    private class PrecomputeAggregator extends BogusAggregator {
+        PrecomputeAggregator(SearchContext searchContext, Aggregator parent) throws IOException {
+            super(searchContext, parent);
+        }
+
+        @Override
+        protected boolean tryPrecomputeAggregationForLeaf(LeafReaderContext ctx) {
+            return true;
+        }
+    }
+
+    public void testSegmentPrecomputeSkippedUnderIntraSegmentSearch() throws IOException {
+        IndexService indexService = createIndexWithSimpleMappings("precompute_gate", Settings.EMPTY, "bytes", "type=keyword");
+        client().prepareIndex("precompute_gate").setSource("bytes", "value").get();
+        indexService.getShard(0).refresh("test");
+        try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
+            LeafReaderContext leafReaderContext = searcher.getIndexReader().leaves().get(0);
+            SearchContext searchContext = mockSearchContext(new MatchAllDocsQuery());
+            when(searchContext.shouldUseIntraSegmentSearch()).thenReturn(true);
+            when(searchContext.shouldUseConcurrentSearch()).thenReturn(true);
+            PrecomputeAggregator intraSegmentAggregator = new PrecomputeAggregator(searchContext, null);
+            intraSegmentAggregator.preCollection();
+            expectThrows(UnsupportedOperationException.class, () -> intraSegmentAggregator.getLeafCollector(leafReaderContext));
+
+            when(searchContext.shouldUseIntraSegmentSearch()).thenReturn(false);
+            when(searchContext.shouldUseConcurrentSearch()).thenReturn(false);
+            PrecomputeAggregator wholeSegmentAggregator = new PrecomputeAggregator(searchContext, null);
+            wholeSegmentAggregator.preCollection();
+            expectThrows(CollectionTerminatedException.class, () -> wholeSegmentAggregator.getLeafCollector(leafReaderContext));
+
+            when(searchContext.shouldUseConcurrentSearch()).thenReturn(true);
+            PrecomputeAggregator concurrentAggregator = new PrecomputeAggregator(searchContext, null);
+            concurrentAggregator.preCollection();
+            expectThrows(UnsupportedOperationException.class, () -> concurrentAggregator.getLeafCollector(leafReaderContext));
         }
     }
 


### PR DESCRIPTION
## Summary

- Initialize `StarTreeQueryContext` before concurrent and intra-segment search path evaluation in `SearchService.parseSource()`
- Gate star-tree segment precompute in `AggregatorBase.getLeafCollector()` so it runs only for sequential, whole-segment collection; concurrent and intra-segment partitioned slices collect via doc-id ranges (`collectRange`) instead
- Skip per-segment star-tree node-id cache under concurrent search to avoid incorrect shared state across slices
- Add regression test `StarTreeConcurrentSearchIT` and unit tests for precompute gating

Fixes #20646



