### PR TITLE
feat: Add REMOTE_STORE_SYNC_TIMEOUT_MARKER to waitForRemoteStoreSync

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2746,9 +2746,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
         }
         throw new IOException(
-            "Failed to upload to remote segment store within remote upload timeout of "
-                + getRecoverySettings().internalRemoteUploadTimeout().getMinutes()
-                + " minutes"
+            REMOTE_STORE_SYNC_TIMEOUT_MARKER + " of " + getRecoverySettings().internalRemoteUploadTimeout().getMinutes() + " minutes"
         );
     }
 
@@ -3851,6 +3849,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * {@link org.opensearch.storage.action.tiering.MergeDrainTimeoutException#MERGE_DRAIN_TIMEOUT_MARKER}.
      */
     public static final String REPLICA_SYNC_TIMEOUT_MARKER = "[REPLICA_SYNC_TIMEOUT]";
+
+    /**
+     * Stable marker substring embedded in remote store sync timeout messages.
+     * Enables log parsing and coordinator-side detection of upload timeouts during tiering preparation.
+     */
+    public static final String REMOTE_STORE_SYNC_TIMEOUT_MARKER = "Failed to upload to remote segment store within remote upload timeout";
 
     /**
      * Waits for all tracked replicas to be in sync with the primary's latest checkpoint.


### PR DESCRIPTION
Extract the error message prefix into a stable marker constant for coordinator-side detection and log parsing of remote store upload timeouts during tiering preparation.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
