### PR TITLE
Add cross-setting validator to prevent balance factor zero crash loop

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -59,9 +59,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -99,6 +101,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         "cluster.routing.allocation.balance.index",
         0.55f,
         0.0f,
+        Float.MAX_VALUE,
+        new IndexBalanceFactorValidator(),
         Property.Dynamic,
         Property.NodeScope
     );
@@ -106,6 +110,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         "cluster.routing.allocation.balance.shard",
         0.45f,
         0.0f,
+        Float.MAX_VALUE,
+        new ShardBalanceFactorValidator(),
         Property.Dynamic,
         Property.NodeScope
     );
@@ -516,6 +522,67 @@ public class BalancedShardsAllocator implements ShardsAllocator {
      */
     public boolean getPreferPrimaryBalance() {
         return preferPrimaryShardBalance;
+    }
+
+    /**
+     * Validates that the index balance factor, combined with the shard balance factor, sums to a value greater than zero.
+     *
+     * @opensearch.internal
+     */
+    static final class IndexBalanceFactorValidator implements Setting.Validator<Float> {
+
+        @Override
+        public void validate(Float value) {}
+
+        @Override
+        public void validate(final Float value, final Map<Setting<?>, Object> settings) {
+            final float shardBalance = (Float) settings.get(SHARD_BALANCE_FACTOR_SETTING);
+            doValidateBalanceFactorSum(value, shardBalance);
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            final List<Setting<?>> settings = Collections.singletonList(SHARD_BALANCE_FACTOR_SETTING);
+            return settings.iterator();
+        }
+    }
+
+    /**
+     * Validates that the shard balance factor, combined with the index balance factor, sums to a value greater than zero.
+     *
+     * @opensearch.internal
+     */
+    static final class ShardBalanceFactorValidator implements Setting.Validator<Float> {
+
+        @Override
+        public void validate(Float value) {}
+
+        @Override
+        public void validate(final Float value, final Map<Setting<?>, Object> settings) {
+            final float indexBalance = (Float) settings.get(INDEX_BALANCE_FACTOR_SETTING);
+            doValidateBalanceFactorSum(indexBalance, value);
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            final List<Setting<?>> settings = Collections.singletonList(INDEX_BALANCE_FACTOR_SETTING);
+            return settings.iterator();
+        }
+    }
+
+    static void doValidateBalanceFactorSum(float indexBalance, float shardBalance) {
+        float sum = indexBalance + shardBalance;
+        if (sum <= 0.0f) {
+            throw new IllegalArgumentException(
+                "Balance factors ["
+                    + INDEX_BALANCE_FACTOR_SETTING.getKey()
+                    + "] and ["
+                    + SHARD_BALANCE_FACTOR_SETTING.getKey()
+                    + "] must sum to a value greater than zero but was ["
+                    + sum
+                    + "]"
+            );
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorSettingsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorSettingsTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing.allocation.allocator;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING;
+import static org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING;
+
+public class BalancedShardsAllocatorSettingsTests extends OpenSearchTestCase {
+
+    public void testBothBalanceFactorsZeroIsRejectedOnConstruction() {
+        final Settings settings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new BalancedShardsAllocator(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
+        );
+        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("must sum to a value greater than zero"));
+    }
+
+    public void testBothBalanceFactorsZeroIsRejectedOnDynamicUpdate() {
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new BalancedShardsAllocator(Settings.EMPTY, clusterSettings);
+
+        final Settings newSettings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .build();
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> clusterSettings.applySettings(newSettings));
+        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("illegal value can't update"));
+        assertNotNull(e.getCause());
+        assertThat(e.getCause().getMessage(), org.hamcrest.Matchers.containsString("must sum to a value greater than zero"));
+    }
+
+    public void testIndexBalanceZeroWithNonZeroShardBalanceIsAccepted() {
+        final Settings settings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "1.0")
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(settings, clusterSettings);
+        assertEquals(0.0f, allocator.getIndexBalance(), 0.0f);
+        assertEquals(1.0f, allocator.getShardBalance(), 0.0f);
+    }
+
+    public void testShardBalanceZeroWithNonZeroIndexBalanceIsAccepted() {
+        final Settings settings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "1.0")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(settings, clusterSettings);
+        assertEquals(1.0f, allocator.getIndexBalance(), 0.0f);
+        assertEquals(0.0f, allocator.getShardBalance(), 0.0f);
+    }
+
+    public void testDynamicUpdateIndexBalanceToZeroWhileShardBalanceAlreadyZeroIsRejected() {
+        final Settings initialSettings = Settings.builder()
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "1.0")
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(initialSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new BalancedShardsAllocator(initialSettings, clusterSettings);
+
+        final Settings newSettings = Settings.builder().put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0").build();
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> clusterSettings.applySettings(newSettings));
+        assertThat(e.getCause().getMessage(), org.hamcrest.Matchers.containsString("must sum to a value greater than zero"));
+    }
+
+    public void testDynamicUpdateShardBalanceToZeroWhileIndexBalanceAlreadyZeroIsRejected() {
+        final Settings initialSettings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "1.0")
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(initialSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new BalancedShardsAllocator(initialSettings, clusterSettings);
+
+        final Settings newSettings = Settings.builder().put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0").build();
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> clusterSettings.applySettings(newSettings));
+        assertThat(e.getCause().getMessage(), org.hamcrest.Matchers.containsString("must sum to a value greater than zero"));
+    }
+
+    public void testValidDynamicUpdateIsAccepted() {
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY, clusterSettings);
+
+        final Settings newSettings = Settings.builder()
+            .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.3")
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.7")
+            .build();
+
+        clusterSettings.applySettings(newSettings);
+        assertEquals(0.3f, allocator.getIndexBalance(), 0.001f);
+        assertEquals(0.7f, allocator.getShardBalance(), 0.001f);
+    }
+}


