### PR TITLE
fix(tiering): Track force merges in activeMerges to prevent tiering before force merge completion

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
@@ -261,6 +261,8 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
                 var replicationStats = primary.getReplicationStatsForTrackedReplicas();
                 for (var stat : replicationStats) {
                     assertEquals("replica should be in sync after prepare (checkpoints behind)", 0, stat.getCheckpointsBehindCount());
+                    assertEquals("replica should be in sync after prepare (bytes behind)", 0, stat.getBytesBehindCount());
+                    assertEquals("replica should have no in-flight replication", 0, stat.getCurrentReplicationTimeMillis());
                 }
             }, 30, TimeUnit.SECONDS);
 

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
@@ -267,8 +267,19 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
             // Data integrity: doc count should be preserved
             assertEquals("all docs should be present", (long) totalDocs, primariesDocCount(ASYNC_INDEX));
 
-            // Force merge target: replica segment count should be 1 after merge completes and replicates
-            long replicaSegmentCount = client().admin()
+            // After prepare, replica should have the same segment layout as primary (in sync)
+            long primarySegments = client().admin()
+                .indices()
+                .prepareStats(ASYNC_INDEX)
+                .clear()
+                .setSegments(true)
+                .get()
+                .getIndex(ASYNC_INDEX)
+                .getPrimaries()
+                .getSegments()
+                .getCount();
+
+            long totalSegments = client().admin()
                 .indices()
                 .prepareStats(ASYNC_INDEX)
                 .clear()
@@ -278,8 +289,13 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
                 .getTotal()
                 .getSegments()
                 .getCount();
-            // Total segments = primary (1) + replica (1) = 2 for a 1P+1R index after force merge
-            assertEquals("primary + replica should each have 1 segment after force merge + prepare", 2, replicaSegmentCount);
+
+            // 1P+1R: total should be exactly 2x primary (replica mirrors primary)
+            assertEquals(
+                "replica segment count should match primary after prepare",
+                primarySegments * 2,
+                totalSegments
+            );
         } finally {
             client().admin().indices().delete(new DeleteIndexRequest(ASYNC_INDEX)).actionGet();
         }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
@@ -24,6 +24,7 @@ import org.opensearch.storage.action.tiering.PrepareTieringRequest;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * End-to-end integration test for the asynchronous pre-tiering sync ({@link PrepareTieringAction}).
@@ -201,5 +202,93 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
         String nodeName = state.nodes().get(primary.currentNodeId()).getName();
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, nodeName);
         return indicesService.indexServiceSafe(resolveIndex(index)).getShard(shardId);
+    }
+
+    /**
+     * Triggers a force merge and immediately calls prepare tiering back-to-back. Whether the force
+     * merge is still in-flight when prepare runs depends on timing — the test verifies that in either
+     * case:
+     * <ul>
+     *   <li>Prepare succeeds (no shard failures)</li>
+     *   <li>All merges (background and force) are drained after prepare completes</li>
+     *   <li>Replicas are in sync with the primary (checkpoints behind == 0)</li>
+     * </ul>
+     * This guards against the race condition where forceMerge was invisible to onMergesDrained,
+     * causing tiering to proceed while a force merge was still running.
+     */
+    public void testPrepareTieringAfterForceMerge_MergesDrainedAndReplicasInSync() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataAndWarmNodes(2);
+
+        Settings settings = Settings.builder()
+            .put(dfaIndexSettings(1))
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .build();
+        client().admin().indices().prepareCreate(ASYNC_INDEX).setSettings(settings).get();
+        ensureGreen(ASYNC_INDEX);
+
+        try {
+            // Index in many batches to create multiple segments worth merging
+            int id = 0;
+            for (int batch = 0; batch < INDEX_BATCHES * 2; batch++) {
+                for (int i = 0; i < DOCS_PER_BATCH; i++) {
+                    client().prepareIndex(ASYNC_INDEX).setSource("field_text", "value_" + id, "field_number", (long) id).get();
+                    id++;
+                }
+                client().admin().indices().prepareRefresh(ASYNC_INDEX).get();
+            }
+            final int totalDocs = id;
+            client().admin().indices().prepareFlush(ASYNC_INDEX).setForce(true).get();
+
+            // Trigger force merge (non-blocking) and immediately call prepare tiering back-to-back.
+            // Whether the merge is still in-flight or already done when prepare runs is timing-dependent —
+            // both outcomes must result in a successful prepare with drained merges.
+            client().admin().indices().prepareForceMerge(ASYNC_INDEX).setMaxNumSegments(1).setFlush(false).execute();
+
+            PrepareTieringRequest request = new PrepareTieringRequest(ASYNC_INDEX);
+            request.timeout(TimeValue.timeValueSeconds(90));
+            BroadcastResponse response = client().execute(PrepareTieringAction.INSTANCE, request).actionGet();
+
+            // Prepare must succeed — regardless of whether force merge was still running or already done
+            assertEquals("all shards targeted", 1, response.getTotalShards());
+            assertEquals("no shard should fail prepare", 0, response.getFailedShards());
+            assertEquals("shard should prepare successfully", 1, response.getSuccessfulShards());
+
+            // After prepare completes, all merges must be drained
+            IndexShard primary = primaryShard(ASYNC_INDEX, 0);
+            assertEquals("active merges should be drained after prepare", 0, primary.getActiveMergeCount());
+            assertFalse("no pending merges should remain after prepare", primary.hasPendingMerges());
+
+            // Replicas must be in sync — checkpoints behind should be 0
+            assertBusy(() -> {
+                var replicationStats = primary.getReplicationStatsForTrackedReplicas();
+                for (var stat : replicationStats) {
+                    assertEquals(
+                        "replica should be in sync after prepare (checkpoints behind)",
+                        0,
+                        stat.getCheckpointsBehindCount()
+                    );
+                }
+            }, 30, TimeUnit.SECONDS);
+
+            // Data integrity: doc count should be preserved
+            assertEquals("all docs should be present", (long) totalDocs, primariesDocCount(ASYNC_INDEX));
+
+            // Force merge target: replica segment count should be 1 after merge completes and replicates
+            long replicaSegmentCount = client().admin()
+                .indices()
+                .prepareStats(ASYNC_INDEX)
+                .clear()
+                .setSegments(true)
+                .get()
+                .getIndex(ASYNC_INDEX)
+                .getTotal()
+                .getSegments()
+                .getCount();
+            // Total segments = primary (1) + replica (1) = 2 for a 1P+1R index after force merge
+            assertEquals("primary + replica should each have 1 segment after force merge + prepare", 2, replicaSegmentCount);
+        } finally {
+            client().admin().indices().delete(new DeleteIndexRequest(ASYNC_INDEX)).actionGet();
+        }
     }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
