### PR TITLE
Add cross-cluster streaming support to the remote cluster client

### DIFF
--- a/plugins/arrow-flight-rpc/docs/backpressure.md
+++ b/plugins/arrow-flight-rpc/docs/backpressure.md
@@ -108,7 +108,7 @@ doesn't formally bound this.
 
 A byte-aware bounded queue at the eventloop entry — that parks (or rejects)
 the producer when the sum of queued batch sizes crosses a per-channel cap —
-would close the gap. Open design questions:
+would close the gap for the async path. Open design questions:
 
 - **Cap dimension**: byte-aware (sum of retained sizes) vs depth-aware (count).
   Bytes is correct for OOM protection.
@@ -119,6 +119,19 @@ would close the gap. Open design questions:
   budget tied to `flight pool max`.
 
 Tracked separately; not addressed in this change.
+
+### Synchronous send (bounded, opt-in)
+
+A caller that needs a hard bound *today* can send synchronously:
+`channel.sendResponseBatch(response, /* sync */ true)`. The batch is still
+serialized and written on the channel's send executor (the same executor the
+async path uses), but the calling thread **blocks until the batch is on the
+wire**, so it cannot queue the next batch ahead of this one — outstanding batches
+are bounded to one, with no eventloop queue to grow.
+
+A caller that opts in **must drive a single stream from a single thread** and must
+not call from the send-executor thread itself. The default
+`sendResponseBatch(response)` is unchanged — async, via the eventloop.
 
 ### ⚠️ Virtual threads for park-bound producers
 

--- a/plugins/arrow-flight-rpc/docs/backpressure.md
+++ b/plugins/arrow-flight-rpc/docs/backpressure.md
@@ -125,9 +125,11 @@ Tracked separately; not addressed in this change.
 A caller that needs a hard bound *today* can send synchronously:
 `channel.sendResponseBatch(response, /* sync */ true)`. The batch is still
 serialized and written on the channel's send executor (the same executor the
-async path uses), but the calling thread **blocks until the batch is on the
-wire**, so it cannot queue the next batch ahead of this one — outstanding batches
-are bounded to one, with no eventloop queue to grow.
+async path uses), but the calling thread **blocks until the batch has been
+pushed to gRPC's per-stream outbound buffer**, so it cannot queue the next batch
+ahead of this one — outstanding batches are bounded to one, with no eventloop
+queue to grow. When that outbound buffer is full, the `isReady()` back-pressure
+gate (above) throttles the producer.
 
 A caller that opts in **must drive a single stream from a single thread** and must
 not call from the send-executor thread itself. The default

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
@@ -22,7 +22,9 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import io.netty.channel.Channel;
@@ -187,6 +189,55 @@ public class ServerConfig {
         Setting.Property.NodeScope
     );
 
