### PR TITLE
Strengthen scroll_id validation

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/TransportSearchHelper.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchHelper.java
@@ -113,7 +113,11 @@ final class TransportSearchHelper {
                 includeContextUUID = false;
                 type = firstChunk;
             }
-            SearchContextIdForNode[] context = new SearchContextIdForNode[in.readVInt()];
+            int count = in.readVInt();
+            if (count < 0 || count > bytes.length) {
+                throw new IllegalArgumentException("Invalid scroll id");
+            }
+            SearchContextIdForNode[] context = new SearchContextIdForNode[count];
             for (int i = 0; i < context.length; ++i) {
                 final String contextUUID = includeContextUUID ? in.readString() : "";
                 long id = in.readLong();

--- a/server/src/test/java/org/opensearch/action/search/TransportSearchHelperTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportSearchHelperTests.java
@@ -41,6 +41,9 @@ import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.VersionUtils;
 
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+
 import static org.hamcrest.Matchers.equalTo;
 
 public class TransportSearchHelperTests extends OpenSearchTestCase {
@@ -91,5 +94,24 @@ public class TransportSearchHelperTests extends OpenSearchTestCase {
         assertNull(parseScrollId.getContext()[2].getClusterAlias());
         assertEquals(42, parseScrollId.getContext()[2].getSearchContextId().getId());
         assertThat(parseScrollId.getContext()[2].getSearchContextId().getSessionId(), equalTo("c"));
+    }
+
+    public void testParseScrollIdRejectsOversizedCount() throws Exception {
+        // Craft a scroll_id with a varint-encoded count far exceeding the payload size.
+        // This would previously cause an OOM by allocating a huge array.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        // Write type string: length=1, char='q' (any valid type)
+        baos.write(1); // vint string length
+        baos.write('q');
+        // Write a massive vint count (Integer.MAX_VALUE encoded as 5-byte varint)
+        baos.write(0xFF);
+        baos.write(0xFF);
+        baos.write(0xFF);
+        baos.write(0xFF);
+        baos.write(0x07);
+        String scrollId = Base64.getUrlEncoder().encodeToString(baos.toByteArray());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> TransportSearchHelper.parseScrollId(scrollId));
+        assertEquals("Cannot parse scroll id", e.getMessage());
     }
 }


### PR DESCRIPTION
### Description

Adds bounds checking on the varint-encoded count in `TransportSearchHelper.parseScrollId()`. Previously, a crafted scroll ID encoding a massive count (e.g., `Integer.MAX_VALUE`) would cause an OOM by allocating an oversized array before any data was read. The fix validates that the decoded count does not exceed the remaining payload size.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