@@ -291,11 +291,7 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
                 .getCount();
 
             // 1P+1R: total should be exactly 2x primary (replica mirrors primary)
-            assertEquals(
-                "replica segment count should match primary after prepare",
-                primarySegments * 2,
-                totalSegments
-            );
+            assertEquals("replica segment count should match primary after prepare", primarySegments * 2, totalSegments);
         } finally {
             client().admin().indices().delete(new DeleteIndexRequest(ASYNC_INDEX)).actionGet();
         }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwarePrepareTieringAsyncIT.java
@@ -220,10 +220,7 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataAndWarmNodes(2);
 
-        Settings settings = Settings.builder()
-            .put(dfaIndexSettings(1))
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .build();
+        Settings settings = Settings.builder().put(dfaIndexSettings(1)).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build();
         client().admin().indices().prepareCreate(ASYNC_INDEX).setSettings(settings).get();
         ensureGreen(ASYNC_INDEX);
 
@@ -263,11 +260,7 @@ public class DataFormatAwarePrepareTieringAsyncIT extends DataFormatAwareReadonl
             assertBusy(() -> {
                 var replicationStats = primary.getReplicationStatsForTrackedReplicas();
                 for (var stat : replicationStats) {
-                    assertEquals(
-                        "replica should be in sync after prepare (checkpoints behind)",
-                        0,
-                        stat.getCheckpointsBehindCount()
-                    );
+                    assertEquals("replica should be in sync after prepare (checkpoints behind)", 0, stat.getCheckpointsBehindCount());
                 }
             }, 30, TimeUnit.SECONDS);
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -780,6 +780,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 TieringUtils.JVM_USAGE_TIERING_THRESHOLD_PERCENT,
                 TieringUtils.FILECACHE_ACTIVE_USAGE_TIERING_THRESHOLD_PERCENT,
                 TieringUtils.PREPARE_TIERING_TIMEOUT,
+                TieringUtils.REPLICA_SYNC_TIMEOUT_SETTING,
 
                 // Settings related to Remote Refresh Segment Pressure
                 RemoteStorePressureSettings.REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED,

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -169,20 +169,7 @@ public class MergeScheduler {
                 runMerge(oneMerge);
             }
         } finally {
-            activeMerges.decrementAndGet();
-            // Fire all drain listeners if all merges completed and none pending.
-            // This ensures tiering's onMergesDrained callback fires after a force merge completes.
-            if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
-                List<Runnable> listeners = List.copyOf(onDrainedListeners);
-                onDrainedListeners.clear();
-                for (Runnable listener : listeners) {
-                    try {
-                        listener.run();
-                    } catch (Exception ex) {
-                        logger.warn("Exception in onDrained listener", ex);
-                    }
-                }
-            }
+            decrementAndFireDrainListeners();
             forceMergeLock.release();
         }
     }
@@ -357,19 +344,7 @@ public class MergeScheduler {
                 // runMerge already invoked onMergeFailureCleanup; swallow to prevent
                 // uncaught exception on the merge thread pool.
             } finally {
-                activeMerges.decrementAndGet();
-                // Fire all drain listeners if all merges completed and none pending
-                if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
-                    List<Runnable> listeners = List.copyOf(onDrainedListeners);
-                    onDrainedListeners.clear();
-                    for (Runnable listener : listeners) {
-                        try {
-                            listener.run();
-                        } catch (Exception ex) {
-                            logger.warn("Exception in onDrained listener", ex);
-                        }
-                    }
-                }
+                decrementAndFireDrainListeners();
                 // A completed merge may free up capacity for new merges, so check again.
                 executeMerge();
             }
