### PR TITLE
Use github default token for releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,21 +9,14 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'opensearch-project/OpenSearch'
     permissions:
       contents: write
     steps:
-      - name: GitHub App token
-        id: github_app_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 # v1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
-          github_token: ${{ steps.github_app_token.outputs.token }}
           bodyFile: release-notes/opensearch.release-notes-${{steps.tag.outputs.tag}}.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The GitHub App installation has been suspended. This PR removes the redundant code and uses default GH token for publishing release on GitHub. Follows similar pattern other standalone components follow. Example: https://github.com/opensearch-project/opensearch-jvector/blob/main/.github/workflows/release-drafter.yml

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/actions/runs/28813538448
### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
