### PR TITLE
[Analytics Engine] Error on BIGINT arithmetic overflow instead of wrapping

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/checked_arith_rewrite.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/checked_arith_rewrite.rs
@@ -1,0 +1,266 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Logical-plan rewrite that makes BIGINT (`Int64`) `+`, `-`, `*` overflow *error* instead of
+//! silently wrapping on the DataFusion backend.
+//!
+//! DataFusion lowers `Operator::Plus/Minus/Multiply` to arrow's wrapping integer kernels, so
+//! `9223372036854775807 * 2` produces a wrapped negative value with no error. PPL callers expect
+//! an error. This pass rewrites every logical `BinaryExpr { op: Plus | Minus | Multiply }` whose
+//! **both operands resolve to `Int64`** into a call to the overflow-checked UDF equivalent
+//! (`checked_add_i64` / `checked_sub_i64` / `checked_mul_i64` — see [`crate::udf::checked_arith`]).
+//!
+//! # Why logical, not physical
+//!
+//! Walking the *logical* plan reaches arithmetic in every node uniformly — Projection exprs,
+//! Filter predicates, Aggregate group/argument exprs (`sum(a*b)`), Window args, Sort keys, Join
+//! conditions — because [`LogicalPlan::map_expressions`] visits each node's top-level exprs and
+//! `Expr::transform_up` recurses into every sub-expr. A physical-plan pass would have to reach the
+//! exprs through per-node accessors, which do not uniformly surface aggregate/window argument
+//! expressions.
+//!
+//! # Type gate
+//!
+//! Only `Int64 op Int64` is rewritten. `Float32/Float64` (which wrap to ±INF by PPL parity),
+//! `Decimal*`, `UInt64`, and narrower integers all pass through untouched. After the SQL-plugin
+//! widening (sql#5603), the only integer arithmetic that reaches DataFusion and can still overflow
+//! is `Int64 op Int64`, so this gate is both correct and sufficient. Note the analytics scan
+//! boundary already narrows `UInt64 -> Int64` (see `schema_coerce::coerce_inferred_schema`), so
+//! OpenSearch `long` columns resolve to `Int64` here.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{DFSchema, DFSchemaRef, Result};
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::logical_expr::expr_rewriter::NamePreserver;
+use datafusion::logical_expr::{BinaryExpr, Expr, ExprSchemable, LogicalPlan, Operator, ScalarUDF};
+
+use crate::udf::checked_arith::{checked_add_udf, checked_mul_udf, checked_sub_udf};
+
+/// Rewrite every `Int64 {+,-,*} Int64` `BinaryExpr` in `plan` into an overflow-checked UDF call.
+/// Non-`Int64` arithmetic and non-`+/-/*` operators are left unchanged.
+pub fn rewrite_checked_int64_arith(plan: LogicalPlan) -> Result<LogicalPlan> {
+    plan.transform_up(|node| {
+        // Operands of a node's expressions are evaluated over the node's *input* columns, so
+        // resolve types against the merged input schema. For leaf nodes (no inputs) fall back to
+        // the node's own schema.
+        let schema = merged_input_schema(&node);
+        // Preserve each expression's output name: rewriting `sum(a * b)` to
+        // `sum(checked_mul_i64(a, b))` would otherwise let a later `recompute_schema` rename the
+        // output field, breaking any parent node that references it by the original derived name.
+        // NamePreserver re-aliases only when the name actually changed, and is a no-op for nodes
+        // whose expressions don't contribute to the output schema (Filter/Join/…).
+        let name_preserver = NamePreserver::new(&node);
+        node.map_expressions(|expr| {
+            let saved_name = name_preserver.save(&expr);
+            expr.transform_up(|e| rewrite_expr(e, &schema))
+                .map(|t| t.update_data(|rewritten| saved_name.restore(rewritten)))
+        })
+    })
+    .map(|t| t.data)
+}
+
+/// Merge the schemas of a node's inputs so operand `Column`s resolve. Leaf nodes have no inputs,
+/// so their own schema is used (their exprs, if any, are typed over it).
+fn merged_input_schema(node: &LogicalPlan) -> DFSchemaRef {
+    let inputs = node.inputs();
+    if inputs.is_empty() {
+        return Arc::new(node.schema().as_ref().clone());
+    }
+    let mut merged = DFSchema::empty();
+    for child in inputs {
+        // merge() is order-preserving and dedups by qualified name; ignore duplicate-column errors.
+        merged.merge(child.schema());
+    }
+    Arc::new(merged)
+}
+
+fn rewrite_expr(expr: Expr, schema: &DFSchema) -> Result<Transformed<Expr>> {
+    let Expr::BinaryExpr(BinaryExpr { left, op, right }) = &expr else {
+        return Ok(Transformed::no(expr));
+    };
+    if !matches!(op, Operator::Plus | Operator::Minus | Operator::Multiply) {
+        return Ok(Transformed::no(expr));
+    }
+    // Resolve operand types. If either operand's type cannot be resolved against this schema
+    // (an edge case such as a correlated column not present in the merged input schema), leave
+    // the expression unchanged rather than failing the whole query — a missed rewrite falls back
+    // to today's wrapping behavior, whereas propagating the error would break a working query.
+    let (Ok(lt), Ok(rt)) = (left.get_type(schema), right.get_type(schema)) else {
+        return Ok(Transformed::no(expr));
+    };
+    if lt != DataType::Int64 || rt != DataType::Int64 {
+        return Ok(Transformed::no(expr));
+    }
+
+    // Consume `expr` to move the boxed operands into the UDF call without cloning.
+    let Expr::BinaryExpr(BinaryExpr { left, op, right }) = expr else {
+        unreachable!("matched BinaryExpr above");
+    };
+    let udf: Arc<ScalarUDF> = match op {
+        Operator::Plus => checked_add_udf(),
+        Operator::Minus => checked_sub_udf(),
+        Operator::Multiply => checked_mul_udf(),
+        _ => unreachable!("op guarded above"),
+    };
+    let call = Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![*left, *right]));
+    Ok(Transformed::yes(call))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::Field;
+    use datafusion::logical_expr::{col, lit, LogicalPlanBuilder};
+
+    /// Count how many `ScalarFunction`s named `name` appear anywhere in the plan's expressions.
+    fn count_udf(plan: &LogicalPlan, name: &str) -> usize {
+        use std::cell::Cell;
+        let count = Cell::new(0usize);
+        plan.apply(|node| {
+            node.apply_expressions(|expr| {
+                expr.apply(|e| {
+                    if let Expr::ScalarFunction(sf) = e {
+                        if sf.func.name() == name {
+                            count.set(count.get() + 1);
+                        }
+                    }
+                    Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+                })
+            })
+        })
+        .unwrap();
+        count.get()
+    }
+
+    /// A schema-carrying `EmptyRelation` builder; enough to type-resolve column operands for the
+    /// rewrite without a real table provider.
+    fn scan(fields: Vec<Field>) -> LogicalPlanBuilder {
+        use datafusion::logical_expr::{EmptyRelation, LogicalPlan};
+        let arrow_schema = datafusion::arrow::datatypes::Schema::new(fields);
+        let schema = Arc::new(DFSchema::try_from(arrow_schema).unwrap());
+        LogicalPlanBuilder::new(LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema,
+        }))
+    }
+
+    fn int_float_scan() -> LogicalPlanBuilder {
+        scan(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+            Field::new("c", DataType::Int64, true),
+            Field::new("f", DataType::Float64, true),
+            Field::new("g", DataType::Float64, true),
+        ])
+    }
+
+    #[test]
+    fn rewrites_int64_mul_in_projection() {
+        let plan = int_float_scan()
+            .project(vec![(col("a") * col("b")).alias("x")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 1);
+        assert_eq!(count_udf(&out, "checked_add_i64"), 0);
+    }
+
+    #[test]
+    fn rewrites_int64_add_and_sub() {
+        let plan = int_float_scan()
+            .project(vec![
+                (col("a") + col("b")).alias("s"),
+                (col("a") - col("b")).alias("d"),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_add_i64"), 1);
+        assert_eq!(count_udf(&out, "checked_sub_i64"), 1);
+    }
+
+    #[test]
+    fn leaves_float_mul_untouched() {
+        let plan = int_float_scan()
+            .project(vec![(col("f") * col("g")).alias("x")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 0);
+    }
+
+    #[test]
+    fn leaves_divide_untouched() {
+        let plan = int_float_scan()
+            .project(vec![(col("a") / col("b")).alias("x")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        // No checked_* udf: DIVIDE is not in {Plus,Minus,Multiply}.
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 0);
+        assert_eq!(count_udf(&out, "checked_add_i64"), 0);
+        assert_eq!(count_udf(&out, "checked_sub_i64"), 0);
+    }
+
+    #[test]
+    fn rewrites_arithmetic_in_filter_predicate() {
+        // Proves node-agnostic coverage: the arithmetic lives in a Filter, not a Projection.
+        let plan = int_float_scan()
+            .filter((col("a") * col("b")).gt(lit(5i64)))
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 1);
+    }
+
+    #[test]
+    fn rewrites_nested_arithmetic_bottom_up() {
+        // (a * b) + c  ->  checked_add(checked_mul(a, b), c)
+        let plan = int_float_scan()
+            .project(vec![((col("a") * col("b")) + col("c")).alias("x")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 1);
+        assert_eq!(count_udf(&out, "checked_add_i64"), 1);
+    }
+
+    #[test]
+    fn rewrites_arithmetic_in_sort_key() {
+        // Arithmetic inside a Sort key must be reached (node-agnostic coverage beyond
+        // Projection/Filter — the same map_expressions traversal reaches Aggregate/Window args).
+        let plan = int_float_scan()
+            .sort(vec![(col("a") * col("b")).sort(true, false)])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 1);
+    }
+
+    #[test]
+    fn leaves_int64_literal_times_float_untouched() {
+        // Mixed Int64 * Float64 -> operands are (Int64, Float64); gate requires BOTH Int64.
+        let plan = int_float_scan()
+            .project(vec![(col("a") * col("f")).alias("x")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let out = rewrite_checked_int64_arith(plan).unwrap();
+        assert_eq!(count_udf(&out, "checked_mul_i64"), 0);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -962,6 +962,13 @@ async unsafe fn execute_indexed_with_context_inner(
     let plan = Plan::decode(substrait_bytes.as_slice())
         .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    // Make BIGINT +,-,* overflow error instead of wrapping in this plan too, since its filter
+    // predicates seed the parquet pushdown predicate (`where long1 * long2 > k` would otherwise be
+    // scan-filtered with wrapping arithmetic, dropping overflowing rows silently before the executed
+    // plan's checked filter runs). Checked arithmetic appears only nested inside a comparison operand
+    // — never as a top-level AND/OR or COLLECTOR/DELEGATION_POSSIBLE marker — so delegation
+    // classification (expr_to_bool_tree) is unaffected.
+    let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
 
     // Sort-aware segment iteration. Mirror of `ContextIndexSearcher.shouldUseTimeSeriesDescSortOptimization`
     // for the indexed-parquet path. When the index has `index.sort.field` and the query's leading
@@ -1414,6 +1421,8 @@ async unsafe fn execute_indexed_with_context_inner(
     ctx.register_table(&register_name, provider)?;
 
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+    let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
     log_debug!(
         "DataFusion logical plan:\n{}",
         logical_plan.display_indent()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -964,6 +964,13 @@ async unsafe fn execute_indexed_with_context_inner(
     let plan = Plan::decode(substrait_bytes.as_slice())
         .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    // Make BIGINT +,-,* overflow error instead of wrapping in this plan too, since its filter
+    // predicates seed the parquet pushdown predicate (`where long1 * long2 > k` would otherwise be
+    // scan-filtered with wrapping arithmetic, dropping overflowing rows silently before the executed
+    // plan's checked filter runs). Checked arithmetic appears only nested inside a comparison operand
+    // — never as a top-level AND/OR or COLLECTOR/DELEGATION_POSSIBLE marker — so delegation
+    // classification (expr_to_bool_tree) is unaffected.
+    let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
 
     // Sort-aware segment iteration. Mirror of `ContextIndexSearcher.shouldUseTimeSeriesDescSortOptimization`
     // for the indexed-parquet path. When the index has `index.sort.field` and the query's leading
@@ -1416,6 +1423,8 @@ async unsafe fn execute_indexed_with_context_inner(
     ctx.register_table(&register_name, provider)?;
 
     let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+    let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
     log_debug!(
         "DataFusion logical plan:\n{}",
         logical_plan.display_indent()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) mod agg_mode;
 pub mod api;
 pub mod cache;
 pub mod cancellation;
+pub mod checked_arith_rewrite;
 pub mod cross_rt_stream;
 pub mod datafusion_query_config;
 pub mod executor;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -25,6 +25,7 @@ pub mod api;
 pub mod cache;
 pub mod can_match;
 pub mod cancellation;
+pub mod checked_arith_rewrite;
 pub mod cross_rt_stream;
 pub mod datafusion_query_config;
 pub mod executor;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -204,6 +204,8 @@ impl LocalSession {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+        let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
         log_debug!(
             "DataFusion logical plan:\n{}",
             logical_plan.display_indent()
@@ -249,6 +251,8 @@ impl LocalSession {
             ))
         })?;
         let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+        let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
         let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
         // Strip first so `force_aggregate_mode(Final)` can find the Final/Partial pair

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -149,6 +149,8 @@ async fn build_dataframe(
     let substrait_plan = Plan::decode(plan_bytes)
         .map_err(|e| DataFusionError::Execution(format!("Failed to decode Substrait: {}", e)))?;
     let logical_plan = from_substrait_plan(&ctx.state(), &substrait_plan).await?;
+    // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+    let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
     ctx.execute_logical_plan(logical_plan).await
 }
 
@@ -251,6 +253,8 @@ pub async fn execute_with_context(
 
         // Union schema widening was applied at table registration (session_context::widen_to_union_schema).
         let logical_plan = from_substrait_plan(&handle.ctx.state(), &substrait_plan).await?;
+        // Make BIGINT +,-,* overflow error instead of silently wrapping (see checked_arith_rewrite).
+        let logical_plan = crate::checked_arith_rewrite::rewrite_checked_int64_arith(logical_plan)?;
         log_debug!(
             "DataFusion logical plan:\n{}",
             logical_plan.display_indent()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/checked_arith.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/checked_arith.rs
@@ -1,0 +1,246 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Overflow-checked BIGINT arithmetic UDFs: `checked_add_i64`, `checked_sub_i64`,
+//! `checked_mul_i64`.
+//!
+//! DataFusion's default integer arithmetic (`Operator::Plus/Minus/Multiply`) uses arrow's
+//! *wrapping* kernels, so `9223372036854775807 * 2` silently wraps into a negative i64 instead
+//! of erroring. PPL callers expect an error, not a wrapped value. [`crate::checked_arith_rewrite`]
+//! rewrites every `Int64 {+,-,*} Int64` logical `BinaryExpr` into a call to one of these UDFs,
+//! which invoke arrow's *checked* numeric kernels (`add`/`sub`/`mul`) and surface a stable,
+//! self-authored error on overflow.
+//!
+//! The overflow message carries [`OVERFLOW_KEYPHRASE`] verbatim; `NativeErrorConverter` (Java)
+//! matches on that substring and maps it to an `IllegalArgumentException` (HTTP 400).
+
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::compute::kernels::numeric::{add, mul, sub};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{exec_datafusion_err, DataFusionError, Result};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+
+/// Stable Rust→Java contract phrase. `NativeErrorConverter.PATTERNS` matches on this exact
+/// substring to classify the error as a client (400) error. Changing it requires a coordinated
+/// edit in `NativeErrorConverter.java`.
+pub const OVERFLOW_KEYPHRASE: &str = "BIGINT arithmetic overflow";
+
+#[derive(Copy, Clone, Debug)]
+enum Op {
+    Add,
+    Sub,
+    Mul,
+}
+
+impl Op {
+    fn verb(self) -> &'static str {
+        match self {
+            Op::Add => "addition",
+            Op::Sub => "subtraction",
+            Op::Mul => "multiplication",
+        }
+    }
+}
+
+/// `checked_{add,sub,mul}_i64(bigint, bigint) -> bigint`. Errors on 64-bit overflow instead of
+/// wrapping. The return type is `Int64`, identical to the `BinaryExpr` it replaces, so the
+/// rewrite leaves plan schemas byte-identical.
+#[derive(Debug)]
+pub struct CheckedArithUdf {
+    op: Op,
+    name: &'static str,
+    signature: Signature,
+}
+
+impl CheckedArithUdf {
+    fn new(op: Op, name: &'static str) -> Self {
+        Self {
+            op,
+            name,
+            // Exact (Int64, Int64) — the rewrite only ever emits this shape. Immutable (not
+            // Volatile) so the UDF still participates in predicate pushdown and common-subexpression
+            // elimination. Const-folding an *overflowing* literal pair does not lose the error:
+            // DataFusion's ConstEvaluator preserves the original expr on a UDF runtime error
+            // (it only fails-fast for CAST), so overflow still surfaces at execution with our
+            // stable message; a non-overflowing constant simply folds to its exact value.
+            signature: Signature::exact(
+                vec![DataType::Int64, DataType::Int64],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+// `ScalarUDFImpl` requires DynEq + DynHash. Instances are distinguished only by name.
+impl PartialEq for CheckedArithUdf {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+impl Eq for CheckedArithUdf {}
+impl Hash for CheckedArithUdf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl ScalarUDFImpl for CheckedArithUdf {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        // Must equal the BinaryExpr output type (Int64) so plan schemas are unchanged by the
+        // rewrite (see checked_arith_rewrite: no recompute_schema).
+        Ok(DataType::Int64)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 2 {
+            return Err(exec_datafusion_err!(
+                "{} expects exactly 2 arguments, got {}",
+                self.name,
+                args.args.len()
+            ));
+        }
+        let n = args.number_rows;
+        // Normalize both operands to arrays; scalar-scalar calls arrive with number_rows == 1.
+        let lhs: ArrayRef = args.args[0].to_array(n)?;
+        let rhs: ArrayRef = args.args[1].to_array(n)?;
+
+        // arrow's checked kernels null-propagate (null in either operand -> null out) and return
+        // Err(ArithmeticOverflow) only for non-null overflowing pairs. `&dyn Array` is a `Datum`.
+        let result = match self.op {
+            Op::Add => add(&lhs, &rhs),
+            Op::Sub => sub(&lhs, &rhs),
+            Op::Mul => mul(&lhs, &rhs),
+        };
+        match result {
+            Ok(arr) => Ok(ColumnarValue::Array(arr)),
+            // Re-wrap arrow's ArithmeticOverflow into a stable, self-authored message so the
+            // Java-side keyphrase does not depend on arrow's wording across version bumps.
+            Err(e) => Err(DataFusionError::Execution(format!(
+                "{OVERFLOW_KEYPHRASE}: {} of two BIGINT values exceeded the 64-bit range \
+                 (underlying: {e})",
+                self.op.verb()
+            ))),
+        }
+    }
+}
+
+fn make_udf(op: Op, name: &'static str) -> Arc<ScalarUDF> {
+    Arc::new(ScalarUDF::from(CheckedArithUdf::new(op, name)))
+}
+
+/// `checked_add_i64(bigint, bigint) -> bigint`.
+pub fn checked_add_udf() -> Arc<ScalarUDF> {
+    make_udf(Op::Add, "checked_add_i64")
+}
+
+/// `checked_sub_i64(bigint, bigint) -> bigint`.
+pub fn checked_sub_udf() -> Arc<ScalarUDF> {
+    make_udf(Op::Sub, "checked_sub_i64")
+}
+
+/// `checked_mul_i64(bigint, bigint) -> bigint`.
+pub fn checked_mul_udf() -> Arc<ScalarUDF> {
+    make_udf(Op::Mul, "checked_mul_i64")
+}
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::clone(&checked_add_udf()));
+    ctx.register_udf(ScalarUDF::clone(&checked_sub_udf()));
+    ctx.register_udf(ScalarUDF::clone(&checked_mul_udf()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Array, AsArray, Int64Array};
+    use datafusion::arrow::datatypes::{Field, Int64Type};
+    use datafusion::logical_expr::ColumnarValue;
+
+    fn call(udf: Arc<ScalarUDF>, a: &[Option<i64>], b: &[Option<i64>]) -> Result<ArrayRef> {
+        let la: ArrayRef = Arc::new(Int64Array::from(a.to_vec()));
+        let lb: ArrayRef = Arc::new(Int64Array::from(b.to_vec()));
+        let return_field = Arc::new(Field::new("r", DataType::Int64, true));
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(la), ColumnarValue::Array(lb)],
+            arg_fields: vec![
+                Arc::new(Field::new("a", DataType::Int64, true)),
+                Arc::new(Field::new("b", DataType::Int64, true)),
+            ],
+            number_rows: a.len(),
+            return_field,
+            config_options: Arc::new(Default::default()),
+        };
+        match udf.inner().invoke_with_args(args)? {
+            ColumnarValue::Array(arr) => Ok(arr),
+            other => panic!("expected array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mul_overflow_errors_with_stable_phrase() {
+        let err = call(checked_mul_udf(), &[Some(i64::MAX)], &[Some(2)]).unwrap_err();
+        assert!(err.to_string().contains(OVERFLOW_KEYPHRASE), "got: {err}");
+    }
+
+    #[test]
+    fn add_overflow_errors() {
+        let err = call(checked_add_udf(), &[Some(i64::MAX)], &[Some(1)]).unwrap_err();
+        assert!(err.to_string().contains(OVERFLOW_KEYPHRASE), "got: {err}");
+    }
+
+    #[test]
+    fn sub_overflow_errors() {
+        let err = call(checked_sub_udf(), &[Some(i64::MIN)], &[Some(1)]).unwrap_err();
+        assert!(err.to_string().contains(OVERFLOW_KEYPHRASE), "got: {err}");
+    }
+
+    #[test]
+    fn no_overflow_returns_exact_value() {
+        let out = call(checked_mul_udf(), &[Some(3)], &[Some(4)]).unwrap();
+        assert_eq!(out.as_primitive::<Int64Type>().value(0), 12);
+    }
+
+    #[test]
+    fn negative_product_is_exact_not_overflow() {
+        // -3 * 20000 = -60000, well within i64 range; must not error.
+        let out = call(checked_mul_udf(), &[Some(-3)], &[Some(20000)]).unwrap();
+        assert_eq!(out.as_primitive::<Int64Type>().value(0), -60000);
+    }
+
+    #[test]
+    fn null_operand_propagates_null_not_error() {
+        let out = call(checked_mul_udf(), &[None], &[Some(2)]).unwrap();
+        assert!(out.as_primitive::<Int64Type>().is_null(0));
+    }
+
+    #[test]
+    fn one_overflow_in_batch_fails_whole_call() {
+        // arrow's checked kernel errors on the first overflowing pair, failing the batch.
+        let err = call(
+            checked_mul_udf(),
+            &[Some(1), Some(i64::MAX)],
+            &[Some(1), Some(2)],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains(OVERFLOW_KEYPHRASE), "got: {err}");
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -121,6 +121,7 @@ pub(crate) fn coerce_args(
 }
 
 pub mod binary_to_base64;
+pub mod checked_arith;
 pub mod conv;
 pub mod conversion;
 pub mod convert_tz;
@@ -175,6 +176,7 @@ pub mod width_bucket;
 // and restart the OpenSearch JVM (the loaded dylib is JVM-cached).
 pub fn register_all(ctx: &SessionContext) {
     binary_to_base64::register_all(ctx);
+    checked_arith::register_all(ctx);
     conv::register_all(ctx);
     convert_tz::register_all(ctx);
     conversion::register_all(ctx);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/NativeErrorConverter.java
@@ -66,6 +66,9 @@ public final class NativeErrorConverter {
 
     private static final String ADMISSION_REJECTED_MSG = "Native query admission rejected: insufficient memory budget available";
 
+    /** Stable Rust→Java contract phrase; must match {@code OVERFLOW_KEYPHRASE} in udf/checked_arith.rs. */
+    static final String BIGINT_OVERFLOW_MSG = "BIGINT arithmetic overflow";
+
     /**
      * Registered error patterns, checked in order. First match wins.
      * Key phrases include both the Rust-originated messages (for data-node local conversion)
@@ -92,7 +95,11 @@ public final class NativeErrorConverter {
         // (deeply nested function calls). Converted at the FFM boundary into a clean 400.
         new ErrorPattern("recursion limit reached", NativeErrorConverter::convertRecursionLimit),
         // Controlled message, as a coordinator-side safety net if it arrives via StreamException.
-        new ErrorPattern("Query too deeply nested", NativeErrorConverter::convertRecursionLimit)
+        new ErrorPattern("Query too deeply nested", NativeErrorConverter::convertRecursionLimit),
+        // BIGINT (Int64) +, -, * overflow produced by the checked_arith UDF (see the Rust
+        // udf/checked_arith.rs). Client error → HTTP 400. The message is self-authored (carries no
+        // native internals), so it is surfaced verbatim from the keyphrase onward.
+        new ErrorPattern(BIGINT_OVERFLOW_MSG, NativeErrorConverter::convertBigintOverflow)
     );
 
     /**
@@ -170,6 +177,23 @@ public final class NativeErrorConverter {
             "Query too deeply nested: the expression exceeds the maximum nesting depth supported by the execution engine. "
                 + "Simplify the query by reducing nested function calls."
         );
+    }
+
+    private static Exception convertBigintOverflow(MatchedError match) {
+        // The message is self-authored by the Rust UDF and carries no native internals, so surface it
+        // from the keyphrase onward — stripping any DataFusion "Execution error:" wrapper prefix and
+        // trailing cause detail. No cause is attached (parity with the other converters).
+        //
+        // Return a status-bearing OpenSearchStatusException (400) rather than a bare
+        // IllegalArgumentException: on distributed-aggregate paths the failure is re-wrapped several
+        // times across the Flight boundary (e.g. RuntimeException("Failed to start streaming
+        // fragment", ...) -> StreamException), and only a typed OpenSearchException carrying a
+        // non-500 status is recovered by the coordinator's statusBearingCause walk. A plain
+        // IllegalArgumentException would be redacted to a generic 500 there.
+        String msg = match.message();
+        int start = msg.indexOf(BIGINT_OVERFLOW_MSG);
+        String clean = start >= 0 ? msg.substring(start) : BIGINT_OVERFLOW_MSG;
+        return new OpenSearchStatusException(clean, RestStatus.BAD_REQUEST);
     }
 
     // ─── Message parsing ────────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeErrorConverterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeErrorConverterTests.java
@@ -159,6 +159,36 @@ public class NativeErrorConverterTests extends OpenSearchTestCase {
         assertTrue(result.getMessage().contains("too deeply nested"));
     }
 
+    public void testBigintOverflowConvertsToBadRequestStatusException() {
+        // Raw message as authored by the Rust checked_arith UDF, wrapped by DataFusion's Display.
+        String message = "Execution error: BIGINT arithmetic overflow: multiplication of two BIGINT values "
+            + "exceeded the 64-bit range (underlying: Arithmetic overflow: Overflow happened on: 9223372036854775807 * 2)";
+        RuntimeException original = new RuntimeException(message);
+
+        Exception result = NativeErrorConverter.convert(original);
+
+        // Status-bearing 400 so distributed-aggregate re-wrapping still surfaces a client error.
+        assertTrue(result instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) result).status());
+        // Message is surfaced from the keyphrase onward; the "Execution error:" wrapper is stripped.
+        assertTrue(result.getMessage().startsWith("BIGINT arithmetic overflow"));
+        assertTrue(result.getMessage().contains("exceeded the 64-bit range"));
+        // No cause attached (parity with the other converters).
+        assertNull(result.getCause());
+    }
+
+    public void testBigintOverflowControlledMessageConvertsOnCoordinator() {
+        // Coordinator-side safety net: the message arriving via StreamException after transport.
+        String controlledMessage = "BIGINT arithmetic overflow: addition of two BIGINT values exceeded the 64-bit range";
+        RuntimeException transportException = new RuntimeException(controlledMessage);
+
+        Exception result = NativeErrorConverter.convert(transportException);
+
+        assertTrue(result instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) result).status());
+        assertEquals(controlledMessage, result.getMessage());
+    }
+
     public void testUnrecognizedErrorPassedThrough() {
         RuntimeException original = new RuntimeException("Some unknown error from native code");
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsTransportErrors.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsTransportErrors.java
@@ -66,8 +66,28 @@ final class AnalyticsTransportErrors {
         if (cancelled != null) {
             return new StreamException(StreamErrorCode.CANCELLED, cancelled.getMessage(), e);
         }
+        // A BIGINT-arithmetic overflow is a client error (HTTP 400): the data node's
+        // NativeErrorConverter has already turned it into an IllegalArgumentException carrying the
+        // stable phrase. Without an explicit code it would cross Flight as INTERNAL and surface as a
+        // generic 500 on distributed-aggregate paths. Tag it INVALID_ARGUMENT so fromWireError can
+        // rebuild a 400 on the coordinator.
+        Throwable badRequest = ExceptionsHelper.unwrapCausesAndSuppressed(
+            e,
+            t -> t.getMessage() != null && t.getMessage().contains(BIGINT_OVERFLOW_PHRASE)
+        ).orElse(null);
+        if (badRequest != null) {
+            return new StreamException(StreamErrorCode.INVALID_ARGUMENT, badRequest.getMessage(), e);
+        }
         return e;
     }
+
+    /**
+     * Stable phrase identifying a BIGINT-arithmetic overflow client error, produced by the
+     * DataFusion backend's {@code checked_arith} UDF and surfaced by {@code NativeErrorConverter}.
+     * Kept in sync with {@code NativeErrorConverter.BIGINT_OVERFLOW_MSG} and the Rust
+     * {@code OVERFLOW_KEYPHRASE}.
+     */
+    static final String BIGINT_OVERFLOW_PHRASE = "BIGINT arithmetic overflow";
 
     /**
      * Coordinator receive side. Inverse of {@link #toWireError}: maps a {@link StreamException} that
@@ -80,6 +100,8 @@ final class AnalyticsTransportErrors {
      *   drop (node gone, connection reset) is "service unavailable", not an internal error.
      *   <li>{@link StreamErrorCode#CANCELLED} → {@link TaskCancelledException} — a shard cancel (e.g. SBP)
      *   stays a recognizable cancellation instead of degrading to a generic ISE that clients would retry.
+     *   <li>{@link StreamErrorCode#INVALID_ARGUMENT} → 400 {@link OpenSearchStatusException} — a client
+     *   error (e.g. BIGINT arithmetic overflow) stays a 400 instead of being redacted to a generic 500.
      * </ul>
      * Anything else passes through unchanged.
      */
@@ -89,12 +111,17 @@ final class AnalyticsTransportErrors {
             t -> t instanceof StreamException s
                 && (s.getErrorCode() == StreamErrorCode.RESOURCE_EXHAUSTED
                     || s.getErrorCode() == StreamErrorCode.UNAVAILABLE
-                    || s.getErrorCode() == StreamErrorCode.CANCELLED)
+                    || s.getErrorCode() == StreamErrorCode.CANCELLED
+                    || s.getErrorCode() == StreamErrorCode.INVALID_ARGUMENT)
         ).orElse(null);
         if (se == null) {
             return e;
         }
         String message = se.getMessage();
+        if (se.getErrorCode() == StreamErrorCode.INVALID_ARGUMENT) {
+            // Client error (e.g. BIGINT arithmetic overflow) → 400, so it isn't redacted to a 500.
+            return new OpenSearchStatusException(message != null ? message : "invalid argument", RestStatus.BAD_REQUEST, e);
+        }
         if (se.getErrorCode() == StreamErrorCode.RESOURCE_EXHAUSTED) {
             // CircuitBreakingException has no cause-accepting ctor; attach the wire exception via initCause
             // so the original StreamException/stack is kept for server-side troubleshooting.

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsTransportErrorsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/AnalyticsTransportErrorsTests.java
@@ -165,4 +165,66 @@ public class AnalyticsTransportErrorsTests extends OpenSearchTestCase {
         );
         assertEquals("sbp cancel", recovered.getMessage());
     }
+
+    // ── BIGINT overflow (client 400) ──────────────────────────────────────
+
+    public void testToWireErrorTagsBigintOverflowAsInvalidArgument() {
+        // NativeErrorConverter turns the DataFusion overflow into this IllegalArgumentException.
+        IllegalArgumentException overflow = new IllegalArgumentException(
+            "BIGINT arithmetic overflow: multiplication of two BIGINT values exceeded the 64-bit range"
+        );
+
+        Exception wire = AnalyticsTransportErrors.toWireError(overflow);
+
+        assertTrue(wire instanceof StreamException);
+        assertEquals(StreamErrorCode.INVALID_ARGUMENT, ((StreamException) wire).getErrorCode());
+        assertTrue(wire.getMessage().contains("BIGINT arithmetic overflow"));
+    }
+
+    public void testToWireErrorFindsBigintOverflowInCauseChain() {
+        // The distributed-aggregate path wraps the failure: RuntimeException("Stage N failed", cause).
+        Exception wrapped = new RuntimeException(
+            "Stage 0 failed",
+            new IllegalArgumentException("BIGINT arithmetic overflow: addition of two BIGINT values exceeded the 64-bit range")
+        );
+
+        Exception wire = AnalyticsTransportErrors.toWireError(wrapped);
+
+        assertTrue(wire instanceof StreamException);
+        assertEquals(StreamErrorCode.INVALID_ARGUMENT, ((StreamException) wire).getErrorCode());
+    }
+
+    public void testFromWireErrorRebuildsBigintOverflowAs400() {
+        StreamException wire = new StreamException(StreamErrorCode.INVALID_ARGUMENT, "BIGINT arithmetic overflow: ...");
+
+        Exception recovered = AnalyticsTransportErrors.fromWireError(wire);
+
+        assertTrue(recovered instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) recovered).status());
+        assertTrue(recovered.getMessage().contains("BIGINT arithmetic overflow"));
+    }
+
+    public void testFromWireErrorFindsInvalidArgumentInCauseChain() {
+        Exception wrapped = new RuntimeException(
+            "Stage 0 failed",
+            new StreamException(StreamErrorCode.INVALID_ARGUMENT, "BIGINT arithmetic overflow: ...")
+        );
+
+        Exception recovered = AnalyticsTransportErrors.fromWireError(wrapped);
+
+        assertTrue(recovered instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) recovered).status());
+    }
+
+    public void testBigintOverflowSurvivesRoundTripAs400() {
+        IllegalArgumentException overflow = new IllegalArgumentException(
+            "BIGINT arithmetic overflow: multiplication of two BIGINT values exceeded the 64-bit range"
+        );
+
+        Exception onWire = AnalyticsTransportErrors.toWireError(overflow);
+        Exception recovered = AnalyticsTransportErrors.fromWireError(onWire);
+
+        assertTrue(recovered instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) recovered).status());
+    }
 }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BigintOverflowIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/BigintOverflowIT.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+
+/**
+ * Verifies that BIGINT (Int64) {@code +}, {@code -}, {@code *} overflow on the analytics-engine
+ * DataFusion backend returns an HTTP 400 error instead of silently wrapping to a negative value.
+ *
+ * <p>DataFusion's default integer arithmetic uses arrow's wrapping kernels; the
+ * {@code checked_arith_rewrite} logical pass rewrites {@code Int64 op Int64} arithmetic to the
+ * overflow-checked {@code checked_*_i64} UDFs, whose error is mapped to 400 by
+ * {@code NativeErrorConverter}. Non-overflowing arithmetic and floating-point arithmetic are
+ * unaffected.
+ *
+ * <p>The {@code long_val * long_val} overflow mirrors the reported large-multiplier case where a
+ * product exceeds the signed 64-bit range.
+ */
+public class BigintOverflowIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "bigint_overflow_test";
+    private boolean provisioned = false;
+
+    private void ensureProvisioned() throws IOException {
+        if (provisioned) {
+            return;
+        }
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity(
+            "{"
+                + "\"settings\": {"
+                + "  \"index.number_of_shards\": 1,"
+                + "  \"index.number_of_replicas\": 0,"
+                + "  \"index.pluggable.dataformat.enabled\": true,"
+                + "  \"index.pluggable.dataformat\": \"composite\","
+                + "  \"index.composite.primary_data_format\": \"parquet\","
+                + "  \"index.composite.secondary_data_formats\": [\"lucene\"]"
+                + "},"
+                + "\"mappings\": {"
+                + "  \"properties\": {"
+                + "    \"long_val\": {\"type\": \"long\"},"
+                + "    \"double_val\": {\"type\": \"double\"}"
+                + "  }"
+                + "}"
+                + "}"
+        );
+        client().performRequest(create);
+
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        // 5000000000000000000 ≈ 5e18; times 2 overflows i64 max (~9.22e18). times 1 does not.
+        bulk.setJsonEntity(
+            "{\"index\":{}}\n{\"long_val\":5000000000000000000,\"double_val\":3.5}\n"
+                + "{\"index\":{}}\n{\"long_val\":3,\"double_val\":8.2}\n"
+        );
+        client().performRequest(bulk);
+
+        Request flush = new Request("POST", "/" + INDEX + "/_flush");
+        flush.addParameter("force", "true");
+        client().performRequest(flush);
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "yellow");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+
+        provisioned = true;
+    }
+
+    public void testLongColumnMultiplyOverflowReturns400() throws IOException {
+        ensureProvisioned();
+        // long_val (5e18) * 2 overflows i64 for the first row. Column arithmetic reaches the
+        // DataFusion backend (a pure literal * literal would be constant-folded by the PPL/Calcite
+        // front end before ever reaching the backend, so we always overflow via a column operand).
+        assertOverflow400("source=" + INDEX + " | eval x = long_val * 2 | fields x");
+    }
+
+    public void testLongLiteralPlusColumnOverflowReturns400() throws IOException {
+        ensureProvisioned();
+        // i64::MAX + long_val overflows for the first (non-zero) row.
+        assertOverflow400("source=" + INDEX + " | eval x = 9223372036854775807 + long_val | fields x");
+    }
+
+    public void testArithmeticInWherePredicateOverflowReturns400() throws IOException {
+        ensureProvisioned();
+        // Arithmetic inside a WHERE predicate must also be checked. On the indexed path this
+        // predicate seeds the parquet pushdown; without rewriting the extraction plan it would be
+        // scan-filtered with wrapping arithmetic and drop the overflowing row silently.
+        assertOverflow400("source=" + INDEX + " | where long_val * 2 > 0 | fields long_val");
+    }
+
+    public void testArithmeticInStatsAggregateOverflowReturns400() throws IOException {
+        ensureProvisioned();
+        // Arithmetic inside an aggregate argument must be reached (sum over the per-row product,
+        // where long_val * long_val overflows for the 5e18 row).
+        assertOverflow400("source=" + INDEX + " | stats sum(long_val * long_val) as s | fields s");
+    }
+
+    public void testNonOverflowingLongArithmeticSucceeds() throws IOException {
+        ensureProvisioned();
+        // 3 * 4 = 12, well within range: must return 200 with the correct value.
+        Map<String, Object> response = executePpl("source=" + INDEX + " | where long_val = 3 | eval x = long_val * 4 | fields x");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull(rows);
+        assertEquals(1, rows.size());
+        assertEquals(12L, ((Number) rows.get(0).get(0)).longValue());
+    }
+
+    public void testDoubleArithmeticDoesNotError() throws IOException {
+        ensureProvisioned();
+        // Floating-point arithmetic never routes through the checked rewrite (gate is Int64-only);
+        // it must return 200 — double overflow wraps to Infinity by PPL/Calcite parity, never 400.
+        Map<String, Object> response = executePpl(
+            "source=" + INDEX + " | where long_val = 3 | eval x = double_val * double_val | fields x"
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull(rows);
+        assertEquals(1, rows.size());
+    }
+
+    private void assertOverflow400(String ppl) throws IOException {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\"}");
+        try {
+            client().performRequest(request);
+            fail("Expected 400 BIGINT overflow error for query: " + ppl);
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            String body = new String(e.getResponse().getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+            assertEquals("Expected 400 but got " + status + ": " + body, 400, status);
+            assertTrue("Error should mention BIGINT overflow, got: " + body, body.contains("BIGINT arithmetic overflow"));
+        }
+    }
+}


### PR DESCRIPTION
### Description

BIGINT (`long` / Int64) arithmetic (`+`, `-`, `*`) on the analytics-engine DataFusion backend silently **wraps** on 64-bit overflow instead of erroring. For example `eval x = long_col * long_col` where the product exceeds `9,223,372,036,854,775,807` returns a wrapped negative value with HTTP 200, rather than a clear client error. DataFusion lowers integer `Plus`/`Minus`/`Multiply` to arrow's *wrapping* kernels (`add_wrapping`/`sub_wrapping`/`mul_wrapping`) by default.

This makes BIGINT overflow an explicit **HTTP 400** on the DataFusion route.

#### Mechanism

A logical-plan rewrite (`checked_arith_rewrite`) runs between `from_substrait_plan` and `create_physical_plan` on every executor. It walks the plan with `LogicalPlan::map_expressions` + `Expr::transform_up` and rewrites every `BinaryExpr { op: Plus | Minus | Multiply }` **whose both operands resolve to `Int64`** into a call to an overflow-checked scalar UDF (`checked_add_i64` / `checked_sub_i64` / `checked_mul_i64`). The UDFs invoke arrow's *checked* numeric kernels (`add`/`sub`/`mul`), which return an error on overflow. The error carries a stable, self-authored phrase (`BIGINT arithmetic overflow`) that `NativeErrorConverter` maps to an `IllegalArgumentException` → HTTP 400.

Why a logical rewrite (rather than flipping DataFusion's physical `BinaryExpr::fail_on_overflow`): walking the *logical* plan reaches arithmetic in **every** node uniformly — projection exprs, filter predicates, aggregate group/argument exprs (`sum(a*b)`), window args, sort keys, join conditions — because those are all first-class top-level `Expr`s at the logical level. The physical-plan approach would depend on per-node expression accessors that do not uniformly surface aggregate/window argument expressions, leaving silent overflow gaps.

#### Type gate (what is and isn't affected)

Only `Int64 op Int64` is rewritten. Everything else passes through unchanged:

| operands | behavior |
|---|---|
| `Int64` `{+,-,*}` `Int64` | **checked → 400 on overflow** |
| `Float32`/`Float64` | unchanged (wrap to ±Infinity, PPL/Calcite parity) |
| `Decimal*` | unchanged (own overflow path) |
| narrower ints (`Int8/16/32`), `UInt64` | unchanged |
| `/`, `%` | unchanged (not `+/-/*`) |

The analytics scan boundary already narrows the only `UInt64` source (`unsigned_long`) to `Int64` before planning (`schema_coerce`), and the SQL-plugin widening (opensearch-project/sql#5603) widens all sub-BIGINT integer arithmetic to `Int64` **before** the engine fork — so `Int64 op Int64` is the only integer arithmetic that reaches DataFusion and can still overflow. The gate is therefore both correct and sufficient.

Type resolution failures (e.g. a correlated column absent from the merged input schema) fall through to "leave unchanged" rather than propagate, so the rewrite can never turn a previously-working query into a planning error.

The UDFs are `Volatility::Immutable`, and their `return_type` is `Int64` — identical to the `BinaryExpr` they replace — so plan schemas are byte-identical (no `recompute_schema`, no `relabel_exec` churn), and predicate pushdown / CSE still apply. Const-folding an *overflowing* literal pair does not lose the error: DataFusion's `ConstEvaluator` preserves the original expr on a UDF runtime error (it only fails-fast for `CAST`), so overflow still surfaces at execution with the stable message; a non-overflowing constant simply folds to its exact value. Each rewritten expression's output name is preserved (`NamePreserver`) so a later `recompute_schema` can't rename an aggregate measure like `sum(a * b)` and break a parent node that references it by the derived name.

#### Distributed / aggregate path (transport)

Flight transport does not serialize the Java exception type — only a `StreamErrorCode` + message survive. A client-error `IllegalArgumentException` with no HTTP status would cross as `INTERNAL` and be redacted to a generic 500 on the coordinator (this is what `stats sum(a*b)` overflow originally did). `AnalyticsTransportErrors` now tags the overflow as `StreamErrorCode.INVALID_ARGUMENT` on the data-node send side and rebuilds it as a `BAD_REQUEST` (400) `OpenSearchStatusException` on the coordinator receive side — mirroring the existing breaker→429 and cancel→CANCELLED mappings — so the 400 survives the distributed reduce.

#### Indexed path

On the data-node indexed path the rewrite is applied to both the executed plan **and** the plan used for filter extraction, so arithmetic inside a `WHERE` predicate that seeds the parquet pushdown predicate is checked too (otherwise `where long1 * long2 > k` would be scan-filtered with wrapping arithmetic and drop overflowing rows silently). Checked arithmetic only ever appears nested inside a comparison operand — never as a top-level `AND`/`OR` or delegation marker — so predicate delegation classification is unaffected.

### Scope

This is the DataFusion-backend half of the fix for the residual `long × long` overflow that operand-widening cannot address (there is no wider primitive than `long`). The Calcite/v2 half — rewriting `long` `+`/`-`/`*` to `Math.*Exact` and surfacing a 4xx — landed in opensearch-project/sql#5604 (merged), so both engines now **error consistently** on `long` overflow rather than one wrapping and one erroring. This PR closes the gap on the analytics route.

Resolves the reported analytics-engine `long`-arithmetic overflow (see opensearch-project/sql#5164).

### Testing

| test | before | after |
|---|---|---|
| `checked_arith` Rust UDF unit tests (overflow errors, null-propagation, exact values, batch-fail) | — | 7/7 pass |
| `checked_arith_rewrite` Rust unit tests (Int64 `+/-/*` rewritten; float/mixed/divide untouched; nested bottom-up; Filter + Sort node coverage) | — | 8/8 pass |
| full `analytics-backend-datafusion` Rust lib suite (regression) | 1284 pass | 1284 pass |
| `NativeErrorConverterTests` (raw + controlled `BIGINT arithmetic overflow` → `IllegalArgumentException`) | — | 19/19 pass |
| `AnalyticsTransportErrorsTests` (BIGINT overflow → `INVALID_ARGUMENT` → 400 round-trip) | — | 20/20 pass |
| `BigintOverflowIT` QA (column `*`, literal+column, `where`-arith, `stats sum(arith)` → 400; non-overflow → 200; double → 200 no-error) | overflow → 200 wrapped | overflow → **400**, non-overflow → 200 |

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (module docs + PR).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

