### PR TITLE
Feature/node delay cluster settings

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -134,7 +134,8 @@ public class TransportClusterAllocationExplainAction extends TransportClusterMan
             state,
             clusterInfo,
             snapshotsInfoService.snapshotShardSizes(),
-            System.nanoTime()
+            System.nanoTime(),
+            clusterService.getSettings()
         );
 
         ShardRouting shardRouting = findShardToExplain(request, allocation);

--- a/server/src/main/java/org/opensearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/DelayedAllocationService.java
@@ -44,6 +44,7 @@ import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.threadpool.Scheduler;
@@ -57,7 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * if there are unassigned shards with delayed allocation (unassigned shards that have
  * the delay marker). These are shards that have become unassigned due to a node leaving
  * and which were assigned the delay marker based on the index delay setting
- * {@link UnassignedInfo#INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING}
+ * {@link UnassignedInfo#INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING} or the cluster-level delayed node-left timeout
  * (see {@link AllocationService#disassociateDeadNodes(RoutingAllocation)}.
  * This class is responsible for choosing the next (closest) delay expiration of a
  * delayed shard to schedule a reroute to remove the delay marker.
@@ -75,6 +76,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
     final ThreadPool threadPool;
     private final ClusterService clusterService;
     private final AllocationService allocationService;
+    private final Settings settings;
 
     AtomicReference<DelayedRerouteTask> delayedRerouteTask = new AtomicReference<>(); // package private to access from tests
 
@@ -150,7 +152,8 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.allocationService = allocationService;
-        if (DiscoveryNode.isClusterManagerNode(clusterService.getSettings())) {
+        this.settings = clusterService.getSettings();
+        if (DiscoveryNode.isClusterManagerNode(settings)) {
             clusterService.addListener(this);
         }
     }
@@ -197,7 +200,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
      */
     private synchronized void scheduleIfNeeded(long currentNanoTime, ClusterState state) {
         assertClusterOrClusterManagerStateThread();
-        long nextDelayNanos = UnassignedInfo.findNextDelayedAllocation(currentNanoTime, state);
+        long nextDelayNanos = UnassignedInfo.findNextDelayedAllocation(currentNanoTime, state, clusterSettings(state));
         if (nextDelayNanos < 0) {
             logger.trace("no need to schedule reroute - no delayed unassigned shards");
             removeTaskAndCancel();
@@ -233,6 +236,10 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
                 logger.trace("no need to reschedule delayed reroute - currently scheduled delayed reroute in [{}] is enough", nextDelay);
             }
         }
+    }
+
+    private Settings clusterSettings(ClusterState state) {
+        return Settings.builder().put(settings).put(state.metadata().settings()).build();
     }
 
     // protected so that it can be overridden (and disabled) by unit tests

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -442,12 +442,15 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     }
 
     /**
-     * Calculates the delay left based on current time (in nanoseconds) and the delay defined by the index settings.
+     * Calculates the delay left based on current time (in nanoseconds) and the delay defined by the index settings,
+     * or the built-in cluster default if the index setting is not set.
      * Only relevant if shard is effectively delayed (see {@link #isDelayed()})
      * Returns 0 if delay is negative
      *
      * @return calculated delay in nanoseconds
+     * @deprecated use {@link #getRemainingDelay(long, Settings, Settings)} with effective cluster settings.
      */
+    @Deprecated
     public long getRemainingDelay(final long nanoTimeNow, final Settings indexSettings) {
         return getRemainingDelay(nanoTimeNow, indexSettings, Settings.EMPTY);
     }
@@ -478,7 +481,10 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * Finds the next (closest) delay expiration of an delayed shard in nanoseconds based on current time.
      * Returns 0 if delay is negative.
      * Returns -1 if no delayed shard is found.
+     *
+     * @deprecated use {@link #findNextDelayedAllocation(long, ClusterState, Settings)} with effective cluster settings.
      */
+    @Deprecated
     public static long findNextDelayedAllocation(long currentNanoTime, ClusterState state) {
         return findNextDelayedAllocation(currentNanoTime, state, state.metadata().settings());
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -70,9 +70,18 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
 
     public static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("date_optional_time").withZone(ZoneOffset.UTC);
 
+    public static final TimeValue DEFAULT_DELAYED_NODE_LEFT_TIMEOUT = TimeValue.timeValueMinutes(1);
+
+    public static final Setting<TimeValue> CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING = Setting.positiveTimeSetting(
+        "cluster.routing.allocation.unassigned.node_left.delayed_timeout",
+        DEFAULT_DELAYED_NODE_LEFT_TIMEOUT,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final Setting<TimeValue> INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING = Setting.positiveTimeSetting(
         "index.unassigned.node_left.delayed_timeout",
-        TimeValue.timeValueMinutes(1),
+        DEFAULT_DELAYED_NODE_LEFT_TIMEOUT,
         Property.Dynamic,
         Property.IndexScope
     );
@@ -245,7 +254,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     private final Reason reason;
     private final long unassignedTimeMillis; // used for display and log messages, in milliseconds
     private final long unassignedTimeNanos; // in nanoseconds, used to calculate delay for delayed shard allocation
-    private final boolean delayed; // if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING
+    private final boolean delayed; // if allocation of this shard is delayed due to delayed node-left timeout settings
     private final String message;
     private final Exception failure;
     private final int failedAllocations;
@@ -278,7 +287,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * @param failure              the shard level failure that caused this shard to be unassigned, if exists.
      * @param unassignedTimeNanos  the time to use as the base for any delayed re-assignment calculation
      * @param unassignedTimeMillis the time of unassignment used to display to in our reporting.
-     * @param delayed              if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.
+     * @param delayed              if allocation of this shard is delayed due to delayed node-left timeout settings.
      * @param lastAllocationStatus the result of the last allocation attempt for this shard
      * @param failedNodeIds        a set of nodeIds that failed to complete allocations for this shard
      */
@@ -344,7 +353,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     }
 
     /**
-     * Returns true if allocation of this shard is delayed due to {@link #INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING}
+     * Returns true if allocation of this shard is delayed due to delayed node-left timeout settings.
      */
     public boolean isDelayed() {
         return delayed;
@@ -422,6 +431,17 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     }
 
     /**
+     * Returns the node-left delayed allocation timeout from the index settings if explicitly configured,
+     * otherwise returns the cluster-level delayed allocation timeout.
+     */
+    public static TimeValue getNodeLeftDelayedTimeout(final Settings indexSettings, final Settings clusterSettings) {
+        if (INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.exists(indexSettings)) {
+            return INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexSettings);
+        }
+        return CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(clusterSettings);
+    }
+
+    /**
      * Calculates the delay left based on current time (in nanoseconds) and the delay defined by the index settings.
      * Only relevant if shard is effectively delayed (see {@link #isDelayed()})
      * Returns 0 if delay is negative
@@ -429,7 +449,19 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * @return calculated delay in nanoseconds
      */
     public long getRemainingDelay(final long nanoTimeNow, final Settings indexSettings) {
-        long delayTimeoutNanos = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexSettings).nanos();
+        return getRemainingDelay(nanoTimeNow, indexSettings, Settings.EMPTY);
+    }
+
+    /**
+     * Calculates the delay left based on current time (in nanoseconds) and the effective delay defined by
+     * the index settings or the cluster-level default.
+     * Only relevant if shard is effectively delayed (see {@link #isDelayed()})
+     * Returns 0 if delay is negative
+     *
+     * @return calculated delay in nanoseconds
+     */
+    public long getRemainingDelay(final long nanoTimeNow, final Settings indexSettings, final Settings clusterSettings) {
+        long delayTimeoutNanos = getNodeLeftDelayedTimeout(indexSettings, clusterSettings).nanos();
         assert nanoTimeNow >= unassignedTimeNanos;
         return Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
     }
@@ -448,6 +480,16 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * Returns -1 if no delayed shard is found.
      */
     public static long findNextDelayedAllocation(long currentNanoTime, ClusterState state) {
+        return findNextDelayedAllocation(currentNanoTime, state, state.metadata().settings());
+    }
+
+    /**
+     * Finds the next (closest) delay expiration of a delayed shard in nanoseconds based on current time
+     * and the supplied effective cluster settings.
+     * Returns 0 if delay is negative.
+     * Returns -1 if no delayed shard is found.
+     */
+    public static long findNextDelayedAllocation(long currentNanoTime, ClusterState state, Settings clusterSettings) {
         Metadata metadata = state.metadata();
         RoutingTable routingTable = state.routingTable();
         long nextDelayNanos = Long.MAX_VALUE;
@@ -456,7 +498,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
             if (unassignedInfo.isDelayed()) {
                 Settings indexSettings = metadata.index(shard.index()).getSettings();
                 // calculate next time to schedule
-                final long newComputedLeftDelayNanos = unassignedInfo.getRemainingDelay(currentNanoTime, indexSettings);
+                final long newComputedLeftDelayNanos = unassignedInfo.getRemainingDelay(currentNanoTime, indexSettings, clusterSettings);
                 if (newComputedLeftDelayNanos < nextDelayNanos) {
                     nextDelayNanos = newComputedLeftDelayNanos;
                 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -81,7 +81,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.opensearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.opensearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE;
 
 /**
@@ -177,7 +176,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            settings
         );
         // as starting a primary relocation target can reinitialize replica shards, start replicas first
         startedShards = new ArrayList<>(startedShards);
@@ -266,7 +266,8 @@ public class AllocationService {
             tmpState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime
+            currentNanoTime,
+            settings
         );
 
         for (FailedShard failedShardEntry : failedShards) {
@@ -341,7 +342,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            settings
         );
 
         // first, clear from the shards any node id they used to belong to that is now dead
@@ -368,7 +370,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            settings
         );
         final Map<Integer, List<String>> autoExpandReplicaChanges = AutoExpandReplicas.getAutoExpandReplicaChanges(
             clusterState.metadata(),
@@ -440,7 +443,8 @@ public class AllocationService {
             if (unassignedInfo.isDelayed()) {
                 final long newComputedLeftDelayNanos = unassignedInfo.getRemainingDelay(
                     allocation.getCurrentNanoTime(),
-                    metadata.getIndexSafe(shardRouting.index()).getSettings()
+                    metadata.getIndexSafe(shardRouting.index()).getSettings(),
+                    allocation.clusterSettings()
                 );
                 if (newComputedLeftDelayNanos == 0) {
                     unassignedIterator.updateUnassigned(
@@ -524,7 +528,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            settings
         );
         // don't short circuit deciders, we want a full explanation
         allocation.debugDecision(true);
@@ -561,7 +566,8 @@ public class AllocationService {
             fixedClusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            settings
         );
         reroute(allocation);
         if (fixedClusterState == clusterState && allocation.routingNodesChanged() == false) {
@@ -666,7 +672,8 @@ public class AllocationService {
             // now, go over all the shards routing on the node, and fail them
             for (ShardRouting shardRouting : node.copyShards()) {
                 final IndexMetadata indexMetadata = allocation.metadata().getIndexSafe(shardRouting.index());
-                boolean delayed = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexMetadata.getSettings()).nanos() > 0;
+                boolean delayed = UnassignedInfo.getNodeLeftDelayedTimeout(indexMetadata.getSettings(), allocation.clusterSettings())
+                    .nanos() > 0;
                 UnassignedInfo unassignedInfo = new UnassignedInfo(
                     UnassignedInfo.Reason.NODE_LEFT,
                     "node_left [" + node.nodeId() + "]",

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/RoutingAllocation.java
@@ -44,6 +44,7 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.snapshots.RestoreService.RestoreInProgressUpdater;
 import org.opensearch.snapshots.SnapshotShardSizeInfo;
@@ -72,6 +73,8 @@ public class RoutingAllocation {
     private final RoutingNodes routingNodes;
 
     private final Metadata metadata;
+
+    private final Settings clusterSettings;
 
     private final RoutingTable routingTable;
 
@@ -117,9 +120,30 @@ public class RoutingAllocation {
         SnapshotShardSizeInfo shardSizeInfo,
         long currentNanoTime
     ) {
+        this(deciders, routingNodes, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, Settings.EMPTY);
+    }
+
+    /**
+     * Creates a new {@link RoutingAllocation}
+     *  @param deciders {@link AllocationDeciders} to used to make decisions for routing allocations
+     * @param routingNodes Routing nodes in the current cluster
+     * @param clusterState cluster state before rerouting
+     * @param currentNanoTime the nano time to use for all delay allocation calculation (typically {@link System#nanoTime()})
+     * @param nodeSettings node level settings to use as defaults for cluster scoped settings
+     */
+    public RoutingAllocation(
+        AllocationDeciders deciders,
+        RoutingNodes routingNodes,
+        ClusterState clusterState,
+        ClusterInfo clusterInfo,
+        SnapshotShardSizeInfo shardSizeInfo,
+        long currentNanoTime,
+        Settings nodeSettings
+    ) {
         this.deciders = deciders;
         this.routingNodes = routingNodes;
         this.metadata = clusterState.metadata();
+        this.clusterSettings = Settings.builder().put(nodeSettings).put(metadata.settings()).build();
         this.routingTable = clusterState.routingTable();
         this.nodes = clusterState.nodes();
         this.customs = clusterState.customs();
@@ -166,6 +190,13 @@ public class RoutingAllocation {
      */
     public Metadata metadata() {
         return metadata;
+    }
+
+    /**
+     * Returns cluster scoped settings, including node-level defaults overridden by dynamic cluster-state settings.
+     */
+    public Settings clusterSettings() {
+        return clusterSettings;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -63,6 +63,7 @@ import org.opensearch.cluster.coordination.Reconfigurator;
 import org.opensearch.cluster.metadata.IndexGraveyard;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.OperationRouting;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -300,6 +301,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING,
                 EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING,
                 EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING,
+                UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING,
                 ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE,
                 FilterAllocationDecider.CLUSTER_ROUTING_INCLUDE_GROUP_SETTING,
                 FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP_SETTING,

--- a/server/src/main/java/org/opensearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ReplicaShardAllocator.java
@@ -64,8 +64,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.opensearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
-
 /**
  * Allocates replica shards
  *
@@ -338,8 +336,13 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 UnassignedInfo unassignedInfo = unassignedShard.unassignedInfo();
                 Metadata metadata = allocation.metadata();
                 IndexMetadata indexMetadata = metadata.index(unassignedShard.index());
-                totalDelayMillis = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexMetadata.getSettings()).getMillis();
-                long remainingDelayNanos = unassignedInfo.getRemainingDelay(System.nanoTime(), indexMetadata.getSettings());
+                totalDelayMillis = UnassignedInfo.getNodeLeftDelayedTimeout(indexMetadata.getSettings(), allocation.clusterSettings())
+                    .getMillis();
+                long remainingDelayNanos = unassignedInfo.getRemainingDelay(
+                    System.nanoTime(),
+                    indexMetadata.getSettings(),
+                    allocation.clusterSettings()
+                );
                 remainingDelayMillis = TimeValue.timeValueNanos(remainingDelayNanos).millis();
             }
             return AllocateUnassignedDecision.delayed(remainingDelayMillis, totalDelayMillis, nodeDecisions);

--- a/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -233,6 +233,79 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
         verifyNoMoreInteractions(clusterService);
     }
 
+    public void testDelayedUnassignedScheduleRerouteUsesNodeLevelClusterDefault() throws Exception {
+        TimeValue delaySetting = timeValueMillis(100);
+        Settings nodeSettings = Settings.builder()
+            .put(NodeRoles.clusterManagerOnlyNode())
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delaySetting)
+            .build();
+        ClusterService localClusterService = mock(ClusterService.class);
+        MockAllocationService localAllocationService = createAllocationService(nodeSettings, new DelayedShardsMockGatewayAllocator());
+        when(localClusterService.getSettings()).thenReturn(nodeSettings);
+        TestDelayAllocationService localDelayedAllocationService = new TestDelayAllocationService(
+            threadPool,
+            localClusterService,
+            localAllocationService
+        );
+        verify(localClusterService).addListener(localDelayedAllocationService);
+        verify(localClusterService).getSettings();
+
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).localNodeId("node1").clusterManagerNodeId("node1"))
+            .build();
+        final long baseTimestampNanos = System.nanoTime();
+        localAllocationService.setNanoTimeOverride(baseTimestampNanos);
+        clusterState = localAllocationService.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(localAllocationService, clusterState);
+        clusterState = startInitializingShardsAndReroute(localAllocationService, clusterState);
+
+        String replicaNodeId = null;
+        for (ShardRouting shardRouting : clusterState.getRoutingTable().allShards("test")) {
+            if (shardRouting.primary() == false) {
+                replicaNodeId = shardRouting.currentNodeId();
+                break;
+            }
+        }
+        assertNotNull(replicaNodeId);
+
+        ClusterState beforeNodeLeft = clusterState;
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove(replicaNodeId)).build();
+        clusterState = localAllocationService.disassociateDeadNodes(clusterState, true, "reroute");
+        ClusterState stateWithDelayedShard = clusterState;
+        // isDelayed alone cannot distinguish the node-level 100ms setting from the built-in 1m default.
+        // The scheduled nextDelay assertion below is the regression check for the node-level setting path.
+        assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShard));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ClusterStateUpdateTask> clusterStateUpdateTask = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            clusterStateUpdateTask.set((ClusterStateUpdateTask) invocationOnMock.getArguments()[1]);
+            latch.countDown();
+            return null;
+        }).when(localClusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class));
+
+        long delayUntilClusterChangeEvent = TimeValue.timeValueNanos(randomInt((int) delaySetting.nanos() - 1)).nanos();
+        long clusterChangeEventTimestampNanos = baseTimestampNanos + delayUntilClusterChangeEvent;
+        localDelayedAllocationService.setNanoTimeOverride(clusterChangeEventTimestampNanos);
+        localDelayedAllocationService.clusterChanged(new ClusterChangedEvent("fake node left", stateWithDelayedShard, beforeNodeLeft));
+
+        DelayedAllocationService.DelayedRerouteTask delayedRerouteTask = localDelayedAllocationService.delayedRerouteTask.get();
+        assertNotNull(delayedRerouteTask);
+        assertFalse(delayedRerouteTask.cancelScheduling.get());
+        assertThat(delayedRerouteTask.baseTimestampNanos, equalTo(clusterChangeEventTimestampNanos));
+        assertThat(
+            delayedRerouteTask.nextDelay.nanos(),
+            equalTo(delaySetting.nanos() - (clusterChangeEventTimestampNanos - baseTimestampNanos))
+        );
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        verify(localClusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask.get()));
+    }
+
     /**
      * This tests that a new delayed reroute is scheduled right after a delayed reroute was run
      */

--- a/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -415,7 +415,13 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
         assertThat(firstDelayedRerouteTask.baseTimestampNanos, equalTo(clusterChangeEventTimestampNanos));
         assertThat(
             firstDelayedRerouteTask.nextDelay.nanos(),
-            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithDelayedShards))
+            equalTo(
+                UnassignedInfo.findNextDelayedAllocation(
+                    clusterChangeEventTimestampNanos,
+                    stateWithDelayedShards,
+                    stateWithDelayedShards.metadata().settings()
+                )
+            )
         );
         assertThat(
             firstDelayedRerouteTask.nextDelay.nanos(),
@@ -459,7 +465,13 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
         assertThat(secondDelayedRerouteTask.baseTimestampNanos, equalTo(clusterChangeEventTimestampNanos));
         assertThat(
             secondDelayedRerouteTask.nextDelay.nanos(),
-            equalTo(UnassignedInfo.findNextDelayedAllocation(clusterChangeEventTimestampNanos, stateWithOnlyOneDelayedShard))
+            equalTo(
+                UnassignedInfo.findNextDelayedAllocation(
+                    clusterChangeEventTimestampNanos,
+                    stateWithOnlyOneDelayedShard,
+                    stateWithOnlyOneDelayedShard.metadata().settings()
+                )
+            )
         );
         assertThat(
             secondDelayedRerouteTask.nextDelay.nanos(),

--- a/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
@@ -421,14 +421,14 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
         final Settings indexSettings = Settings.builder()
             .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueNanos(totalDelayNanos))
             .build();
-        long delay = unassignedInfo.getRemainingDelay(baseTime, indexSettings);
+        long delay = unassignedInfo.getRemainingDelay(baseTime, indexSettings, Settings.EMPTY);
         assertThat(delay, equalTo(totalDelayNanos));
         long delta1 = randomIntBetween(1, (int) (totalDelayNanos - 1));
-        delay = unassignedInfo.getRemainingDelay(baseTime + delta1, indexSettings);
+        delay = unassignedInfo.getRemainingDelay(baseTime + delta1, indexSettings, Settings.EMPTY);
         assertThat(delay, equalTo(totalDelayNanos - delta1));
-        delay = unassignedInfo.getRemainingDelay(baseTime + totalDelayNanos, indexSettings);
+        delay = unassignedInfo.getRemainingDelay(baseTime + totalDelayNanos, indexSettings, Settings.EMPTY);
         assertThat(delay, equalTo(0L));
-        delay = unassignedInfo.getRemainingDelay(baseTime + totalDelayNanos + randomIntBetween(1, 20), indexSettings);
+        delay = unassignedInfo.getRemainingDelay(baseTime + totalDelayNanos + randomIntBetween(1, 20), indexSettings, Settings.EMPTY);
         assertThat(delay, equalTo(0L));
     }
 
@@ -620,7 +620,10 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
             clusterState = allocation.reroute(clusterState, "time moved");
         }
 
-        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime + delta, clusterState), equalTo(expectMinDelaySettingsNanos - delta));
+        assertThat(
+            UnassignedInfo.findNextDelayedAllocation(baseTime + delta, clusterState, clusterState.metadata().settings()),
+            equalTo(expectMinDelaySettingsNanos - delta)
+        );
     }
 
     public void testFindNextDelayedAllocationUsesClusterDefault() {
@@ -650,7 +653,10 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
         clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
 
-        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime, clusterState), equalTo(clusterDelay.nanos()));
+        assertThat(
+            UnassignedInfo.findNextDelayedAllocation(baseTime, clusterState, clusterState.metadata().settings()),
+            equalTo(clusterDelay.nanos())
+        );
     }
 
     public void testFindNextDelayedAllocationUsesNodeLevelClusterDefault() {

--- a/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
@@ -432,6 +432,41 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
         assertThat(delay, equalTo(0L));
     }
 
