### PR TITLE
Add HTTP request body decompression to reactor-netty4 transport

### DIFF
--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -83,6 +83,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.netty.Connection;
 import reactor.netty.DisposableChannel;
 import reactor.netty.DisposableServer;
+import reactor.netty.NettyPipeline;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.http.server.HttpServerRequest;
@@ -314,8 +315,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                 .runOn(sharedGroup.getLowLevelGroup())
                 .bindAddress(() -> socketAddress)
                 .compress(true)
-                .doOnConnection(conn -> conn.addHandlerFirst(
-                    NettyPipeline.HttpDecompressor, createDecompressor()))
+                .doOnConnection(conn -> conn.addHandlerFirst(NettyPipeline.HttpDecompressor, createDecompressor()))
                 .http2Settings(spec -> spec.maxHeaderListSize(maxHeaderSize.bytesAsInt()).maxConcurrentStreams(h2MaxConcurrentStreams))
                 .httpRequestDecoder(
                     spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())
@@ -381,8 +381,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                         .runOn(sharedGroup.getLowLevelGroup())
                         .bindAddress(() -> socketAddress)
                         .compress(true)
-                        .doOnConnection(conn -> conn.addHandlerFirst(
-                            NettyPipeline.HttpDecompressor, createDecompressor()))
+                        .doOnConnection(conn -> conn.addHandlerFirst(NettyPipeline.HttpDecompressor, createDecompressor()))
                         .httpRequestDecoder(
                             spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())
                                 .h2cMaxContentLength(h2cMaxContentLength.bytesAsInt())

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -315,7 +315,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                 .bindAddress(() -> socketAddress)
                 .compress(true)
                 .doOnConnection(conn -> conn.addHandlerFirst(
-                    "request_decompressor", createDecompressor()))
+                    NettyPipeline.HttpDecompressor, createDecompressor()))
                 .http2Settings(spec -> spec.maxHeaderListSize(maxHeaderSize.bytesAsInt()).maxConcurrentStreams(h2MaxConcurrentStreams))
                 .httpRequestDecoder(
                     spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -382,7 +382,7 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                         .bindAddress(() -> socketAddress)
                         .compress(true)
                         .doOnConnection(conn -> conn.addHandlerFirst(
-                            "request_decompressor", createDecompressor()))
+                            NettyPipeline.HttpDecompressor, createDecompressor()))
                         .httpRequestDecoder(
                             spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())
                                 .h2cMaxContentLength(h2cMaxContentLength.bytesAsInt())

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -59,11 +59,13 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.quic.QuicSslContextBuilder;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
@@ -110,6 +112,11 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
 
     private static final String SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS = "http.netty.max_composite_buffer_components";
     private static final ByteSizeValue MTU = new ByteSizeValue(Long.parseLong(System.getProperty("opensearch.net.mtu", "1500")));
+
+    /**
+     * The size of the http content decompressor buffer that is going to be used for request body decompression.
+     */
+    private static final int UNLIMITED_DECOMPRESSOR_BUFFER = 0;
 
     /**
      * Configure the maximum length of the content of the HTTP/2.0 clear-text upgrade request.
@@ -307,6 +314,8 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                 .runOn(sharedGroup.getLowLevelGroup())
                 .bindAddress(() -> socketAddress)
                 .compress(true)
+                .doOnConnection(conn -> conn.addHandlerFirst(
+                    "request_decompressor", createDecompressor()))
                 .http2Settings(spec -> spec.maxHeaderListSize(maxHeaderSize.bytesAsInt()).maxConcurrentStreams(h2MaxConcurrentStreams))
                 .httpRequestDecoder(
                     spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())
@@ -372,6 +381,8 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
                         .runOn(sharedGroup.getLowLevelGroup())
                         .bindAddress(() -> socketAddress)
                         .compress(true)
+                        .doOnConnection(conn -> conn.addHandlerFirst(
+                            "request_decompressor", createDecompressor()))
                         .httpRequestDecoder(
                             spec -> spec.maxChunkSize(maxChunkSize.bytesAsInt())
                                 .h2cMaxContentLength(h2cMaxContentLength.bytesAsInt())
@@ -493,6 +504,16 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
     @Override
     public void serverAcceptedChannel(HttpChannel httpChannel) {
         super.serverAcceptedChannel(httpChannel);
+    }
+
+    /**
+     * Extension point that allows a NetworkPlugin to override the default netty HttpContentDecompressor
+     * and supply a custom decompressor.
+     *
+     * Used in instances to conditionally decompress depending on the outcome from header verification.
+     */
+    protected ChannelInboundHandlerAdapter createDecompressor() {
+        return new HttpContentDecompressor(UNLIMITED_DECOMPRESSOR_BUFFER);
     }
 
     /**


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Enabling decompression of gzip/deflate-encoded request bodies. This matches the behavior of the standard transport and is required for compatibility with clients like opensearch-java's `AwsSdk2Transport`, which auto-compresses request bodies larger than 8KB.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