+    // gRPC server keepalive. Defaults match gRPC's own server defaults (time 2h, timeout 20s) so
+    // behaviour is unchanged from before this setting existed; lower the time for faster
+    // dead-connection detection (releases resources held by a stalled stream on a half-open connection).
+    static final Setting<TimeValue> FLIGHT_KEEPALIVE_TIME = Setting.timeSetting(
+        "flight.keepalive.time",
+        TimeValue.timeValueHours(2),
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.NodeScope
+    );
+
+    // Must be strictly less than FLIGHT_KEEPALIVE_TIME (else a slow-but-alive peer is
+    // false-disconnected); enforced by the validator below.
+    static final Setting<TimeValue> FLIGHT_KEEPALIVE_TIMEOUT = new Setting<>(
+        "flight.keepalive.timeout",
+        TimeValue.timeValueSeconds(20).getStringRep(),
+        s -> TimeValue.parseTimeValue(s, "flight.keepalive.timeout"),
+        new KeepAliveTimeoutValidator(),
+        Setting.Property.NodeScope
+    );
+
+    /** Enforces {@code flight.keepalive.timeout < flight.keepalive.time}. */
+    static final class KeepAliveTimeoutValidator implements Setting.Validator<TimeValue> {
+        @Override
+        public void validate(final TimeValue value) {}
+
+        @Override
+        public void validate(final TimeValue timeout, final Map<Setting<?>, Object> settings) {
+            final TimeValue time = (TimeValue) settings.get(FLIGHT_KEEPALIVE_TIME);
+            if (timeout.nanos() >= time.nanos()) {
+                throw new IllegalArgumentException(
+                    "["
+                        + FLIGHT_KEEPALIVE_TIMEOUT.getKey()
+                        + "] ("
+                        + timeout
+                        + ") must be less than ["
+                        + FLIGHT_KEEPALIVE_TIME.getKey()
+                        + "] ("
+                        + time
+                        + ")"
+                );
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(FLIGHT_KEEPALIVE_TIME).iterator();
+        }
+    }
+
     /**
      * The thread pool name for the Flight producer handling
      */
@@ -207,6 +258,8 @@ public class ServerConfig {
     private static int threadPoolMax;
     private static TimeValue keepAlive;
     private static int eventLoopThreads;
+    private static TimeValue grpcKeepAliveTime;
+    private static TimeValue grpcKeepAliveTimeout;
 
     /**
      * Initializes the server configuration with the provided settings.
@@ -230,6 +283,18 @@ public class ServerConfig {
         threadPoolMax = FLIGHT_THREAD_POOL_MAX_SIZE.get(settings);
         keepAlive = FLIGHT_THREAD_POOL_KEEP_ALIVE.get(settings);
         eventLoopThreads = FLIGHT_EVENT_LOOP_THREADS.get(settings);
+        grpcKeepAliveTime = FLIGHT_KEEPALIVE_TIME.get(settings);
+        grpcKeepAliveTimeout = FLIGHT_KEEPALIVE_TIMEOUT.get(settings);
+    }
+
+    /** gRPC keepalive PING interval on the Flight server (connection-level liveness). */
+    public static TimeValue getGrpcKeepAliveTime() {
+        return grpcKeepAliveTime;
+    }
+
+    /** gRPC keepalive ack timeout: kill the connection if a PING is unacked for this long. */
+    public static TimeValue getGrpcKeepAliveTimeout() {
+        return grpcKeepAliveTimeout;
     }
 
     /**
@@ -290,6 +355,8 @@ public class ServerConfig {
                 ARROW_ENABLE_DEBUG_ALLOCATOR,
                 ARROW_ENABLE_UNSAFE_MEMORY_ACCESS,
                 ARROW_SSL_ENABLE,
+                FLIGHT_KEEPALIVE_TIME,
+                FLIGHT_KEEPALIVE_TIMEOUT,
                 FLIGHT_EVENT_LOOP_THREADS,
                 FLIGHT_THREAD_POOL_MIN_SIZE,
                 FLIGHT_READY_TIMEOUT,

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -168,8 +168,9 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
                     messageListener.onResponseSent(requestId, action, e);
                 }
             });
-            // sync blocks the caller until the batch is on the wire (bounding outstanding batches to one);
-            // async returns once it is queued. Both run on the channel executor, and both transfer source
+            // sync blocks the caller until the batch has been pushed to gRPC's outbound buffer (bounding
+            // outstanding batches to one; a full buffer is throttled by the readiness gate above); async
+            // returns once it is queued. Both run on the channel executor, and both transfer source
             // ownership to that task the moment it is accepted — so handedOff is set before any blocking
             // wait, ensuring the finally's releaseUnsent never double-frees a source the task already owns.
             if (sync) {
@@ -189,9 +190,10 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
 
     /**
      * Blocks the caller until the executor has run the submitted send, so the caller cannot submit the
-     * next batch until this one is on the wire. The send itself runs on the channel's flight executor (so
-     * it is serialized with the stream-root free that {@code close()} posts to the same executor); this
-     * only parks the caller for the result. The caller must be a producer thread, not the flight executor
+     * next batch until this one has been pushed to gRPC's outbound buffer (a full buffer is throttled by
+     * the readiness back-pressure gate). The send itself runs on the channel's flight executor (so it is
+     * serialized with the stream-root free that {@code close()} posts to the same executor); this only
+     * parks the caller for the result. The caller must be a producer thread, not the flight executor
      * thread itself (blocking on the result from that thread would deadlock the single-threaded executor).
      */
     private void awaitSend(Future<?> future) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -26,11 +26,14 @@ import org.opensearch.transport.TransportMessageListener;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.nativeprotocol.NativeOutboundMessage;
+import org.opensearch.transport.stream.StreamErrorCode;
 import org.opensearch.transport.stream.StreamException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 /**
  * Outbound handler for Arrow Flight streaming responses.
@@ -120,7 +123,8 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         final String action,
         final TransportResponse response,
         final boolean compress,
-        final boolean isHandshake
+        final boolean isHandshake,
+        final boolean sync
     ) throws IOException {
         BatchTask task = new BatchTask(
             nodeVersion,
@@ -157,18 +161,53 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             // docs/backpressure.md "Known limitation: unbounded eventloop queue".
             flightChannel.awaitReadyOrThrow();
 
-            flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
+            final Runnable sendBatch = threadPool.getThreadContext().preserveContext(() -> {
                 try (BatchTask ignored = task) {
                     processBatchTask(task);
                 } catch (Exception e) {
                     messageListener.onResponseSent(requestId, action, e);
                 }
-            }));
-            handedOff = true;
+            });
+            // sync blocks the caller until the batch is on the wire (bounding outstanding batches to one);
+            // async returns once it is queued. Both run on the channel executor, and both transfer source
+            // ownership to that task the moment it is accepted — so handedOff is set before any blocking
+            // wait, ensuring the finally's releaseUnsent never double-frees a source the task already owns.
+            if (sync) {
+                Future<?> future = flightChannel.getExecutor().submit(sendBatch);
+                handedOff = true; // task accepted; it now owns (and will free) the source
+                awaitSend(future);
+            } else {
+                flightChannel.getExecutor().execute(sendBatch);
+                handedOff = true;
+            }
         } finally {
             if (handedOff == false) {
                 flightChannel.releaseUnsent(response);
             }
+        }
+    }
+
+    /**
+     * Blocks the caller until the executor has run the submitted send, so the caller cannot submit the
+     * next batch until this one is on the wire. The send itself runs on the channel's flight executor (so
+     * it is serialized with the stream-root free that {@code close()} posts to the same executor); this
+     * only parks the caller for the result. The caller must be a producer thread, not the flight executor
+     * thread itself (blocking on the result from that thread would deadlock the single-threaded executor).
+     */
+    private void awaitSend(Future<?> future) {
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new StreamException(StreamErrorCode.INTERNAL, "Interrupted while sending batch synchronously", e);
+        } catch (ExecutionException e) {
+            // The work body catches its own exceptions and routes them to the listener, so this is not
+            // expected; surface it rather than swallow if it ever happens.
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof StreamException se) {
+                throw se;
+            }
+            throw new StreamException(StreamErrorCode.INTERNAL, "Error sending batch synchronously", cause);
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -180,6 +180,11 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         return allocator;
     }
 
+    /** Whether the client cancelled the gRPC stream (onChannelCancelled fired). Read by FlightTransportChannel. */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
     /** Returns the current stream root. Package-private; intended for tests/assertions only. */
     VectorSchemaRoot getRoot() {
         return root;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -52,8 +52,16 @@ import static org.opensearch.arrow.flight.transport.FlightErrorMapper.mapFromCal
  * until gRPC's outbound buffer drains below {@code setOnReadyThreshold}.
  *
  * <p><b>Ownership &amp; concurrency — single-writer model.</b> This channel is the sole owner of
- * every Arrow buffer it sends and of the gRPC stream lifecycle. It keeps that ownership safe by
- * confining the stream root to a single thread:
+ * every Arrow buffer it sends and of the gRPC stream lifecycle.
+ *
+ * <p><b>Invariant: this channel is NOT thread-safe. All send-side mutation — the stream {@link #root}
+ * (create/transfer/serialize/free), {@link #terminalSent}, and every {@code serverStreamListener} call
+ * — MUST run on the channel's single {@link #getExecutor() flight-executor thread}, and never
+ * concurrently from more than one thread.</b> The executor is single-threaded, so it serializes those
+ * mutations and the buffer frees among themselves. Violating this (e.g. mutating the root from a
+ * producer thread while {@code close()} frees it on the executor) is a data race that corrupts Arrow
+ * reference counts and can orphan or double-free buffers (an off-heap leak). It keeps that ownership
+ * safe by confining the stream root to that single thread:
  * <ul>
  *   <li><b>The stream {@link #root} and every {@code serverStreamListener} call
  *       ({@code start}/{@code putNext}/{@code completed}/{@code error}) happen only on the channel's

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -251,6 +251,17 @@ class FlightTransport extends TcpTransport {
                     .backpressureThreshold((int) ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(settings).getBytes())
                     .middleware(SERVER_HEADER_KEY, factory);
 
+                // Server-side gRPC keepalive (see ServerConfig.FLIGHT_KEEPALIVE_TIME). NOTE: only the
+                // server pings today; adding a client keepalive also requires
+                // permitKeepAliveTime/permitKeepAliveWithoutCalls here, else the server GOAWAYs the
+                // client with "too_many_pings".
+                final long keepAliveTimeMs = ServerConfig.getGrpcKeepAliveTime().millis();
+                final long keepAliveTimeoutMs = ServerConfig.getGrpcKeepAliveTimeout().millis();
+                builder.transportHint("grpc.builderConsumer", (java.util.function.Consumer<io.grpc.netty.NettyServerBuilder>) b -> {
+                    b.keepAliveTime(keepAliveTimeMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+                    b.keepAliveTimeout(keepAliveTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+                });
+
                 builder.location(locations.get(0));
                 for (int i = 1; i < locations.size(); i++) {
                     builder.addListenAddress(locations.get(i));

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -65,8 +65,10 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
@@ -257,9 +259,9 @@ class FlightTransport extends TcpTransport {
                 // client with "too_many_pings".
                 final long keepAliveTimeMs = ServerConfig.getGrpcKeepAliveTime().millis();
                 final long keepAliveTimeoutMs = ServerConfig.getGrpcKeepAliveTimeout().millis();
-                builder.transportHint("grpc.builderConsumer", (java.util.function.Consumer<io.grpc.netty.NettyServerBuilder>) b -> {
-                    b.keepAliveTime(keepAliveTimeMs, java.util.concurrent.TimeUnit.MILLISECONDS);
-                    b.keepAliveTimeout(keepAliveTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+                builder.transportHint("grpc.builderConsumer", (Consumer<NettyServerBuilder>) b -> {
+                    b.keepAliveTime(keepAliveTimeMs, TimeUnit.MILLISECONDS);
+                    b.keepAliveTimeout(keepAliveTimeoutMs, TimeUnit.MILLISECONDS);
                 });
 
                 builder.location(locations.get(0));

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportChannel.java
@@ -85,6 +85,11 @@ class FlightTransportChannel extends TcpTransportChannel implements ArrowFlightC
 
     @Override
     public void sendResponseBatch(TransportResponse response) {
+        sendResponseBatch(response, false);
+    }
+
+    @Override
+    public void sendResponseBatch(TransportResponse response, boolean sync) {
         if (!streamOpen.get()) {
             throw new StreamException(StreamErrorCode.UNAVAILABLE, "Stream is closed for requestId [" + requestId + "]");
         }
@@ -101,7 +106,8 @@ class FlightTransportChannel extends TcpTransportChannel implements ArrowFlightC
                 action,
                 response,
                 compressResponse,
-                isHandshake
+                isHandshake,
+                sync
             );
         } catch (StreamException e) {
             // Cancelled: consumer is gone, release ends the call cleanly. For other
@@ -154,5 +160,10 @@ class FlightTransportChannel extends TcpTransportChannel implements ArrowFlightC
     @Override
     public BufferAllocator getAllocator() {
         return ((FlightServerChannel) getChannel()).getAllocator();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return getChannel() instanceof FlightServerChannel fsc && fsc.isCancelled();
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightServerKeepAliveTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightServerKeepAliveTests.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.arrow.flight;
+
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import io.grpc.netty.NettyServerBuilder;
+
+/**
+ * Proves the gRPC keepalive wiring actually reaches the {@link NettyServerBuilder}.
+ *
+ * <p>{@code FlightTransport} configures server keepalive by registering a
+ * {@code Consumer<NettyServerBuilder>} under the {@code "grpc.builderConsumer"} transport hint, which
+ * {@link OSFlightServer.Builder#build()} applies to the live builder. The hint is best-effort ("not
+ * guaranteed to have any effect"), so this test guards that the key is honored on the pinned Arrow /
+ * gRPC versions: it registers the same consumer, recovers it from the builder's options, applies it to
+ * a real {@link NettyServerBuilder}, and reads back gRPC's own keepalive fields to confirm the exact
+ * values landed. If an Arrow upgrade ever dropped/renamed the hook, or the gRPC keepalive API changed,
+ * this fails instead of the keepalive silently becoming a no-op.
+ */
+public class OSFlightServerKeepAliveTests extends OpenSearchTestCase {
+
+    @SuppressWarnings("unchecked")
+    @SuppressForbidden(reason = "reads private builderOptions + gRPC keepalive fields to verify the hint is applied")
+    public void testKeepAliveConsumerReachesNettyServerBuilder() throws Exception {
+        final long keepAliveMs = 60_000L;
+        final long keepAliveTimeoutMs = 20_000L;
+
+        // Register the consumer exactly as FlightTransport does.
+        OSFlightServer.Builder builder = OSFlightServer.builder();
+        builder.transportHint("grpc.builderConsumer", (Consumer<NettyServerBuilder>) b -> {
+            b.keepAliveTime(keepAliveMs, TimeUnit.MILLISECONDS);
+            b.keepAliveTimeout(keepAliveTimeoutMs, TimeUnit.MILLISECONDS);
+        });
+
+        // Recover the consumer the same way OSFlightServer.build() does (builderOptions is private).
+        final Field optionsField = OSFlightServer.Builder.class.getDeclaredField("builderOptions");
+        optionsField.setAccessible(true);
+        final Map<String, Object> options = (Map<String, Object>) optionsField.get(builder);
+        final Object hook = options.get("grpc.builderConsumer");
+        assertNotNull("grpc.builderConsumer hint must be stored on the builder", hook);
+
+        // Apply it to a real NettyServerBuilder. accept() not throwing already proves the hint key is
+        // honored and the gRPC keepAliveTime/keepAliveTimeout(long, TimeUnit) signatures still match.
+        NettyServerBuilder nettyBuilder = NettyServerBuilder.forPort(0);
+        ((Consumer<NettyServerBuilder>) hook).accept(nettyBuilder);
+
+        // And confirm the exact values landed by reading gRPC's own keepalive fields (nanos).
+        assertEquals(
+            "keepAliveTime must be applied to the gRPC builder",
+            TimeUnit.MILLISECONDS.toNanos(keepAliveMs),
+            readLongField(nettyBuilder, "keepAliveTimeInNanos")
+        );
+        assertEquals(
+            "keepAliveTimeout must be applied to the gRPC builder",
+            TimeUnit.MILLISECONDS.toNanos(keepAliveTimeoutMs),
+            readLongField(nettyBuilder, "keepAliveTimeoutInNanos")
+        );
+    }
+
+    @SuppressForbidden(reason = "reads gRPC's private keepalive field to verify the value was applied")
+    private static long readLongField(NettyServerBuilder builder, String name) throws Exception {
+        final Field f = NettyServerBuilder.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.getLong(builder);
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
@@ -7,12 +7,15 @@
  */
 package org.opensearch.arrow.flight.bootstrap;
 
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
+
+import java.util.Set;
 
 import static org.opensearch.arrow.flight.bootstrap.ServerConfig.SETTING_FLIGHT_PUBLISH_PORT;
 
@@ -95,6 +98,35 @@ public class ServerConfigTests extends OpenSearchTestCase {
             .build();
         assertEquals(TimeValue.timeValueSeconds(5), ServerConfig.FLIGHT_READY_TIMEOUT.get(overridden));
         assertEquals(16L * 1024 * 1024, ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(overridden).getBytes());
+    }
+
+    public void testKeepAliveDefaultsMatchGrpc() {
+        assertEquals(TimeValue.timeValueHours(2), ServerConfig.FLIGHT_KEEPALIVE_TIME.get(Settings.EMPTY));
+        assertEquals(TimeValue.timeValueSeconds(20), ServerConfig.FLIGHT_KEEPALIVE_TIMEOUT.get(Settings.EMPTY));
+    }
+
+    public void testKeepAliveTimeoutMustBeLessThanTime() {
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Set.of(ServerConfig.FLIGHT_KEEPALIVE_TIME, ServerConfig.FLIGHT_KEEPALIVE_TIMEOUT)
+        );
+        Settings equal = Settings.builder()
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIME.getKey(), TimeValue.timeValueSeconds(30))
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIMEOUT.getKey(), TimeValue.timeValueSeconds(30))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> clusterSettings.validate(equal, false));
+
+        Settings greater = Settings.builder()
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIME.getKey(), TimeValue.timeValueSeconds(30))
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIMEOUT.getKey(), TimeValue.timeValueSeconds(40))
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> clusterSettings.validate(greater, false));
+
+        Settings ok = Settings.builder()
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIME.getKey(), TimeValue.timeValueSeconds(60))
+            .put(ServerConfig.FLIGHT_KEEPALIVE_TIMEOUT.getKey(), TimeValue.timeValueSeconds(20))
+            .build();
+        clusterSettings.validate(ok, false);
     }
 
     public void testReadyTimeoutMinimum() {

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -104,6 +105,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -177,6 +179,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             "test-action",
             mock(TransportResponse.class),
             false,
+            false,
             false
         );
 
@@ -201,6 +204,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 1L,
                 "test-action",
                 mock(TransportResponse.class),
+                false,
                 false,
                 false
             );
@@ -250,6 +254,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 "test-action",
                 response,
                 false,
+                false,
                 false
             );
 
@@ -278,6 +283,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -311,6 +317,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 "test-action",
                 response,
                 false,
+                false,
                 false
             )
         );
@@ -341,6 +348,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 "test-action",
                 response,
                 false,
+                false,
                 false
             )
         );
@@ -366,6 +374,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             response,
+            false,
             false,
             false
         );
@@ -394,6 +403,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -427,6 +437,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -466,6 +477,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             "test-action",
             mock(TransportResponse.class),
             false,
+            false,
             false
         );
 