+    public void testRemainingDelayUsesClusterDefaultWhenIndexSettingIsMissing() {
+        final long baseTime = System.nanoTime();
+        UnassignedInfo unassignedInfo = new UnassignedInfo(
+            UnassignedInfo.Reason.NODE_LEFT,
+            "test",
+            null,
+            0,
+            baseTime,
+            System.currentTimeMillis(),
+            true,
+            AllocationStatus.NO_ATTEMPT,
+            Collections.emptySet()
+        );
+        final TimeValue clusterDelay = TimeValue.timeValueMillis(randomIntBetween(1, 200));
+        final Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), clusterDelay)
+            .build();
+
+        assertThat(UnassignedInfo.getNodeLeftDelayedTimeout(Settings.EMPTY, clusterSettings), equalTo(clusterDelay));
+        assertThat(unassignedInfo.getRemainingDelay(baseTime, Settings.EMPTY, clusterSettings), equalTo(clusterDelay.nanos()));
+    }
+
+    public void testIndexDelayedAllocationSettingOverridesClusterDefault() {
+        final TimeValue clusterDelay = TimeValue.timeValueMillis(randomIntBetween(201, 400));
+        final TimeValue indexDelay = TimeValue.timeValueMillis(randomIntBetween(1, 200));
+        final Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), clusterDelay)
+            .build();
+        final Settings indexSettings = Settings.builder()
+            .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), indexDelay)
+            .build();
+
+        assertThat(UnassignedInfo.getNodeLeftDelayedTimeout(indexSettings, clusterSettings), equalTo(indexDelay));
+    }
+
     public void testNumberOfDelayedUnassigned() throws Exception {
         MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
         Metadata metadata = Metadata.builder()
@@ -457,6 +492,85 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
         // make sure both replicas are marked as delayed (i.e. not reallocated)
         clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
         assertThat(clusterState.toString(), UnassignedInfo.getNumberOfDelayedUnassigned(clusterState), equalTo(2));
+    }
+
+    public void testClusterDelayedAllocationSettingControlsNodeLeftDelay() {
+        MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
+        Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0))
+            .build();
+        ClusterState clusterState = createStartedClusterState(allocation, clusterSettings, Settings.EMPTY);
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(clusterState.getRoutingNodes().unassigned().size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().unassigned().iterator().next().unassignedInfo().isDelayed(), equalTo(false));
+    }
+
+    public void testNodeLevelClusterDelayedAllocationSettingControlsNodeLeftDelay() {
+        Settings nodeSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0))
+            .build();
+        MockAllocationService allocation = createAllocationService(nodeSettings, new DelayedShardsMockGatewayAllocator());
+        ClusterState clusterState = createStartedClusterState(allocation, Settings.EMPTY, Settings.EMPTY);
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(clusterState.getRoutingNodes().unassigned().size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().unassigned().iterator().next().unassignedInfo().isDelayed(), equalTo(false));
+    }
+
+    public void testClusterStateSettingOverridesNodeLevelClusterSettingForNodeLeftDelay() {
+        Settings nodeSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0))
+            .build();
+        Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100))
+            .build();
+        MockAllocationService allocation = createAllocationService(nodeSettings, new DelayedShardsMockGatewayAllocator());
+        ClusterState clusterState = createStartedClusterState(allocation, clusterSettings, Settings.EMPTY);
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(clusterState.getRoutingNodes().unassigned().size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().unassigned().iterator().next().unassignedInfo().isDelayed(), equalTo(true));
+    }
+
+    public void testClusterStateSettingOverridesNodeLevelClusterSettingWithNoDelayForNodeLeftDelay() {
+        Settings nodeSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100))
+            .build();
+        Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0))
+            .build();
+        MockAllocationService allocation = createAllocationService(nodeSettings, new DelayedShardsMockGatewayAllocator());
+        ClusterState clusterState = createStartedClusterState(allocation, clusterSettings, Settings.EMPTY);
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(clusterState.getRoutingNodes().unassigned().size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().unassigned().iterator().next().unassignedInfo().isDelayed(), equalTo(false));
+    }
+
+    public void testIndexDelayedAllocationSettingOverridesClusterSettingForNodeLeftDelay() {
+        MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
+        Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0))
+            .build();
+        Settings indexSettings = Settings.builder()
+            .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100))
+            .build();
+        ClusterState clusterState = createStartedClusterState(allocation, clusterSettings, indexSettings);
+
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(clusterState.getRoutingNodes().unassigned().size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().unassigned().iterator().next().unassignedInfo().isDelayed(), equalTo(true));
     }
 
     public void testFindNextDelayedAllocation() {
@@ -509,6 +623,65 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
         assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime + delta, clusterState), equalTo(expectMinDelaySettingsNanos - delta));
     }
 
