### PR TITLE
Route custom preferences to search replicas

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -675,6 +675,14 @@ public class IndexShardRoutingTable extends AbstractDiffable<IndexShardRoutingTa
     }
 
     /**
+     * Returns an iterator over search only replicas ordered deterministically by the provided seed, so that a
+     * caller-supplied routing preference resolves to the same search replica across requests.
+     */
+    public ShardIterator searchReplicaActiveInitializingShardIt(int seed) {
+        return filterAndOrderShards(ShardRouting::isSearchOnly, seed);
+    }
+
+    /**
      * Returns an ordered iterator on active replica shards, followed by the primary shard.
      */
     public ShardIterator replicaFirstActiveInitializingShardsIt() {
@@ -703,8 +711,12 @@ public class IndexShardRoutingTable extends AbstractDiffable<IndexShardRoutingTa
     }
 
     private ShardIterator filterAndOrderShards(Predicate<ShardRouting> filter) {
+        return filterAndOrderShards(filter, shuffler.nextSeed());
+    }
+
+    private ShardIterator filterAndOrderShards(Predicate<ShardRouting> filter, int seed) {
         LinkedList<ShardRouting> ordered = new LinkedList<>();
-        for (ShardRouting replica : shuffler.shuffle(replicas)) {
+        for (ShardRouting replica : shuffler.shuffle(replicas, seed)) {
             if (filter.test(replica)) {
                 if (replica.active()) {
                     ordered.addFirst(replica);

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -224,7 +224,8 @@ public class OperationRouting {
             preference,
             null,
             null,
-            clusterState.getMetadata().weightedRoutingMetadata()
+            clusterState.getMetadata().weightedRoutingMetadata(),
+            false // defaultToSearchReplicas: realtime GET may need the primary or writer replicas
         );
     }
 
@@ -237,7 +238,8 @@ public class OperationRouting {
             preference,
             null,
             null,
-            clusterState.metadata().weightedRoutingMetadata()
+            clusterState.metadata().weightedRoutingMetadata(),
+            false // defaultToSearchReplicas: realtime GET may need the primary or writer replicas
         );
     }
 
@@ -275,11 +277,7 @@ public class OperationRouting {
                 preference = Preference.PRIMARY_FIRST.type();
             }
 
-            if (preference == null || preference.isEmpty()) {
-                if (indexMetadataForShard.getNumberOfSearchOnlyReplicas() > 0 && isStrictSearchOnlyShardRouting) {
-                    preference = Preference.SEARCH_REPLICA.type();
-                }
-            }
+            boolean defaultToSearchReplicas = isStrictSearchOnlyShardRouting && indexMetadataForShard.getNumberOfSearchOnlyReplicas() > 0;
 
             ShardIterator iterator = preferenceActiveShardIterator(
                 shard,
@@ -288,7 +286,8 @@ public class OperationRouting {
                 preference,
                 collectorService,
                 nodeCounts,
-                clusterState.metadata().weightedRoutingMetadata()
+                clusterState.metadata().weightedRoutingMetadata(),
+                defaultToSearchReplicas
             );
             if (iterator != null) {
                 shardIterators.computeIfAbsent(iterator.shardId().getIndex(), k -> new ArrayList<>()).add(iterator);
@@ -361,9 +360,17 @@ public class OperationRouting {
         @Nullable String preference,
         @Nullable ResponseCollectorService collectorService,
         @Nullable Map<String, Long> nodeCounts,
-        @Nullable WeightedRoutingMetadata weightedRoutingMetadata
+        @Nullable WeightedRoutingMetadata weightedRoutingMetadata,
+        boolean defaultToSearchReplicas
     ) {
+        // When search replicas are the default target, search traffic stays isolated on them unless the caller gives an
+        // explicit shard-type preference. This covers an empty preference and a custom preference key (which selects a
+        // shard for consistency, not a shard type); explicit '_' preferences such as _primary override it. Non-search
+        // requests (e.g. realtime GET) pass false here since they may need the primary or writer replicas.
         if (preference == null || preference.isEmpty()) {
+            if (defaultToSearchReplicas) {
+                return indexShard.searchReplicaActiveInitializingShardIt();
+            }
             return shardRoutings(indexShard, nodes, collectorService, nodeCounts, weightedRoutingMetadata);
         }
 
@@ -435,6 +442,9 @@ public class OperationRouting {
         // for a different element in the list by also incorporating the
         // shard ID into the hash of the user-supplied preference key.
         routingHash = 31 * routingHash + indexShard.shardId.hashCode();
+        if (defaultToSearchReplicas) {
+            return indexShard.searchReplicaActiveInitializingShardIt(routingHash);
+        }
         if (WeightedRoutingUtils.shouldPerformStrictWeightedRouting(
             isStrictWeightedShardRouting,
             ignoreWeightedRouting,

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -1266,6 +1266,192 @@ public class OperationRoutingTests extends OpenSearchTestCase {
         }
     }
 
+    public void testSearchReplicaRoutingWithCustomPreferenceWhenStrict() throws Exception {
+        final int numShards = 1;
+        final int numReplicas = 2;
+        final int numSearchReplicas = 2;
+        final String indexName = "test";
+        final String[] indexNames = new String[] { indexName };
+
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            // Strict search-only routing is enabled by default.
+            OperationRouting opRouting = new OperationRouting(
+                Settings.builder().build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+
+            ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(
+                indexNames,
+                numShards,
+                numReplicas,
+                numSearchReplicas
+            );
+
+            threadPool = new TestThreadPool("testSearchReplicaRoutingWithCustomPreferenceWhenStrict");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            // A caller-supplied preference that does not start with '_' must still be confined to search replicas.
+            String customPreference = "user-session-123";
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, customPreference);
+            assertThat("one group per shard", groupIterator.size(), equalTo(numShards));
+            for (ShardIterator shardIterator : groupIterator) {
+                assertThat("Only search replicas should be routed to", shardIterator.size(), equalTo(numSearchReplicas));
+                for (ShardRouting shardRouting : shardIterator) {
+                    assertTrue("Custom preference must resolve only to search replicas", shardRouting.isSearchOnly());
+                }
+            }
+
+            // The same custom preference should deterministically resolve to the same ordering across calls.
+            GroupShardsIterator<ShardIterator> firstIterator = opRouting.searchShards(state, indexNames, null, customPreference);
+            GroupShardsIterator<ShardIterator> repeatIterator = opRouting.searchShards(state, indexNames, null, customPreference);
+            List<ShardRouting> firstOrder = new ArrayList<>();
+            firstIterator.iterator().next().forEach(firstOrder::add);
+            List<ShardRouting> repeatOrder = new ArrayList<>();
+            repeatIterator.iterator().next().forEach(repeatOrder::add);
+            assertFalse("Determinism check requires a non-empty ordering", firstOrder.isEmpty());
+            assertEquals("Custom preference routing must be consistent across requests", firstOrder, repeatOrder);
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
+    public void testSearchReplicaRoutingWithCustomPreferenceWhenNotStrict() throws Exception {
+        final int numShards = 1;
+        final int numReplicas = 2;
+        final int numSearchReplicas = 2;
+        final String indexName = "test";
+        final String[] indexNames = new String[] { indexName };
+
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            OperationRouting opRouting = new OperationRouting(
+                Settings.builder().build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+            opRouting.setStrictSearchOnlyShardRouting(false);
+
+            ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(
+                indexNames,
+                numShards,
+                numReplicas,
+                numSearchReplicas
+            );
+
+            threadPool = new TestThreadPool("testSearchReplicaRoutingWithCustomPreferenceWhenNotStrict");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            // With strict routing disabled, a custom preference must not be confined to search replicas.
+            String customPreference = "user-session-123";
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, customPreference);
+            assertThat("one group per shard", groupIterator.size(), equalTo(numShards));
+            for (ShardIterator shardIterator : groupIterator) {
+                assertThat("All active shards should be routable", shardIterator.size(), equalTo(numReplicas + numSearchReplicas + 1));
+                boolean hasNonSearchOnly = false;
+                for (ShardRouting shardRouting : shardIterator) {
+                    if (shardRouting.isSearchOnly() == false) {
+                        hasNonSearchOnly = true;
+                    }
+                }
+                assertTrue("Non-search shards must be reachable when routing is not strict", hasNonSearchOnly);
+            }
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
+    public void testExplicitPrimaryPreferenceIsHonoredOverSearchReplicaRouting() throws Exception {
+        final int numShards = 1;
+        final int numReplicas = 2;
+        final int numSearchReplicas = 2;
+        final String indexName = "test";
+        final String[] indexNames = new String[] { indexName };
+
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            // Strict search-only routing is enabled by default.
+            OperationRouting opRouting = new OperationRouting(
+                Settings.builder().build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+
+            ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(
+                indexNames,
+                numShards,
+                numReplicas,
+                numSearchReplicas
+            );
+
+            threadPool = new TestThreadPool("testExplicitPrimaryPreferenceIsHonoredOverSearchReplicaRouting");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            // An explicit '_' preference must win over strict search-replica routing.
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, Preference.PRIMARY.type());
+            assertThat("one group per shard", groupIterator.size(), equalTo(numShards));
+            for (ShardIterator shardIterator : groupIterator) {
+                assertThat("Only the primary should be routed to", shardIterator.size(), equalTo(1));
+                for (ShardRouting shardRouting : shardIterator) {
+                    assertTrue("Explicit _primary preference must resolve to the primary", shardRouting.primary());
+                    assertFalse("Explicit _primary preference must not resolve to a search replica", shardRouting.isSearchOnly());
+                }
+            }
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
+    public void testGetWithCustomPreferenceIsNotConfinedToSearchReplicas() throws Exception {
+        final int numShards = 1;
+        final int numReplicas = 2;
+        final int numSearchReplicas = 2;
+        final String indexName = "test";
+        final String[] indexNames = new String[] { indexName };
+
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            // Strict search-only routing is enabled by default.
+            OperationRouting opRouting = new OperationRouting(
+                Settings.builder().build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+
+            ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(
+                indexNames,
+                numShards,
+                numReplicas,
+                numSearchReplicas
+            );
+
+            threadPool = new TestThreadPool("testGetWithCustomPreferenceIsNotConfinedToSearchReplicas");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            // Realtime GET must never be confined to search replicas, even with strict routing and a custom preference.
+            ShardIterator shardIterator = opRouting.getShards(state, indexName, 0, "user-session-123");
+            assertThat("All active shards should be routable for GET", shardIterator.size(), equalTo(numReplicas + numSearchReplicas + 1));
+            boolean hasNonSearchOnly = false;
+            for (ShardRouting shardRouting : shardIterator) {
+                if (shardRouting.isSearchOnly() == false) {
+                    hasNonSearchOnly = true;
+                }
+            }
+            assertTrue("GET must be able to reach the primary or writer replicas", hasNonSearchOnly);
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
     private DiscoveryNode[] setupNodes() {
         // Sets up two data nodes in zone-a and one data node in zone-b
         List<String> zones = Arrays.asList("a", "a", "b");


### PR DESCRIPTION
### Description

When strict search-replica routing is enabled (`cluster.routing.search_replica.strict`, default `true`) and an index has search replicas, search traffic is expected to stay isolated on those search replicas, keeping it off the primary/writer copies.

Today that isolation only holds when the request has **no preference**. `OperationRouting#searchShards` forced an empty preference onto `_search_replica`, but a caller-supplied **custom preference** (a non-`_` key, typically used for session-consistent routing) fell through to `activeInitializingShardsIt(...)`, which spreads across primaries and writer replicas. So a custom preference silently disabled the strict search-replica isolation.

This change makes the search-replica target the default whenever strict routing applies and the index has search replicas, covering both the empty-preference and custom-preference cases:

- The decision is computed once in `searchShards` (`defaultToSearchReplicas = isStrictSearchOnlyShardRouting && numberOfSearchOnlyReplicas > 0`) and passed into `preferenceActiveShardIterator`.
- For a custom preference, routing is confined to search replicas **while preserving preference-based consistency** — the preference hash seeds search-replica selection via a new `IndexShardRoutingTable#searchReplicaActiveInitializingShardIt(int seed)`, so the same key resolves to the same search replica across requests.
- Explicit `_` preferences (e.g. `_primary`, `_only_nodes`) still override, since they are handled before the default kicks in.
- Realtime GET (`getShards`) is unaffected — it passes `false`, so it can still reach the primary/writer replicas.

**Behavior note (weighted routing):** when a custom preference is now confined to search replicas, weighted/AZ routing is not applied to that selection. This matches the existing behavior of the explicit `_search_replica` preference (which also bypasses weighted routing), so it is internally consistent; but for clusters relying on weighted routing, custom-preference searches against search replicas will not honor those weights.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/22395

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
