### PR TITLE
Bound remote translog purge for small nodes

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -854,6 +854,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_UPLOADED_SEGMENTS_CLEANUP_THRESHOLD_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRANSFER_TIMEOUT_SETTING,
+                RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING,
+                RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_SEGMENT_TRANSFER_TIMEOUT_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING,

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -163,12 +163,26 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
             triggerTrimOnMinRemoteGenReferencedChange.set(false);
         }
 
+        if (indexDeleted == false && tryScheduleRemotePurge() == false) {
+            return;
+        }
+
         // Since remote generation deletion is async, this ensures that only one generation deletion happens at a time.
         // Remote generations involves 2 async operations - 1) Delete translog generation files 2) Delete metadata files
         // We try to acquire 2 permits and if we can not, we return from here itself.
         if (remoteGenerationDeletionPermits.tryAcquire(REMOTE_DELETION_PERMITS) == false) {
+            if (indexDeleted == false) {
+                completeRemotePurgeScheduling();
+            }
             return;
         }
+
+        Runnable onRemotePurgeComplete = () -> {
+            remoteGenerationDeletionPermits.release();
+            if (indexDeleted == false) {
+                completeRemotePurgeCycle();
+            }
+        };
 
         ActionListener<List<BlobMetadata>> listMetadataFilesListener = new ActionListener<>() {
             @Override
@@ -179,6 +193,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     if (indexDeleted == false && metadataFiles.size() <= 1) {
                         logger.debug("No stale translog metadata files found");
                         remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        completeRemotePurgeCycle();
                         return;
                     }
 
@@ -186,6 +201,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     if (indexDeleted == false && RemoteStoreUtils.isPinnedTimestampStateStale()) {
                         logger.debug("Skipping remote translog garbage collection as last fetch of pinned timestamp is stale");
                         remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        completeRemotePurgeCycle();
                         return;
                     }
 
@@ -199,6 +215,9 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     if (metadataFilesToBeDeleted.isEmpty()) {
                         logger.debug("No metadata files to delete");
                         remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        if (indexDeleted == false) {
+                            completeRemotePurgeCycle();
+                        }
                         return;
                     }
 
@@ -232,16 +251,14 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                             translogTransferManager.deleteGenerationAsync(
                                 primaryTermSupplier.getAsLong(),
                                 generationsToBeDeleted,
-                                remoteGenerationDeletionPermits::release
+                                onRemotePurgeComplete
                             );
                         } catch (Exception e) {
                             logger.error("Exception in delete generations flow", e);
-                            // Release permit that is meant for metadata files and return
-                            remoteGenerationDeletionPermits.release();
-                            assert remoteGenerationDeletionPermits.availablePermits() == REMOTE_DELETION_PERMITS : "Available permits "
-                                + remoteGenerationDeletionPermits.availablePermits()
-                                + " is not equal to "
-                                + REMOTE_DELETION_PERMITS;
+                            remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                            if (indexDeleted == false) {
+                                completeRemotePurgeCycle();
+                            }
                             return;
                         }
                     } else {
@@ -251,17 +268,22 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     if (metadataFilesToBeDeleted.isEmpty() == false) {
                         // Delete stale metadata files
                         try {
-                            translogTransferManager.deleteMetadataFilesAsync(
-                                metadataFilesToBeDeleted,
-                                remoteGenerationDeletionPermits::release
+                            int maxFilesToDelete = Math.min(
+                                metadataFilesToBeDeleted.size(),
+                                translogTransferManager.getTranslogPurgeBatchSize() * translogTransferManager
+                                    .getEffectiveMaxBatchesPerCycle(
+                                        metadataFiles.size() == translogTransferManager.getTranslogPurgeListLimit(),
+                                        metadataFiles.size()
+                                    )
                             );
+                            List<String> metadataFilesThisCycle = metadataFilesToBeDeleted.subList(0, maxFilesToDelete);
+                            translogTransferManager.deleteMetadataFilesInBatches(metadataFilesThisCycle, onRemotePurgeComplete);
                         } catch (Exception e) {
                             logger.error("Exception in delete metadata files flow", e);
-                            // Permits is already released by deleteMetadataFilesAsync
-                            assert remoteGenerationDeletionPermits.availablePermits() == REMOTE_DELETION_PERMITS : "Available permits "
-                                + remoteGenerationDeletionPermits.availablePermits()
-                                + " is not equal to "
-                                + REMOTE_DELETION_PERMITS;
+                            remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                            if (indexDeleted == false) {
+                                completeRemotePurgeCycle();
+                            }
                             return;
                         }
 
@@ -276,20 +298,26 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                 } catch (Exception e) {
                     logger.error("Exception in trimUnreferencedReaders", e);
                     remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
-                    assert remoteGenerationDeletionPermits.availablePermits() == REMOTE_DELETION_PERMITS : "Available permits "
-                        + remoteGenerationDeletionPermits.availablePermits()
-                        + " is not equal to "
-                        + REMOTE_DELETION_PERMITS;
+                    if (indexDeleted == false) {
+                        completeRemotePurgeCycle();
+                    }
                 }
             }
 
             @Override
             public void onFailure(Exception e) {
                 remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                if (indexDeleted == false) {
+                    completeRemotePurgeCycle();
+                }
                 logger.error("Exception while listing translog metadata files", e);
             }
         };