+    public void testFindNextDelayedAllocationUsesClusterDefault() {
+        MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
+        final TimeValue clusterDelay = TimeValue.timeValueMillis(randomIntBetween(1, 200));
+        final Settings clusterSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), clusterDelay)
+            .build();
+
+        Metadata metadata = Metadata.builder()
+            .persistentSettings(clusterSettings)
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+            .build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")))
+            .build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        final long baseTime = System.nanoTime();
+        allocation.setNanoTimeOverride(baseTime);
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime, clusterState), equalTo(clusterDelay.nanos()));
+    }
+
+    public void testFindNextDelayedAllocationUsesNodeLevelClusterDefault() {
+        MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
+        final TimeValue nodeDelay = TimeValue.timeValueMillis(randomIntBetween(1, 200));
+        final Settings nodeSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), nodeDelay)
+            .build();
+
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+            .build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")))
+            .build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+
+        final long baseTime = System.nanoTime();
+        allocation.setNanoTimeOverride(baseTime);
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+
+        assertThat(UnassignedInfo.findNextDelayedAllocation(baseTime, clusterState, nodeSettings), equalTo(nodeDelay.nanos()));
+    }
+
     public void testAllocationStatusSerialization() throws IOException {
         for (AllocationStatus allocationStatus : AllocationStatus.values()) {
             BytesStreamOutput out = new BytesStreamOutput();
@@ -517,5 +690,22 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
             AllocationStatus readStatus = AllocationStatus.readFrom(in);
             assertThat(readStatus, equalTo(allocationStatus));
         }
+    }
+
+    private ClusterState createStartedClusterState(MockAllocationService allocation, Settings clusterSettings, Settings indexSettings) {
+        Metadata metadata = Metadata.builder()
+            .persistentSettings(clusterSettings)
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT).put(indexSettings)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+            .build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")))
+            .build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        return startInitializingShardsAndReroute(allocation, clusterState);
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/opensearch/gateway/ReplicaShardAllocatorTests.java
@@ -52,6 +52,8 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.TestShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
+import org.opensearch.cluster.routing.allocation.AllocateUnassignedDecision;
+import org.opensearch.cluster.routing.allocation.AllocationDecision;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
@@ -446,6 +448,30 @@ public class ReplicaShardAllocatorTests extends OpenSearchAllocationTestCase {
         );
     }
 
