### PR TITLE
Return 409 for PUT index when index exists

### DIFF
--- a/server/src/main/java/org/opensearch/ResourceAlreadyExistsException.java
+++ b/server/src/main/java/org/opensearch/ResourceAlreadyExistsException.java
@@ -60,6 +60,6 @@ public class ResourceAlreadyExistsException extends OpenSearchException {
 
     @Override
     public RestStatus status() {
-        return RestStatus.BAD_REQUEST;
+        return RestStatus.CONFLICT;
     }
 }

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -114,7 +114,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         assertThat(exception.status(), equalTo(RestStatus.NOT_FOUND));
 
         exception = new RemoteTransportException("test", new ResourceAlreadyExistsException("test"));
-        assertThat(exception.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(exception.status(), equalTo(RestStatus.CONFLICT));
 
         exception = new RemoteTransportException("test", new IllegalArgumentException("foobar"));
         assertThat(exception.status(), equalTo(RestStatus.BAD_REQUEST));

--- a/server/src/test/java/org/opensearch/rest/BytesRestResponseTests.java
+++ b/server/src/test/java/org/opensearch/rest/BytesRestResponseTests.java
@@ -298,7 +298,7 @@ public class BytesRestResponseTests extends OpenSearchTestCase {
                     "action",
                     new ResourceAlreadyExistsException("OpenSearchWrapperException with a cause that has a custom status")
                 );
-                status = RestStatus.BAD_REQUEST;
+                status = RestStatus.CONFLICT;
                 if (detailed) {
                     type = "resource_already_exists_exception";
                     reason = "OpenSearchWrapperException with a cause that has a custom status";


### PR DESCRIPTION
## Summary
- Return HTTP 409 (Conflict) instead of 400 when `PUT <index>` is called for an index that already exists
- Map `ResourceAlreadyExistsException` to `RestStatus.CONFLICT`
- Update related unit tests

Fixes #20072

