### PR TITLE
Fix Flight transport response close race

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -29,6 +29,7 @@ import org.opensearch.transport.stream.StreamTransportResponse;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.opensearch.arrow.flight.transport.ClientHeaderMiddleware.CORRELATION_ID_KEY;
 
@@ -53,6 +54,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     private volatile long currentBatchSize;
     private volatile boolean firstBatchConsumed;
     private volatile boolean closed;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
     private volatile boolean prefetchStarted;
     private volatile Header initialHeader;
 
@@ -93,6 +95,22 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                 try {
                     long start = System.nanoTime();
                     flightStream = flightClient.getStream(ticket, new HeaderCallOption(callHeaders));
+                    // close() may have run while we were inside getStream() and missed the stream because
+                    // flightStream was still null. Now that it is published, re-check the flag: if a close()
+                    // already happened, self-close the stream we just opened so the prefetched first-batch
+                    // root is not stranded, then abort. This check is performed *before* future.complete(),
+                    // so once the future completes, any subsequent close() always observes flightStream != null
+                    // and owns the close itself. There is no post-completion window in which both this thread
+                    // and a racing close() could close the same stream.
+                    if (closed) {
+                        try {
+                            closeStreamQuietly();
+                        } catch (StreamException e) {
+                            logger.warn("Error closing flight stream after close() raced the prefetch", e);
+                        }
+                        future.completeExceptionally(new StreamException(StreamErrorCode.UNAVAILABLE, "Stream is closed"));
+                        return;
+                    }
                     long elapsedMs = (System.nanoTime() - start) / 1_000_000;
                     logger.debug("FlightClient.getStream() for correlationId: {} took {}ms", correlationId, elapsedMs);
                     start = System.nanoTime();
@@ -105,13 +123,6 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                     future.completeExceptionally(FlightErrorMapper.fromFlightException(e));
                 } catch (Exception e) {
                     future.completeExceptionally(new StreamException(StreamErrorCode.INTERNAL, "Stream open/prefetch failed", e));
-                } finally {
-                    // If close() ran while we were opening/prefetching, it may have missed the stream
-                    // we just published. Re-close here so the prefetched first-batch root is released
-                    // (FlightStream.close() is idempotent).
-                    if (closed) {
-                        closeStreamQuietly();
-                    }
                 }
             });
         }
@@ -194,16 +205,13 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     @Override
     public void close() {
         if (closed) return;
-        // Set closed=true before closing so a prefetch still in flight re-checks it and self-closes
-        // the stream it publishes (covers close() racing ahead of flightStream being set).
         closed = true;
         closeStreamQuietly();
     }
 
-    /** Closes the flight stream if present, swallowing the benign already-closed error. Idempotent. */
     private void closeStreamQuietly() {
         FlightStream stream = flightStream;
-        if (stream != null) {
+        if (stream != null && streamClosed.compareAndSet(false, true)) {
             try {
                 stream.close();
             } catch (IllegalStateException ignore) {} catch (Exception e) {

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -95,15 +95,15 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         future.get(5, TimeUnit.SECONDS); // prefetch finished → flightStream published
 
         response.close();
-        // close() ran after publish; the finally in the prefetch saw closed=false, so close() owns the close.
+        // close() ran after publish; the prefetch had already passed its closed-check, so close() owns the close.
         verify(stream, timeout(5_000).atLeastOnce()).close();
     }
 
     /**
      * The race the fix targets: close() runs while the prefetch thread is still inside getStream(),
      * so close() sees flightStream==null and closes nothing. When the prefetch then publishes the
-     * stream, its finally block must self-close it (closed already true) so the first-batch root is
-     * not stranded on the client allocator.
+     * stream, its synchronous closed-check must self-close it (closed already true) so the first-batch
+     * root is not stranded on the client allocator.
      */
     public void testCloseDuringPrefetchSelfClosesStream() throws Exception {
         FlightStream stream = mock(FlightStream.class);
@@ -127,7 +127,7 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         response.close(); // sees flightStream==null → closes nothing itself
         verify(stream, never()).close();
 
-        // Let the prefetch publish the stream; its finally must self-close it.
+        // Let the prefetch publish the stream; its closed-check must self-close it.
         proceed.countDown();
         verify(stream, timeout(5_000)).close();
     }
@@ -156,7 +156,8 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         response.close();
         response.close();
         response.close();
-        // The prefetch finally saw closed=false (publish happened first), so only the first close() closes.
+        // The prefetch passed its closed-check before publishing the future, so it never self-closes;
+        // only the first close() closes the stream and the later calls short-circuit.
         verify(stream, times(1)).close();
     }
 
@@ -177,7 +178,6 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
     }
 
     /** An unexpected error from the stream is wrapped as a StreamException. */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/22249")
     public void testCloseRethrowsUnexpectedErrorAsStreamException() throws Exception {
         FlightClient client = mock(FlightClient.class);
         FlightStream stream = mock(FlightStream.class);


### PR DESCRIPTION
The prefetch thread re-read the closed flag in a finally block that ran after it completed the open future. A close() arriving in that window double-closed the Flight stream, which intermittently failed FlightTransportResponseTests and, when the stream's close threw, surfaced an uncaught exception on the virtual thread that in turn failed unrelated neighbor tests in the same class.

Perform the closed check synchronously right after the stream is published and before the future completes, so any later close() always observes the stream and owns the close. Guard the physical FlightStream.close() with an AtomicBoolean so it is invoked at most once even when two close() calls race.

### Related Issues
Resolves #22258

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