+    public void testDelayedAllocationExplainUsesClusterDefault() {
+        TimeValue clusterDelay = TimeValue.timeValueHours(1);
+        Settings nodeSettings = Settings.builder()
+            .put(UnassignedInfo.CLUSTER_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), clusterDelay)
+            .build();
+        RoutingAllocation allocation = onePrimaryOnNode1And1Replica(
+            yesAllocationDeciders(),
+            Settings.EMPTY,
+            nodeSettings,
+            UnassignedInfo.Reason.NODE_LEFT
+        );
+        allocation.debugDecision(true);
+        testAllocator.addData(node1, "MATCH", new StoreFileMetadata("file1", 10, "MATCH_CHECKSUM", MIN_SUPPORTED_LUCENE_VERSION));
+
+        ShardRouting unassignedShard = allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).get(0);
+        AllocateUnassignedDecision decision = testAllocator.makeAllocationDecision(unassignedShard, allocation, testAllocator.logger);
+
+        assertThat(decision.getAllocationDecision(), equalTo(AllocationDecision.ALLOCATION_DELAYED));
+        assertThat(decision.getAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.DELAYED_ALLOCATION));
+        assertThat(decision.getConfiguredDelayInMillis(), equalTo(clusterDelay.millis()));
+        assertThat(decision.getRemainingDelayInMillis() > 0, equalTo(true));
+        assertThat(decision.getRemainingDelayInMillis() <= clusterDelay.millis(), equalTo(true));
+    }
+
     public void testCancelRecoveryBetterSyncId() {
         RoutingAllocation allocation = onePrimaryOnNode1And1ReplicaRecovering(yesAllocationDeciders());
         testAllocator.addData(node1, "MATCH", new StoreFileMetadata("file1", 10, "MATCH_CHECKSUM", MIN_SUPPORTED_LUCENE_VERSION))
@@ -548,17 +574,30 @@ public class ReplicaShardAllocatorTests extends OpenSearchAllocationTestCase {
         return onePrimaryOnNode1And1Replica(deciders, Settings.EMPTY, UnassignedInfo.Reason.CLUSTER_RECOVERED);
     }
 
-    private RoutingAllocation onePrimaryOnNode1And1Replica(AllocationDeciders deciders, Settings settings, UnassignedInfo.Reason reason) {
+    private RoutingAllocation onePrimaryOnNode1And1Replica(
+        AllocationDeciders deciders,
+        Settings indexSettings,
+        UnassignedInfo.Reason reason
+    ) {
+        return onePrimaryOnNode1And1Replica(deciders, indexSettings, Settings.EMPTY, reason);
+    }
+
+    private RoutingAllocation onePrimaryOnNode1And1Replica(
+        AllocationDeciders deciders,
+        Settings indexSettings,
+        Settings nodeSettings,
+        UnassignedInfo.Reason reason
+    ) {
         ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId, node1.getId(), true, ShardRoutingState.STARTED);
         IndexMetadata.Builder indexMetadata = IndexMetadata.builder(shardId.getIndexName())
-            .settings(settings(Version.CURRENT).put(settings))
+            .settings(settings(Version.CURRENT).put(indexSettings))
             .numberOfShards(1)
             .numberOfReplicas(1)
             .putInSyncAllocationIds(0, Sets.newHashSet(primaryShard.allocationId().getId()));
         Metadata metadata = Metadata.builder().put(indexMetadata).build();
         // mark shard as delayed if reason is NODE_LEFT
         boolean delayed = reason == UnassignedInfo.Reason.NODE_LEFT
-            && UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(settings).nanos() > 0;
+            && UnassignedInfo.getNodeLeftDelayedTimeout(indexSettings, nodeSettings).nanos() > 0;
         int failedAllocations = reason == UnassignedInfo.Reason.ALLOCATION_FAILED ? 1 : 0;
         RoutingTable routingTable = RoutingTable.builder()
             .add(
@@ -598,7 +637,8 @@ public class ReplicaShardAllocatorTests extends OpenSearchAllocationTestCase {
             state,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            nodeSettings
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/cluster/OpenSearchAllocationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/OpenSearchAllocationTestCase.java
@@ -55,6 +55,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.gateway.GatewayAllocator;
 import org.opensearch.snapshots.SnapshotShardSizeInfo;
 import org.opensearch.snapshots.SnapshotsInfoService;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.gateway.TestGatewayAllocator;
 
@@ -106,7 +107,8 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
             new TestGatewayAllocator(),
             new BalancedShardsAllocator(settings),
             EmptyClusterInfoService.INSTANCE,
-            SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES
+            SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES,
+            settings
         );
     }
 
@@ -116,7 +118,8 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
             new TestGatewayAllocator(),
             new BalancedShardsAllocator(settings),
             clusterInfoService,
-            SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES
+            SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES,
+            settings
         );
     }
 
