### PR TITLE
Fix flaky DataFormatAwareReplicaGetByIdIT when zero docs are indexed

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicaGetByIdIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicaGetByIdIT.java
@@ -26,9 +26,11 @@ import java.util.List;
 public class DataFormatAwareReplicaGetByIdIT extends DataFormatAwareReplicationBaseIT {
 
     public void testGetByIdFromReplica() throws Exception {
-        int maxDocs = randomInt(20);
+        // At least one doc: assertCatalogSnapshotsConverged asserts the lucene index/ has segment
+        // data files beyond segments_N, which an empty index never produces (randomInt(20) can be 0).
+        int maxDocs = randomIntBetween(1, 20);
         createDfaIndex(1); // 1 replica, 2 data nodes (from base)
-        List<String> ids = indexDocs(maxDocs);     // ids 0..19, RefreshPolicy.NONE
+        List<String> ids = indexDocs(maxDocs);     // ids 1..20, RefreshPolicy.NONE
         client().admin().indices().prepareRefresh(INDEX_NAME).get();
         // Ensure the replica's catalog has converged with the primary (segments replicated).
         assertCatalogSnapshotsConverged(INDEX_NAME);


### PR DESCRIPTION
### Description
`testGetByIdFromReplica` picked its document count with `randomInt(20)`, which is inclusive of 0. On the (~1-in-21) runs where it rolled 0, the test indexed no documents and then failed in `assertCatalogSnapshotsConverged(...)`.
With 0 docs, the index only ever produces a `segments_N` commit file. `assertCatalogSnapshotsConverged` calls `assertLuceneIndexDirContents`, which — because this suite runs with a Lucene secondary format (`hasLuceneSecondary()` returns `true`) — asserts the shard's `index/` directory contains segment data files beyond `segments_N` (.si, .cfs, etc.). An empty index never writes those, so the assertion tripped:
> parquet+lucene: index/ must have segment data files beyond segments_N, got [segments_N, write.lock]

The failure was purely a function of the random seed, making it an intermittent (flaky) failure rather than a real regression in the replica get-by-id path.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
