### PR TITLE
Add Arpit Bandejiya (alchemist51) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,22 +7,22 @@
 # Default ownership for all repo files
 * @opensearch-project/opensearch-core-maintainers
 
-/modules/lang-painless/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
-/modules/parent-join/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/modules/lang-painless/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/modules/parent-join/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
 /modules/transport-netty4/ @opensearch-project/opensearch-core-maintainers @peternied
 
-/server/src/internalClusterTest/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
-/server/src/internalClusterTest/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/internalClusterTest/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/internalClusterTest/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
 
 /server/src/main/java/org/opensearch/extensions/ @opensearch-project/opensearch-core-maintainers @peternied
 /server/src/main/java/org/opensearch/identity/ @opensearch-project/opensearch-core-maintainers @peternied @cwperks
-/server/src/main/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
-/server/src/main/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/main/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/main/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
 /server/src/main/java/org/opensearch/threadpool/ @opensearch-project/opensearch-core-maintainers @jed326 @peternied
 /server/src/main/java/org/opensearch/transport/ @opensearch-project/opensearch-core-maintainers @peternied
 
-/server/src/test/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
-/server/src/test/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/test/java/org/opensearch/index/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
+/server/src/test/java/org/opensearch/search/ @opensearch-project/opensearch-core-maintainers @alchemist51 @andrross @ashking94 @Bukhtawar @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @owaiskazi19 @reta @sachinpkale @saratvemulapalli @shwetathareja @sohami
 
 /.github/ @opensearch-project/opensearch-core-maintainers @jed326 @peternied
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
 | Andriy Redko      | [reta](https://github.com/reta)                         | Independent |
 | Ankit Jain        | [jainankitk](https://github.com/jainankitk)             | Amazon      |
+| Arpit Bandejiya   | [alchemist51](https://github.com/alchemist51)           | Amazon      |
 | Ashish Singh      | [ashking94](https://github.com/ashking94)               | Amazon      |
 | Atri Sharma       | [atris](https://github.com/atris)                       | Apple       |
 | Bharathwaj G      | [bharath-techie](https://github.com/bharath-techie)     | Amazon      |


### PR DESCRIPTION
### Description

This PR nominates **Arpit Bandejiya** ([@alchemist51](https://github.com/alchemist51)) as a maintainer of the OpenSearch repository, adding him to `MAINTAINERS.md` and to the core maintainer entries in `.github/CODEOWNERS`.

Arpit has been actively contributing to OpenSearch core since December 2022. His contributions span core engine internals, cluster state management, remote store architecture, and performance optimization — ranging from complex multi-PR features to production-critical bug fixes and mentoring through code reviews.

### Contribution summary

- **23 issues** authored, including **2 RFCs**
- **55 PRs** merged across the opensearch-project org
- **86 PRs** reviewed for others in OpenSearch core
- Maintainer of the **asynchronous-search** plugin, where he managed 42 PRs covering releases 2.4 through 2.12
- Three-time OpenSearchCon speaker:
  - *Optimising Performance Through Heat Aware Operations* — OpenSearchCon Europe 2026
  - *Vendor Agnostic Analytics with OpenSearch* — OpenSearchCon Europe 2026
  - *Shard Allocation for High Performance Clusters* — OpenSearchCon NA 2025
- Authored the official OpenSearch blog post: *Launch highlight: Paginate with Point in Time*

### Key highlights

**Remote Routing Table & Remote State Publication**
- Initial setup for remote routing table: https://github.com/opensearch-project/OpenSearch/pull/13304
- Write flow implementation: https://github.com/opensearch-project/OpenSearch/pull/13870
- Read flow implementation: https://github.com/opensearch-project/OpenSearch/pull/13894
- Integration tests: https://github.com/opensearch-project/OpenSearch/pull/14631
- Service refactoring for remote state interfaces: https://github.com/opensearch-project/OpenSearch/pull/14668
- Remote publication download stats: https://github.com/opensearch-project/OpenSearch/pull/15291
- S3 repository retry mechanism: https://github.com/opensearch-project/OpenSearch/pull/15978

**Pluggable Engine & DataFusion (2025–2026)**
- Composite indexing execution engine sandbox plugin: https://github.com/opensearch-project/OpenSearch/pull/20909
- Indexing write path for composable engine: https://github.com/opensearch-project/OpenSearch/pull/20790
- CatalogSnapshotManager for multi-format file state: https://github.com/opensearch-project/OpenSearch/pull/20982
- Committer abstraction for durable catalog snapshot persistence: https://github.com/opensearch-project/OpenSearch/pull/21103
- Exception handling for multi-format writes: https://github.com/opensearch-project/OpenSearch/pull/21417
- Cluster-scope settings for pluggable data-format configuration: https://github.com/opensearch-project/OpenSearch/pull/21435
- Indexed query execution path settings: https://github.com/opensearch-project/OpenSearch/pull/21522
- DataFusion memory pool integration: https://github.com/opensearch-project/OpenSearch/pull/19992
- DataFusion concurrency support: https://github.com/opensearch-project/OpenSearch/pull/20671
- Query-Then-Fetch late materialization: https://github.com/opensearch-project/OpenSearch/pull/21653, https://github.com/opensearch-project/OpenSearch/pull/21563

**Shard Allocation & Rebalancing**
- Cluster primary balance constraint for rebalancing with buffer: https://github.com/opensearch-project/OpenSearch/pull/12656
- Allocation decider for mixed clusters: https://github.com/opensearch-project/OpenSearch/pull/12505

**Key reviews**
- https://github.com/opensearch-project/OpenSearch/pull/21211
- https://github.com/opensearch-project/OpenSearch/pull/20930
- https://github.com/opensearch-project/OpenSearch/pull/21703
- https://github.com/opensearch-project/OpenSearch/pull/21599
- https://github.com/opensearch-project/OpenSearch/pull/15145
- https://github.com/opensearch-project/OpenSearch/pull/13909

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable.
- [x] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
