### PR TITLE
Fix filter rewrite crash with sub-aggregations

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/PointTreeTraversal.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/PointTreeTraversal.java
@@ -78,10 +78,12 @@ final class PointTreeTraversal {
         PointValues.IntersectVisitor visitor = getIntersectVisitor(collector);
         try {
             intersectWithRanges(visitor, tree, collector);
+            collector.finalizePreviousRange();
         } catch (CollectionTerminatedException e) {
+            // early termination is always preceded by a finalizePreviousRange call
+            // in the visitor, so there is nothing left to flush here
             logger.debug("Early terminate since no more range to collect");
         }
-        collector.finalizePreviousRange();
         return collector.getResult();
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/rangecollector/SubAggRangeCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/rangecollector/SubAggRangeCollector.java
@@ -99,14 +99,6 @@ public class SubAggRangeCollector extends SimpleRangeCollector {
     public void finalizePreviousRange() {
         super.finalizePreviousRange();
 
-        // Traversal can terminate early once values exceed the last range, leaving
-        // activeIndex past the end of the ranges array. No documents are collected
-        // beyond the last range, so there is nothing to flush for the sub-agg.
-        if (activeIndex >= ranges.getSize()) {
-            bitSet.clear();
-            return;
-        }
-
         long bucketOrd = getBucketOrd.apply(activeIndex);
         logger.trace("finalize range {} with bucket ordinal {}", activeIndex, bucketOrd);
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/rangecollector/SubAggRangeCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/rangecollector/SubAggRangeCollector.java
@@ -99,6 +99,14 @@ public class SubAggRangeCollector extends SimpleRangeCollector {
     public void finalizePreviousRange() {
         super.finalizePreviousRange();
 
+        // Traversal can terminate early once values exceed the last range, leaving
+        // activeIndex past the end of the ranges array. No documents are collected
+        // beyond the last range, so there is nothing to flush for the sub-agg.
+        if (activeIndex >= ranges.getSize()) {
+            bitSet.clear();
+            return;
+        }
+
         long bucketOrd = getBucketOrd.apply(activeIndex);
         logger.trace("finalize range {} with bucket ordinal {}", activeIndex, bucketOrd);
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/filterrewrite/FilterRewriteSubAggTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/filterrewrite/FilterRewriteSubAggTests.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -419,6 +420,43 @@ public class FilterRewriteSubAggTests extends AggregatorTestCase {
         assertEquals(11, fifthStats.getSum(), 0);
     }
 
+    public void testDateHistoWithDocsBeyondQueryUpperBound() throws IOException {
+        // Regression test for https://github.com/opensearch-project/OpenSearch/issues/22342
+        // Documents with values beyond the query's upper bound share the segment with
+        // matching documents. During BKD traversal the collector's activeIndex advances
+        // past the end of the ranges array and traversal terminates early; the final
+        // finalizePreviousRange() then looked up the bucket for activeIndex == ranges.size
+        // and threw ArrayIndexOutOfBoundsException.
+        List<TestDoc> docs = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            docs.add(new TestDoc(month, Instant.parse(String.format(Locale.ROOT, "2024-%02d-15T00:00:00Z", month))));
+        }
+        // docs beyond the query upper bound, in the same segment
+        docs.add(new TestDoc(100, Instant.parse("2025-01-15T00:00:00Z")));
+        docs.add(new TestDoc(101, Instant.parse("2025-02-15T00:00:00Z")));
+
+        Query rangeQuery = LongPoint.newRangeQuery(dateFieldName, Long.MIN_VALUE, dateFieldType.parse("2024-12-31T23:59:59Z"));
+
+        DateHistogramAggregationBuilder dateHistogramAggregationBuilder = new DateHistogramAggregationBuilder(dateAggName).field(
+            dateFieldName
+        )
+            .calendarInterval(DateHistogramInterval.MONTH)
+            .minDocCount(1L)
+            .subAggregation(AggregationBuilders.stats(statsAggName).field(longFieldName));
+
+        InternalDateHistogram result = executeAggregation(docs, dateHistogramAggregationBuilder, false, rangeQuery);
+
+        List<? extends InternalDateHistogram.Bucket> buckets = result.getBuckets();
+        assertEquals(12, buckets.size());
+        for (int i = 0; i < 12; i++) {
+            InternalDateHistogram.Bucket bucket = buckets.get(i);
+            assertEquals(1, bucket.getDocCount());
+            InternalStats stats = bucket.getAggregations().get(statsAggName);
+            assertEquals(1, stats.getCount());
+            assertEquals(i + 1, stats.getSum(), 0);
+        }
+    }
+
     public void testAutoDateHisto() throws IOException {
         AutoDateHistogramAggregationBuilder autoDateHistogramAggregationBuilder = new AutoDateHistogramAggregationBuilder(dateAggName)
             .field(dateFieldName)
@@ -583,9 +621,18 @@ public class FilterRewriteSubAggTests extends AggregatorTestCase {
         AggregationBuilder aggregationBuilder,
         boolean random
     ) throws IOException {
+        return executeAggregation(docs, aggregationBuilder, random, matchAllQuery);
+    }
+
+    private <IA extends InternalAggregation> IA executeAggregation(
+        List<TestDoc> docs,
+        AggregationBuilder aggregationBuilder,
+        boolean random,
+        Query query
+    ) throws IOException {
         try (Directory directory = setupIndex(docs, random)) {
             try (DirectoryReader indexReader = DirectoryReader.open(directory)) {
-                return executeAggregationOnReader(indexReader, aggregationBuilder);
+                return executeAggregationOnReader(indexReader, aggregationBuilder, null, query);
             }
         }
     }
@@ -644,13 +691,22 @@ public class FilterRewriteSubAggTests extends AggregatorTestCase {
         AggregationBuilder aggregationBuilder,
         IndexSettings indexSettings
     ) throws IOException {
+        return executeAggregationOnReader(indexReader, aggregationBuilder, indexSettings, matchAllQuery);
+    }
+
+    private <IA extends InternalAggregation> IA executeAggregationOnReader(
+        DirectoryReader indexReader,
+        AggregationBuilder aggregationBuilder,
+        IndexSettings indexSettings,
+        Query query
+    ) throws IOException {
         IndexSearcher indexSearcher = new IndexSearcher(indexReader);
 
         MultiBucketConsumerService.MultiBucketConsumer bucketConsumer = createBucketConsumer();
         SearchContext searchContext = createSearchContext(
             indexSearcher,
             indexSettings != null ? indexSettings : createIndexSettings(),
-            matchAllQuery,
+            query,
             bucketConsumer,
             longFieldType,
             dateFieldType,
@@ -661,7 +717,7 @@ public class FilterRewriteSubAggTests extends AggregatorTestCase {
 
         // Execute aggregation
         countingAggregator.preCollection();
-        indexSearcher.search(matchAllQuery, countingAggregator);
+        indexSearcher.search(query, countingAggregator);
         countingAggregator.postCollection();
 
         // Reduce results


### PR DESCRIPTION
### Description

Fixes an `ArrayIndexOutOfBoundsException` thrown by `date_histogram` (and other bucket aggregations using the filter rewrite optimization) when a sub-aggregation is present and the segment contains documents beyond the query's upper bound.

**Root cause:** when BKD traversal encounters values beyond the last range, `AbstractRangeCollector.iterateRangeEnd` advances `activeIndex` one past the end of the ranges array as its "ranges exhausted" signal and traversal terminates early via `CollectionTerminatedException`. `PointTreeTraversal.multiRangesTraverse` then always makes one final `finalizePreviousRange()` call to flush the in-progress bucket. `SimpleRangeCollector` is safe there because its flush is guarded by `counter > 0`, but `SubAggRangeCollector.finalizePreviousRange()` unconditionally looked up the bucket ordinal for `activeIndex`, reading `ranges.lowers[activeIndex]` on a full array and throwing `ArrayIndexOutOfBoundsException: Index N out of bounds for length N`.

**Fix:** a bounds check at the top of `SubAggRangeCollector.finalizePreviousRange()`. When `activeIndex >= ranges.getSize()`, traversal ended past the last range; no documents can be collected beyond the last range, so there is nothing to flush for the sub-aggregation.

This matches the reporter's observations in #22342: the plain `date_histogram` works (the no-sub-agg path is guarded), the failure appears only when a sub-aggregation is added, and disabling the optimization (`search.max_aggregation_rewrite_filters: 0`) works around it.

**Regression test:** one doc per month of 2024 plus two docs in early 2025 sharing a segment, a range query bounded at 2024-12-31, and a `date_histogram` with a `stats` sub-aggregation. Throws `ArrayIndexOutOfBoundsException` before the fix; returns 12 correct buckets with correct per-bucket stats after.

@bowenlan-amzn @jainankitk tagging you as the authors of this code path (#17447, #19933) in case you'd like to review.

First contribution, happy to adjust if I've missed any process steps (labels, backports).

### Related Issues
Resolves #22342

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