@@ -138,7 +141,8 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
             gatewayAllocator,
             new BalancedShardsAllocator(settings),
             EmptyClusterInfoService.INSTANCE,
-            snapshotsInfoService
+            snapshotsInfoService,
+            settings
         );
     }
 
@@ -153,7 +157,8 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
             gatewayAllocator,
             new BalancedShardsAllocator(settings, clusterSettings),
             EmptyClusterInfoService.INSTANCE,
-            snapshotsInfoService
+            snapshotsInfoService,
+            settings
         );
     }
 
@@ -487,6 +492,25 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
             SnapshotsInfoService snapshotsInfoService
         ) {
             super(allocationDeciders, gatewayAllocator, shardsAllocator, clusterInfoService, snapshotsInfoService);
+        }
+
+        public MockAllocationService(
+            AllocationDeciders allocationDeciders,
+            GatewayAllocator gatewayAllocator,
+            ShardsAllocator shardsAllocator,
+            ClusterInfoService clusterInfoService,
+            SnapshotsInfoService snapshotsInfoService,
+            Settings settings
+        ) {
+            super(
+                allocationDeciders,
+                shardsAllocator,
+                clusterInfoService,
+                snapshotsInfoService,
+                settings,
+                new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
+            );
+            setExistingShardsAllocators(Collections.singletonMap(GatewayAllocator.ALLOCATOR_NAME, gatewayAllocator));
         }
 
         public void setNanoTimeOverride(long nanoTime) {


### PR DESCRIPTION
Resolves [#22373](https://github.com/opensearch-project/OpenSearch/issues/22373)


OpenSearch only supports delayed shard allocation timeout at the index level: _index.unassigned.node_left.delayed_timeout_

This works well for individual indices, but it must be configured per index or through index templates. In clusters with many indices and templates, keeping this value consistent is operationally cumbersome.

This PR adds a cluster-level default setting: _cluster.routing.allocation.unassigned.node_left.delayed_timeout_
 
When both index-level and cluster-level settings are defined, index-level settings wins. 


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