### PR DESCRIPTION
## Summary

Setting both `cluster.routing.allocation.balance.shard` and `cluster.routing.allocation.balance.index` to `0.0` causes an unrecoverable cluster-manager crash loop. Each setting independently allows `0.0` as minimum, but the `WeightFunction` requires their sum to be > 0. When both are set to zero, the cluster-manager crashes on every election attempt and becomes unrecoverable via the API.

### Changes

- Add `IndexBalanceFactorValidator` and `ShardBalanceFactorValidator` (same pattern as `DiskThresholdSettings.LowDiskWatermarkValidator`) that validate the sum of both balance factors > 0 before settings enter cluster state
- Add unit tests for both valid and invalid setting combinations

### Impact

- **Before**: Setting both balance factors to 0 causes permanent cluster-manager crash loop requiring manual node restart to recover
- **After**: The API rejects the invalid combination with a clear error message (HTTP 400)

## Test Plan

- [x] Unit tests verify invalid combinations are rejected on construction and dynamic update
- [x] Unit tests verify valid combinations (one factor at 0 with the other > 0) are accepted
- [x] Manually tested on a 6-node cluster (3 master + 3 data nodes): confirmed the API returns HTTP 400 with clear error message when attempting to set both factors to 0

### Manual test output (post-fix):

```bash
curl -X PUT "http://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{
    "transient": {
      "cluster.routing.allocation.balance.shard": "0",
      "cluster.routing.allocation.balance.index": "0"
    }
  }'
```

```json
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "Balance factors [cluster.routing.allocation.balance.index] and [cluster.routing.allocation.balance.shard] must sum to a value greater than zero but was [0.0]"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "Balance factors [cluster.routing.allocation.balance.index] and [cluster.routing.allocation.balance.shard] must sum to a value greater than zero but was [0.0]"
  },
  "status": 400
}
```

## Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch/issues/22305