-        translogTransferManager.listTranslogMetadataFilesAsync(listMetadataFilesListener);
+        if (indexDeleted) {
+            translogTransferManager.listTranslogMetadataFilesAsync(listMetadataFilesListener);
+        } else {
+            translogTransferManager.listTranslogMetadataFilesForPurgeAsync(listMetadataFilesListener);
+        }
     }
 
     private long getMinGenerationToKeepInRemote() {

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -72,6 +72,7 @@ public class RemoteFsTranslog extends Translog {
     protected final TranslogTransferManager translogTransferManager;
     protected final FileTransferTracker fileTransferTracker;
     protected final BooleanSupplier startedPrimarySupplier;
+    protected final ThreadPool threadPool;
     private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
     private volatile long maxRemoteTranslogGenerationUploaded;
 
@@ -91,6 +92,9 @@ public class RemoteFsTranslog extends Translog {
 
     // Semaphore used to allow only single remote generation to happen at a time
     protected final Semaphore remoteGenerationDeletionPermits = new Semaphore(REMOTE_DELETION_PERMITS);
+
+    private final AtomicBoolean remotePurgeInProgress = new AtomicBoolean(false);
+    private final AtomicBoolean remotePurgePending = new AtomicBoolean(false);
 
     // These permits exist to allow any inflight background triggered upload.
     private static final int SYNC_PERMIT = 1;
@@ -126,6 +130,7 @@ public class RemoteFsTranslog extends Translog {
             channelFactory
         );
         logger = Loggers.getLogger(getClass(), shardId);
+        this.threadPool = threadPool;
         this.startedPrimarySupplier = startedPrimarySupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
         fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
@@ -600,12 +605,22 @@ public class RemoteFsTranslog extends Translog {
             return;
         }
 
+        if (tryScheduleRemotePurge() == false) {
+            return;
+        }
+
         // Since remote generation deletion is async, this ensures that only one generation deletion happens at a time.
         // Remote generations involves 2 async operations - 1) Delete translog generation files 2) Delete metadata files
         // We try to acquire 2 permits and if we can not, we return from here itself.
         if (remoteGenerationDeletionPermits.tryAcquire(REMOTE_DELETION_PERMITS) == false) {
+            completeRemotePurgeScheduling();
             return;
         }
+
+        Runnable onRemotePurgeComplete = () -> {
+            remoteGenerationDeletionPermits.release();
+            completeRemotePurgeCycle();
+        };
 
         // cleans up remote translog files not referenced in latest uploaded metadata.
         // This enables us to restore translog from the metadata in case of failover or relocation.
@@ -618,17 +633,46 @@ public class RemoteFsTranslog extends Translog {
         }
         if (generationsToDelete.isEmpty() == false) {
             try {
-                deleteRemoteGeneration(generationsToDelete);
+                deleteRemoteGeneration(generationsToDelete, onRemotePurgeComplete);
             } catch (Exception e) {
                 logger.error("Exception in delete generations flow", e);
-                // Release permit that is meant for metadata files and return
-                remoteGenerationDeletionPermits.release();
+                remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                completeRemotePurgeCycle();
                 return;
             }
-            translogTransferManager.deleteStaleTranslogMetadataFilesAsync(remoteGenerationDeletionPermits::release);
+            translogTransferManager.deleteStaleTranslogMetadataFilesAsync(onRemotePurgeComplete);
             deleteStaleRemotePrimaryTerms();
         } else {
             remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+            completeRemotePurgeCycle();
+        }
+    }
+
+    protected boolean tryScheduleRemotePurge() {
+        if (remotePurgeInProgress.compareAndSet(false, true)) {
+            return true;
+        }
+        remotePurgePending.set(true);
+        return false;
+    }
+
+    protected void completeRemotePurgeScheduling() {
+        remotePurgeInProgress.set(false);
+    }
+
+    protected void completeRemotePurgeCycle() {
+        if (remoteGenerationDeletionPermits.availablePermits() != REMOTE_DELETION_PERMITS) {
+            return;
+        }
+        completeRemotePurgeScheduling();
+        if (remotePurgePending.getAndSet(false)) {
+            threadPool.executor(ThreadPool.Names.REMOTE_PURGE).execute(() -> {
+                try {
+                    trimUnreferencedReaders(false);
+                } catch (IOException e) {
+                    logger.error("Exception while continuing remote translog purge", e);
+                }
+            });
         }
     }
 
@@ -636,12 +680,8 @@ public class RemoteFsTranslog extends Translog {
      * Deletes remote translog and metadata files asynchronously corresponding to the generations.
      * @param generations generations to be deleted.
      */
-    private void deleteRemoteGeneration(Set<Long> generations) {
-        translogTransferManager.deleteGenerationAsync(
-            primaryTermSupplier.getAsLong(),
-            generations,
-            remoteGenerationDeletionPermits::release
-        );
+    private void deleteRemoteGeneration(Set<Long> generations, Runnable onCompletion) {
+        translogTransferManager.deleteGenerationAsync(primaryTermSupplier.getAsLong(), generations, onCompletion);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -529,23 +529,41 @@ public class TranslogTransferManager {
      */
     public void deleteGenerationAsync(long primaryTerm, Set<Long> generations, Runnable onCompletion) {
         try {
-            List<String> translogFiles = new ArrayList<>();
-            generations.forEach(generation -> {
-                // Add .ckp and .tlog file to translog file list which is located in basePath/<primaryTerm>
-                String ckpFileName = Translog.getCommitCheckpointFileName(generation);
-                String translogFileName = Translog.getFilename(generation);
-                if (isTranslogMetadataEnabled == false) {
-                    translogFiles.addAll(List.of(ckpFileName, translogFileName));
-                } else {
-                    translogFiles.add(translogFileName);
-                }
-            });
-            // Delete the translog and checkpoint files asynchronously
-            deleteTranslogFilesAsync(primaryTerm, translogFiles, onCompletion);
+            if (generations.isEmpty()) {
+                onCompletion.run();
+                return;
+            }
+            List<Long> generationList = new ArrayList<>(generations);
+            deleteGenerationAsyncBatched(primaryTerm, generationList, 0, onCompletion);
         } catch (Exception e) {
             onCompletion.run();
             throw e;
         }
+    }
+
+    private void deleteGenerationAsyncBatched(long primaryTerm, List<Long> generationList, int fromIndex, Runnable onCompletion) {
+        if (fromIndex >= generationList.size()) {
+            onCompletion.run();
+            return;
+        }
+        int batchSize = getTranslogPurgeBatchSize();
+        int toIndex = Math.min(fromIndex + batchSize, generationList.size());
+        List<String> translogFiles = new ArrayList<>();
+        for (int i = fromIndex; i < toIndex; i++) {
+            long generation = generationList.get(i);
+            String ckpFileName = Translog.getCommitCheckpointFileName(generation);
+            String translogFileName = Translog.getFilename(generation);
+            if (isTranslogMetadataEnabled == false) {
+                translogFiles.addAll(List.of(ckpFileName, translogFileName));
+            } else {
+                translogFiles.add(translogFileName);
+            }
+        }
+        deleteTranslogFilesAsync(
+            primaryTerm,
+            translogFiles,
+            () -> deleteGenerationAsyncBatched(primaryTerm, generationList, toIndex, onCompletion)
+        );
     }
 
     /**
@@ -639,47 +657,119 @@ public class TranslogTransferManager {
     }
 
     public void listTranslogMetadataFilesAsync(ActionListener<List<BlobMetadata>> listener) {
+        listTranslogMetadataFilesAsync(listener, Integer.MAX_VALUE);
+    }
+
+    public void listTranslogMetadataFilesForPurgeAsync(ActionListener<List<BlobMetadata>> listener) {
+        listTranslogMetadataFilesAsync(listener, getTranslogPurgeListLimit());
+    }
+
+    private void listTranslogMetadataFilesAsync(ActionListener<List<BlobMetadata>> listener, int limit) {
         transferService.listAllInSortedOrderAsync(
             ThreadPool.Names.REMOTE_PURGE,
             remoteMetadataTransferPath,
             TranslogTransferMetadata.METADATA_PREFIX,
-            Integer.MAX_VALUE,
+            limit,
             listener
         );
     }
 
     public void deleteStaleTranslogMetadataFilesAsync(Runnable onCompletion) {
-        try {
-            transferService.listAllInSortedOrderAsync(
-                ThreadPool.Names.REMOTE_PURGE,
-                remoteMetadataTransferPath,
-                TranslogTransferMetadata.METADATA_PREFIX,
-                Integer.MAX_VALUE,
-                new ActionListener<>() {
-                    @Override
-                    public void onResponse(List<BlobMetadata> blobMetadata) {
-                        List<String> sortedMetadataFiles = blobMetadata.stream().map(BlobMetadata::name).collect(Collectors.toList());
-                        if (sortedMetadataFiles.size() <= 1) {
-                            logger.trace("Remote Metadata file count is {}, so skipping deletion", sortedMetadataFiles.size());
-                            onCompletion.run();
-                            return;
-                        }
-                        List<String> metadataFilesToDelete = sortedMetadataFiles.subList(1, sortedMetadataFiles.size());
-                        logger.trace("Deleting remote translog metadata files {}", metadataFilesToDelete);
-                        deleteMetadataFilesAsync(metadataFilesToDelete, onCompletion);
-                    }
+        runDeleteStaleTranslogMetadataPurge(onCompletion);
+    }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        logger.error("Exception occurred while listing translog metadata files from remote store", e);
+    private void runDeleteStaleTranslogMetadataPurge(Runnable onCompletion) {
+        try {
+            int listLimit = getTranslogPurgeListLimit();
+            listTranslogMetadataFilesAsync(new ActionListener<>() {
+                @Override
+                public void onResponse(List<BlobMetadata> blobMetadata) {
+                    List<String> sortedMetadataFiles = blobMetadata.stream().map(BlobMetadata::name).collect(Collectors.toList());
+                    if (sortedMetadataFiles.size() <= 1) {
+                        logger.trace("Remote Metadata file count is {}, so skipping deletion", sortedMetadataFiles.size());
                         onCompletion.run();
+                        return;
                     }
+                    boolean backlogRemaining = sortedMetadataFiles.size() == listLimit;
+                    List<String> metadataFilesToDelete = new ArrayList<>(sortedMetadataFiles.subList(1, sortedMetadataFiles.size()));
+                    int maxFilesToDelete = Math.min(
+                        metadataFilesToDelete.size(),
+                        getTranslogPurgeBatchSize() * getEffectiveMaxBatchesPerCycle(backlogRemaining, sortedMetadataFiles.size())
+                    );
+                    if (maxFilesToDelete == 0) {
+                        onCompletion.run();
+                        return;
+                    }
+                    List<String> metadataFilesThisCycle = metadataFilesToDelete.subList(0, maxFilesToDelete);
+                    logger.trace(
+                        "Deleting remote translog metadata files count={}, backlogRemaining={}",
+                        metadataFilesThisCycle.size(),
+                        backlogRemaining
+                    );
+                    deleteMetadataFilesInBatches(metadataFilesThisCycle, () -> {
+                        if (backlogRemaining) {
+                            runDeleteStaleTranslogMetadataPurge(onCompletion);
+                        } else {
+                            onCompletion.run();
+                        }
+                    });
                 }
-            );
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error("Exception occurred while listing translog metadata files from remote store", e);
+                    onCompletion.run();
+                }
+            }, listLimit);
         } catch (Exception e) {
             logger.error("Exception occurred while listing translog metadata files from remote store", e);
             onCompletion.run();
         }
+    }
+
+    /**
+     * Deletes metadata files in bounded batches using the {@code REMOTE_PURGE} threadpool.
+     *
+     * @param files list of metadata files to be deleted.
+     * @param onCompletion runnable to run on completion of deletion regardless of success/failure.
+     */
+    public void deleteMetadataFilesInBatches(List<String> files, Runnable onCompletion) {
+        if (files.isEmpty()) {
+            onCompletion.run();
+            return;
+        }
+        deleteMetadataFilesInBatches(files, 0, onCompletion);
+    }
+
+    private void deleteMetadataFilesInBatches(List<String> files, int fromIndex, Runnable onCompletion) {
+        if (fromIndex >= files.size()) {
+            onCompletion.run();
+            return;
+        }
+        int batchSize = getTranslogPurgeBatchSize();
+        int toIndex = Math.min(fromIndex + batchSize, files.size());
+        List<String> batch = files.subList(fromIndex, toIndex);
+        deleteMetadataFilesAsync(batch, () -> deleteMetadataFilesInBatches(files, toIndex, onCompletion));
+    }
+
+    public int getTranslogPurgeBatchSize() {
+        return remoteStoreSettings.getTranslogPurgeBatchSize();
+    }
+
+    public int getTranslogPurgeMaxBatchesPerCycle() {
+        return remoteStoreSettings.getTranslogPurgeMaxBatchesPerCycle();
+    }
+
+    public int getTranslogPurgeListLimit() {
+        return getTranslogPurgeBatchSize() * getTranslogPurgeMaxBatchesPerCycle() + 1;
+    }
+
+    public int getEffectiveMaxBatchesPerCycle(boolean backlogRemaining, int listedMetadataFiles) {
+        int maxBatchesPerCycle = getTranslogPurgeMaxBatchesPerCycle();
+        if (backlogRemaining && listedMetadataFiles > getTranslogPurgeBatchSize() * 10) {
+            return 1;
+        }
+        return maxBatchesPerCycle;
     }
 
     public void deleteTranslogFiles() throws IOException {

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -29,6 +29,12 @@ public class RemoteStoreSettings {
     private static final int MIN_UPLOADED_SEGMENTS_CLEANUP_THRESHOLD = 100;
     private static final int MAX_UPLOADED_SEGMENTS_CLEANUP_THRESHOLD = 100000;
     private static final int DEFAULT_UPLOADED_SEGMENTS_CLEANUP_THRESHOLD = 1000;
+    static final int DEFAULT_TRANSLOG_PURGE_BATCH_SIZE = 500;
+    static final int DEFAULT_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE = 2;
+    private static final int MIN_TRANSLOG_PURGE_BATCH_SIZE = 1;
+    private static final int MAX_TRANSLOG_PURGE_BATCH_SIZE = 10000;
+    private static final int MIN_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE = 1;
+    private static final int MAX_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE = 100;
 
     /**
      * Used to specify the default translog buffer interval for remote store backed indexes.
@@ -67,6 +73,31 @@ public class RemoteStoreSettings {
         "cluster.remote_store.translog.transfer_timeout",
         TimeValue.timeValueSeconds(30),
         TimeValue.timeValueSeconds(30),
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
+     * Maximum number of remote translog metadata or data files deleted per remote purge batch.
+     */
+    public static final Setting<Integer> CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING = Setting.intSetting(
+        "cluster.remote_store.translog.purge_batch_size",
+        DEFAULT_TRANSLOG_PURGE_BATCH_SIZE,
+        MIN_TRANSLOG_PURGE_BATCH_SIZE,
+        MAX_TRANSLOG_PURGE_BATCH_SIZE,
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
+     * Maximum number of remote translog purge batches executed per purge cycle. When a large metadata backlog is
+     * detected, purge automatically reduces this to one batch per cycle to limit resource usage on small nodes.
+     */
+    public static final Setting<Integer> CLUSTER_REMOTE_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE_SETTING = Setting.intSetting(
+        "cluster.remote_store.translog.purge_max_batches_per_cycle",
+        DEFAULT_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE,
+        MIN_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE,
+        MAX_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE,
         Property.NodeScope,
         Property.Dynamic
     );
@@ -235,6 +266,8 @@ public class RemoteStoreSettings {
     private final String translogPathFixedPrefix;
     private final String segmentsPathFixedPrefix;
     private volatile int uploadedSegmentsCleanupThreshold;
+    private volatile int translogPurgeBatchSize;
+    private volatile int translogPurgeMaxBatchesPerCycle;
 
     public RemoteStoreSettings(Settings settings, ClusterSettings clusterSettings) {
         clusterRemoteTranslogBufferInterval = CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(settings);
@@ -287,6 +320,15 @@ public class RemoteStoreSettings {
         clusterSettings.addSettingsUpdateConsumer(
             CLUSTER_REMOTE_UPLOADED_SEGMENTS_CLEANUP_THRESHOLD_SETTING,
             this::setUploadedSegmentsCleanupThreshold
+        );
+
+        translogPurgeBatchSize = CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING, this::setTranslogPurgeBatchSize);
+
+        translogPurgeMaxBatchesPerCycle = CLUSTER_REMOTE_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(
+            CLUSTER_REMOTE_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE_SETTING,
+            this::setTranslogPurgeMaxBatchesPerCycle
         );
     }
 
@@ -395,5 +437,21 @@ public class RemoteStoreSettings {
 
     private void setUploadedSegmentsCleanupThreshold(int uploadedSegmentsCleanupThreshold) {
         this.uploadedSegmentsCleanupThreshold = uploadedSegmentsCleanupThreshold;
+    }
+
+    public int getTranslogPurgeBatchSize() {
+        return translogPurgeBatchSize;
+    }
+
+    private void setTranslogPurgeBatchSize(int translogPurgeBatchSize) {
+        this.translogPurgeBatchSize = translogPurgeBatchSize;
+    }
+
+    public int getTranslogPurgeMaxBatchesPerCycle() {
+        return translogPurgeMaxBatchesPerCycle;
+    }
+
+    private void setTranslogPurgeMaxBatchesPerCycle(int translogPurgeMaxBatchesPerCycle) {
+        this.translogPurgeMaxBatchesPerCycle = translogPurgeMaxBatchesPerCycle;
     }
 }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -19,6 +19,8 @@ import org.opensearch.common.blobstore.InputStreamWithMetadata;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.support.PlainBlobMetadata;
 import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
@@ -614,6 +616,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         String tm1 = new TranslogTransferMetadata(1, 1, 1, 2).getFileName();
         String tm2 = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
         String tm3 = new TranslogTransferMetadata(2, 3, 1, 2).getFileName();
+        int purgeListLimit = translogTransferManager.getTranslogPurgeListLimit();
         doAnswer(invocation -> {
             ActionListener<List<BlobMetadata>> actionListener = invocation.getArgument(4);
             List<BlobMetadata> bmList = new LinkedList<>();
@@ -636,7 +639,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
                 eq(ThreadPool.Names.REMOTE_PURGE),
                 any(BlobPath.class),
                 eq(TranslogTransferMetadata.METADATA_PREFIX),
-                eq(Integer.MAX_VALUE),
+                eq(purgeListLimit),
                 any()
             );
             verify(transferService).deleteBlobsAsync(
@@ -646,6 +649,105 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
                 any(ActionListener.class)
             );
         });
+    }
+
+    public void testDeleteStaleTranslogMetadataBatchedPurge() throws Exception {
+        Settings settings = Settings.builder()
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING.getKey(), 2)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_PURGE_MAX_BATCHES_PER_CYCLE_SETTING.getKey(), 2)
+            .build();
+        RemoteStoreSettings purgeSettings = new RemoteStoreSettings(
+            settings,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        TranslogTransferManager batchedPurgeManager = new TranslogTransferManager(
+            shardId,
+            transferService,
+            remoteBaseTransferPath.add(TRANSLOG.getName()),
+            remoteBaseTransferPath.add(METADATA.getName()),
+            tracker,
+            remoteTranslogTransferTracker,
+            purgeSettings,
+            isTranslogMetadataEnabled
+        );
+        int purgeListLimit = batchedPurgeManager.getTranslogPurgeListLimit();
+        assertEquals(5, purgeListLimit);
+
+        List<String> metadataFiles = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            metadataFiles.add(new TranslogTransferMetadata(1, i + 1L, 1, 2).getFileName());
+        }
+        doAnswer(invocation -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocation.getArgument(4);
+            List<BlobMetadata> bmList = metadataFiles.stream().map(name -> new PlainBlobMetadata(name, 1)).collect(Collectors.toList());
+            actionListener.onResponse(bmList);
+            return null;
+        }).when(transferService)
+            .listAllInSortedOrderAsync(
+                eq(ThreadPool.Names.REMOTE_PURGE),
+                any(BlobPath.class),
+                eq(TranslogTransferMetadata.METADATA_PREFIX),
+                eq(purgeListLimit),
+                any(ActionListener.class)
+            );
+
+        AtomicInteger deleteInvocationCount = new AtomicInteger();
+        doAnswer(invocation -> {
+            deleteInvocationCount.incrementAndGet();
+            @SuppressWarnings("unchecked")
+            ActionListener<Void> listener = invocation.getArgument(3);
+            listener.onResponse(null);
+            return null;
+        }).when(transferService).deleteBlobsAsync(any(), any(BlobPath.class), any(), any(ActionListener.class));
+
+        AtomicBoolean purgeCompleted = new AtomicBoolean(false);
+        batchedPurgeManager.deleteStaleTranslogMetadataFilesAsync(() -> purgeCompleted.set(true));
+        assertBusy(() -> assertTrue(purgeCompleted.get()));
+        assertEquals(2, deleteInvocationCount.get());
+        verify(transferService).deleteBlobsAsync(
+            eq(ThreadPool.Names.REMOTE_PURGE),
+            any(BlobPath.class),
+            eq(metadataFiles.subList(1, 3)),
+            any(ActionListener.class)
+        );
+        verify(transferService).deleteBlobsAsync(
+            eq(ThreadPool.Names.REMOTE_PURGE),
+            any(BlobPath.class),
+            eq(metadataFiles.subList(3, 4)),
+            any(ActionListener.class)
+        );
+    }
+
+    public void testDeleteGenerationAsyncBatched() throws Exception {
+        Settings settings = Settings.builder()
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_PURGE_BATCH_SIZE_SETTING.getKey(), 1)
+            .build();
+        RemoteStoreSettings purgeSettings = new RemoteStoreSettings(
+            settings,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        BlobStore blobStore = mock(BlobStore.class);
+        BlobContainer blobContainer = mock(BlobContainer.class);
+        when(blobStore.blobContainer(any(BlobPath.class))).thenReturn(blobContainer);
+        BlobStoreTransferService blobStoreTransferService = new BlobStoreTransferService(blobStore, threadPool);
+        TranslogTransferManager batchedDeleteManager = new TranslogTransferManager(
+            shardId,
+            blobStoreTransferService,
+            remoteBaseTransferPath.add(TRANSLOG.getName()),
+            remoteBaseTransferPath.add(METADATA.getName()),
+            tracker,
+            remoteTranslogTransferTracker,
+            purgeSettings,
+            isTranslogMetadataEnabled
+        );
+        tracker.add("translog-18.tlog", true);
+        tracker.add("translog-18.ckp", true);
+        tracker.add("translog-19.tlog", true);
+        tracker.add("translog-19.ckp", true);
+        batchedDeleteManager.deleteGenerationAsync(primaryTerm, Set.of(18L, 19L), () -> {});
+        assertBusy(() -> assertEquals(0, tracker.allUploaded().size()));
+        verify(blobContainer).deleteBlobsIgnoringIfNotExists(eq(List.of("translog-18.ckp", "translog-18.tlog")));
+        verify(blobContainer).deleteBlobsIgnoringIfNotExists(eq(List.of("translog-19.ckp", "translog-19.tlog")));
     }
 
     public void testDeleteTranslogFailure() throws Exception {


### PR DESCRIPTION
## Summary

  Fix #20138

- Batch remote translog metadata and data file deletions instead of listing/deleting unbounded file lists on `remote_purge`, addressing heap and queue buildup on small-core nodes .
- Add cluster settings `cluster.remote_store.translog.purge_batch_size` (default 500) and `cluster.remote_store.translog.purge_max_batches_per_cycle` (default 2), with adaptive throttling when a large backlog is detected.
- Coalesce overlapping remote purge work per shard via single-flight scheduling in `RemoteFsTranslog` / `RemoteFsTimestampAwareTranslog`.