@@ -497,6 +509,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -530,6 +543,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             "test-action",
             mock(TransportResponse.class),
             false,
+            false,
             false
         );
 
@@ -557,6 +571,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             1L,
             "test-action",
             mock(TransportResponse.class),
+            false,
             false,
             false
         );
@@ -622,6 +637,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             "test-action",
             mock(TransportResponse.class),
             false,
+            false,
             false
         );
 
@@ -629,6 +645,144 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         assertTrue("awaitReadyOrThrow must run before sendResponseBatch returns", awaitCalled.get());
         assertTrue("Executor task should complete", executorRan.await(5, TimeUnit.SECONDS));
         verify(mockFlightChannel).awaitReadyOrThrow();
+    }
+
+    /** Async (sync=false): the batch send is handed to the channel executor, off the calling thread. */
+    public void testAsyncSendUsesChannelExecutor() throws Exception {
+        ExecutorService submitTrap = mock(ExecutorService.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(submitTrap);
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false,
+            false // sync=false
+        );
+
+        verify(submitTrap).execute(any()); // dispatched to the executor
+    }
+
+    /**
+     * Sync (sync=true): the batch send is submitted to the channel executor (so it is serialized against
+     * the root free that close() posts to the same executor) AND the caller blocks until it has run.
+     * Contrast with async, which dispatches via execute() and returns without waiting.
+     */
+    public void testSyncSendRunsOnExecutorAndBlocks() throws Exception {
+        // Real named single-thread executor: the send must run ON it (not the caller thread), and the
+        // sync call must not return until the send has completed.
+        ExecutorService flightExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "flight-eventloop-unittest"));
+        try {
+            when(mockFlightChannel.getExecutor()).thenReturn(flightExecutor);
+            AtomicBoolean sentBeforeReturn = new AtomicBoolean(false);
+            AtomicReference<String> ranOnThread = new AtomicReference<>();
+            doAnswer(invocation -> {
+                ranOnThread.set(Thread.currentThread().getName());
+                sentBeforeReturn.set(true);
+                return null;
+            }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+
+            handler.sendResponseBatch(
+                Version.CURRENT,
+                Collections.emptySet(),
+                mockFlightChannel,
+                mock(FlightTransportChannel.class),
+                1L,
+                "test-action",
+                mock(TransportResponse.class),
+                false,
+                false,
+                true // sync=true
+            );
+
+            // sync blocks on the submitted task, so the send has completed by the time the call returns...
+            assertTrue("sync send must have run (and notified) before returning", sentBeforeReturn.get());
+            // ...and it ran on the flight executor thread, not the calling test thread.
+            assertEquals("sync send must run on the flight executor, not the caller", "flight-eventloop-unittest", ranOnThread.get());
+        } finally {
+            flightExecutor.shutdownNow();
+            flightExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * A sync send whose executor work throws (e.g. onResponseSent itself fails) must surface the failure
+     * to the caller as a StreamException rather than hang or swallow it — the ExecutionException unwrap in
+     * runOnExecutorAndWait. Uses an executor that runs the task but lets its exception escape the Future.
+     */
+    public void testSyncSendSurfacesWorkFailureAsStreamException() throws Exception {
+        ExecutorService flightExecutor = Executors.newSingleThreadExecutor();
+        try {
+            when(mockFlightChannel.getExecutor()).thenReturn(flightExecutor);
+            // sendBatch's own catch routes processBatchTask failures to the listener; make that listener
+            // call itself throw so the exception escapes the submitted Runnable and reaches Future.get().
+            doThrow(new RuntimeException("listener boom")).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+            doThrow(new RuntimeException("send failed")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+
+            StreamException thrown = expectThrows(
+                StreamException.class,
+                () -> handler.sendResponseBatch(
+                    Version.CURRENT,
+                    Collections.emptySet(),
+                    mockFlightChannel,
+                    mock(FlightTransportChannel.class),
+                    1L,
+                    "test-action",
+                    mock(TransportResponse.class),
+                    false,
+                    false,
+                    true // sync
+                )
+            );
+            assertEquals(StreamErrorCode.INTERNAL, thrown.getErrorCode());
+        } finally {
+            flightExecutor.shutdownNow();
+            flightExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Regression: a sync send whose blocking wait throws AFTER the task was accepted must NOT also run
+     * releaseUnsent — the accepted task already owns and frees the source, so a second free would be a
+     * double free. Ownership (handedOff) is transferred at submit time, before the wait, so the handler's
+     * finally must skip releaseUnsent even though the wait threw.
+     */
+    public void testSyncSendDoesNotReleaseUnsentAfterTaskAccepted() throws Exception {
+        ExecutorService flightExecutor = Executors.newSingleThreadExecutor();
+        try {
+            when(mockFlightChannel.getExecutor()).thenReturn(flightExecutor);
+            // Force the blocking wait to throw AFTER submit succeeds: the task runs, its send fails, and
+            // routing that failure to the listener throws, so the exception escapes to Future.get().
+            doThrow(new RuntimeException("send failed")).when(mockFlightChannel).sendBatch(any(TransportResponse.class), any());
+            doThrow(new RuntimeException("listener boom")).when(mockListener).onResponseSent(anyLong(), anyString(), any(Exception.class));
+
+            expectThrows(
+                StreamException.class,
+                () -> handler.sendResponseBatch(
+                    Version.CURRENT,
+                    Collections.emptySet(),
+                    mockFlightChannel,
+                    mock(FlightTransportChannel.class),
+                    1L,
+                    "test-action",
+                    mock(TransportResponse.class),
+                    false,
+                    false,
+                    true // sync
+                )
+            );
+
+            // The accepted task owns the source; releaseUnsent must NOT run (that would be the double free).
+            verify(mockFlightChannel, never()).releaseUnsent(any());
+        } finally {
+            flightExecutor.shutdownNow();
+            flightExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 
     /**
@@ -653,6 +807,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
                 1L,
                 "test-action",
                 mock(TransportResponse.class),
+                false,
                 false,
                 false
             )

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
@@ -89,7 +89,8 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
         doAnswer(invocation -> {
             latch.countDown();
             return null;
-        }).when(mockOutboundHandler).sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean());
+        }).when(mockOutboundHandler)
+            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean());
 
         channel.sendResponseBatch(response);
 
@@ -103,6 +104,45 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
             eq("test-action"),
             eq(response),
             eq(false),
+            eq(false),
+            eq(false)
+        );
+    }
+
+    public void testExplicitSyncIsPropagatedToHandler() throws IOException {
+        TransportResponse response = mock(TransportResponse.class);
+
+        // sync is opt-in and passed straight through to the handler.
+        channel.sendResponseBatch(response, true);
+        verify(mockOutboundHandler).sendResponseBatch(
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any(),
+            eq(response),
+            anyBoolean(),
+            anyBoolean(),
+            eq(true)
+        );
+    }
+
+    public void testDefaultSendResponseBatchIsAsync() throws IOException {
+        TransportResponse response = mock(TransportResponse.class);
+
+        // The 1-arg form defaults to async (sync=false); no response type is auto-synced.
+        channel.sendResponseBatch(response);
+        verify(mockOutboundHandler).sendResponseBatch(
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any(),
+            eq(response),
+            anyBoolean(),
+            anyBoolean(),
             eq(false)
         );
     }
@@ -122,7 +162,7 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
         StreamException cancellationException = new StreamException(StreamErrorCode.CANCELLED, "cancelled");
 
         doThrow(cancellationException).when(mockOutboundHandler)
-            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean());
+            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean());
 
         StreamException thrown = assertThrows(StreamException.class, () -> channel.sendResponseBatch(response));
         assertEquals(StreamErrorCode.CANCELLED, thrown.getErrorCode());
@@ -139,7 +179,7 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
         RuntimeException genericException = new RuntimeException("generic error");
 
         doThrow(genericException).when(mockOutboundHandler)
-            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean());
+            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean());
 
         StreamException thrown = assertThrows(StreamException.class, () -> channel.sendResponseBatch(response));
         assertEquals(StreamErrorCode.INTERNAL, thrown.getErrorCode());
@@ -156,7 +196,7 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
         StreamException timedOut = new StreamException(StreamErrorCode.TIMED_OUT, "consumer not ready");
 
         doThrow(timedOut).when(mockOutboundHandler)
-            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean());
+            .sendResponseBatch(any(), any(), any(), any(), anyLong(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean());
 
         StreamException thrown = assertThrows(StreamException.class, () -> channel.sendResponseBatch(response));
         assertSame(timedOut, thrown);

--- a/server/src/main/java/org/opensearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteClusterAwareClient.java
@@ -35,29 +35,48 @@ import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionType;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.support.AbstractClient;
 
 /**
- * Client that is aware of remote clusters
+ * Client that is aware of remote clusters. Beyond the regular request/response path it exposes
+ * {@link #sendStreamRequest} for streaming (Arrow Flight) requests to a remote cluster, so it is a
+ * public type callers can hold to reach that streaming path.
  *
- * @opensearch.internal
+ * @opensearch.experimental
  */
-final class RemoteClusterAwareClient extends AbstractClient {
+@ExperimentalApi
+public final class RemoteClusterAwareClient extends AbstractClient {
 
     private final TransportService service;
     private final String clusterAlias;
     private final RemoteClusterService remoteClusterService;
+    // Null when the stream transport is not enabled on this node; sendStreamRequest then throws rather
+    // than falling back to the regular request/response path.
+    private final StreamTransportService streamTransportService;
 
     RemoteClusterAwareClient(Settings settings, ThreadPool threadPool, TransportService service, String clusterAlias) {
+        this(settings, threadPool, service, clusterAlias, null);
+    }
+
+    RemoteClusterAwareClient(
+        Settings settings,
+        ThreadPool threadPool,
+        TransportService service,
+        String clusterAlias,
+        StreamTransportService streamTransportService
+    ) {
         super(settings, threadPool);
         this.service = service;
         this.clusterAlias = clusterAlias;
         this.remoteClusterService = service.getRemoteClusterService();
+        this.streamTransportService = streamTransportService;
     }
 
     @Override
@@ -82,6 +101,63 @@ final class RemoteClusterAwareClient extends AbstractClient {
                 new ActionListenerResponseHandler<>(listener, action.getResponseReader())
             );
         }, listener::onFailure));
+    }
+
+    /**
+     * Streaming sibling of {@link #doExecute}: sends {@code request} to the remote cluster over the
+     * stream (Arrow Flight) transport and delivers the response batches to {@code handler}.
+     *
+     * <p>Semantics mirror {@link #doExecute} exactly — same {@code ensureConnected} on the remote
+     * cluster, same node selection ({@link RemoteClusterAwareRequest#getPreferredTargetNode()} when
+     * the request implements it, otherwise any connected remote node) — except the request is
+     * carried by {@link StreamTransportService} with {@link TransportRequestOptions.Type#STREAM}.
+     * Because the stream transport maintains its own connections, the target node is connected on
+     * the stream transport (no-op if already connected) before the request is sent.
+     *
+     * @throws IllegalStateException if the stream transport is not enabled on this node.
+     */
+    public <T extends TransportResponse> void sendStreamRequest(
+        String action,
+        TransportRequest request,
+        DiscoveryNode targetNode,
+        StreamTransportResponseHandler<T> handler
+    ) {
+        if (streamTransportService == null) {
+            throw new IllegalStateException(
+                "stream transport is not enabled on this node; cannot open a streaming request to remote cluster [" + clusterAlias + "]"
+            );
+        }
+        remoteClusterService.ensureConnected(clusterAlias, ActionListener.wrap(v -> {
+            final DiscoveryNode node = targetNode != null ? targetNode : selectTargetNode(request);
+            // The stream transport has its own connection manager, so connect the node there separately
+            // (the ensureConnected above only covers the regular transport).
+            streamTransportService.connectToNode(node, null, ActionListener.wrap(c -> {
+                final TransportRequestOptions options = TransportRequestOptions.builder()
+                    .withType(TransportRequestOptions.Type.STREAM)
+                    .withTimeout(streamTransportService.getStreamTransportReqTimeout())
+                    .build();
+                streamTransportService.sendRequest(node, action, request, options, handler);
+            }, e -> handler.handleException(wrapAsTransportException(node, e))));
+        }, e -> handler.handleException(wrapAsTransportException(null, e))));
+    }
+
+    /**
+     * Node-selection rule shared with {@link #doExecute}: the request's preferred target when it is a
+     * {@link RemoteClusterAwareRequest}, otherwise any connected remote node. ({@code doExecute} keeps
+     * its connection-oriented form because it needs a {@link Transport.Connection}, not just the node.)
+     */
+    private DiscoveryNode selectTargetNode(TransportRequest request) {
+        if (request instanceof RemoteClusterAwareRequest remoteClusterAwareRequest) {
+            return remoteClusterAwareRequest.getPreferredTargetNode();
+        }
+        return remoteClusterService.getConnection(clusterAlias).getNode();
+    }
+
+    private static TransportException wrapAsTransportException(DiscoveryNode node, Exception e) {
+        if (e instanceof TransportException te) {
+            return te;
+        }
+        return node != null ? new ConnectTransportException(node, "failed to open streaming connection", e) : new TransportException(e);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
@@ -409,6 +409,22 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
      * @throws IllegalArgumentException if the given clusterAlias doesn't exist
      */
     public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias) {
+        return getRemoteClusterClient(threadPool, clusterAlias, null);
+    }
+
+    /**
+     * Returns a client to the remote cluster that additionally supports streaming requests over the
+     * given {@link StreamTransportService} (Arrow Flight) via
+     * {@link RemoteClusterAwareClient#sendStreamRequest}. Regular request/response behaviour is
+     * identical to {@link #getRemoteClusterClient(ThreadPool, String)}; passing a null
+     * {@code streamTransportService} yields a client whose streaming path is disabled.
+     *
+     * @param threadPool             the {@link ThreadPool} for the client
+     * @param clusterAlias           the cluster alias the remote cluster is registered under
+     * @param streamTransportService node-local stream transport service, or null if not enabled
+     * @throws IllegalArgumentException if the given clusterAlias doesn't exist
+     */
+    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias, StreamTransportService streamTransportService) {
         if (transportService.getRemoteClusterService().isEnabled() == false) {
             throw new IllegalArgumentException(
                 "this node does not have the " + DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName() + " role"
@@ -417,7 +433,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         if (transportService.getRemoteClusterService().getRemoteClusterNames().contains(clusterAlias) == false) {
             throw new NoSuchRemoteClusterException(clusterAlias);
         }
-        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias);
+        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias, streamTransportService);
     }
 
     Collection<RemoteClusterConnection> getConnections() {

--- a/server/src/main/java/org/opensearch/transport/StreamTransportService.java
+++ b/server/src/main/java/org/opensearch/transport/StreamTransportService.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -31,8 +32,9 @@ import static org.opensearch.discovery.HandshakingTransportAddressConnector.PROB
 
 /**
  * Transport service for streaming requests, handling StreamTransportResponse.
- * @opensearch.internal
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public class StreamTransportService extends TransportService {
     private static final Logger logger = LogManager.getLogger(StreamTransportService.class);
     public static final Setting<TimeValue> STREAM_TRANSPORT_REQ_TIMEOUT_SETTING = Setting.timeSetting(
@@ -133,5 +135,15 @@ public class StreamTransportService extends TransportService {
 
     private void setStreamTransportReqTimeout(TimeValue streamTransportReqTimeout) {
         this.streamTransportReqTimeout = streamTransportReqTimeout;
+    }
+
+    /**
+     * The configured streaming request timeout ({@code transport.stream.request_timeout}). Callers
+     * that build their own {@link TransportRequestOptions} (rather than using the
+     * {@link #sendChildRequest} overload that injects it) should apply this so streaming requests
+     * honor the same timeout the service applies by default.
+     */
+    public TimeValue getStreamTransportReqTimeout() {
+        return streamTransportReqTimeout;
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
@@ -79,6 +79,16 @@ public class TaskTransportChannel implements TransportChannel {
     }
 
     @Override
+    public void sendResponseBatch(TransportResponse response, boolean sync) {
+        channel.sendResponseBatch(response, sync);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return channel.isCancelled();
+    }
+
+    @Override
     public void completeStream() {
         try {
             onTaskFinished.close();

--- a/server/src/main/java/org/opensearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TransportChannel.java
@@ -75,18 +75,20 @@ public interface TransportChannel {
     }
 
     /**
-     * Sends a batch of responses, optionally blocking the caller until the batch is on the wire.
-     * Defaults to the asynchronous behaviour of {@link #sendResponseBatch(TransportResponse)} when
-     * {@code sync == false}.
+     * Sends a batch of responses, optionally blocking the caller until the batch has been handed off to
+     * the transport. Defaults to the asynchronous behaviour of {@link #sendResponseBatch(TransportResponse)}
+     * when {@code sync == false}.
      *
-     * <p>With {@code sync == true} the caller blocks until the batch has been written, so it cannot
-     * queue the next batch ahead of this one — an end-to-end bound on outstanding batches (useful when
-     * the batch holds large buffers that must not accumulate). The send itself still runs on the
-     * channel's send executor; only the caller is made to wait. A caller that requests this MUST drive
-     * a single stream from a single thread and MUST NOT call from the channel's send-executor thread.
+     * <p>With {@code sync == true} the caller blocks until the batch has been written to the transport's
+     * outbound buffer, so it cannot queue the next batch ahead of this one — a bound on outstanding
+     * batches (useful when the batch holds large buffers that must not accumulate). This does not wait
+     * for the bytes to leave the machine; if the outbound buffer is full the transport's own readiness
+     * back-pressure gates the send. The send itself still runs on the channel's send executor; only the
+     * caller is made to wait. A caller that requests this MUST drive a single stream from a single thread
+     * and MUST NOT call from the channel's send-executor thread.
      *
      * @param response the batch of responses to send
-     * @param sync     {@code true} to block the caller until the batch is on the wire; {@code false} for async dispatch
+     * @param sync     {@code true} to block the caller until the batch is handed to the transport; {@code false} for async dispatch
      * @throws StreamException with {@link StreamErrorCode#CANCELLED} if the stream has been canceled.
      */
     @ExperimentalApi

--- a/server/src/main/java/org/opensearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TransportChannel.java
@@ -75,12 +75,44 @@ public interface TransportChannel {
     }
 
     /**
+     * Sends a batch of responses, optionally blocking the caller until the batch is on the wire.
+     * Defaults to the asynchronous behaviour of {@link #sendResponseBatch(TransportResponse)} when
+     * {@code sync == false}.
+     *
+     * <p>With {@code sync == true} the caller blocks until the batch has been written, so it cannot
+     * queue the next batch ahead of this one — an end-to-end bound on outstanding batches (useful when
+     * the batch holds large buffers that must not accumulate). The send itself still runs on the
+     * channel's send executor; only the caller is made to wait. A caller that requests this MUST drive
+     * a single stream from a single thread and MUST NOT call from the channel's send-executor thread.
+     *
+     * @param response the batch of responses to send
+     * @param sync     {@code true} to block the caller until the batch is on the wire; {@code false} for async dispatch
+     * @throws StreamException with {@link StreamErrorCode#CANCELLED} if the stream has been canceled.
+     */
+    @ExperimentalApi
+    default void sendResponseBatch(TransportResponse response, boolean sync) {
+        sendResponseBatch(response);
+    }
+
+    /**
      * Call this method on a successful completion the streaming response.
      * Note: not calling this method on success will result in a memory leak
      */
     @ExperimentalApi
     default void completeStream() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Whether the stream has been cancelled (by the consumer, or due to a transport error) without
+     * waiting for the next {@link #sendResponseBatch(TransportResponse)} to throw. A long-lived sender
+     * that parks between sends can poll this to exit promptly when the consumer goes away, instead of
+     * leaking until its next send throws or a keepalive timeout fires. Default {@code false} for
+     * channels without a cancellation signal.
+     */
+    @ExperimentalApi
+    default boolean isCancelled() {
+        return false;
     }
 
     void sendResponse(TransportResponse response) throws IOException;

--- a/server/src/main/java/org/opensearch/transport/stream/StreamingTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/stream/StreamingTransportChannel.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 @ExperimentalApi
 public interface StreamingTransportChannel extends TransportChannel {
 
-    // TODO: introduce a way to poll for cancellation in addition to current way of detection i.e. depending on channel
-    // throwing StreamException with CANCELLED error code.
     /**
      * Sends a batch of responses to the request that this channel is associated with.
      * Call {@link #completeStream()} on a successful completion.

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterAwareClientTests.java
@@ -39,13 +39,17 @@ import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.stream.StreamTransportResponse;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,6 +60,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RemoteClusterAwareClientTests extends OpenSearchTestCase {
 
@@ -116,6 +127,145 @@ public class RemoteClusterAwareClientTests extends OpenSearchTestCase {
                 }
             }
         }
+    }
+
+    public void testSendStreamRequestThrowsWhenStreamTransportDisabled() throws Exception {
+        // The streaming send path must NOT fall back to the regular transport when the stream transport
+        // is unavailable — enabling streaming is a deliberate opt-in, so a missing stream transport is a
+        // misconfiguration that surfaces as an error (routed to the handler), not a silent pull.
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes)) {
+            knownNodes.add(seedTransport.getLocalDiscoNode());
+            Settings.Builder builder = Settings.builder();
+            builder.putList("cluster.remote.cluster1.seeds", seedTransport.getLocalDiscoNode().getAddress().toString());
+            try (
+                MockTransportService service = MockTransportService.createNewService(
+                    builder.build(),
+                    Version.CURRENT,
+                    threadPool,
+                    NoopTracer.INSTANCE
+                )
+            ) {
+                service.start();
+                service.acceptIncomingRequests();
+
+                // 4-arg constructor => streamTransportService is null (stream transport not enabled).
+                try (RemoteClusterAwareClient client = new RemoteClusterAwareClient(Settings.EMPTY, threadPool, service, "cluster1")) {
+                    IllegalStateException e = expectThrows(
+                        IllegalStateException.class,
+                        () -> client.sendStreamRequest(
+                            "internal:test/stream",
+                            new SearchRequest("test-index"),
+                            seedTransport.getLocalDiscoNode(),
+                            noopStreamHandler()
+                        )
+                    );
+                    assertTrue(
+                        "message should explain the stream transport is not enabled, was: " + e.getMessage(),
+                        e.getMessage().contains("stream transport is not enabled")
+                    );
+                }
+            }
+        }
+    }
+
+    public void testSendStreamRequestConnectsToTargetNodeOnStreamTransport() throws Exception {
+        // sendStreamRequest routes through the stream transport: after ensureConnected on the remote
+        // cluster it connects the resolved target node on the StreamTransportService before sending. Here
+        // that connect fails, so we can assert (a) it targeted the requested node and (b) the failure is
+        // wrapped as a ConnectTransportException delivered to the handler (wrapAsTransportException).
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes)) {
+            DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
+            knownNodes.add(seedNode);
+            Settings.Builder builder = Settings.builder();
+            builder.putList("cluster.remote.cluster1.seeds", seedNode.getAddress().toString());
+            try (
+                MockTransportService service = MockTransportService.createNewService(
+                    builder.build(),
+                    Version.CURRENT,
+                    threadPool,
+                    NoopTracer.INSTANCE
+                )
+            ) {
+                service.start();
+                service.acceptIncomingRequests();
+
+                StreamTransportService streamTransportService = mock(StreamTransportService.class);
+                when(streamTransportService.getStreamTransportReqTimeout()).thenReturn(TimeValue.timeValueSeconds(30));
+                // connectToNode (non-final, stream-transport-specific) fails synchronously.
+                doAnswer(inv -> {
+                    ActionListener<Void> l = inv.getArgument(2);
+                    l.onFailure(new RuntimeException("no stream route"));
+                    return null;
+                }).when(streamTransportService).connectToNode(any(DiscoveryNode.class), any(), any());
+
+                CountDownLatch failed = new CountDownLatch(1);
+                AtomicReference<TransportException> handlerError = new AtomicReference<>();
+                try (
+                    RemoteClusterAwareClient client = new RemoteClusterAwareClient(
+                        Settings.EMPTY,
+                        threadPool,
+                        service,
+                        "cluster1",
+                        streamTransportService
+                    )
+                ) {
+                    client.sendStreamRequest(
+                        "internal:test/stream",
+                        new SearchRequest("test-index"),
+                        seedNode,
+                        new StreamTransportResponseHandler<>() {
+                            @Override
+                            public void handleStreamResponse(StreamTransportResponse<TransportResponse> s) {}
+
+                            @Override
+                            public void handleException(TransportException exp) {
+                                handlerError.set(exp);
+                                failed.countDown();
+                            }
+
+                            @Override
+                            public String executor() {
+                                return ThreadPool.Names.SAME;
+                            }
+
+                            @Override
+                            public TransportResponse read(StreamInput in) {
+                                return null;
+                            }
+                        }
+                    );
+
+                    assertTrue("handler must be notified of the connect failure", failed.await(5, TimeUnit.SECONDS));
+                    verify(streamTransportService).connectToNode(eq(seedNode), any(), any());
+                    assertTrue(
+                        "connect failure must be wrapped as ConnectTransportException, was: " + handlerError.get(),
+                        handlerError.get() instanceof ConnectTransportException
+                    );
+                }
+            }
+        }
+    }
+
+    private static StreamTransportResponseHandler<TransportResponse> noopStreamHandler() {
+        return new StreamTransportResponseHandler<>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<TransportResponse> s) {}
+
+            @Override
+            public void handleException(TransportException exp) {}
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public TransportResponse read(StreamInput in) {
+                return null;
+            }
+        };
     }
 
     public void testSearchShardsThreadContextHeader() {

--- a/server/src/test/java/org/opensearch/transport/TaskTransportChannelTests.java
+++ b/server/src/test/java/org/opensearch/transport/TaskTransportChannelTests.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * TaskTransportChannel wraps the real channel for task tracking, so it must forward the streaming
+ * methods to the delegate — otherwise a task-tracked streaming action (the normal registration path)
+ * can't reach them. In particular the {@code sendResponseBatch(response, sync)} and {@code isCancelled()}
+ * calls must land on the wrapped channel, not on the base default (which no-ops / throws).
+ */
+public class TaskTransportChannelTests extends OpenSearchTestCase {
+
+    private TransportChannel delegate;
+    private TaskTransportChannel channel;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        delegate = mock(TransportChannel.class);
+        channel = new TaskTransportChannel(delegate, () -> {});
+    }
+
+    public void testSyncSendResponseBatchIsForwarded() {
+        TransportResponse response = mock(TransportResponse.class);
+        channel.sendResponseBatch(response, true);
+        verify(delegate).sendResponseBatch(response, true);
+    }
+
+    public void testAsyncSendResponseBatchIsForwarded() {
+        TransportResponse response = mock(TransportResponse.class);
+        channel.sendResponseBatch(response);
+        verify(delegate).sendResponseBatch(response);
+    }
+
+    public void testIsCancelledIsForwarded() {
+        when(delegate.isCancelled()).thenReturn(true);
+        assertTrue(channel.isCancelled());
+        verify(delegate).isCancelled();
+    }
+}


### PR DESCRIPTION
### Description

Adds **cross-cluster streaming support to the remote cluster client**: a plugin can open an Arrow Flight stream to a *remote cluster* (mirroring the existing regular remote-client request path), with a poll-able cancellation signal so a long-lived sender doesn't leak when the consumer goes away, plus an opt-in synchronous send for callers that need a hard bound on outstanding batches.

This is transport infrastructure underneath cross-cluster replication's streaming GetChanges, but it carries **no replication-specific code** and is reusable by any streaming cross-cluster action. Three pieces:

#### 1. Stream-aware remote client
`RemoteClusterAwareClient.sendStreamRequest(...)` sends a streaming request to a remote cluster over the stream (Arrow Flight) transport, with the same connect + node-selection as the existing `doExecute` request/response path; `RemoteClusterService.getRemoteClusterClient(threadPool, alias, streamTransportService)` builds such a client. No fallback to the regular transport — a missing stream transport throws. The class is `public @ExperimentalApi` because streaming has no polymorphic home on the `Client` interface (streaming is initiated on `StreamTransportService`, not `Client`), so a cross-module caller holds this concrete type to reach `sendStreamRequest`.

#### 2. Optional synchronous send (`sendResponseBatch(response, sync)`)
By default a batch send is dispatched to the channel's send executor and the producer returns once it is queued. The new opt-in overload lets a caller instead **block until the batch is on the wire**:
- `sendResponseBatch(response)` — async (default, unchanged).
- `sendResponseBatch(response, true)` — the send still runs on the channel's send executor, but the caller blocks until it completes, so it cannot queue the next batch ahead of this one. Outstanding batches are bounded to one (useful when batches hold large buffers that must not accumulate).

The send always runs on the same single-threaded executor that the channel's `close()` posts its stream-root free to, so a batch send and a concurrent `close()` are FIFO-serialized on that executor and cannot race on the stream root. A caller that opts into `sync` must drive a single stream from a single thread and must not call from the send-executor thread.

#### 3. Cancellation + liveness
`TransportChannel.isCancelled()` (default method, forwarded by `TaskTransportChannel`) lets a parked sender poll for consumer cancellation instead of leaking until its next send throws; plus gRPC server keepalive on the Flight server (`flight.keepalive.time`/`timeout`, defaulting to gRPC's own 2h/20s so behaviour is unchanged out of the box) to free senders on half-open connections.

### Related Issues
N/A — extracted from internal cross-cluster-replication streaming work for upstream review.

### Check List
- [x] Functionality includes testing (stream client connect/route + no-fallback contract, sync send runs on the executor and blocks, sync failure surfaces as StreamException, async dispatch, `TaskTransportChannel` forwarding, keepalive defaults + validator + applied to the gRPC builder).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public APIs annotated (`@ExperimentalApi`).
- [x] Docs updated (`backpressure.md`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