@@ -407,6 +382,26 @@ public class MergeScheduler {
             throw e instanceof IOException ? (IOException) e : new IOException(e);
         } finally {
             mergeStatsTracker.afterMerge(tookMS, totalNumDocs, totalSizeInBytes);
+        }
+    }
+
+    /**
+     * Decrements the active merge count and fires all registered drain listeners if the scheduler
+     * is frozen and no merges (active or pending) remain. Called from both the background merge
+     * ({@link #submitMergeTask}) and force merge ({@link #forceMerge}) completion paths.
+     */
+    private void decrementAndFireDrainListeners() {
+        activeMerges.decrementAndGet();
+        if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
+            List<Runnable> listeners = List.copyOf(onDrainedListeners);
+            onDrainedListeners.clear();
+            for (Runnable listener : listeners) {
+                try {
+                    listener.run();
+                } catch (Exception ex) {
+                    logger.warn("Exception in onDrained listener", ex);
+                }
+            }
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/merge/MergeScheduler.java
@@ -154,6 +154,7 @@ public class MergeScheduler {
         assert Thread.currentThread().getName().contains(ThreadPool.Names.FORCE_MERGE)
             : "forceMerge must be called on FORCE_MERGE thread but was: " + Thread.currentThread().getName();
         forceMergeLock.acquireUninterruptibly();
+        activeMerges.incrementAndGet();
         try {
             if (isShutdown.get()) {
                 logger.debug("MergeScheduler is shutdown, skipping force merge");
@@ -168,6 +169,20 @@ public class MergeScheduler {
                 runMerge(oneMerge);
             }
         } finally {
+            activeMerges.decrementAndGet();
+            // Fire all drain listeners if all merges completed and none pending.
+            // This ensures tiering's onMergesDrained callback fires after a force merge completes.
+            if (isFrozen() && activeMerges.get() == 0 && !mergeHandler.hasPendingMerges() && !onDrainedListeners.isEmpty()) {
+                List<Runnable> listeners = List.copyOf(onDrainedListeners);
+                onDrainedListeners.clear();
+                for (Runnable listener : listeners) {
+                    try {
+                        listener.run();
+                    } catch (Exception ex) {
+                        logger.warn("Exception in onDrained listener", ex);
+                    }
+                }
+            }
             forceMergeLock.release();
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3846,6 +3846,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Stable marker substring embedded in every replica-sync-timeout message. Used for detection
+     * in mixed-version clusters or log parsing, analogous to
+     * {@link org.opensearch.storage.action.tiering.MergeDrainTimeoutException#MERGE_DRAIN_TIMEOUT_MARKER}.
+     */
+    public static final String REPLICA_SYNC_TIMEOUT_MARKER = "[REPLICA_SYNC_TIMEOUT]";
+
+    /**
      * Waits for all tracked replicas to be in sync with the primary's latest checkpoint.
      * Polls every 500ms until either all replicas report {@code checkpointsBehindCount == 0}
      * or the timeout is exceeded.
@@ -3889,7 +3896,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         long behindCount = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0).count();
         long maxBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
         throw new IOException(
-            "Shard ["
+            REPLICA_SYNC_TIMEOUT_MARKER
+                + " Shard ["
                 + shardId
                 + "] replicas failed to sync within "
                 + timeout

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -416,6 +416,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     // Used to limit the number of concurrent translog tasks. When the semaphore is exhausted, serial recovery is used.
     private static final Semaphore translogConcurrentRecoverySemaphore = new Semaphore(1000);
 
+    private static final long REPLICA_SYNC_POLL_INTERVAL_MS = 500;
+
     private final DataFormatRegistry dataFormatRegistry;
 
     private final Map<String, FormatChecksumStrategy> checksumStrategies;
@@ -3876,7 +3878,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 maxBehind
             );
             try {
-                Thread.sleep(500);
+                // TODO: Replace sleep-based polling with a listener on ReplicationTracker checkpoint updates
+                Thread.sleep(REPLICA_SYNC_POLL_INTERVAL_MS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new OpenSearchException("Interrupted waiting for replica sync on shard [" + shardId + "]", e);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3872,29 +3872,35 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         Set<SegmentReplicationShardStats> stats = Set.of();
         while (System.nanoTime() - startNanos < timeout.nanos()) {
             stats = getReplicationStatsForTrackedReplicas();
-            if (stats.isEmpty() || stats.stream().allMatch(s -> s.getCheckpointsBehindCount() == 0)) {
+            if (stats.isEmpty()
+                || stats.stream()
+                    .allMatch(
+                        s -> s.getCheckpointsBehindCount() == 0 && s.getBytesBehindCount() == 0 && s.getCurrentReplicationTimeMillis() == 0
+                    )) {
                 logger.debug("All replicas in sync for shard [{}]", shardId);
                 return;
             }
-            long behindReplicas = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0).count();
-            long maxBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
+            long behindReplicas = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0 || s.getBytesBehindCount() > 0).count();
+            long maxCheckpointsBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
+            long maxBytesBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).max().orElse(0);
             logger.debug(
-                "Waiting for replica sync on shard [{}]: {} replica(s) still behind, max checkpoints behind: {}",
+                "Waiting for replica sync on shard [{}]: {} replica(s) still behind, max checkpoints behind: {}, max bytes behind: {}",
                 shardId,
                 behindReplicas,
-                maxBehind
+                maxCheckpointsBehind,
+                maxBytesBehind
             );
             try {
-                // TODO: Replace sleep-based polling with a listener on ReplicationTracker checkpoint updates
-                Thread.sleep(REPLICA_SYNC_POLL_INTERVAL_MS);
+                Thread.sleep(500);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new OpenSearchException("Interrupted waiting for replica sync on shard [" + shardId + "]", e);
             }
         }
         // Build diagnostic message with per-replica details
-        long behindCount = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0).count();
+        long behindCount = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0 || s.getBytesBehindCount() > 0).count();
         long maxBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
+        long maxBytes = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).max().orElse(0);
         throw new IOException(
             REPLICA_SYNC_TIMEOUT_MARKER
                 + " Shard ["
@@ -3905,6 +3911,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 + behindCount
                 + ", max checkpoints behind: "
                 + maxBehind
+                + ", max bytes behind: "
+                + maxBytes
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3843,6 +3843,60 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return replicationTracker.getSegmentReplicationStats();
     }
 
+    /**
+     * Waits for all tracked replicas to be in sync with the primary's latest checkpoint.
+     * Polls every 500ms until either all replicas report {@code checkpointsBehindCount == 0}
+     * or the timeout is exceeded.
+     * <p>
+     * Used during tiering preparation to verify replicas are in sync after
+     * {@code waitForRemoteStoreSync()} — ensures replicas have downloaded the latest
+     * segments before shard relocation begins.
+     *
+     * @param timeout maximum time to wait for replicas to sync
+     * @throws IOException if replicas fail to sync within the timeout
+     */
+    public void waitForReplicaSync(TimeValue timeout) throws IOException {
+        if (!indexSettings.isSegRepEnabledOrRemoteNode()) {
+            return;
+        }
+        long startNanos = System.nanoTime();
+        Set<SegmentReplicationShardStats> stats = Set.of();
+        while (System.nanoTime() - startNanos < timeout.nanos()) {
+            stats = getReplicationStatsForTrackedReplicas();
+            if (stats.isEmpty() || stats.stream().allMatch(s -> s.getCheckpointsBehindCount() == 0)) {
+                logger.debug("All replicas in sync for shard [{}]", shardId);
+                return;
+            }
+            long behindReplicas = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0).count();
+            long maxBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
+            logger.debug(
+                "Waiting for replica sync on shard [{}]: {} replica(s) still behind, max checkpoints behind: {}",
+                shardId,
+                behindReplicas,
+                maxBehind
+            );
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new OpenSearchException("Interrupted waiting for replica sync on shard [" + shardId + "]", e);
+            }
+        }
+        // Build diagnostic message with per-replica details
+        long behindCount = stats.stream().filter(s -> s.getCheckpointsBehindCount() > 0).count();
+        long maxBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getCheckpointsBehindCount).max().orElse(0);
+        throw new IOException(
+            "Shard ["
+                + shardId
+                + "] replicas failed to sync within "
+                + timeout
+                + ". Replicas still behind: "
+                + behindCount
+                + ", max checkpoints behind: "
+                + maxBehind
+        );
+    }
+
     public ReplicationStats getReplicationStats() {
         if (indexSettings.isSegRepEnabledOrRemoteNode() && !routingEntry().primary()) {
             return segmentReplicationStatsProvider.apply(shardId);

--- a/server/src/main/java/org/opensearch/storage/action/tiering/TransportPrepareTieringAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/TransportPrepareTieringAction.java
@@ -59,11 +59,11 @@ public class TransportPrepareTieringAction extends TransportBroadcastByNodeActio
 
     private static final Logger logger = LogManager.getLogger(TransportPrepareTieringAction.class);
     private static final TimeValue PERMITS_ACQUIRE_TIMEOUT = TimeValue.timeValueSeconds(30);
-    private static final TimeValue REPLICA_SYNC_TIMEOUT = TimeValue.timeValueSeconds(30);
 
     private final IndicesService indicesService;
     private final ThreadPool threadPool;
     private volatile TimeValue prepareTieringTimeout;
+    private volatile TimeValue replicaSyncTimeout;
 
     /**
      * Constructs a TransportPrepareTieringAction.
@@ -95,11 +95,19 @@ public class TransportPrepareTieringAction extends TransportBroadcastByNodeActio
         this.threadPool = transportService.getThreadPool();
         this.prepareTieringTimeout = TieringUtils.PREPARE_TIERING_TIMEOUT.get(clusterService.getSettings());
         clusterService.getClusterSettings().addSettingsUpdateConsumer(TieringUtils.PREPARE_TIERING_TIMEOUT, this::setPrepareTieringTimeout);
+        this.replicaSyncTimeout = TieringUtils.REPLICA_SYNC_TIMEOUT_SETTING.get(clusterService.getSettings());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(TieringUtils.REPLICA_SYNC_TIMEOUT_SETTING, this::setReplicaSyncTimeout);
     }
 
     private void setPrepareTieringTimeout(TimeValue timeout) {
         this.prepareTieringTimeout = timeout;
         logger.info("Updated prepare tiering timeout to [{}]", timeout);
+    }
+
+    private void setReplicaSyncTimeout(TimeValue timeout) {
+        this.replicaSyncTimeout = timeout;
+        logger.info("Updated replica sync timeout to [{}]", timeout);
     }
 
     /**
@@ -257,7 +265,7 @@ public class TransportPrepareTieringAction extends TransportBroadcastByNodeActio
         indexShard.waitForRemoteStoreSync();
         // Wait for replicas to apply the latest checkpoint before relocation.
         // This ensures replicas have downloaded the merged segment(s) from remote store.
-        indexShard.waitForReplicaSync(REPLICA_SYNC_TIMEOUT);
+        indexShard.waitForReplicaSync(replicaSyncTimeout);
         verifyNoUncommittedOps(indexShard, shardRouting);
 
         logger.debug("Shard [{}] prepared for tiering successfully", shardRouting.shardId());

--- a/server/src/main/java/org/opensearch/storage/action/tiering/TransportPrepareTieringAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/TransportPrepareTieringAction.java
@@ -59,6 +59,7 @@ public class TransportPrepareTieringAction extends TransportBroadcastByNodeActio
 
     private static final Logger logger = LogManager.getLogger(TransportPrepareTieringAction.class);
     private static final TimeValue PERMITS_ACQUIRE_TIMEOUT = TimeValue.timeValueSeconds(30);
+    private static final TimeValue REPLICA_SYNC_TIMEOUT = TimeValue.timeValueSeconds(30);
 
     private final IndicesService indicesService;
     private final ThreadPool threadPool;
@@ -254,6 +255,9 @@ public class TransportPrepareTieringAction extends TransportBroadcastByNodeActio
         // "prepare_tiering" source bypasses the freeze guard — this is the last refresh ever.
         indexShard.refresh("prepare_tiering");
         indexShard.waitForRemoteStoreSync();
+        // Wait for replicas to apply the latest checkpoint before relocation.
+        // This ensures replicas have downloaded the merged segment(s) from remote store.
+        indexShard.waitForReplicaSync(REPLICA_SYNC_TIMEOUT);
         verifyNoUncommittedOps(indexShard, shardRouting);
 
         logger.debug("Shard [{}] prepared for tiering successfully", shardRouting.shardId());

--- a/server/src/main/java/org/opensearch/storage/common/tiering/TieringUtils.java
+++ b/server/src/main/java/org/opensearch/storage/common/tiering/TieringUtils.java
@@ -143,6 +143,17 @@ public class TieringUtils {
         Setting.Property.NodeScope
     );
 
+    public static final String REPLICA_SYNC_TIMEOUT_KEY = "tiering.prepare.replica_sync_timeout";
+    /** Setting for how long to wait for replicas to sync during tiering preparation. Dynamically updatable. */
+    public static final Setting<TimeValue> REPLICA_SYNC_TIMEOUT_SETTING = Setting.timeSetting(
+        REPLICA_SYNC_TIMEOUT_KEY,
+        TimeValue.timeValueSeconds(30),
+        TimeValue.timeValueSeconds(5),
+        TimeValue.timeValueMinutes(5),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     /**
      * List of index name prefixes that should be allowed to be migrated.
      * This takes precedence over the 'block-listed' index prefixes.

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/merge/MergeSchedulerOnDrainedTests.java
@@ -14,6 +14,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.MergeResult;
+import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.storage.action.tiering.MergeDrainTimeoutException;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
@@ -569,5 +570,113 @@ public class MergeSchedulerOnDrainedTests extends OpenSearchTestCase {
 
         assertNull("concurrent onDrained() must not throw", error.get());
         assertEquals("every listener must fire inline when already drained", numThreads, fired.get());
+    }
+
+    /**
+     * Verifies that an in-flight force merge blocks {@code onDrained} from firing immediately.
+     * The drain listener must only fire after the force merge completes. This tests the fix for
+     * the tiering race condition where {@code onMergesDrained} would fire immediately during
+     * a running force merge because {@code activeMerges} was never incremented.
+     */
+    public void testOnDrained_BlockedByInFlightForceMerge() throws Exception {
+        MergeHandler mockHandler = mock(MergeHandler.class);
+        when(mockHandler.hasPendingMerges()).thenReturn(false);
+
+        Segment s1 = new Segment(1L, Collections.emptyMap());
+        OneMerge oneMerge = new OneMerge(Collections.singletonList(s1));
+        when(mockHandler.findForceMerges(1)).thenReturn(Collections.singletonList(oneMerge));
+
+        // doMerge blocks until we release the latch — simulates a long-running merge
+        CountDownLatch mergeStarted = new CountDownLatch(1);
+        CountDownLatch mergeCanProceed = new CountDownLatch(1);
+        when(mockHandler.doMerge(oneMerge)).thenAnswer(invocation -> {
+            mergeStarted.countDown();
+            mergeCanProceed.await(10, TimeUnit.SECONDS);
+            return new MergeResult(Collections.emptyMap());
+        });
+
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
+        ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+
+        // Start force merge on a FORCE_MERGE-named thread (required by assertion)
+        AtomicReference<Exception> forceMergeError = new AtomicReference<>();
+        Thread forceMergeThread = new Thread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (Exception e) {
+                forceMergeError.set(e);
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-test");
+        forceMergeThread.setDaemon(true);
+        forceMergeThread.start();
+
+        // Wait for merge to actually start
+        assertTrue("Force merge should have started", mergeStarted.await(5, TimeUnit.SECONDS));
+
+        // Now freeze and try to drain — should NOT fire immediately
+        scheduler.freeze();
+        AtomicBoolean drainListenerFired = new AtomicBoolean(false);
+        scheduler.onDrained(() -> drainListenerFired.set(true));
+
+        // Drain listener must NOT have fired — force merge is still running
+        assertFalse("onDrained listener must NOT fire while force merge is in-flight", drainListenerFired.get());
+
+        // Verify activeMerges reflects the running force merge
+        assertEquals("activeMerges should be 1 during force merge", 1, scheduler.getActiveMergeCount());
+
+        // Now let the merge complete
+        mergeCanProceed.countDown();
+        forceMergeThread.join(10_000);
+        assertNull("forceMerge should complete without error", forceMergeError.get());
+
+        // After force merge completes, drain listener should have fired
+        assertTrue("onDrained listener must fire after force merge completes", drainListenerFired.get());
+        assertEquals("activeMerges should be 0 after force merge", 0, scheduler.getActiveMergeCount());
+    }
+
+    /**
+     * Verifies that {@code getActiveMergeCount()} correctly includes a running force merge.
+     * Before the fix, force merges never incremented {@code activeMerges}, making them invisible
+     * to the tiering drain mechanism.
+     */
+    public void testGetActiveMergeCount_IncludesForceMerge() throws Exception {
+        MergeHandler mockHandler = mock(MergeHandler.class);
+        when(mockHandler.hasPendingMerges()).thenReturn(false);
+
+        Segment s1 = new Segment(1L, Collections.emptyMap());
+        OneMerge oneMerge = new OneMerge(Collections.singletonList(s1));
+        when(mockHandler.findForceMerges(1)).thenReturn(Collections.singletonList(oneMerge));
+
+        CountDownLatch mergeStarted = new CountDownLatch(1);
+        CountDownLatch mergeCanProceed = new CountDownLatch(1);
+        when(mockHandler.doMerge(oneMerge)).thenAnswer(invocation -> {
+            mergeStarted.countDown();
+            mergeCanProceed.await(10, TimeUnit.SECONDS);
+            return new MergeResult(Collections.emptyMap());
+        });
+
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
+        ShardId testShardId = new ShardId(indexSettings.getIndex(), 0);
+        MergeScheduler scheduler = new MergeScheduler(mockHandler, (result, merge) -> {}, () -> {}, testShardId, indexSettings, threadPool);
+
+        assertEquals("activeMerges should be 0 before force merge", 0, scheduler.getActiveMergeCount());
+
+        Thread forceMergeThread = new Thread(() -> {
+            try {
+                scheduler.forceMerge(1);
+            } catch (Exception e) {
+                // ignore
+            }
+        }, ThreadPool.Names.FORCE_MERGE + "-test");
+        forceMergeThread.setDaemon(true);
+        forceMergeThread.start();
+
+        assertTrue("Merge should have started", mergeStarted.await(5, TimeUnit.SECONDS));
+        assertEquals("activeMerges should be 1 during force merge", 1, scheduler.getActiveMergeCount());
+
+        mergeCanProceed.countDown();
+        forceMergeThread.join(10_000);
+        assertEquals("activeMerges should be 0 after force merge", 0, scheduler.getActiveMergeCount());
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -5657,6 +5657,8 @@ public class IndexShardTests extends IndexShardTestCase {
             IndexShard spyShard = spy(shard);
             SegmentReplicationShardStats inSyncStat = mock(SegmentReplicationShardStats.class);
             when(inSyncStat.getCheckpointsBehindCount()).thenReturn(0L);
+            when(inSyncStat.getBytesBehindCount()).thenReturn(0L);
+            when(inSyncStat.getCurrentReplicationTimeMillis()).thenReturn(0L);
             doReturn(Set.of(inSyncStat)).when(spyShard).getReplicationStatsForTrackedReplicas();
 
             spyShard.waitForReplicaSync(TimeValue.timeValueSeconds(10));
@@ -5687,6 +5689,55 @@ public class IndexShardTests extends IndexShardTestCase {
             IOException ex = expectThrows(IOException.class, () -> spyShard.waitForReplicaSync(TimeValue.timeValueMillis(600)));
             assertThat(ex.getMessage(), containsString("replicas failed to sync within"));
             assertThat(ex.getMessage(), containsString("max checkpoints behind: 3"));
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * Verifies {@code waitForReplicaSync} does NOT return immediately when bytesBehind is non-zero,
+     * even if checkpointsBehindCount is zero. This catches the DFA metadata mismatch scenario.
+     */
+    public void testWaitForReplicaSync_BytesBehindNonZero_TimesOut() throws IOException {
+        Settings segRepSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT.toString())
+            .build();
+        IndexShard shard = newStartedShard(true, segRepSettings);
+        try {
+            IndexShard spyShard = spy(shard);
+            SegmentReplicationShardStats behindStat = mock(SegmentReplicationShardStats.class);
+            when(behindStat.getCheckpointsBehindCount()).thenReturn(0L);
+            when(behindStat.getBytesBehindCount()).thenReturn(26600000000L);
+            when(behindStat.getCurrentReplicationTimeMillis()).thenReturn(0L);
+            doReturn(Set.of(behindStat)).when(spyShard).getReplicationStatsForTrackedReplicas();
+
+            IOException ex = expectThrows(IOException.class, () -> spyShard.waitForReplicaSync(TimeValue.timeValueMillis(600)));
+            assertThat(ex.getMessage(), containsString(IndexShard.REPLICA_SYNC_TIMEOUT_MARKER));
+            assertThat(ex.getMessage(), containsString("max bytes behind:"));
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * Verifies {@code waitForReplicaSync} does NOT return immediately when replication is in progress
+     * (currentReplicationTimeMillis > 0), even if checkpoints and bytes behind are zero.
+     */
+    public void testWaitForReplicaSync_ReplicationInProgress_TimesOut() throws IOException {
+        Settings segRepSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT.toString())
+            .build();
+        IndexShard shard = newStartedShard(true, segRepSettings);
+        try {
+            IndexShard spyShard = spy(shard);
+            SegmentReplicationShardStats replicatingStat = mock(SegmentReplicationShardStats.class);
+            when(replicatingStat.getCheckpointsBehindCount()).thenReturn(0L);
+            when(replicatingStat.getBytesBehindCount()).thenReturn(0L);
+            when(replicatingStat.getCurrentReplicationTimeMillis()).thenReturn(5000L);
+            doReturn(Set.of(replicatingStat)).when(spyShard).getReplicationStatsForTrackedReplicas();
+
+            IOException ex = expectThrows(IOException.class, () -> spyShard.waitForReplicaSync(TimeValue.timeValueMillis(600)));
+            assertThat(ex.getMessage(), containsString(IndexShard.REPLICA_SYNC_TIMEOUT_MARKER));
         } finally {
             closeShards(shard);
         }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -5623,4 +5623,18 @@ public class IndexShardTests extends IndexShardTestCase {
             closeShards(replica);
         }
     }
+
+    /**
+     * Verifies {@code waitForReplicaSync} returns immediately on a non-segment-replication index
+     * (the method is a no-op when segment replication is not enabled).
+     */
+    public void testWaitForReplicaSync_NonSegRepIndex_ReturnsImmediately() throws IOException {
+        IndexShard shard = newStartedShard(true);
+        try {
+            // Should not throw — returns immediately for non-seg-rep indices
+            shard.waitForReplicaSync(TimeValue.timeValueSeconds(1));
+        } finally {
+            closeShards(shard);
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -98,6 +98,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.DocIdSeqNoAndSource;
@@ -230,7 +231,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Simple unit-test IndexShard related operations.
@@ -5633,6 +5639,54 @@ public class IndexShardTests extends IndexShardTestCase {
         try {
             // Should not throw — returns immediately for non-seg-rep indices
             shard.waitForReplicaSync(TimeValue.timeValueSeconds(1));
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * Verifies {@code waitForReplicaSync} returns immediately when replicas are already in sync.
+     */
+    public void testWaitForReplicaSync_AlreadyInSync_ReturnsImmediately() throws IOException {
+        Settings segRepSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT.toString())
+            .build();
+        IndexShard shard = newStartedShard(true, segRepSettings);
+        try {
+            // Spy on the shard to simulate a replica that's already in sync
+            IndexShard spyShard = spy(shard);
+            SegmentReplicationShardStats inSyncStat = mock(SegmentReplicationShardStats.class);
+            when(inSyncStat.getCheckpointsBehindCount()).thenReturn(0L);
+            doReturn(Set.of(inSyncStat)).when(spyShard).getReplicationStatsForTrackedReplicas();
+
+            spyShard.waitForReplicaSync(TimeValue.timeValueSeconds(10));
+
+            // Should have checked stats exactly once and returned — no polling loop
+            verify(spyShard, times(1)).getReplicationStatsForTrackedReplicas();
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * Verifies {@code waitForReplicaSync} throws IOException when replicas fail to sync within timeout.
+     */
+    public void testWaitForReplicaSync_Timeout_ThrowsIOException() throws IOException {
+        Settings segRepSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT.toString())
+            .build();
+        IndexShard shard = newStartedShard(true, segRepSettings);
+        try {
+            // Spy on the shard to simulate a replica that's always behind
+            IndexShard spyShard = spy(shard);
+            SegmentReplicationShardStats behindStat = mock(SegmentReplicationShardStats.class);
+            when(behindStat.getCheckpointsBehindCount()).thenReturn(3L);
+            doReturn(Set.of(behindStat)).when(spyShard).getReplicationStatsForTrackedReplicas();
+
+            // Use a very short timeout so the test doesn't take 30s
+            IOException ex = expectThrows(IOException.class, () -> spyShard.waitForReplicaSync(TimeValue.timeValueMillis(600)));
+            assertThat(ex.getMessage(), containsString("replicas failed to sync within"));
+            assertThat(ex.getMessage(), containsString("max checkpoints behind: 3"));
         } finally {
             closeShards(shard);
         }

--- a/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
@@ -200,12 +200,13 @@ public class TransportPrepareTieringActionTests extends OpenSearchTestCase {
 
         doThrow(
             new IOException(
-                "Shard [[clickbench][0]] replicas failed to sync within 30s. " + "Replicas still behind: 1, max checkpoints behind: 2"
+                "[REPLICA_SYNC_TIMEOUT] Shard [[clickbench][0]] replicas failed to sync within 30s. "
+                    + "Replicas still behind: 1, max checkpoints behind: 2"
             )
         ).when(mockIndexShard).waitForReplicaSync(any(TimeValue.class));
 
         IOException ex = expectThrows(IOException.class, () -> executeShardOperation(mockIndexShard, primaryShardRouting));
-        assertThat(ex.getMessage(), containsString("replicas failed to sync within"));
+        assertThat(ex.getMessage(), containsString("[REPLICA_SYNC_TIMEOUT]"));
 
         // Verify permit was released despite the exception
         verify(mockPermit, timeout(5000)).close();

--- a/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
@@ -1090,7 +1090,10 @@ public class TransportPrepareTieringActionTests extends OpenSearchTestCase {
     private TransportPrepareTieringAction newRealAction(TestThreadPool threadPool) {
         ClusterService mockClusterService = mock(ClusterService.class);
         Settings nodeSettings = Settings.EMPTY;
-        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, java.util.Set.of(TieringUtils.PREPARE_TIERING_TIMEOUT));
+        ClusterSettings clusterSettings = new ClusterSettings(
+            nodeSettings,
+            java.util.Set.of(TieringUtils.PREPARE_TIERING_TIMEOUT, TieringUtils.REPLICA_SYNC_TIMEOUT_SETTING)
+        );
         when(mockClusterService.getSettings()).thenReturn(nodeSettings);
         when(mockClusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/tiering/TransportPrepareTieringActionTests.java
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -144,6 +145,7 @@ public class TransportPrepareTieringActionTests extends OpenSearchTestCase {
             indexShard.flush(new FlushRequest().force(true).waitIfOngoing(true));
             indexShard.refresh("prepare_tiering");
             indexShard.waitForRemoteStoreSync();
+            indexShard.waitForReplicaSync(TimeValue.timeValueSeconds(30));
 
             int uncommitted = indexShard.translogStats().getUncommittedOperations();
             if (uncommitted > 0) {
@@ -173,7 +175,8 @@ public class TransportPrepareTieringActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Verifies that the shard operation calls sync, flush, refresh, and waitForRemoteStoreSync in order.
+     * Verifies that the shard operation calls sync, flush, refresh, waitForRemoteStoreSync,
+     * and waitForReplicaSync in order.
      */
     public void testShardOperation_SyncFlushRefreshAndWaitForRemoteSync() throws IOException {
         mockPermitAcquisitionSuccess();
@@ -185,6 +188,27 @@ public class TransportPrepareTieringActionTests extends OpenSearchTestCase {
         inOrder.verify(mockIndexShard).flush(any(FlushRequest.class));
         inOrder.verify(mockIndexShard).refresh("prepare_tiering");
         inOrder.verify(mockIndexShard).waitForRemoteStoreSync();
+        inOrder.verify(mockIndexShard).waitForReplicaSync(any(TimeValue.class));
+    }
+
+    /**
+     * Verifies that if waitForReplicaSync throws (replicas failed to sync in time),
+     * the exception propagates and the prepare action fails — allowing retry.
+     */
+    public void testShardOperation_WaitForReplicaSyncTimeout_PropagatesFailure() throws IOException {
+        mockPermitAcquisitionSuccess();
+
+        doThrow(
+            new IOException(
+                "Shard [[clickbench][0]] replicas failed to sync within 30s. " + "Replicas still behind: 1, max checkpoints behind: 2"
+            )
+        ).when(mockIndexShard).waitForReplicaSync(any(TimeValue.class));
+
+        IOException ex = expectThrows(IOException.class, () -> executeShardOperation(mockIndexShard, primaryShardRouting));
+        assertThat(ex.getMessage(), containsString("replicas failed to sync within"));
+
+        // Verify permit was released despite the exception
+        verify(mockPermit, timeout(5000)).close();
     }
 
     /**


### PR DESCRIPTION
## Description

MergeScheduler.forceMerge() bypasses the activeMerges counter, making in-flight force merges invisible to onMergesDrained(). When AutoForceMergeManager triggers a force merge and tiering starts before it completes, tiering proceeds without waiting — causing the merged segment to never reach remote store and leaving the
replica permanently diverged. 

## Changes

- **MergeScheduler.java**: Increment/decrement activeMerges in forceMerge() + fire drain listeners on completion
- **IndexShard.java**: Add waitForReplicaSync(TimeValue) as belt-and-suspenders check
- **TransportPrepareTieringAction.java**: Call waitForReplicaSync after waitForRemoteStoreSync
- **Tests**: Verify force merges block drain, activeMerges includes force merges, waitForReplicaSync timeout propagates

## Testing

- Unit tests: MergeSchedulerOnDrainedTests, TransportPrepareTieringActionTests, IndexShardTests
- Integration test: Added

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
