### PR TITLE
Attempt to fix flaky AzureBlobStoreRepositoryTests test cases

### DIFF
--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
@@ -124,6 +124,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testReadNonExistingPath() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             expectThrows(NoSuchFileException.class, () -> {
@@ -135,6 +137,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testWriteRead() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
@@ -164,6 +168,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testReadRange() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             final byte[] data = randomBytes(4096);
@@ -185,6 +191,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testList() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             assertThat(container.listBlobs().size(), CoreMatchers.equalTo(0));
@@ -225,6 +233,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testDeleteBlobs() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final List<String> blobNames = Arrays.asList("foobar", "barfoo");
             final BlobContainer container = store.blobContainer(new BlobPath());
@@ -257,6 +267,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testContainerCreationAndDeletion() throws IOException {
+        ensureGreen();
+
         try (BlobStore store = newBlobStore()) {
             final BlobContainer containerFoo = store.blobContainer(new BlobPath().add("foo"));
             final BlobContainer containerBar = store.blobContainer(new BlobPath().add("bar"));
@@ -315,6 +327,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testSnapshotAndRestore() throws Exception {
+        ensureGreen();
+
         final String repoName = createRepository(randomName());
         int indexCount = randomIntBetween(1, 5);
         int[] docCounts = new int[indexCount];
@@ -391,6 +405,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testMultipleSnapshotAndRollback() throws Exception {
+        ensureGreen();
+
         final String repoName = createRepository(randomName());
         int iterationCount = randomIntBetween(2, 5);
         int[] docCounts = new int[iterationCount];
@@ -455,6 +471,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     }
 
     public void testIndicesDeletedFromRepository() throws Exception {
+        ensureGreen();
+
         final String repoName = createRepository("test-repo-" + randomAlphaOfLength(8));
         Client client = client();
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchMockAPIBasedRepositoryIntegTestCase.java
@@ -156,6 +156,8 @@ public abstract class OpenSearchMockAPIBasedRepositoryIntegTestCase extends Open
      * Test the snapshot and restore of an index which has large segments files.
      */
     public void testSnapshotWithLargeSegmentFiles() throws Exception {
+        ensureGreen();
+
         final String repository = createRepository(randomName());
         final String index = "index-no-merges";
         createIndex(
@@ -188,6 +190,8 @@ public abstract class OpenSearchMockAPIBasedRepositoryIntegTestCase extends Open
     }
 
     public void testRequestStats() throws Exception {
+        ensureGreen();
+
         final String repository = createRepository(randomName());
         final String index = "index-no-merges";
         createIndex(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Attempt to fix flaky AzureBlobStoreRepositoryTests test cases. Spent some time on this one and I think I understand what is going on:
 - the repository creation was attempted
 - while in progress, cluster manager changes
 - another repository creation attempt was issues

From logs:

```
[2026-04-30T03:03:45,226][INFO ][o.o.c.s.ClusterApplierService] [node_t1] cluster-manager node changed {previous [], current [{node_t0}{TjFuBicRQ7iFbycAVUvOyg}{l0mvI483REmd8qKqtNSF1g}{127.0.0.1}{127.0.0.1:45591}{dimr}{shard_indexing_pressure_enabled=true}]}, added {{node_t0}{TjFuBicRQ7iFbycAVUvOyg}{l0mvI483REmd8qKqtNSF1g}{127.0.0.1}{127.0.0.1:45591}{dimr}{shard_indexing_pressure_enabled=true}}, term: 1, version: 3, reason: ApplyCommitRequest{term=1, version=3, sourceNode={node_t0}{TjFuBicRQ7iFbycAVUvOyg}{l0mvI483REmd8qKqtNSF1g}{127.0.0.1}{127.0.0.1:45591}{dimr}}
...
[2026-04-30T03:03:45,230][INFO ][o.o.c.s.ClusterApplierService] [node_t0] added {{node_t1}{QBtlc6w4TdqDw77H_Dks8Q}{666qxsf2TumSBqRmHdlNtA}{127.0.0.1}{127.0.0.1:46581}{shard_indexing_pressure_enabled=true}}, term: 1, version: 3, reason: Publication{term=1, version=3}
...
[2026-04-30T03:03:45,662][INFO ][o.o.r.a.AzureBlobStoreRepositoryTests] [testMultipleSnapshotAndRollback] before test
[2026-04-30T03:03:45,698][INFO ][o.o.r.RepositoriesService] [node_t0] put repository [esuosrxwl]
[2026-04-30T03:03:48,304][INFO ][o.o.r.a.A.AzureHTTPStatsCollectorHandler] [[HTTP-Dispatcher]] PUT /container/tests-puKY7Us-SAOvND9s6-DYIg%2Fmaster.dat
[2026-04-30T03:03:48,646][INFO ][o.o.r.a.A.AzureHTTPStatsCollectorHandler] [[HTTP-Dispatcher]] PUT /container/tests-puKY7Us-SAOvND9s6-DYIg%2Fmaster.dat
[2026-04-30T03:03:49,212][INFO ][o.o.r.a.AzureBlobStoreRepositoryTests] [testMultipleSnapshotAndRollback] after test
```

Notice two ` PUT /container/tests-puKY7Us-SAOvND9s6-DYIg%2Fmaster.dat` requests for a single `put repository [esuosrxwl]`, that happens approximately right when `cluster-manager node changed` occurred.

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/14291
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
