### PR TITLE
Add clippy check to sandbox CI

### DIFF
--- a/.github/workflows/sandbox-check.yml
+++ b/.github/workflows/sandbox-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Check Rust formatting
         run: cargo fmt --all --manifest-path sandbox/libs/dataformat-native/rust/Cargo.toml -- --check
       - name: Install protobuf compiler
@@ -51,6 +51,12 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Set Cargo build jobs
         run: echo "CARGO_BUILD_JOBS=$(nproc)" >> $GITHUB_ENV
+      - name: Run Rust clippy
+        # Run from the workspace dir so the crate's .cargo/config.toml (which sets
+        # `--cfg tokio_unstable`, required by the tokio RuntimeMetrics calls) is picked up.
+        # cargo only reads .cargo/config.toml relative to the working directory, not --manifest-path.
+        working-directory: sandbox/libs/dataformat-native/rust
+        run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Run sandbox check
         run: ./gradlew check -p sandbox -Dsandbox.enabled=true -PrustDebug
       - name: Upload test results

--- a/sandbox/libs/dataformat-native/rust/common/src/allocator.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/allocator.rs
@@ -289,6 +289,12 @@ pub extern "C" fn native_jemalloc_heap_prof_deactivate() -> i64 {
 /// FFI: Dumps a heap profile to the given path. Path must be a null-terminated C string.
 /// Returns 0 on success, negative error pointer on failure.
 /// Called from Java when the cluster setting `native.jemalloc.heap_prof_dump_path` is updated.
+///
+/// # Safety
+///
+/// If `path` is non-null it must point to a valid, null-terminated C string that
+/// remains live for the duration of the call. A null `path` is handled
+/// gracefully and returns an error rather than being undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn native_jemalloc_heap_prof_dump(path: *const std::ffi::c_char) -> i64 {
     ffm_wrap("native_jemalloc_heap_prof_dump", || {

--- a/sandbox/libs/dataformat-native/rust/common/src/error.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/error.rs
@@ -11,7 +11,7 @@
 //! Convention: FFM functions return `i64`.
 //!   - `>= 0` → success (value or pointer)
 //!   - `< 0`  → error. Negate to get a pointer to a heap-allocated error.
-//!              Call `native_error_message` to read, `native_error_free` to free.
+//!     Call `native_error_message` to read, `native_error_free` to free.
 
 use std::ffi::CString;
 use std::os::raw::c_char;
@@ -48,12 +48,26 @@ where
 }
 
 /// Returns a pointer to the null-terminated error message.
+///
+/// # Safety
+///
+/// `ptr` must be a value previously produced by [`into_error_ptr`] (i.e. the
+/// negated pointer, re-negated back to a positive `i64`) that has not yet been
+/// freed via [`native_error_free`]. Passing any other value yields a dangling
+/// or invalid pointer when reinterpreted as `*const c_char`.
 #[no_mangle]
 pub unsafe extern "C" fn native_error_message(ptr: i64) -> *const c_char {
     ptr as *const c_char
 }
 
 /// Frees a heap-allocated error string.
+///
+/// # Safety
+///
+/// `ptr` must be either `0` or a pointer previously produced by
+/// [`into_error_ptr`] (re-negated back to a positive `i64`) that has not
+/// already been freed. Double-freeing or passing an arbitrary value results in
+/// undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn native_error_free(ptr: i64) {
     if ptr != 0 {
@@ -62,6 +76,12 @@ pub unsafe extern "C" fn native_error_free(ptr: i64) {
 }
 
 /// Deliberately panics with the given message. For testing panic handling.
+///
+/// # Safety
+///
+/// `msg_ptr` must point to at least `msg_len` initialized bytes of valid UTF-8
+/// that remain live for the duration of the call. `msg_len` must be
+/// non-negative and must not exceed the length of the buffer at `msg_ptr`.
 #[no_mangle]
 pub unsafe extern "C" fn native_test_panic(msg_ptr: *const u8, msg_len: i64) -> i64 {
     match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| -> Result<i64, String> {
@@ -85,6 +105,12 @@ pub unsafe extern "C" fn native_test_panic(msg_ptr: *const u8, msg_len: i64) -> 
 }
 
 /// Returns an error (not a panic) with the given message. For testing error handling.
+///
+/// # Safety
+///
+/// `msg_ptr` must point to at least `msg_len` initialized bytes of valid UTF-8
+/// that remain live for the duration of the call. `msg_len` must be
+/// non-negative and must not exceed the length of the buffer at `msg_ptr`.
 #[no_mangle]
 pub unsafe extern "C" fn native_test_error(msg_ptr: *const u8, msg_len: i64) -> i64 {
     let msg = std::str::from_utf8_unchecked(std::slice::from_raw_parts(msg_ptr, msg_len as usize));
@@ -93,6 +119,12 @@ pub unsafe extern "C" fn native_test_error(msg_ptr: *const u8, msg_len: i64) -> 
 
 /// Validates a string from (ptr, len). Returns 0 on valid UTF-8, error pointer on invalid input.
 /// Used for testing input validation (null ptr, negative len, bad UTF-8).
+///
+/// # Safety
+///
+/// If `ptr` is non-null it must point to at least `len` initialized bytes that
+/// remain live for the duration of the call. `len` is validated internally, so
+/// a null `ptr` or negative `len` are handled gracefully rather than being UB.
 #[no_mangle]
 pub unsafe extern "C" fn native_test_validate_str(ptr: *const u8, len: i64) -> i64 {
     if ptr.is_null() {

--- a/sandbox/libs/dataformat-native/rust/common/src/logger.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/logger.rs
@@ -50,6 +50,13 @@ pub extern "C" fn native_logger_set_level(level: i32) {
 }
 
 /// Called by Java at startup to register the log callback.
+///
+/// # Safety
+///
+/// `callback` must be a valid function pointer matching the [`LogCallback`]
+/// signature (`void log(int, const char*, long)`) and must remain valid for the
+/// entire lifetime of the process, since it is stored globally and invoked from
+/// arbitrary threads on every subsequent log call.
 #[no_mangle]
 pub unsafe extern "C" fn native_logger_init(callback: LogCallback) {
     LOG_CALLBACK.store(callback as *mut (), Ordering::Release);

--- a/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/ffm.rs
@@ -172,7 +172,7 @@ pub extern "C" fn ts_destroy_tiered_object_store(ptr: i64) -> i64 {
 // File registry operations via TieredObjectStore pointer
 // ---------------------------------------------------------------------------
 
-/// Register a file in the TieredObjectStore's registry.
+// Register a file in the TieredObjectStore's registry.
 // TODO (writable warm): add ts_register_file for single-file registration (afterSyncToRemote).
 
 /// Batch register files in the TieredObjectStore's registry.
@@ -182,6 +182,9 @@ pub extern "C" fn ts_destroy_tiered_object_store(ptr: i64) -> i64 {
 /// Each triplet is (path, remotePath, size). For Local files, remotePath can be empty.
 /// `count`: number of file triplets (entries_len contains 3*count lines).
 /// `location`: 0=Local, 1=Remote — applied to all files in the batch.
+// clippy::not_unsafe_ptr_arg_deref — `#[no_mangle] extern "C"` FFM entry point called from
+// the JVM; pointer contract documented above. `unsafe fn` is meaningless for C-ABI callers.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[ffm_safe]
 #[no_mangle]
 pub extern "C" fn ts_register_files(
@@ -235,6 +238,9 @@ pub extern "C" fn ts_register_files(
 }
 
 /// Remove a file from the registry.
+// clippy::not_unsafe_ptr_arg_deref — `#[no_mangle] extern "C"` FFM entry point called from
+// the JVM; pointer contract documented above. `unsafe fn` is meaningless for C-ABI callers.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[ffm_safe]
 #[no_mangle]
 pub extern "C" fn ts_remove_file(store_ptr: i64, path_ptr: *const u8, path_len: i64) -> i64 {

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store.rs
@@ -465,7 +465,7 @@ impl TieredObjectStore {
         fetched: &[Bytes],
         miss_indices: &[usize],
         miss_ranges: &[Range<u64>],
-        slots: &mut Vec<Option<Bytes>>,
+        slots: &mut [Option<Bytes>],
     ) {
         if let Some(ref cache) = self.cache {
             for (fetched_bytes, (&slot_i, miss_range)) in fetched

--- a/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
+++ b/sandbox/libs/tiered-storage/src/main/rust/src/tiered_object_store_tests.rs
@@ -1116,6 +1116,9 @@ fn setup_with_cache() -> (
     (registry, local, cache, tiered)
 }
 
+// The `&[start..end]` args are intentionally a one-element slice of a Range
+// (the put_metadata API takes `&[Range<u64>]`), not a range-based collection.
+#[allow(clippy::single_range_in_vec_init)]
 #[tokio::test]
 async fn test_put_metadata_served_from_cache_on_get_opts() {
     let (registry, _local, _cache, tiered) = setup_with_cache();
@@ -1142,6 +1145,8 @@ async fn test_put_metadata_served_from_cache_on_get_opts() {
     assert_eq!(bytes.as_ref(), b"FOOTER");
 }
 
+// The `&[start..end]` arg is intentionally a one-element slice of a Range.
+#[allow(clippy::single_range_in_vec_init)]
 #[tokio::test]
 async fn test_put_metadata_routes_to_metadata_tier_only() {
     let (registry, _local, cache, tiered) = setup_with_cache();
@@ -1163,6 +1168,8 @@ async fn test_put_metadata_routes_to_metadata_tier_only() {
     );
 }
 
+// The `&[start..end]` arg is intentionally a one-element slice of a Range.
+#[allow(clippy::single_range_in_vec_init)]
 #[tokio::test]
 async fn test_put_metadata_noop_without_cache() {
     // No cache attached — must be a no-op, not a panic.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/cross_rt_throughput_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/cross_rt_throughput_bench.rs
@@ -44,7 +44,7 @@ fn test_batch(rows: usize) -> RecordBatch {
 fn make_executor() -> DedicatedExecutor {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(4).enable_all();
-    DedicatedExecutor::new("bench-cpu", builder)
+    DedicatedExecutor::new("bench-cpu", builder, 4)
 }
 
 /// Benchmark: push N batches through CrossRtStream and consume them.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/memory_budget_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/memory_budget_bench.rs
@@ -7,7 +7,7 @@
 //!
 //! Run: cargo bench --bench memory_budget_bench
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::execution::memory_pool::{
     GreedyMemoryPool, MemoryConsumer, MemoryPool, TrackConsumersPool,
@@ -63,7 +63,7 @@ fn bench_acquire_budget_moderate_pressure(c: &mut Criterion) {
 
     // Pre-fill pool to 80% with a long-lived reservation
     let consumer = MemoryConsumer::new("background_load");
-    let mut bg_reservation = consumer.register(&pool);
+    let bg_reservation = consumer.register(&pool);
     bg_reservation.try_grow(80_000_000).unwrap();
 
     c.bench_function("acquire_budget/80pct_pressure/narrow_schema", |b| {
@@ -170,7 +170,7 @@ fn bench_phantom_reservation_cycle(c: &mut Criterion) {
     c.bench_function("phantom_reservation/grow_shrink_cycle", |b| {
         b.iter(|| {
             let consumer = MemoryConsumer::new("phantom").with_can_spill(true);
-            let mut reservation = consumer.register(&pool);
+            let reservation = consumer.register(&pool);
             reservation.try_grow(phantom_size).unwrap();
             drop(reservation); // shrinks
         });

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/memory_pressure_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/memory_pressure_bench.rs
@@ -135,7 +135,7 @@ fn simulate_concurrent_queries(
 
                         let operator_state_bytes = budget.batch_size * avg_row_bytes / 2;
                         let consumer = MemoryConsumer::new("simulated_hash_agg");
-                        let mut reservation = consumer.register(&pool);
+                        let reservation = consumer.register(&pool);
                         if reservation.try_grow(operator_state_bytes).is_err() {
                             budgeted_spills.fetch_add(1, Ordering::Relaxed);
                         }
@@ -187,7 +187,7 @@ fn simulate_concurrent_queries(
                 // No budget — allocate at full configured parallelism
                 let operator_state_bytes = batch_size * avg_row_bytes / 2;
                 let consumer = MemoryConsumer::new("simulated_hash_agg_nobudget");
-                let mut reservation = consumer.register(&pool);
+                let reservation = consumer.register(&pool);
                 if reservation.try_grow(operator_state_bytes).is_err() {
                     unbudgeted_spills.fetch_add(1, Ordering::Relaxed);
                 }
@@ -350,8 +350,8 @@ fn print_result(label: &str, r: &SimulationResult) {
         }
     );
     println!("├────────────────── LATENCY (per query, includes 10ms sleep) ──────┤");
-    let (b_avg, b_min, b_p50, b_p99) = latency_stats(&r.budgeted_latencies_ns);
-    let (u_avg, u_min, u_p50, u_p99) = latency_stats(&r.unbudgeted_latencies_ns);
+    let (b_avg, _b_min, b_p50, b_p99) = latency_stats(&r.budgeted_latencies_ns);
+    let (u_avg, _u_min, u_p50, u_p99) = latency_stats(&r.unbudgeted_latencies_ns);
     println!(
         "│ With budget:    avg={}, p50={}, p99={:<12} │",
         fmt_ns(b_avg),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/query_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/query_bench.rs
@@ -51,7 +51,7 @@ fn setup() -> (RuntimeManager, DataFusionRuntime, tempfile::TempDir) {
     (mgr, df_runtime, tmp)
 }
 
-fn get_substrait(mgr: &RuntimeManager, df: &DataFusionRuntime, dir: &str, sql: &str) -> Vec<u8> {
+fn get_substrait(mgr: &RuntimeManager, _df: &DataFusionRuntime, dir: &str, sql: &str) -> Vec<u8> {
     use datafusion::datasource::file_format::parquet::ParquetFormat;
     use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
     use datafusion_substrait::logical_plan::producer::to_substrait_plan;
@@ -114,6 +114,10 @@ fn bench_execute_query(c: &mut Criterion) {
                             &opensearch_datafusion::datafusion_query_config::DatafusionQueryConfig::test_default(),
                             0,
                             Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                            None,
+                            &[],
+                            &[],
+                            opensearch_datafusion::datafusion_query_config::InternalSearch::Off,
                         ).await.unwrap();
                         // Consume and free the stream
                         let mut stream = unsafe {
@@ -162,6 +166,10 @@ fn bench_stream_next(c: &mut Criterion) {
                     ),
                     0,
                     Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                    None,
+                    &[],
+                    &[],
+                    opensearch_datafusion::datafusion_query_config::InternalSearch::Off,
                 )
                 .await
                 .unwrap();
@@ -173,7 +181,7 @@ fn bench_stream_next(c: &mut Criterion) {
                     )
                 };
                 let mut batches = 0u64;
-                while let Some(_) = stream.try_next().await.unwrap() {
+                while stream.try_next().await.unwrap().is_some() {
                     batches += 1;
                 }
                 batches
@@ -212,6 +220,10 @@ fn bench_aggregation(c: &mut Criterion) {
                     ),
                     0,
                     Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                    None,
+                    &[],
+                    &[],
+                    opensearch_datafusion::datafusion_query_config::InternalSearch::Off,
                 )
                 .await
                 .unwrap();
@@ -222,7 +234,7 @@ fn bench_aggregation(c: &mut Criterion) {
                         >,
                     )
                 };
-                while let Some(_) = stream.try_next().await.unwrap() {}
+                while stream.try_next().await.unwrap().is_some() {}
             }
         });
     });

--- a/sandbox/plugins/analytics-backend-datafusion/rust/benches/row_id_bench.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/benches/row_id_bench.rs
@@ -18,6 +18,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::execution::memory_pool::GreedyMemoryPool;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::TryStreamExt;
 use object_store::local::LocalFileSystem;
 use object_store::{ObjectStore, ObjectStoreExt};
@@ -46,7 +47,7 @@ fn bench_file() -> String {
 }
 
 fn setup() -> (RuntimeManager, DataFusionRuntime) {
-    let mgr = RuntimeManager::new(4);
+    let mgr = RuntimeManager::new(4, 1.5, 1.5);
     let runtime_env = RuntimeEnvBuilder::new()
         .with_memory_pool(Arc::new(GreedyMemoryPool::new(2 * 1024 * 1024 * 1024)))
         .build()
@@ -123,8 +124,11 @@ fn bench_clickbench(c: &mut Criterion) {
     let path = std::path::Path::new(&file);
     let size = std::fs::metadata(path).unwrap().len();
     let fh = std::fs::File::open(path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&fh, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &fh,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -147,7 +151,10 @@ fn bench_clickbench(c: &mut Criterion) {
         parquet_size: size,
         row_groups: rgs,
         metadata: Arc::clone(&parquet_meta),
+        arrow_schema: parquet_schema.clone(),
         global_base: 0,
+        sort_min: None,
+        sort_max: None,
     };
 
     // Schema with ___row_id appended (virtual column)
@@ -208,6 +215,10 @@ fn bench_clickbench(c: &mut Criterion) {
                         &config,
                         0,
                         Arc::new(LocalFileSystem::new()) as Arc<dyn ObjectStore>,
+                        None,
+                        &[],
+                        &[],
+                        opensearch_datafusion::datafusion_query_config::InternalSearch::Off,
                     )
                     .await
                     .unwrap();
@@ -264,9 +275,10 @@ fn bench_clickbench(c: &mut Criterion) {
                         let factory: opensearch_datafusion::indexed_table::table_provider::EvaluatorFactory = {
                             let tree = Arc::clone(&tree);
                             let schema = schema.clone();
-                            Arc::new(move |seg, _chunk, _sm| {
+                            Arc::new(move |seg, _chunk, _sm, _stats_prune_tree| {
                                 let resolved = tree.resolve(&[])?;
-                                let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata)));
+                                let pruner =
+                                    Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata), seg.arrow_schema.clone()));
                                 let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                                     tree: Arc::new(resolved),
                                     evaluator: Arc::new(BitmapTreeEvaluator),
@@ -282,6 +294,8 @@ fn bench_clickbench(c: &mut Criterion) {
                                         opensearch_datafusion::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(_sm),
                                     ),
                                     collector_strategy: opensearch_datafusion::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                                    stats_prune_tree: None,
+                                    rg_index_to_pos: std::collections::HashMap::new(),
                                 });
                                 Ok(eval)
                             })
@@ -303,6 +317,10 @@ fn bench_clickbench(c: &mut Criterion) {
                             }),
                             predicate_columns: vec![search_phrase_idx],
                             emit_row_ids: true,
+                            prune_tree_config: None,
+                            sort_fields: vec![],
+                            sort_orders: vec![],
+                            cancellation_token: None,
                         }));
 
                         let ctx = datafusion::prelude::SessionContext::new();
@@ -354,9 +372,10 @@ fn bench_clickbench(c: &mut Criterion) {
                         let factory: opensearch_datafusion::indexed_table::table_provider::EvaluatorFactory = {
                             let tree = Arc::clone(&tree);
                             let schema = schema.clone();
-                            Arc::new(move |seg, _chunk, _sm| {
+                            Arc::new(move |seg, _chunk, _sm, _stats_prune_tree| {
                                 let resolved = tree.resolve(&[])?;
-                                let pruner = Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata)));
+                                let pruner =
+                                    Arc::new(PagePruner::new(&schema, Arc::clone(&seg.metadata), seg.arrow_schema.clone()));
                                 let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                                     tree: Arc::new(resolved),
                                     evaluator: Arc::new(BitmapTreeEvaluator),
@@ -372,6 +391,8 @@ fn bench_clickbench(c: &mut Criterion) {
                                         opensearch_datafusion::indexed_table::page_pruner::PagePruneMetrics::from_stream_metrics(_sm),
                                     ),
                                     collector_strategy: opensearch_datafusion::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
+                                    stats_prune_tree: None,
+                                    rg_index_to_pos: std::collections::HashMap::new(),
                                 });
                                 Ok(eval)
                             })
@@ -393,6 +414,10 @@ fn bench_clickbench(c: &mut Criterion) {
                             }),
                             predicate_columns: vec![search_phrase_idx],
                             emit_row_ids: false,
+                            prune_tree_config: None,
+                            sort_fields: vec![],
+                            sort_orders: vec![],
+                            cancellation_token: None,
                         }));
 
                         let ctx = datafusion::prelude::SessionContext::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/agg_mode.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/agg_mode.rs
@@ -235,6 +235,8 @@ mod tests {
         displayable(plan.as_ref()).indent(true).to_string()
     }
 
+    // Test helper retained for plan-shape assertions; not used by every test.
+    #[allow(dead_code)]
     fn contains_node(plan: &Arc<dyn ExecutionPlan>, name: &str) -> bool {
         if plan.name().contains(name) {
             return true;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -793,7 +793,7 @@ static REDUCE_TARGET_PARTITIONS: std::sync::atomic::AtomicUsize =
 
 pub fn set_reduce_target_partitions(value: i64) {
     REDUCE_TARGET_PARTITIONS.store(
-        value.max(1).min(32) as usize,
+        value.clamp(1, 32) as usize,
         std::sync::atomic::Ordering::Release,
     );
 }
@@ -818,8 +818,8 @@ pub fn get_reduce_target_partitions() -> usize {
 /// `filenames` are kept in the order supplied by the caller.
 ///
 /// `store_ptr`: 0 = use default LocalFileSystem (hot path),
-/// >0 = `Box<Arc<dyn MetadataCachingStore>>` pointer (routes reads through TieredObjectStore;
-///       trait upcasts to `dyn ObjectStore` for DataFusion APIs that take `Arc<dyn ObjectStore>`).
+/// `>0` = `Box<Arc<dyn MetadataCachingStore>>` pointer (routes reads through TieredObjectStore;
+/// trait upcasts to `dyn ObjectStore` for DataFusion APIs that take `Arc<dyn ObjectStore>`).
 pub fn create_reader(
     table_path: &str,
     filenames: Vec<String>,
@@ -911,6 +911,8 @@ pub unsafe fn close_reader(ptr: i64) {
 ///
 /// # Safety
 /// `shard_view_ptr` and `runtime_ptr` must be valid, non-zero pointers.
+// Real FFM-facing API; argument count mirrors the Java-provided query inputs.
+#[allow(clippy::too_many_arguments)]
 pub async unsafe fn execute_query(
     shard_view_ptr: i64,
     table_name: &str,
@@ -989,7 +991,7 @@ pub async unsafe fn execute_query(
 
     let stream_ptr = cancellation::cancellable(token.as_ref(), context_id, query_future)
         .await
-        .map_err(|e| DataFusionError::Execution(e))?;
+        .map_err(DataFusionError::Execution)?;
 
     // Reconstruct the stream from the raw pointer returned by the executor.
     let stream = *Box::from_raw(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>);
@@ -1012,6 +1014,11 @@ pub async unsafe fn execute_query(
 /// Uses shared helpers from query_executor for runtime setup, file info building,
 /// and stream wrapping. The fetch-specific logic is building ParquetAccessPlans
 /// from row IDs and computing global __row_id__ = __row_id__ + row_base in SQL.
+///
+/// # Safety
+/// `shard_view` and `runtime` must reference live objects that outlive the call,
+/// and the shard's underlying object store / file handles must remain valid for
+/// the duration of query execution.
 pub async unsafe fn fetch_by_row_ids(
     shard_view: &ShardView,
     runtime: &DataFusionRuntime,
@@ -1195,6 +1202,8 @@ pub async unsafe fn fetch_by_row_ids(
 /// Resolve the dynamic spill limit based on available disk space.
 /// Uses 80% of available space on the spill directory's filesystem.
 /// Falls back to 8GB if disk space cannot be determined.
+// Retained for dynamic spill-limit sizing; not currently wired into the runtime setup path.
+#[allow(dead_code)]
 fn resolve_dynamic_spill_limit(spill_dir: &str) -> u64 {
     const FRACTION: f64 = 0.80;
     const FALLBACK: u64 = 8 * 1024 * 1024 * 1024; // 8GB
@@ -1297,7 +1306,6 @@ fn try_acquire_budget_from_cache(
     pool: &Arc<dyn MemoryPool>,
     config: &DatafusionQueryConfig,
 ) -> Option<crate::query_budget::QueryMemoryBudget> {
-    use datafusion::execution::cache::CacheAccessor;
     use parquet::arrow::parquet_to_arrow_schema;
     use parquet::file::metadata::ParquetMetaData;
 
@@ -1372,7 +1380,7 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
             .map_err(|e: DataFusionError| e)
     })
     .await
-    .map_err(|e| DataFusionError::Execution(e))?;
+    .map_err(DataFusionError::Execution)?;
 
     match result {
         Some(batch) => {
@@ -2140,6 +2148,8 @@ pub unsafe fn sender_close(sender_ptr: i64) {
     }
 }
 
+// Memtable helper entry points below intentionally follow this test module.
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2631,7 +2641,7 @@ mod tests {
     #[test]
     fn stringview_gc_inline_strings_no_change() {
         let strings: Vec<&str> = (0..100).map(|_| "short").collect();
-        let string_view_array = StringViewArray::from_iter_values(strings.into_iter());
+        let string_view_array = StringViewArray::from_iter_values(strings);
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "str_col",

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
@@ -19,7 +19,7 @@ use datafusion::execution::cache::cache_manager::{
 };
 use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::execution::cache::CacheAccessor;
-use log::{debug, error};
+use log::error;
 use native_bridge_common::log_debug;
 use object_store::path::Path;
 use object_store::ObjectMeta;
@@ -113,7 +113,7 @@ fn create_object_meta_from_file(
 
     let modified = metadata
         .modified()
-        .map(|t| DateTime::<Utc>::from(t))
+        .map(DateTime::<Utc>::from)
         .unwrap_or_else(|_| Utc::now());
 
     let object_meta = ObjectMeta {
@@ -135,6 +135,12 @@ pub struct CustomCacheManager {
     statistics_cache: Option<Arc<CustomStatisticsCache>>,
     column_index_registered: bool,
     offset_index_registered: bool,
+}
+
+impl Default for CustomCacheManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CustomCacheManager {
@@ -384,7 +390,7 @@ impl CustomCacheManager {
             crate::cache::metadata_cache::CACHE_TYPE_STATS => self
                 .statistics_cache
                 .as_ref()
-                .map_or(false, |cache| cache.contains_key(&Path::from(file_path))),
+                .is_some_and(|cache| cache.contains_key(&Path::from(file_path))),
             metadata_cache::CACHE_TYPE_COLUMN_INDEX => {
                 if !self.column_index_registered {
                     return false;
@@ -716,7 +722,6 @@ impl CustomCacheManager {
         // Put lightweight footer-only metadata into heap cache
         use datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData;
         use datafusion::execution::cache::cache_manager::CachedFileMetadataEntry;
-        use datafusion::execution::cache::CacheAccessor;
         let cached_entry = CachedFileMetadataEntry::new(
             object_meta.clone(),
             Arc::new(CachedParquetMetaData::new(Arc::clone(&parquet_metadata))),
@@ -991,7 +996,6 @@ impl CustomCacheManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::eviction_policy::PolicyType;
     use crate::cache::page_index::{
         clear_scoped_cache_for_test, column_index_cache_stats, offset_index_cache_stats,
         SCOPED_CACHE_TEST_GUARD,
@@ -1122,7 +1126,7 @@ mod tests {
         let schema = Arc::new(Schema::new(fields));
 
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(stats)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/eviction_policy.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/eviction_policy.rs
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_lru_policy_basic_operations() {
-        let mut policy = LruPolicy::new();
+        let policy = LruPolicy::new();
         assert_eq!(policy.policy_name(), "lru");
 
         policy.on_insert("key1", 100);
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_lru_policy_victim_selection() {
-        let mut policy = LruPolicy::new();
+        let policy = LruPolicy::new();
 
         policy.on_insert("oldest", 100);
         thread::sleep(Duration::from_millis(1));
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_lfu_policy_victim_selection() {
-        let mut policy = LfuPolicy::new();
+        let policy = LfuPolicy::new();
 
         policy.on_insert("rarely_used", 100);
         policy.on_insert("sometimes_used", 100);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/metadata_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/metadata_cache.rs
@@ -240,6 +240,7 @@ mod strip_page_index_tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
     use object_store::ObjectMeta;
     use prost::bytes::Bytes;
@@ -275,7 +276,7 @@ mod strip_page_index_tests {
     fn full_index_entry(bytes: &Bytes) -> CachedFileMetadataEntry {
         let meta = ArrowReaderMetadata::load(
             &bytes.clone(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let pq = meta.metadata().clone();
@@ -329,7 +330,7 @@ mod strip_page_index_tests {
         let bytes = parquet_with_page_index();
         let meta = ArrowReaderMetadata::load(
             &bytes.clone(),
-            ArrowReaderOptions::new().with_page_index(false),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Skip),
         )
         .unwrap();
         let pq = meta.metadata().clone();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/cache_store.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/cache_store.rs
@@ -68,7 +68,7 @@ pub(crate) const DEFAULT_SCOPED_CACHE_LIMIT: usize = 150 * 1024 * 1024;
 /// 2. Wire it in `mod.rs` by passing it to `BoundedCache::new`.
 /// 3. Expose a `PolicyType` variant in the Java API and route it from
 ///    `df_create_cache` in `ffm.rs`.
-pub(super) trait ScopedEvictionPolicy<K>: Send + Sync {
+pub(crate) trait ScopedEvictionPolicy<K>: Send + Sync {
     /// Called when a new entry is inserted (or an existing key is overwritten).
     /// The policy should record `key` as the most-recently inserted entry.
     fn on_insert(&self, key: K);
@@ -119,7 +119,7 @@ pub(super) trait ScopedEvictionPolicy<K>: Send + Sync {
 /// S3-FIFO (planned successor) wraps two FIFO queues with a ghost set. If its
 /// `on_access` needs to update state from the read path, it would need its own
 /// interior mutability (e.g. atomics for frequency counters).
-pub(super) struct FifoPolicy<K> {
+pub(crate) struct FifoPolicy<K> {
     /// Guarded by the outer `BoundedCache` write lock — no inner lock needed.
     queue: UnsafeCell<VecDeque<K>>,
 }
@@ -136,6 +136,11 @@ impl<K> FifoPolicy<K> {
     }
 
     /// Borrow the queue mutably. Caller must hold the outer write lock.
+    // clippy::mut_from_ref — intentional interior mutability: the `UnsafeCell` is only ever
+    // accessed while the caller holds `BoundedCache`'s write lock (see SAFETY notes above and
+    // on the `unsafe impl Send/Sync`). Restructuring to `&mut self` would defeat the lock-free
+    // read design this type exists for.
+    #[allow(clippy::mut_from_ref)]
     #[inline]
     fn queue_mut(&self) -> &mut VecDeque<K> {
         // SAFETY: caller holds the `BoundedCache` write lock.
@@ -202,7 +207,7 @@ pub struct ScopedCacheStats {
 ///
 /// `K` must implement `Display` so `evict_by_prefix` can match keys by their
 /// string representation (e.g. `"path:col:rg"` → prefix `"path"`).
-pub(super) struct BoundedCache<K, V, P = FifoPolicy<K>>
+pub(crate) struct BoundedCache<K, V, P = FifoPolicy<K>>
 where
     K: Eq + Hash + Clone + Display + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
@@ -242,6 +247,8 @@ where
     }
 
     /// Create a new cache with FIFO eviction — shorthand for tests.
+    // Retained as a convenience constructor / future API; not currently called.
+    #[allow(dead_code)]
     pub(super) fn new(limit: usize) -> Self {
         Self::with_named_policy(limit, CacheEvictionPolicy::Fifo)
     }
@@ -287,6 +294,8 @@ where
     ///
     /// If `size > limit` the entry is silently dropped. Takes the write lock
     /// for accounting; IO must be done by the caller before calling this.
+    // Retained as part of the cache API; not currently called outside tests.
+    #[allow(dead_code)]
     pub(super) fn insert(&self, key: K, value: V, size: usize) {
         let limit = self.limit_snapshot.load(Relaxed);
         if size > limit {
@@ -563,7 +572,7 @@ mod tests {
         for (k, v, s) in entries.clone() {
             c1.insert(k, v, s);
         }
-        c2.insert_batch(entries.into_iter());
+        c2.insert_batch(entries);
         assert_eq!(c1.get(&Key::new("a")), c2.get(&Key::new("a")));
         assert_eq!(c1.get(&Key::new("b")), c2.get(&Key::new("b")));
         assert_eq!(c1.get(&Key::new("c")), c2.get(&Key::new("c")));

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
@@ -13,7 +13,6 @@
 //! schema evolution (see [`resolve_predicate_parquet_columns`] for details).
 
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
 use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
@@ -46,7 +45,6 @@ pub fn resolve_predicate_parquet_columns(
     predicate_column_names: &[String],
     file_schema: &SchemaRef,
 ) -> Vec<usize> {
-    let parquet_schema = metadata.file_metadata().schema_descr();
     resolve_with_schema(file_schema, metadata, predicate_column_names)
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
@@ -17,22 +17,20 @@ use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, BooleanArray, UInt64Array};
-use arrow::datatypes::SchemaRef;
-use datafusion::parquet::arrow::arrow_reader::statistics::StatisticsConverter;
 use datafusion::parquet::errors::{ParquetError, Result as ParquetResult};
 use datafusion::parquet::file::metadata::{
     ColumnChunkMetaData, OffsetIndexBuilder, ParquetColumnIndex, ParquetMetaData,
     ParquetOffsetIndex,
 };
 use datafusion::parquet::file::page_index::column_index::ColumnIndexMetaData;
+// TODO: migrate to ParquetMetaDataReader once arrow-rs exposes a page-index
+// column/row-group projection (apache/arrow-rs#8643). These are currently the
+// only PUBLIC column-subset decoders, so we keep the deprecated import scoped.
+#[allow(deprecated)]
 use datafusion::parquet::file::page_index::index_reader::{
     read_columns_indexes, read_offset_indexes,
 };
 use datafusion::parquet::file::reader::{ChunkReader, Length};
-use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
-use datafusion::scalar::ScalarValue;
 use object_store::ObjectStore;
 use parquet::file::page_index::offset_index::OffsetIndexMetaData;
 use prost::bytes::{buf, Buf, Bytes};
@@ -660,32 +658,35 @@ impl BufferChunkReader {
     }
 }
 #[cfg(test)]
+// test-only: each test takes `CACHE_TEST_GUARD` (a std Mutex) to serialize access to the
+// global scoped-index cache, and holds it across `.await` intentionally so the whole test
+// body runs under the lock. Not a production deadlock risk.
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::super::column_schema_resolver::{
         resolve_predicate_parquet_columns, resolve_predicate_parquet_columns_pair,
     };
     use super::super::{
         clear_scoped_cache_for_test, column_index_cache_stats, offset_index_cache_stats,
-        scoped_cache_stats, set_column_index_cache_limit_for_test, set_whole_region_fetch_enabled,
-        ScopedCacheStats, SCOPED_CACHE_TEST_GUARD,
+        set_column_index_cache_limit_for_test, set_whole_region_fetch_enabled, ScopedCacheStats,
     };
     use super::*;
     use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruner};
     use arrow::array::{Int32Array, RecordBatch};
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::ScalarValue;
     use datafusion::logical_expr::Operator;
     use datafusion::parquet::arrow::arrow_reader::{
         ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector,
     };
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
     use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
     use datafusion::physical_expr::PhysicalExpr;
     use object_store::memory::InMemory;
     use object_store::path::Path as ObjPath;
     use object_store::{ObjectStoreExt, PutPayload};
-    use parquet::arrow::parquet_to_arrow_schema;
 
     use super::super::SCOPED_CACHE_TEST_GUARD as CACHE_TEST_GUARD;
 
@@ -708,7 +709,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -737,7 +738,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(10)
+            .set_max_row_group_row_count(Some(10))
             .set_data_page_row_count_limit(5)
             .set_write_batch_size(5)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -774,7 +775,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(ROWS as usize)
+            .set_max_row_group_row_count(Some(ROWS as usize))
             .set_data_page_row_count_limit(32)
             .set_write_batch_size(32)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -799,7 +800,7 @@ mod tests {
     fn footer_only(bytes: &Bytes) -> Arc<ParquetMetaData> {
         ArrowReaderMetadata::load(
             &bytes.clone(),
-            ArrowReaderOptions::new().with_page_index(false),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Skip),
         )
         .unwrap()
         .metadata()
@@ -809,7 +810,7 @@ mod tests {
     fn full_index(bytes: &Bytes) -> Arc<ParquetMetaData> {
         ArrowReaderMetadata::load(
             &bytes.clone(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap()
         .metadata()
@@ -855,7 +856,7 @@ mod tests {
             .build()
             .map_err(|e| format!("build reader: {e}"))?;
         let mut out = Vec::new();
-        while let Some(next) = reader.next() {
+        for next in reader.by_ref() {
             let batch = next.map_err(|e| format!("read batch: {e}"))?;
             let a = batch
                 .column(0)
@@ -1025,7 +1026,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
@@ -439,6 +439,10 @@ impl CustomStatisticsCache {
             .unwrap_or(0)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn clear(&self) {
         self.inner_cache.clear();
         if let Ok(mut state) = self.memory_state.lock() {
@@ -626,7 +630,7 @@ mod tests {
             cache.put_statistics(&path, stats, &meta);
         }
         assert!(cache.memory_consumed() <= 1000);
-        assert!(cache.len() > 0);
+        assert!(!cache.is_empty());
     }
 
     #[test]
@@ -800,7 +804,7 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
-        assert!(cache.len() > 0);
+        assert!(!cache.is_empty());
     }
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cross_rt_stream.rs
@@ -51,6 +51,8 @@ pub struct CrossRtStream {
 }
 
 impl CrossRtStream {
+    // Alternate constructor retained for API completeness / future use.
+    #[allow(dead_code)]
     fn new_with_tx<F, Fut>(f: F, schema: SchemaRef) -> Self
     where
         F: FnOnce(Sender<Result<RecordBatch, DataFusionError>>) -> Fut,
@@ -169,10 +171,8 @@ impl Stream for CrossRtStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
 
-        if !this.driver_ready {
-            if this.driver.poll_unpin(cx).is_ready() {
-                this.driver_ready = true;
-            }
+        if !this.driver_ready && this.driver.poll_unpin(cx).is_ready() {
+            this.driver_ready = true;
         }
 
         if this.inner_done {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/executor.rs
@@ -603,16 +603,16 @@ mod tests {
 
     // ─── Property-based tests ────────────────────────────────────────────
 
-    /// **Validates: Requirements 3.1, 3.2, 3.4**
-    ///
-    /// Property 1: Resize reaches target capacity
-    ///
-    /// For any valid ConcurrencyGate with initial max permits `initial_max`
-    /// and any valid target `target` (both in [1, 256]), after `resize(target)`
-    /// completes, the effective max permits SHALL equal `target`.
-    /// Since no queries are active in this test, available permits SHALL be
-    /// at least `target` (may exceed target due to the bulk-release behavior
-    /// of acquire_many_owned poison permits on scale-up-after-scale-down).
+    // **Validates: Requirements 3.1, 3.2, 3.4**
+    //
+    // Property 1: Resize reaches target capacity
+    //
+    // For any valid ConcurrencyGate with initial max permits `initial_max`
+    // and any valid target `target` (both in [1, 256]), after `resize(target)`
+    // completes, the effective max permits SHALL equal `target`.
+    // Since no queries are active in this test, available permits SHALL be
+    // at least `target` (may exceed target due to the bulk-release behavior
+    // of acquire_many_owned poison permits on scale-up-after-scale-down).
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
@@ -654,13 +654,13 @@ mod tests {
         }
     }
 
-    /// **Validates: Requirements 5.2, 5.6**
-    ///
-    /// Property 3: Last-writer-wins convergence
-    ///
-    /// For any random sequence of resize targets [T1, T2, ..., Tn] (length 2..20,
-    /// values in [1, 128]) applied sequentially to a gate, after all resizes
-    /// complete, the gate's effective max_permits SHALL equal Tn (the last value).
+    // **Validates: Requirements 5.2, 5.6**
+    //
+    // Property 3: Last-writer-wins convergence
+    //
+    // For any random sequence of resize targets [T1, T2, ..., Tn] (length 2..20,
+    // values in [1, 128]) applied sequentially to a gate, after all resizes
+    // complete, the gate's effective max_permits SHALL equal Tn (the last value).
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
@@ -691,19 +691,19 @@ mod tests {
         }
     }
 
-    /// **Validates: Requirements 5.4**
-    ///
-    /// Property 5: Concurrent acquire/resize safety
-    ///
-    /// For any interleaving of acquire() calls from query tasks and concurrent
-    /// resize() calls, no thread SHALL panic, deadlock, or receive an invalid
-    /// permit. All acquired permits SHALL be backed by the single shared
-    /// semaphore.
-    ///
-    /// This test generates random gate sizes, numbers of concurrent acquires,
-    /// and a sequence of resize targets (1..5), then spawns multiple tokio tasks
-    /// that acquire permits concurrently with multiple resize operations.
-    /// A timeout detects deadlocks.
+    // **Validates: Requirements 5.4**
+    //
+    // Property 5: Concurrent acquire/resize safety
+    //
+    // For any interleaving of acquire() calls from query tasks and concurrent
+    // resize() calls, no thread SHALL panic, deadlock, or receive an invalid
+    // permit. All acquired permits SHALL be backed by the single shared
+    // semaphore.
+    //
+    // This test generates random gate sizes, numbers of concurrent acquires,
+    // and a sequence of resize targets (1..5), then spawns multiple tokio tasks
+    // that acquire permits concurrently with multiple resize operations.
+    // A timeout detects deadlocks.
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
@@ -816,19 +816,19 @@ mod tests {
         assert_eq!(gate.pending_acquire_batches(), 0);
     }
 
-    /// **Validates: Requirements 2.5**
-    ///
-    /// Property 7: Permit computation correctness
-    ///
-    /// For any valid cpu_threads (in [1, 128]) and multiplier (in [0.1, 10.0]),
-    /// the computed newMaxPermits SHALL equal max(1, floor(cpu_threads × multiplier)),
-    /// ensuring the result is always at least 1.
-    ///
-    /// This mirrors the Java-side computation:
-    ///   Math.max(1, (int)(cpuThreads * multiplier))
-    ///
-    /// We generate multiplier as an integer in [1, 100] divided by 10.0 to get
-    /// values in [0.1, 10.0] without floating-point strategy complexity.
+    // **Validates: Requirements 2.5**
+    //
+    // Property 7: Permit computation correctness
+    //
+    // For any valid cpu_threads (in [1, 128]) and multiplier (in [0.1, 10.0]),
+    // the computed newMaxPermits SHALL equal max(1, floor(cpu_threads × multiplier)),
+    // ensuring the result is always at least 1.
+    //
+    // This mirrors the Java-side computation:
+    //   Math.max(1, (int)(cpuThreads * multiplier))
+    //
+    // We generate multiplier as an integer in [1, 100] divided by 10.0 to get
+    // values in [0.1, 10.0] without floating-point strategy complexity.
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -7,6 +7,13 @@
  */
 
 //! FFM bridge for DataFusion.
+//!
+//! Every public function here is an `extern "C"` FFM entry point invoked from
+//! Java via raw `i64`/pointer handles. Documenting per-function `# Safety`
+//! preconditions would be redundant across ~57 identical FFI boundaries, so the
+//! `missing_safety_doc` lint is allowed at the module level; the general FFI
+//! contract (valid, non-freed handles owned by the Java side) applies uniformly.
+#![allow(clippy::missing_safety_doc)]
 
 use std::slice;
 use std::str;
@@ -522,7 +529,7 @@ pub unsafe extern "C" fn df_stream_get_metrics(
 #[no_mangle]
 pub unsafe extern "C" fn df_free_metrics_buf(ptr: *mut u8, len: i64) {
     if !ptr.is_null() && len > 0 {
-        let _ = Box::from_raw(std::slice::from_raw_parts_mut(ptr, len as usize));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len as usize));
     }
 }
 
@@ -1437,7 +1444,7 @@ pub unsafe extern "C" fn df_stats(runtime_ptr: i64, out_ptr: *mut u8, out_cap: i
             .custom_cache_manager
             .as_ref()
             .map(pack_cache_stats)
-            .unwrap_or_else(CacheStatsRepr::default)
+            .unwrap_or_default()
     } else {
         CacheStatsRepr::default()
     };

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -89,6 +89,8 @@ use crate::parquet_page_cache::{
 // TODO: remove once api.rs migrates to instruction-based path directly.
 // Kept as thin wrapper to make existing tests exercise execute_indexed_with_context
 // with minimal changes.
+// Real API surface; argument count mirrors the query pipeline inputs.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_indexed_query(
     substrait_bytes: Vec<u8>,
     table_name: String,
@@ -285,6 +287,8 @@ fn collect_leaf_exprs(extraction: Option<&ExtractionResult>) -> Vec<Arc<dyn Phys
     exprs
 }
 
+// Retained for predicate column-index analysis; not currently wired into the executor path.
+#[allow(dead_code)]
 fn collect_predicate_column_indices(extraction: Option<&ExtractionResult>) -> Vec<usize> {
     let Some(e) = extraction else { return vec![] };
     let mut exprs = Vec::new();
@@ -356,6 +360,8 @@ fn collect_plan_column_names(plan: &datafusion::logical_expr::LogicalPlan) -> Ve
 
 /// Build the `prune_tree_config` tuple from a BoolNode tree and schema.
 /// Builds per-leaf PruningPredicates from pre-collected leaf exprs.
+// Return tuple mirrors the prune_tree_config shape consumed downstream; not worth a type alias.
+#[allow(clippy::type_complexity)]
 fn build_prune_tree_config(
     tree: &Arc<BoolNode>,
     schema: &SchemaRef,
@@ -459,6 +465,8 @@ impl TableProvider for PlaceholderProvider {
     }
 }
 
+// Execution entry points below intentionally follow this test module.
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -812,6 +820,12 @@ mod tests {
 /// TODO: extract shared logic with `execute_indexed_query` to avoid duplication.
 /// For now this delegates to the existing function by reconstructing the needed args
 /// from the handle.
+///
+/// # Safety
+/// `session_ctx_ptr` must be a valid, non-null pointer to a `SessionContextHandle`
+/// produced by the session-context creation path and not yet freed. Ownership is
+/// taken here (the box is reconstructed and dropped), so the pointer must not be
+/// used again after this call.
 pub async unsafe fn execute_indexed_with_context(
     session_ctx_ptr: i64,
     substrait_bytes: Vec<u8>,
@@ -900,7 +914,7 @@ async unsafe fn execute_indexed_with_context_inner(
     });
 
     let query_config = Arc::new(handle.query_config);
-    let num_partitions = query_config.target_partitions.max(1);
+    let _num_partitions = query_config.target_partitions.max(1);
     let aggregate_mode = handle.aggregate_mode;
     let ctx = handle.ctx;
     let table_name = handle.table_name;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bloom_pruner.rs
@@ -119,10 +119,11 @@ pub async fn bloom_prune_rg(
     rg_idx: usize,
     predicate: &PruningPredicate,
 ) -> bool {
-    match bloom_prune_rg_inner(store, path, metadata, arrow_schema, rg_idx, predicate).await {
-        Ok(should_prune) => should_prune,
-        Err(_) => false, // conservative: don't prune on error
-    }
+    // On any error (missing bloom filter, I/O, parse) default to `false`:
+    // conservative, meaning do not prune the row group.
+    bloom_prune_rg_inner(store, path, metadata, arrow_schema, rg_idx, predicate)
+        .await
+        .unwrap_or_default()
 }
 
 async fn bloom_prune_rg_inner(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter_probe.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/dynamic_filter_probe.rs
@@ -27,7 +27,6 @@ use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::Result;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::{col, DynamicFilterPhysicalExpr};
-use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalSortExpr};
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -157,6 +157,9 @@ impl TreeEvaluator for BitmapTreeEvaluator {
 //     because Predicate supersets shrink at refinement (OR still needs
 //     the real Collector bitmaps for correct results).
 
+// Real recursive evaluation API: each parameter carries distinct evaluation
+// context that cannot be reasonably bundled without obscuring the traversal.
+#[allow(clippy::too_many_arguments)]
 fn prefetch_node(
     node: &ResolvedNode,
     ctx: &RgEvalContext,
@@ -568,7 +571,7 @@ fn intersect_range_lists(a: &[(i32, i32)], b: &[(i32, i32)]) -> Vec<(i32, i32)> 
 ///   workload-dependent (Lucene posting iteration is fast for narrow
 ///   queries, slower for wide ones) so "10" is a conservative default.
 ///   Tune (or make config-driven) if profiling shows it matters.
-
+///
 /// Internal scale factor for cost computation. All costs are multiplied
 /// by this so integer division preserves meaningful selectivity differences.
 /// A predicate keeping 1/8 pages costs `1000 * 1/8 = 125` vs one keeping
@@ -635,7 +638,7 @@ pub(crate) fn subtree_cost(
                                 }
                                 row_offset = seg_end;
                             }
-                            return (base * kept_pages + total - 1) / total;
+                            return (base * kept_pages).div_ceil(total);
                         }
                     }
                 }
@@ -1057,6 +1060,7 @@ mod tests {
         ArrowReaderMetadata, ArrowReaderOptions, RowSelection, RowSelector,
     };
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
     use std::collections::{HashMap, HashSet};
 
@@ -1105,7 +1109,7 @@ mod tests {
         writer.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         PagePruner::new(
@@ -1343,23 +1347,23 @@ mod tests {
 
     // ── Phase 2 short-circuit ─────────────────────────────────────────
 
-    /// Evaluator that counts how many times its `leaf_bitmap` was called —
-    /// used to observe Phase 2 short-circuit by wrapping predicate leaves as
-    /// collectors whose bitmaps are the "predicate mask".
-    ///
-    /// We can't directly inspect Phase 2 calls since they go through
-    /// `on_batch_node`, but we can observe them by making Phase 2 evaluation
-    /// visible via side effect on a counting LeafBitmapSource.
-    ///
-    /// For Phase 2 specifically, `ResolvedNode::Collector` uses
-    /// `state.per_leaf` lookup (cached Phase 1 bitmaps), not the
-    /// LeafBitmapSource. So short-circuit observation has to be at the
-    /// `on_batch_node` level — we use a custom node tree and assert on the
-    /// resulting mask shape with deliberately-wrong siblings.
-    ///
-    /// The strategy: construct AND(all_false_child, poison_child) where
-    /// `poison_child` would `panic!` if evaluated. If the test passes,
-    /// short-circuit prevented evaluation of the poison child.
+    // Evaluator that counts how many times its `leaf_bitmap` was called —
+    // used to observe Phase 2 short-circuit by wrapping predicate leaves as
+    // collectors whose bitmaps are the "predicate mask".
+    //
+    // We can't directly inspect Phase 2 calls since they go through
+    // `on_batch_node`, but we can observe them by making Phase 2 evaluation
+    // visible via side effect on a counting LeafBitmapSource.
+    //
+    // For Phase 2 specifically, `ResolvedNode::Collector` uses
+    // `state.per_leaf` lookup (cached Phase 1 bitmaps), not the
+    // LeafBitmapSource. So short-circuit observation has to be at the
+    // `on_batch_node` level — we use a custom node tree and assert on the
+    // resulting mask shape with deliberately-wrong siblings.
+    //
+    // The strategy: construct AND(all_false_child, poison_child) where
+    // `poison_child` would `panic!` if evaluated. If the test passes,
+    // short-circuit prevented evaluation of the poison child.
 
     /// Build a ResolvedNode::Collector whose cached Phase 1 bitmap is `bm`.
     fn cached_collector(bm: RoaringBitmap) -> (ResolvedNode, (usize, RoaringBitmap)) {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -265,6 +265,9 @@ pub trait TreeEvaluator: Send + Sync {
     /// map = no page-level predicate pruning; each Predicate leaf falls
     /// back to "every row is a candidate" (safe, identity for the
     /// candidate stage).
+    // Real evaluation API: each parameter carries distinct evaluation context
+    // (tree, row-group context, leaf source, pruning state, metrics).
+    #[allow(clippy::too_many_arguments)]
     fn prefetch(
         &self,
         tree: &ResolvedNode,
@@ -285,6 +288,9 @@ pub trait TreeEvaluator: Send + Sync {
     /// position (identity under full-scan; non-trivial under block-granular
     /// RowSelection). `batch_offset` is the delivered-row index of the
     /// first row in this batch.
+    // Real evaluation API: batch, cached candidate state, and row-position
+    // translation are all distinct inputs to per-batch refinement.
+    #[allow(clippy::too_many_arguments)]
     fn on_batch(
         &self,
         tree: &ResolvedNode,
@@ -460,7 +466,7 @@ impl RowGroupBitsetSource for TreeBitsetSource {
             let mut rg_candidates = RoaringBitmap::new();
             let mut run_start: Option<u32> = None;
             let mut run_end: u32 = 0; // inclusive
-            let mut flush = |bm: &mut RoaringBitmap, start: u32, end_inclusive: u32| {
+            let flush = |bm: &mut RoaringBitmap, start: u32, end_inclusive: u32| {
                 // Range API is half-open; end_inclusive+1 handles the
                 // edge case at u32::MAX via saturating add (roaring
                 // clamps at u32::MAX internally).
@@ -731,6 +737,7 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
 
     fn empty_pruner() -> Arc<PagePruner> {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
@@ -745,7 +752,7 @@ mod tests {
         writer.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         Arc::new(PagePruner::new(

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/predicate_evaluator.rs
@@ -20,7 +20,6 @@ use std::time::Instant;
 use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
-use roaring::RoaringBitmap;
 
 use super::eval_helpers::{
     compute_page_ranges, evaluate_residual, universe_bitmap_from_page_ranges,
@@ -134,6 +133,7 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use std::sync::Arc;
     use tempfile::NamedTempFile;
 
@@ -149,7 +149,7 @@ mod tests {
         writer.write(&batch).unwrap();
         writer.close().unwrap();
         let file = tmp.reopen().unwrap();
-        let options = ArrowReaderOptions::new().with_page_index(true);
+        let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional);
         let meta = ArrowReaderMetadata::load(&file, options).unwrap();
         Arc::new(PagePruner::new(
             meta.schema(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -35,7 +35,7 @@ use crate::indexed_table::ffm_callbacks::{create_provider, FfmSegmentCollector, 
 use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner, StatsPruneTree};
 use crate::indexed_table::row_selection::{
-    bitmap_to_packed_bits, packed_bits_to_boolean_array, row_selection_to_bitmap, PositionMap,
+    bitmap_to_packed_bits, packed_bits_to_boolean_array, PositionMap,
 };
 use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
@@ -111,6 +111,9 @@ impl DelegatedBackendCollectorFactory for FfmDelegatedBackendCollectorFactory {
 /// views via `BooleanBuffer::new(buf.clone(), bit_offset, bit_len)`.
 /// Length of the underlying buffer covers `mask_len` bits (= rg_num_rows).
 struct SingleCollectorState {
+    // Retained candidate bitmap: only read by unit tests today, but kept as
+    // part of the prefetched state for debugging/inspection of the collector.
+    #[allow(dead_code)]
     candidates: RoaringBitmap,
     mask_buffer: datafusion::arrow::buffer::Buffer,
     mask_len: usize,
@@ -200,6 +203,9 @@ pub struct BloomConfig {
 }
 
 impl SingleCollectorEvaluator {
+    // Real constructor wiring together the collector, pruning, metrics, and
+    // delegation machinery — each argument is a distinct collaborator.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         collector: Option<Arc<dyn RowGroupDocsCollector>>,
         page_pruner: Arc<PagePruner>,
@@ -252,7 +258,7 @@ fn should_consult_lucene(
     threshold: f64,
 ) -> bool {
     let surviving_rows = match page_ranges {
-        None => rg.num_rows as i64,
+        None => rg.num_rows,
         Some(ranges) => ranges.iter().map(|(lo, hi)| (hi - lo) as i64).sum::<i64>(),
     };
     if rg.num_rows == 0 {
@@ -658,6 +664,7 @@ mod tests {
     use datafusion::parquet::arrow::arrow_reader::ArrowReaderMetadata;
     use datafusion::parquet::arrow::arrow_reader::ArrowReaderOptions;
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use std::fmt;
     use std::sync::Arc;
     use tempfile::NamedTempFile;
@@ -676,7 +683,7 @@ mod tests {
             max_doc: i32,
         ) -> Result<Vec<u64>, String> {
             let span = (max_doc - min_doc) as usize;
-            let mut bitset = vec![0u64; (span + 63) / 64];
+            let mut bitset = vec![0u64; span.div_ceil(64)];
             for &doc in &self.docs {
                 if doc >= min_doc && doc < max_doc {
                     let idx = (doc - min_doc) as usize;
@@ -706,7 +713,7 @@ mod tests {
             writer.close().unwrap();
         }
         let file = tmp.reopen().unwrap();
-        let options = ArrowReaderOptions::new().with_page_index(true);
+        let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional);
         let meta = ArrowReaderMetadata::load(&file, options).unwrap();
         let pruner = PagePruner::new(
             meta.schema(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/ffm_callbacks.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/ffm_callbacks.rs
@@ -52,6 +52,9 @@ static RELEASE_COLLECTOR: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 /// Not annotated `#[ffm_safe]` because that macro is specific to the
 /// `-> i64` error-pointer convention. We use a manual `catch_unwind`
 /// instead, though the body (atomic stores) can't realistically panic.
+// FFI entry point invoked by Java; safety contract is the FFM ABI, not a
+// Rust-callable API.
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn df_register_filter_tree_callbacks(
     create_provider: CreateProviderFn,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/page_pruner.rs
@@ -531,7 +531,10 @@ fn to_row_selection(keep: Vec<bool>, row_counts: &[usize]) -> RowSelection {
 fn eval_leaf(
     pruning_predicate: &PruningPredicate,
     metadata: &ParquetMetaData,
-    schema: &SchemaRef,
+    // Stats are resolved against `seg_arrow_schema` (the segment's own footer schema),
+    // not the table schema — see the comment below. Kept in the signature because the
+    // recursive `build_from_bool_node` threads it uniformly to all leaf handlers.
+    _schema: &SchemaRef,
     rg_indices: &[usize],
     seg_arrow_schema: &SchemaRef,
 ) -> Vec<bool> {
@@ -798,6 +801,7 @@ mod tests {
     use datafusion::logical_expr::Operator;
     use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
     use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
     use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
     use std::sync::Arc;
     use tempfile::NamedTempFile;
@@ -823,7 +827,7 @@ mod tests {
         .unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -834,7 +838,7 @@ mod tests {
         w.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let arc_meta = meta.metadata().clone();
@@ -1155,7 +1159,7 @@ mod tests {
         .unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -1168,7 +1172,7 @@ mod tests {
         w.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         assert_eq!(meta.metadata().num_row_groups(), 2);
@@ -1217,7 +1221,7 @@ mod tests {
         .unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             // Extreme byte budget forces a page flush after nearly
             // every row for `tag`. Dictionary encoding would collapse
             // the strings to small indices, defeating the budget, so
@@ -1234,7 +1238,7 @@ mod tests {
         w.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let arc_meta = meta.metadata().clone();
@@ -1303,7 +1307,7 @@ mod tests {
             RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vals))]).unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -1314,7 +1318,7 @@ mod tests {
         w.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let pruner = PagePruner::new(&schema, meta.metadata().clone(), schema.clone());
@@ -1370,7 +1374,7 @@ mod tests {
         .unwrap();
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -1381,7 +1385,7 @@ mod tests {
         w.close().unwrap();
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let pruner = PagePruner::new(
@@ -1428,7 +1432,7 @@ mod tests {
         // change writer props between flushes.
         let tmp = NamedTempFile::new().unwrap();
         let props_rg0 = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)
@@ -1467,7 +1471,7 @@ mod tests {
 
         let meta = ArrowReaderMetadata::load(
             &tmp.reopen().unwrap(),
-            ArrowReaderOptions::new().with_page_index(true),
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         assert_eq!(meta.metadata().num_row_groups(), 2);
@@ -1525,7 +1529,7 @@ mod tests {
         )]));
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(10)
+            .set_max_row_group_row_count(Some(10))
             .set_statistics_enabled(EnabledStatistics::Chunk)
             .build();
         let mut w =
@@ -1725,7 +1729,7 @@ mod tests {
         )]));
         let tmp = NamedTempFile::new().unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(10)
+            .set_max_row_group_row_count(Some(10))
             .set_statistics_enabled(EnabledStatistics::Chunk)
             .build();
         let mut w =
@@ -1788,13 +1792,13 @@ mod tests {
 
         // Absolute RG 3 should map to position 1 → can_match = true
         let pos = rg_index_to_pos.get(&3).unwrap();
-        assert_eq!(spt.rg_can_match[*pos], true);
+        assert!(spt.rg_can_match[*pos]);
 
         // Absolute RG 2 should map to position 0 → can_match = false
         let pos = rg_index_to_pos.get(&2).unwrap();
-        assert_eq!(spt.rg_can_match[*pos], false);
+        assert!(!spt.rg_can_match[*pos]);
 
         // Absolute RG 0 (not in chunk) should have no entry
-        assert!(rg_index_to_pos.get(&0).is_none());
+        assert!(!rg_index_to_pos.contains_key(&0));
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -60,9 +60,9 @@ use prost::bytes::Bytes;
 /// Issues a `head()` to learn the file's size + last-modified. Callers that
 /// already hold an authoritative [`ObjectMeta`] (e.g. from the listing snapshot
 /// passed into a `ParquetFileReaderFactory`) should call
-/// [`load_parquet_metadata_with_meta`] instead — the `head()` is a `File::open`
-/// + `fstat` syscall per call on local stores, which adds up under repeated
-/// per-file reader creation.
+/// [`load_parquet_metadata_with_meta`] instead — the `head()` is a
+/// `File::open` + `fstat` syscall per call on local stores, which adds up
+/// under repeated per-file reader creation.
 pub async fn load_parquet_metadata(
     store: Arc<dyn ObjectStore>,
     location: &object_store::path::Path,
@@ -226,6 +226,13 @@ fn create_stream_with_access_plan(
     access_plan: ParquetAccessPlan,
     push_predicate: bool,
 ) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
+    // NOTE: must stay on the deprecated `with_extensions` (not `with_extension`). DataFusion's
+    // Parquet opener retrieves the ParquetAccessPlan via the legacy `insert_dyn` keying that
+    // `with_extensions` uses; `with_extension` keys by concrete type instead, so the opener
+    // silently fails to find the access plan → row selection/predicates are not applied and the
+    // scan returns wrong rows (verified: swapping to `with_extension` breaks 102 boolean_algebra
+    // e2e tests). TODO: migrate once we key the lookup to the concrete extension type.
+    #[allow(deprecated)]
     let partitioned_file = PartitionedFile::new(config.file_path.clone(), config.file_size)
         .with_extensions(Arc::new(access_plan));
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/partitioning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/partitioning.rs
@@ -91,10 +91,10 @@ pub fn compute_assignments(
 
     for (i, rg) in all_rgs.iter().enumerate() {
         // Flush in-progress chunk if segment changed
-        if chunk_seg.is_some() && chunk_seg != Some(rg.segment_idx) {
-            if !chunk_rg_indices.is_empty() {
+        if let Some(seg) = chunk_seg {
+            if seg != rg.segment_idx && !chunk_rg_indices.is_empty() {
                 current_chunks.push(SegmentChunk {
-                    segment_idx: chunk_seg.unwrap(),
+                    segment_idx: seg,
                     doc_min: chunk_doc_min,
                     doc_max: chunk_doc_max,
                     row_group_indices: chunk_rg_indices.clone(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -33,9 +33,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use datafusion::arrow::array::{Array, BooleanArray, UInt64Array};
+use datafusion::arrow::array::{Array, BooleanArray};
 use datafusion::arrow::compute::filter_record_batch;
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::Result;
 use datafusion::execution::SendableRecordBatchStream;
@@ -571,6 +571,9 @@ struct IndexedStream {
     /// Cumulative row offset for this segment within the shard.
     global_base: u64,
     /// When true, the `___row_id` column is computed from position.
+    /// Retained on the stream for provenance/debugging; row-id emission is
+    /// currently driven via `row_id_output_index`.
+    #[allow(dead_code)]
     emit_row_ids: bool,
     /// Index in the output schema where computed `___row_id` is inserted.
     row_id_output_index: Option<usize>,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -168,6 +168,15 @@ fn build_projected_lex_ordering(
     LexOrdering::new(exprs)
 }
 
+/// Query-level pruning inputs for building a `StatsPruneTree` per segment:
+/// the `BoolNode` predicate tree, the prebuilt `PruningPredicate`s keyed by
+/// `Arc` pointer identity, and the schema they were built against.
+pub type PruneTreeConfig = (
+    Arc<BoolNode>,
+    Arc<std::collections::HashMap<usize, Arc<PruningPredicate>>>,
+    SchemaRef,
+);
+
 /// Configuration used to build an `IndexedTableProvider`.
 pub struct IndexedTableConfig {
     pub schema: SchemaRef,
@@ -203,11 +212,7 @@ pub struct IndexedTableConfig {
     pub emit_row_ids: bool,
     /// Query-level data for building StatsPruneTree per segment.
     /// (BoolNode tree, prebuilt PruningPredicates keyed by Arc ptr, schema)
-    pub prune_tree_config: Option<(
-        Arc<BoolNode>,
-        Arc<std::collections::HashMap<usize, Arc<PruningPredicate>>>,
-        SchemaRef,
-    )>,
+    pub prune_tree_config: Option<PruneTreeConfig>,
     /// `index.sort.field` — column names that the parquet writer used to sort
     /// rows on disk. Empty when the index has no `index.sort.field`.
     pub sort_fields: Vec<String>,
@@ -389,23 +394,24 @@ impl TableProvider for IndexedTableProvider {
             None
         };
 
-        let (assignments, eq_properties, advertised_ordering) = if chain_ok
-            && lex_ordering.is_some()
-        {
-            let assignments = compute_assignments_one_per_segment(&self.config.segments, &layouts);
-            let lex = lex_ordering.unwrap();
-            let eq = EquivalenceProperties::new_with_orderings(
-                projected_schema.clone(),
-                vec![lex.clone()],
-            );
-            (assignments, eq, Some(lex))
-        } else {
-            let assignments = compute_assignments(&layouts, target_partitions);
-            (
-                assignments,
-                EquivalenceProperties::new(projected_schema.clone()),
-                None,
-            )
+        let (assignments, eq_properties, advertised_ordering) = match lex_ordering {
+            Some(lex) if chain_ok => {
+                let assignments =
+                    compute_assignments_one_per_segment(&self.config.segments, &layouts);
+                let eq = EquivalenceProperties::new_with_orderings(
+                    projected_schema.clone(),
+                    vec![lex.clone()],
+                );
+                (assignments, eq, Some(lex))
+            }
+            _ => {
+                let assignments = compute_assignments(&layouts, target_partitions);
+                (
+                    assignments,
+                    EquivalenceProperties::new(projected_schema.clone()),
+                    None,
+                )
+            }
         };
 
         let properties = Arc::new(PlanProperties::new(
@@ -838,7 +844,6 @@ impl QueryShardExec {
 mod tests {
     use super::*;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::logical_expr::{col, lit};
     use datafusion::prelude::SessionContext;
 
     fn empty_config() -> IndexedTableConfig {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/constant_predicate.rs
@@ -20,6 +20,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::Operator;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use datafusion::physical_expr::expressions::{BinaryExpr, Literal};
 use datafusion::physical_expr::PhysicalExpr;
 use futures::StreamExt;
@@ -49,8 +50,11 @@ async fn run_constant_residual(residual: Arc<dyn PhysicalExpr>) -> usize {
     let size = std::fs::metadata(&path).unwrap().len();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -24,13 +24,14 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::StreamExt;
 use tempfile::NamedTempFile;
 
 use super::super::eval::RowGroupBitsetSource;
 use super::super::index::RowGroupDocsCollector;
 use super::super::page_pruner::PagePruner;
-use super::super::stream::{FilterStrategy, RowGroupInfo};
+use super::super::stream::RowGroupInfo;
 use super::super::table_provider::{IndexedTableConfig, IndexedTableProvider, SegmentFileInfo};
 
 /// 16 rows, `price` = 15..0 **descending** in file order, 4 rows per row group →
@@ -63,7 +64,7 @@ fn write_fixture() -> (NamedTempFile, SchemaRef) {
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(RG_ROWS)
+        .set_max_row_group_row_count(Some(RG_ROWS))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema.clone(), Some(props)).unwrap();
@@ -96,8 +97,11 @@ async fn run_indexed(sql: &str) -> (Vec<i32>, Arc<dyn datafusion::physical_plan:
     let path = tmp.path().to_path_buf();
     let size = std::fs::metadata(&path).unwrap().len();
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_meta = meta.metadata().clone();
 
     let mut rgs = Vec::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/config.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/config.rs
@@ -125,6 +125,8 @@ pub(in crate::indexed_table::tests_e2e) struct FixtureConfig {
     /// predicate-generation and the pruner, but do NOT exist in the
     /// parquet files. Simulates schema drift / schema evolution. Empty
     /// in most presets.
+    // Read by planned schema-drift fuzz presets; currently only written.
+    #[allow(dead_code)]
     pub phantom_columns: Vec<(String, ColumnKind)>,
 
     /// Probability (0.0..=1.0) that a generated binary-op predicate
@@ -132,6 +134,8 @@ pub(in crate::indexed_table::tests_e2e) struct FixtureConfig {
     /// different columns, rather than a single-column predicate.
     /// Exercises the grid multi-column-OR pruning path that
     /// `PruningPredicate::split_conjunction` discards in DataFusion.
+    // Read by planned multi-column-OR fuzz presets; currently only written.
+    #[allow(dead_code)]
     pub multi_column_or_pct: f64,
 
     /// Override `min_skip_run_default` in the query config. When `Some`,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/corpus.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/corpus.rs
@@ -387,7 +387,7 @@ fn write_parquet(
 ) -> NamedTempFile {
     let tmp = NamedTempFile::new().expect("tempfile");
     let mut builder = WriterProperties::builder()
-        .set_max_row_group_size(rows_per_row_group)
+        .set_max_row_group_row_count(Some(rows_per_row_group))
         .set_data_page_row_count_limit(rows_per_page)
         .set_statistics_enabled(EnabledStatistics::Page)
         // Force different encodings per column type to produce different
@@ -432,6 +432,7 @@ fn random_alphanumeric(rng: &mut StdRng, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::parquet::file::metadata::PageIndexPolicy;
 
     #[test]
     fn corpus_is_deterministic() {
@@ -460,7 +461,7 @@ mod tests {
         let meta = datafusion::parquet::arrow::arrow_reader::ArrowReaderMetadata::load(
             &file,
             datafusion::parquet::arrow::arrow_reader::ArrowReaderOptions::new()
-                .with_page_index(true),
+                .with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         assert!(meta.metadata().num_row_groups() > 1);
@@ -482,7 +483,7 @@ mod tests {
         let meta = datafusion::parquet::arrow::arrow_reader::ArrowReaderMetadata::load(
             &file,
             datafusion::parquet::arrow::arrow_reader::ArrowReaderOptions::new()
-                .with_page_index(true),
+                .with_page_index_policy(PageIndexPolicy::Optional),
         )
         .unwrap();
         let oi = meta.metadata().offset_index().expect("offset index");

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -122,7 +122,6 @@ fn gen_binary_predicate_expr(
     rng: &mut StdRng,
     schema: &datafusion::arrow::datatypes::SchemaRef,
 ) -> Arc<dyn PhysicalExpr> {
-    use datafusion::arrow::datatypes::DataType;
     let col_idx = rng.gen_range(1..schema.fields().len());
     let field = schema.field(col_idx);
     let col_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), col_idx));

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use datafusion::arrow::array::{Array, Int32Array};
 use datafusion::execution::context::SessionContext;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::StreamExt;
 
 use super::corpus::Corpus;
@@ -78,9 +79,11 @@ pub(in crate::indexed_table::tests_e2e) fn load_segment(corpus: &Corpus) -> Load
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_out.is_none() {
             schema_out = Some(meta.schema().clone());
         }
@@ -121,6 +124,9 @@ pub(in crate::indexed_table::tests_e2e) fn load_segment(corpus: &Corpus) -> Load
 /// Execute one tree end-to-end: wire mock collectors, build the table
 /// provider, query it, return the set of `__doc_id` values that came
 /// back.
+// Re-exported test helper retained for fuzz harness callers; not all build
+// configurations exercise it.
+#[allow(dead_code)]
 pub(in crate::indexed_table::tests_e2e) async fn execute_tree(
     _corpus: &Corpus,
     loaded: &LoadedSegment,
@@ -690,6 +696,9 @@ fn bool_to_logical(node: &BoolNode) -> Option<datafusion::logical_expr::Expr> {
 /// at decode time. `pushdown_predicate` provides the residual predicate
 /// to hand parquet via `with_predicate` — mirrors what
 /// `execute_indexed_query` computes from the BoolNode for production.
+// Convenience wrapper over `run_with_factory_plan`; retained for harness
+// callers even when a given build configuration doesn't invoke it.
+#[allow(dead_code)]
 async fn run_with_factory(
     loaded: &LoadedSegment,
     factory: EvaluatorFactory,
@@ -707,6 +716,9 @@ async fn run_with_factory(
     .0
 }
 
+// Full plan-returning variant; retained for harness callers even when a
+// given build configuration doesn't invoke it.
+#[allow(dead_code)]
 async fn run_with_factory_plan(
     loaded: &LoadedSegment,
     factory: EvaluatorFactory,
@@ -1169,7 +1181,7 @@ mod tests {
         use rand::rngs::StdRng;
         use rand::seq::SliceRandom;
         use rand::SeedableRng;
-        let mut rng = StdRng::seed_from_u64(0x1beef_2222);
+        let mut rng = StdRng::seed_from_u64(0x0001_beef_2222);
         let mut candidates: Vec<i32> = (0..corpus.num_rows() as i32).collect();
         candidates.shuffle(&mut rng);
         candidates.truncate(corpus.num_rows() / 20);
@@ -1244,7 +1256,7 @@ mod tests {
         use rand::seq::SliceRandom;
         use rand::SeedableRng;
         let mut rng = StdRng::seed_from_u64(0xbeef_1111);
-        let mut mkset = |rng: &mut StdRng| -> Vec<i32> {
+        let mkset = |rng: &mut StdRng| -> Vec<i32> {
             let mut v: Vec<i32> = (0..corpus.num_rows() as i32).collect();
             v.shuffle(rng);
             v.truncate(corpus.num_rows() / 20);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -27,6 +27,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Operator;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::StreamExt;
 use tempfile::NamedTempFile;
 
@@ -132,7 +133,7 @@ fn write_fixture_parquet() -> NamedTempFile {
     // Use smallish row groups so there's > 1 and the streaming loop cycles.
     // Enable page index so PagePruner can prune predicates.
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(8)
+        .set_max_row_group_row_count(Some(8))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
@@ -207,8 +208,11 @@ async fn run_tree_and_plan(
 
     // Load parquet metadata for the SegmentFileInfo.
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -17,6 +17,7 @@
 //! - Per-segment doc ID locality (each segment has its own `[0, max_doc)`).
 
 use super::*;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 
 // ── Two-segment fixture ───────────────────────────────────────────────
 //
@@ -56,7 +57,7 @@ fn write_segment_rg(
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(max_rg_rows)
+        .set_max_row_group_row_count(Some(max_rg_rows))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
@@ -103,9 +104,11 @@ async fn run_two_segment_query(
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }
@@ -314,9 +317,11 @@ async fn run_two_segment_query_witness(
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }
@@ -536,9 +541,11 @@ async fn run_segments(specs: Vec<SegSpec>, num_partitions: usize) -> Vec<(i32, S
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }
@@ -761,7 +768,7 @@ async fn four_segments_mixed_rg_sizes() {
     // Deliberately uneven: seg0 has 2 RGs, seg1 has 4 RGs, seg2 has 1 RG,
     // seg3 has 8 RGs. Total ~60 rows across 15 RGs. Uneven fan-out
     // stresses compute_assignments.
-    let specs = vec![
+    let specs = [
         SegSpec {
             brand: "amazon",
             base_price: 0,
@@ -981,7 +988,7 @@ fn write_wide_segment(brand: &'static str, rows: usize, max_rg_rows: usize) -> N
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(max_rg_rows)
+        .set_max_row_group_row_count(Some(max_rg_rows))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
@@ -1038,9 +1045,11 @@ async fn run_wide_segments(
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }
@@ -1288,7 +1297,7 @@ async fn wide_multi_segment_not_and_three_column_predicates() {
     ]);
     let expected = wide_oracle(&specs, |i| {
         let i32_i = i as i32;
-        !(i32_i * 10 < 30) && i32_i % 7 > 2 && i % 3 != 2
+        (i32_i * 10 >= 30) && i32_i % 7 > 2 && i % 3 != 2
     });
     for np in [1usize, 3, 5] {
         let rows = run_wide_segments(clone_wide_specs(&specs), tree.clone(), np).await;
@@ -1386,9 +1395,11 @@ async fn run_wide_segments_with_stats_pruning(
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }
@@ -1645,7 +1656,7 @@ async fn stats_prune_multi_segment_multi_partition_with_not() {
         ]),
     ]);
     // NOT is conservative in stats (always true), so actual predicate filters.
-    let expected = wide_oracle(&specs, |i| !((i as i32) * 10 < 40));
+    let expected = wide_oracle(&specs, |i| (i as i32) * 10 >= 40);
     for np in [1usize, 3, 5] {
         let rows =
             run_wide_segments_with_stats_pruning(clone_wide_specs(&specs), tree.clone(), np).await;
@@ -1675,8 +1686,11 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
     let tmp = write_wide_segment(spec.brand, spec.rows, spec.max_rg_rows);
     let path = tmp.path().to_path_buf();
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_meta = meta.metadata().clone();
     let schema = meta.schema().clone();
     assert_eq!(parquet_meta.num_row_groups(), 4);
@@ -1846,7 +1860,7 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
         page_prune_metrics: None,
         collector_strategy: crate::indexed_table::eval::CollectorCallStrategy::TightenOuterBounds,
         stats_prune_tree: Some(Arc::new(spt)),
-        rg_index_to_pos: rg_index_to_pos,
+        rg_index_to_pos,
     };
 
     // RG2 at absolute index 2: should NOT be pruned (prices 80-110, all > 60).
@@ -1900,8 +1914,11 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
     let tmp = write_wide_segment(spec.brand, spec.rows, spec.max_rg_rows);
     let path = tmp.path().to_path_buf();
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_meta = meta.metadata().clone();
     let schema = meta.schema().clone();
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -13,6 +13,7 @@
 //! RGs" combinations that the random-distribution 10k fixture rarely hits.
 
 use super::*;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 
 // ══════════════════════════════════════════════════════════════════════
 // Null-density fixture — 4096 rows, 4 RGs, columns deliberately NULL at
@@ -82,7 +83,7 @@ fn build_null_fixture() -> NullFixture {
     let tmp = NamedTempFile::new().unwrap();
     let (file, path) = tmp.keep().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(1024)
+        .set_max_row_group_row_count(Some(1024))
         .set_data_page_row_count_limit(256)
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
@@ -310,8 +311,11 @@ async fn assert_engine_matches_reference_null(name: &str, tree: NT) {
 
     let size = std::fs::metadata(&f.path).unwrap().len();
     let file = std::fs::File::open(&f.path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -47,6 +47,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Operator;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use datafusion::physical_expr::expressions::{BinaryExpr, Column as PhysColumn, Literal};
 use datafusion::physical_expr::PhysicalExpr;
@@ -93,7 +94,7 @@ fn write_fixture() -> NamedTempFile {
         })
         .collect();
     let brands: Vec<&str> = (0..NUM_PAGES)
-        .flat_map(|p| std::iter::repeat(labels[p]).take(ROWS_PER_PAGE))
+        .flat_map(|p| std::iter::repeat_n(labels[p], ROWS_PER_PAGE))
         .collect();
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -105,7 +106,7 @@ fn write_fixture() -> NamedTempFile {
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = WriterProperties::builder()
-        .set_max_row_group_size(NUM_ROWS)
+        .set_max_row_group_row_count(Some(NUM_ROWS))
         .set_data_page_row_count_limit(ROWS_PER_PAGE)
         .set_write_batch_size(ROWS_PER_PAGE)
         .set_statistics_enabled(EnabledStatistics::Page)
@@ -194,8 +195,11 @@ fn load_segment(tmp: &NamedTempFile) -> (SegmentFileInfo, SchemaRef) {
     let path = tmp.path().to_path_buf();
     let size = std::fs::metadata(&path).unwrap().len();
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -757,7 +761,7 @@ async fn complex_deep_nesting_range_propagation_4_levels() {
     // Verify page 1 prices are all even-indexed (even doc IDs → even prices in page 1)
     let page1_prices: Vec<i32> = prices
         .iter()
-        .filter(|&&p| p >= 10_000 && p < 11_024)
+        .filter(|&&p| (10_000..11_024).contains(&p))
         .copied()
         .collect();
     assert_eq!(page1_prices.len(), 512);
@@ -766,7 +770,7 @@ async fn complex_deep_nesting_range_propagation_4_levels() {
     // Verify all of page 2 is present
     let page2_prices: Vec<i32> = prices
         .iter()
-        .filter(|&&p| p >= 20_000 && p < 21_024)
+        .filter(|&&p| (20_000..21_024).contains(&p))
         .copied()
         .collect();
     assert_eq!(page2_prices.len(), 1024);
@@ -866,15 +870,15 @@ async fn complex_5_wide_or_mixed_predicates_collectors() {
     // Count by page:
     let p1: Vec<_> = prices
         .iter()
-        .filter(|&&p| p >= 10_000 && p < 11_024)
+        .filter(|&&p| (10_000..11_024).contains(&p))
         .collect();
     let p2: Vec<_> = prices
         .iter()
-        .filter(|&&p| p >= 20_000 && p < 21_024)
+        .filter(|&&p| (20_000..21_024).contains(&p))
         .collect();
     let p3: Vec<_> = prices
         .iter()
-        .filter(|&&p| p >= 30_000 && p < 31_024)
+        .filter(|&&p| (30_000..31_024).contains(&p))
         .collect();
     let p0: Vec<_> = prices.iter().filter(|&&p| p < 1_024).collect();
 
@@ -967,7 +971,7 @@ async fn complex_cascading_and_with_not_at_depth() {
     assert_eq!(prices.len(), 512);
 
     // All prices should be in page 2 range
-    assert!(prices.iter().all(|&p| p >= 20_000 && p < 21_024));
+    assert!(prices.iter().all(|&p| (20_000..21_024).contains(&p)));
     // All should be even-indexed within page 2
     assert!(prices.iter().all(|&p| (p - 20_000) % 2 == 0));
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -21,6 +21,7 @@ use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroup
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Operator;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::StreamExt;
 use roaring::RoaringBitmap;
 
@@ -37,8 +38,11 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
     let size = std::fs::metadata(&path).unwrap().len();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -170,8 +174,11 @@ async fn fetch_phase(row_ids: &[i64], fetch_columns: &[&str]) -> Vec<RecordBatch
     let path = tmp.path().to_path_buf();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let file_schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
 
@@ -381,8 +388,11 @@ async fn test_qtf_full_loop_two_segments() {
     let path = tmp.path().to_path_buf();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let file_schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -13,6 +13,7 @@
 use datafusion::arrow::array::Int64Array;
 
 use super::*;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 
 // Why it is complex -->
 // Optimizer + ComputeRowId --> @gbh --> optimizer --> for parquet only right
@@ -26,8 +27,11 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
     let size = std::fs::metadata(&path).unwrap().len();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -203,8 +207,11 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
     let size = std::fs::metadata(&path).unwrap().len();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -489,8 +496,11 @@ async fn test_row_id_with_data_columns() {
     let size = std::fs::metadata(&path).unwrap().len();
 
     let file = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -708,7 +718,7 @@ fn write_row_id_fixture_parquet() -> NamedTempFile {
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(8)
+        .set_max_row_group_row_count(Some(8))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
@@ -731,8 +741,11 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
 
     // Load metadata for segment 1
     let file1 = std::fs::File::open(&path1).unwrap();
-    let meta1 =
-        ArrowReaderMetadata::load(&file1, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta1 = ArrowReaderMetadata::load(
+        &file1,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta1.schema().clone();
     let parquet_meta1 = meta1.metadata().clone();
     let mut rgs1 = Vec::new();
@@ -749,8 +762,11 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
 
     // Load metadata for segment 2
     let file2 = std::fs::File::open(&path2).unwrap();
-    let meta2 =
-        ArrowReaderMetadata::load(&file2, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta2 = ArrowReaderMetadata::load(
+        &file2,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_meta2 = meta2.metadata().clone();
     let mut rgs2 = Vec::new();
     let mut offset = 0i64;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_strategies.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_strategies.rs
@@ -46,7 +46,7 @@ mod tests {
         let file = std::fs::File::create(&path).unwrap();
 
         let props = WriterProperties::builder()
-            .set_max_row_group_size(rows_per_rg)
+            .set_max_row_group_row_count(Some(rows_per_rg))
             .build();
 
         let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
@@ -202,8 +202,8 @@ mod tests {
         // Verify contiguous from 0
         assert_eq!(sorted[0], 0);
         assert_eq!(*sorted.last().unwrap(), (total_rows - 1) as i64);
-        for i in 0..sorted.len() {
-            assert_eq!(sorted[i], i as i64, "Row IDs should be contiguous");
+        for (i, &row_id) in sorted.iter().enumerate() {
+            assert_eq!(row_id, i as i64, "Row IDs should be contiguous");
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/schema_drift.rs
@@ -12,6 +12,7 @@
 //! segment evaluates to UNKNOWN for that predicate and gets filtered out.
 
 use super::*;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 
 // ══════════════════════════════════════════════════════════════════════
 // Missing-column fixture — parquet written without a column that the
@@ -58,7 +59,7 @@ fn build_missing_col_fixture() -> MissingColFixture {
     let tmp = NamedTempFile::new().unwrap();
     let (file, path) = tmp.keep().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(512)
+        .set_max_row_group_row_count(Some(512))
         .set_data_page_row_count_limit(128)
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
@@ -74,8 +75,11 @@ async fn run_missing_col_tree(tree_bool: BoolNode) -> usize {
     let f = missing_col_fixture();
     let size = std::fs::metadata(&f.path).unwrap().len();
     let file = std::fs::File::open(&f.path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
@@ -287,8 +291,11 @@ fn page_pruner_prunes_existing_column_despite_missing_column() {
 
     let f = missing_col_fixture();
     let file = std::fs::File::open(&f.path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     // Schema handed to the pruner includes the missing column.
     let drift_schema = schema_with_missing();
     let pruner = PagePruner::new(&drift_schema, meta.metadata().clone(), drift_schema.clone());
@@ -384,7 +391,7 @@ async fn query_with_mismatched_schema(
     let tmp = NamedTempFile::new().unwrap();
     let (file, path) = tmp.keep().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(256)
+        .set_max_row_group_row_count(Some(256))
         .build();
     let mut w = ArrowWriter::try_new(file, file_schema, Some(props)).unwrap();
     w.write(batch).unwrap();
@@ -392,8 +399,11 @@ async fn query_with_mismatched_schema(
 
     let size = std::fs::metadata(&path).unwrap().len();
     let rfile = std::fs::File::open(&path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&rfile, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &rfile,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let parquet_meta = meta.metadata().clone();
     let mut rgs = Vec::new();
     let mut offset = 0i64;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -31,6 +31,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
 use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 use futures::StreamExt;
 use tempfile::NamedTempFile;
 
@@ -86,7 +87,7 @@ fn write_segment(spec: &SegSpec) -> NamedTempFile {
     .unwrap();
     let tmp = NamedTempFile::new().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(4)
+        .set_max_row_group_row_count(Some(4))
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut w = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
@@ -126,9 +127,11 @@ fn build_segments(tmps: &[NamedTempFile], specs: &[SegSpec]) -> (Vec<SegmentFile
         let path = tmp.path().to_path_buf();
         let size = std::fs::metadata(&path).unwrap().len();
         let file = std::fs::File::open(&path).unwrap();
-        let meta =
-            ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true))
-                .unwrap();
+        let meta = ArrowReaderMetadata::load(
+            &file,
+            ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+        )
+        .unwrap();
         if schema_opt.is_none() {
             schema_opt = Some(meta.schema().clone());
         }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/streaming_at_scale.rs
@@ -14,6 +14,7 @@
 //! short-circuit opportunities.
 
 use super::*;
+use datafusion::parquet::file::metadata::PageIndexPolicy;
 
 // ══════════════════════════════════════════════════════════════════════
 // Large-scale fixture (10_000 rows, multi-RG, multi-page, nullable qty,
@@ -103,7 +104,7 @@ fn build_large_fixture() -> LargeFixture {
     let tmp = NamedTempFile::new().unwrap();
     let (file, path) = tmp.keep().unwrap();
     let props = datafusion::parquet::file::properties::WriterProperties::builder()
-        .set_max_row_group_size(2048)
+        .set_max_row_group_row_count(Some(2048))
         .set_data_page_row_count_limit(512)
         .set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page)
         .build();
@@ -125,6 +126,9 @@ fn build_large_fixture() -> LargeFixture {
 
 /// Leaves specific to the large fixture. We reuse the engine machinery but
 /// add qty-nullable and negative-price cases.
+// The `L` prefix denotes the large-fixture leaf set and is applied
+// consistently across all variants by design.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy)]
 enum LLeaf {
     // Collectors (provider_id = u16, mapped in wire_large).
@@ -289,7 +293,7 @@ fn wire_large_rec(node: &BoolNode, out: &mut Vec<Arc<dyn RowGroupDocsCollector>>
         BoolNode::And(cs) | BoolNode::Or(cs) => cs.iter().for_each(|c| wire_large_rec(c, out)),
         BoolNode::Not(inner) => wire_large_rec(inner, out),
         BoolNode::Collector { annotation_id } => {
-            let tag = Some(*annotation_id as u8).expect("empty tag bytes");
+            let tag = *annotation_id as u8;
             out.push(large_collector_for(tag));
         }
         BoolNode::Predicate(_) => {}
@@ -313,8 +317,8 @@ fn large_collector_for(tag: u8) -> Arc<dyn RowGroupDocsCollector> {
     };
     let matching: Vec<i32> = (0..LARGE_N)
         .filter(|&i| {
-            want_brand.map_or(true, |b| f.brands[i] == b)
-                && want_status.map_or(true, |s| f.statuses[i] == s)
+            want_brand.is_none_or(|b| f.brands[i] == b)
+                && want_status.is_none_or(|s| f.statuses[i] == s)
         })
         .map(|i| i as i32)
         .collect();
@@ -382,8 +386,11 @@ async fn run_large(
     let f = large_fixture();
     let size = std::fs::metadata(&f.path).unwrap().len();
     let file = std::fs::File::open(&f.path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
 
@@ -849,8 +856,11 @@ async fn run_large_partitioned(
     let f = large_fixture();
     let size = std::fs::metadata(&f.path).unwrap().len();
     let file = std::fs::File::open(&f.path).unwrap();
-    let meta =
-        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new().with_page_index(true)).unwrap();
+    let meta = ArrowReaderMetadata::load(
+        &file,
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Optional),
+    )
+    .unwrap();
     let schema = meta.schema().clone();
     let parquet_meta = meta.metadata().clone();
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -650,7 +650,6 @@ mod tests {
     #[test]
     fn set_phantom_stores_reservation() {
         use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryConsumer};
-        use std::num::NonZeroUsize;
 
         let pool: Arc<dyn datafusion::execution::memory_pool::MemoryPool> =
             Arc::new(GreedyMemoryPool::new(10_000_000));
@@ -663,7 +662,7 @@ mod tests {
         assert_eq!(session.phantom_size(), 0);
 
         let consumer = MemoryConsumer::new("test_phantom").with_can_spill(true);
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
         reservation.try_grow(1000).unwrap();
         session.set_phantom(reservation);
 
@@ -685,7 +684,7 @@ mod tests {
         {
             let mut session = LocalSession::new(&env);
             let consumer = MemoryConsumer::new("test_phantom").with_can_spill(true);
-            let mut reservation = consumer.register(&pool);
+            let reservation = consumer.register(&pool);
             reservation.try_grow(5000).unwrap();
             session.set_phantom(reservation);
             assert_eq!(pool.reserved(), reserved_before + 5000);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory.rs
@@ -287,23 +287,23 @@ impl MemoryPool for DynamicLimitPool {
         let limit = dynamic_limit.load(Ordering::Acquire);
         let used = self.used.load(Ordering::Relaxed);
         // Only attempt override if the allocation is plausible (won't overflow).
-        if used.checked_add(additional).is_some() {
-            if crate::memory_guard::should_override(
+        if used.checked_add(additional).is_some()
+            && crate::memory_guard::should_override(
                 limit,
                 crate::memory_guard::OverrideContext::Execution,
-            ) {
-                // jemalloc confirms headroom — allow the grow
-                let _ = self
-                    .used
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |u| {
-                        u.checked_add(additional)
-                    });
-                if exempted {
-                    self.exempt_outstanding
-                        .fetch_add(additional, Ordering::Relaxed);
-                }
-                return Ok(());
+            )
+        {
+            // jemalloc confirms headroom — allow the grow
+            let _ = self
+                .used
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |u| {
+                    u.checked_add(additional)
+                });
+            if exempted {
+                self.exempt_outstanding
+                    .fetch_add(additional, Ordering::Relaxed);
             }
+            return Ok(());
         }
 
         // Both pool and jemalloc confirm pressure. Check if RSS is critical —
@@ -372,7 +372,7 @@ mod tests {
     fn test_try_grow_within_limit() {
         let (pool, _handle) = new_pool(1024);
         let consumer = MemoryConsumer::new("test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
         assert!(reservation.try_grow(512).is_ok());
         assert_eq!(pool.reserved(), 512);
     }
@@ -381,7 +381,7 @@ mod tests {
     fn test_try_grow_exceeds_limit() {
         let (pool, _handle) = new_pool(1024);
         let consumer = MemoryConsumer::new("test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
         assert!(reservation.try_grow(2048).is_err());
         assert_eq!(pool.reserved(), 0);
     }
@@ -390,7 +390,7 @@ mod tests {
     fn test_dynamic_limit_increase() {
         let (pool, handle) = new_pool(1024);
         let consumer = MemoryConsumer::new("test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // Fails at 1024 limit
         assert!(reservation.try_grow(2048).is_err());
@@ -407,7 +407,7 @@ mod tests {
     fn test_dynamic_limit_decrease_existing_reservations_kept() {
         let (pool, handle) = new_pool(4096);
         let consumer = MemoryConsumer::new("test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // Reserve 2048
         assert!(reservation.try_grow(2048).is_ok());
@@ -420,7 +420,7 @@ mod tests {
 
         // But new allocations fail
         let consumer2 = MemoryConsumer::new("test2");
-        let mut reservation2 = consumer2.register(&pool);
+        let reservation2 = consumer2.register(&pool);
         assert!(reservation2.try_grow(1).is_err());
     }
 
@@ -428,7 +428,7 @@ mod tests {
     fn test_try_grow_overflow_protection() {
         let (pool, _handle) = new_pool(usize::MAX);
         let consumer = MemoryConsumer::new("test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
         assert!(reservation.try_grow(1024).is_ok());
         // `additional == usize::MAX` would overflow `used + additional`.
         // checked_add inside fetch_update must reject it cleanly.
@@ -476,7 +476,7 @@ mod tests {
                 thread::spawn(move || {
                     barrier.wait();
                     let consumer = MemoryConsumer::new("race");
-                    let mut reservation = consumer.register(&pool);
+                    let reservation = consumer.register(&pool);
                     // Retry until either allocation succeeds OR the handle reports
                     // the new limit is visible. The previous fixed-iteration loop
                     // flaked on fast runners because the allocator could exhaust
@@ -515,7 +515,7 @@ mod tests {
         assert_eq!(handle.tripped_count(), 0);
 
         let consumer = MemoryConsumer::new("hash_agg");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // First grow succeeds
         assert!(reservation.try_grow(512).is_ok());
@@ -541,12 +541,12 @@ mod tests {
 
         // Consumer A takes 1500 bytes
         let consumer_a = MemoryConsumer::new("sort_buffer");
-        let mut res_a = consumer_a.register(&pool);
+        let res_a = consumer_a.register(&pool);
         assert!(res_a.try_grow(1500).is_ok());
 
         // Consumer B tries 1000 bytes — only 548 available → rejected
         let consumer_b = MemoryConsumer::new("hash_agg");
-        let mut res_b = consumer_b.register(&pool);
+        let res_b = consumer_b.register(&pool);
         assert!(res_b.try_grow(1000).is_err());
         assert_eq!(handle.tripped_count(), 1);
 
@@ -562,7 +562,7 @@ mod tests {
     fn test_tripped_count_zero_when_all_grows_succeed() {
         let (pool, handle) = new_pool(1_000_000);
         let consumer = MemoryConsumer::new("scan");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         for _ in 0..100 {
             assert!(reservation.try_grow(1000).is_ok());
@@ -589,7 +589,7 @@ mod tests {
         }
 
         let consumer = MemoryConsumer::new("hard_guard_test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // The hard guard fires before the CAS — even a tiny grow should be rejected
         let result = reservation.try_grow(1024);
@@ -612,7 +612,7 @@ mod tests {
         let (pool, handle) = new_pool(limit);
 
         let consumer = MemoryConsumer::new("large_pool_test");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // A small allocation should succeed — RSS is far below 95% of 1TB
         let result = reservation.try_grow(4096);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/memory_guard.rs
@@ -57,15 +57,14 @@ pub fn cached_resident_bytes() -> i64 {
     let base = EPOCH_BASE.get_or_init(Instant::now);
     let now_ms = base.elapsed().as_millis() as u64;
     let last = LAST_CHECK_MS.load(Ordering::Relaxed);
-    if now_ms.wrapping_sub(last) >= RESIDENT_CACHE_INTERVAL_MS {
-        if LAST_CHECK_MS
+    if now_ms.wrapping_sub(last) >= RESIDENT_CACHE_INTERVAL_MS
+        && LAST_CHECK_MS
             .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
-        {
-            let r = native_bridge_common::allocator::resident_bytes();
-            CACHED_RESIDENT.store(r, Ordering::Relaxed);
-            return r;
-        }
+    {
+        let r = native_bridge_common::allocator::resident_bytes();
+        CACHED_RESIDENT.store(r, Ordering::Relaxed);
+        return r;
     }
     CACHED_RESIDENT.load(Ordering::Relaxed)
 }
@@ -310,7 +309,7 @@ pub fn mark_spill_disabled() {
 /// Returns:
 /// * `Disabled`     when spill is off — no `statvfs` call, no clamp.
 /// * `Critical`     when spill is on but the spill volume is dangerously low
-///                  (< 64MB after the fraction, or `statvfs` failed). Caller clamps to 1.
+///   (< 64MB after the fraction, or `statvfs` failed). Caller clamps to 1.
 /// * `Available(n)` when spill is on and disk is healthy.
 ///
 /// Cost: one `statvfs` syscall (~1µs) only when spill is enabled. Called once per
@@ -359,7 +358,13 @@ pub fn available_disk_space(path: &str) -> Option<u64> {
         return None;
     }
     let stat = unsafe { stat.assume_init() };
-    Some(stat.f_bavail as u64 * stat.f_frsize as u64)
+    // clippy::unnecessary_cast — `statvfs` field widths are platform-dependent: `f_bavail`
+    // is u64 on Linux (cast is a no-op there, which is why clippy flags it) but u32/c_ulong
+    // on macOS/BSD, where the `as u64` is a real widening cast needed to avoid overflow in
+    // the multiply. Keep the cast for cross-platform correctness.
+    #[allow(clippy::unnecessary_cast)]
+    let avail = stat.f_bavail as u64 * stat.f_frsize as u64;
+    Some(avail)
 }
 
 #[cfg(not(unix))]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/brain.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/brain.rs
@@ -251,12 +251,12 @@ impl BrainLogParser {
             return;
         }
         let tokens_len = tokens.len() - 1;
-        for i in 0..tokens_len {
+        for (i, token) in tokens.iter().enumerate().take(tokens_len) {
             let key = group_token_set_key(tokens_len, group_candidate_str, i);
             self.group_token_set_map
                 .entry(key)
                 .or_default()
-                .insert(tokens[i].clone());
+                .insert(token.clone());
         }
     }
 
@@ -282,8 +282,7 @@ impl BrainLogParser {
 
         let token_capacity = tokens.len() - 1;
         let mut out = Vec::with_capacity(token_capacity);
-        for i in 0..token_capacity {
-            let token = &tokens[i];
+        for (i, token) in tokens.iter().enumerate().take(token_capacity) {
             let tok_key = positioned_token_key(i, token);
             let token_freq = *self
                 .token_freq_map
@@ -303,11 +302,9 @@ impl BrainLogParser {
                     out.push(super::VARIABLE_DENOTER.to_string());
                     continue;
                 }
-            } else if is_lower {
-                if group_set.len() >= self.variable_count_threshold {
-                    out.push(super::VARIABLE_DENOTER.to_string());
-                    continue;
-                }
+            } else if is_lower && group_set.len() >= self.variable_count_threshold {
+                out.push(super::VARIABLE_DENOTER.to_string());
+                continue;
             }
             out.push(token.clone());
         }
@@ -434,7 +431,7 @@ mod tests {
 
     #[test]
     fn word_combination_orders_by_same_freq_count_desc() {
-        let mut v = vec![
+        let mut v = [
             WordCombination::new(5, 1),
             WordCombination::new(2, 3),
             WordCombination::new(3, 3),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/eval.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/eval.rs
@@ -150,9 +150,11 @@ fn calculate_score(tokens: &[String], candidate: &[String]) -> f64 {
     }
     let mut score = 0u64;
     for (preprocessed_token, candidate_token) in tokens.iter().zip(candidate.iter()) {
-        if preprocessed_token == candidate_token {
-            score += 1;
-        } else if preprocessed_token.starts_with("<*") && candidate_token.starts_with("<token") {
+        // A position matches when the tokens are equal, or when a wildcard
+        // input (`<*…>`) lines up with a numbered candidate token (`<token…>`).
+        if preprocessed_token == candidate_token
+            || (preprocessed_token.starts_with("<*") && candidate_token.starts_with("<token"))
+        {
             score += 1;
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/utils.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/patterns/utils.rs
@@ -81,9 +81,8 @@ pub fn parse_pattern(pattern: &str, compiled_pattern: &Regex) -> ParseResult {
     let mut is_token: Vec<bool> = Vec::new();
     let mut token_order: Vec<String> = Vec::new();
     let mut last_end = 0usize;
-    let mut token_count = 1usize;
 
-    for m in compiled_pattern.find_iter(pattern) {
+    for (token_count, m) in (1usize..).zip(compiled_pattern.find_iter(pattern)) {
         let start = m.start();
         let end = m.end();
         if start > last_end {
@@ -93,7 +92,6 @@ pub fn parse_pattern(pattern: &str, compiled_pattern: &Regex) -> ParseResult {
         parts.push(pattern[start..end].to_string());
         is_token.push(true);
         token_order.push(format!("<token{}>", token_count));
-        token_count += 1;
         last_end = end;
     }
     if last_end < pattern.len() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/phantom_corrector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/phantom_corrector.rs
@@ -43,6 +43,8 @@ pub struct PhantomCorrector {
     /// = target_partitions × PARTITION_BUFFER_MULTIPLIER + 1 (output channel)
     batches_in_pipeline: usize,
     /// The per-batch bytes used in the original phantom estimate.
+    // Retained for diagnostics/future correction heuristics; not read yet.
+    #[allow(dead_code)]
     estimated_batch_bytes: usize,
     /// EMA of actual batch bytes (×1000 fixed-point).
     ema_batch_bytes_x1000: AtomicU64,
@@ -117,7 +119,7 @@ impl PhantomCorrector {
         let count = self.batches_observed.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Skip warmup and non-correction intervals
-        if count < WARMUP_BATCHES || count % CORRECTION_INTERVAL != 0 {
+        if count < WARMUP_BATCHES || !count.is_multiple_of(CORRECTION_INTERVAL) {
             return;
         }
 
@@ -147,7 +149,10 @@ impl PhantomCorrector {
 // Send + Sync is auto-derived since all fields are atomic.
 // Explicit assertion for documentation:
 const _: () = {
+    // Compile-time Send + Sync assertion; never called at runtime.
+    #[allow(dead_code)]
     fn assert_send_sync<T: Send + Sync>() {}
+    #[allow(dead_code)]
     fn check() {
         assert_send_sync::<PhantomCorrector>();
     }
@@ -234,7 +239,7 @@ mod tests {
 
         // Simulate 50 batches (typical scan of ~400K rows)
         let mut phantom = initial_phantom as i64;
-        for i in 0..50 {
+        for _ in 0..50 {
             c.observe_batch(actual_batch);
             let delta = c.take_pending_delta();
             if delta != 0 {
@@ -252,7 +257,7 @@ mod tests {
 
         // After convergence, phantom should be within 15% of ideal (1.0-1.15x)
         assert!(
-            bloat_ratio >= 0.85 && bloat_ratio <= 1.15,
+            (0.85..=1.15).contains(&bloat_ratio),
             "Bloat ratio {:.2}x is outside [0.85, 1.15] — corrector not converging",
             bloat_ratio
         );
@@ -289,7 +294,7 @@ mod tests {
 
         // Should be even tighter since starting point was already close
         assert!(
-            bloat_ratio >= 0.90 && bloat_ratio <= 1.10,
+            (0.90..=1.10).contains(&bloat_ratio),
             "Metadata-seeded bloat ratio {:.2}x is outside [0.90, 1.10]",
             bloat_ratio
         );

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/project_row_id_analyzer.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/project_row_id_analyzer.rs
@@ -38,6 +38,12 @@ impl ProjectRowIdAnalyzer {
     }
 }
 
+impl Default for ProjectRowIdAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AnalyzerRule for ProjectRowIdAnalyzer {
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
         let rewritten = plan.transform_up(|node| match &node {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_budget.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_budget.rs
@@ -132,6 +132,8 @@ const PER_COLUMN_DECODE_OVERHEAD_BYTES: usize = 4 * 1024;
 const MIN_BATCH_SIZE: usize = 1024;
 
 /// Default minimum target_partitions floor (used if the dynamic setting hasn't been set).
+// Retained for reference/future use of the dynamic target_partitions floor.
+#[allow(dead_code)]
 const DEFAULT_MIN_TARGET_PARTITIONS: usize = 1;
 
 /// Computed budget for a query. Carries the phantom reservation that must be
@@ -311,7 +313,7 @@ fn acquire_budget_inner(
             target_partitions, batch_size
         ))
         .with_can_spill(true);
-        let mut reservation = consumer.register(pool);
+        let reservation = consumer.register(pool);
 
         match reservation.try_grow(phantom_bytes) {
             Ok(()) => {
@@ -469,7 +471,7 @@ pub fn estimate_avg_row_bytes(schema: &SchemaRef) -> usize {
         }
     }
     // Null bitmaps: 1 bit per nullable column per row, rounded up to bytes
-    total += (nullable_count + 7) / 8;
+    total += nullable_count.div_ceil(8);
     total.max(8)
 }
 
@@ -731,7 +733,7 @@ mod tests {
 
         // Simulate an operator trying to allocate from the same pool
         let consumer = MemoryConsumer::new("hash_agg");
-        let mut reservation = consumer.register(&pool);
+        let reservation = consumer.register(&pool);
 
         // Try to allocate what's left
         let remaining = 10_000_000 - after_phantom;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -40,6 +40,8 @@ use crate::session_context::SessionContextHandle;
 /// `execute_with_context` path (via `api::execute_query`).
 /// TODO: Remove this function and migrate benchmarks to the decomposed path.
 /// Retained only for benchmarks. TODO: migrate benchmarks and remove.
+// Real API surface consumed by benchmarks; argument count mirrors the query pipeline inputs.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_query(
     table_path: ListingTableUrl,
     object_metas: Arc<Vec<ObjectMeta>>,
@@ -345,7 +347,7 @@ pub async fn execute_with_context(
     let (stream_ptr, physical_plan) =
         crate::cancellation::cancellable(token.as_ref(), context_id, query_future)
             .await
-            .map_err(|e| DataFusionError::Execution(e))?;
+            .map_err(DataFusionError::Execution)?;
 
     // Reconstruct the stream from the raw pointer
     let stream = unsafe {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -656,7 +656,7 @@ mod tests {
         let global = make_global_pool(1_000_000);
         let qp = Arc::new(QueryMemoryPool::new(global));
         let pool: Arc<dyn MemoryPool> = qp.clone();
-        let mut reservation = make_reservation(&pool, "test");
+        let reservation = make_reservation(&pool, "test");
 
         reservation.try_grow(1000).unwrap();
         assert_eq!(qp.current_bytes(), 1000);
@@ -682,7 +682,7 @@ mod tests {
         let pool: Arc<dyn MemoryPool> = qp.clone();
 
         {
-            let mut reservation = make_reservation(&pool, "test");
+            let reservation = make_reservation(&pool, "test");
             reservation.try_grow(5000).unwrap();
             assert_eq!(qp.current_bytes(), 5000);
             assert_eq!(qp.peak_bytes(), 5000);
@@ -697,7 +697,7 @@ mod tests {
         let global = make_global_pool(1_000_000);
         let qp = Arc::new(QueryMemoryPool::new(global));
         let pool: Arc<dyn MemoryPool> = qp.clone();
-        let mut reservation = make_reservation(&pool, "test");
+        let reservation = make_reservation(&pool, "test");
 
         reservation.try_grow(2000).unwrap();
         assert!(pool.reserved() >= 2000);
@@ -763,7 +763,7 @@ mod tests {
         let ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
         let qp = ctx.memory_pool().unwrap();
         let pool: Arc<dyn MemoryPool> = qp.clone();
-        let mut reservation = make_reservation(&pool, "lifecycle_test");
+        let reservation = make_reservation(&pool, "lifecycle_test");
 
         reservation.try_grow(5000).unwrap();
         assert_eq!(qp.current_bytes(), 5000);
@@ -800,10 +800,10 @@ mod tests {
         let pool_a = ctx_a.memory_pool().unwrap();
         let pool_b = ctx_b.memory_pool().unwrap();
 
-        let mut res_a = make_reservation(&(pool_a.clone() as Arc<dyn MemoryPool>), "query_a");
+        let res_a = make_reservation(&(pool_a.clone() as Arc<dyn MemoryPool>), "query_a");
         res_a.try_grow(3000).unwrap();
 
-        let mut res_b = make_reservation(&(pool_b.clone() as Arc<dyn MemoryPool>), "query_b");
+        let res_b = make_reservation(&(pool_b.clone() as Arc<dyn MemoryPool>), "query_b");
         res_b.try_grow(7000).unwrap();
 
         assert_eq!(pool_a.current_bytes(), 3000);
@@ -834,7 +834,7 @@ mod tests {
         let ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
         let qp = ctx.memory_pool().unwrap();
         let pool: Arc<dyn MemoryPool> = qp.clone();
-        let mut reservation = make_reservation(&pool, "stream_data");
+        let reservation = make_reservation(&pool, "stream_data");
 
         // Simulate allocations during stream consumption
         reservation.try_grow(4000).unwrap();
@@ -1095,9 +1095,9 @@ mod tests {
         let pool_md: Arc<dyn MemoryPool> = ctx_md.memory_pool().unwrap();
         let pool_hi: Arc<dyn MemoryPool> = ctx_hi.memory_pool().unwrap();
 
-        let mut r_lo = make_reservation(&pool_lo, "lo");
-        let mut r_md = make_reservation(&pool_md, "md");
-        let mut r_hi = make_reservation(&pool_hi, "hi");
+        let r_lo = make_reservation(&pool_lo, "lo");
+        let r_md = make_reservation(&pool_md, "md");
+        let r_hi = make_reservation(&pool_hi, "hi");
         r_lo.try_grow(1_000).unwrap();
         r_md.try_grow(5_000).unwrap();
         r_hi.try_grow(9_000).unwrap();
@@ -1106,7 +1106,7 @@ mod tests {
         // may push entries into the registry, so we filter to our id range.
         let mut buf = fresh_buf(2);
         let written = snapshot_top_n_by_current(&mut buf);
-        assert!(written >= 1 && written <= 2);
+        assert!((1..=2).contains(&written));
 
         let our: Vec<&WireQueryMetric> = buf[..written]
             .iter()
@@ -1139,7 +1139,7 @@ mod tests {
 
         let live_ctx = QueryTrackingContext::new(live_id, Arc::clone(&global), QueryType::Shard);
         let live_pool: Arc<dyn MemoryPool> = live_ctx.memory_pool().unwrap();
-        let mut r_live = make_reservation(&live_pool, "live");
+        let r_live = make_reservation(&live_pool, "live");
         r_live.try_grow(4_096).unwrap();
 
         // Registered but never reserved — current_bytes stays 0.
@@ -1149,7 +1149,7 @@ mod tests {
         // is settled, then drop the context to flip the completed flag.
         let done_ctx = QueryTrackingContext::new(done_id, Arc::clone(&global), QueryType::Shard);
         let done_pool: Arc<dyn MemoryPool> = done_ctx.memory_pool().unwrap();
-        let mut r_done = make_reservation(&done_pool, "done");
+        let r_done = make_reservation(&done_pool, "done");
         r_done.try_grow(8_192).unwrap();
         drop(r_done);
         drop(done_ctx);
@@ -1178,7 +1178,7 @@ mod tests {
         let id = 70_200;
         let ctx = QueryTrackingContext::new(id, global, QueryType::Shard);
         let pool: Arc<dyn MemoryPool> = ctx.memory_pool().unwrap();
-        let mut r = make_reservation(&pool, "only");
+        let r = make_reservation(&pool, "only");
         r.try_grow(2_048).unwrap();
 
         let sentinel = WireQueryMetric {
@@ -1209,8 +1209,8 @@ mod tests {
         for (i, id) in ids.iter().enumerate() {
             let ctx = QueryTrackingContext::new(*id, Arc::clone(&global), QueryType::Shard);
             let pool: Arc<dyn MemoryPool> = ctx.memory_pool().unwrap();
-            let mut r = make_reservation(&pool, "cap");
-            r.try_grow((i as usize + 1) * 1_000).unwrap();
+            let r = make_reservation(&pool, "cap");
+            r.try_grow((i + 1) * 1_000).unwrap();
             reservations.push(r);
             contexts.push(ctx);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/runtime_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/runtime_manager.rs
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-use crate::executor::{ConcurrencyGate, DedicatedExecutor};
+use crate::executor::DedicatedExecutor;
 use log::info;
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};
@@ -40,7 +40,7 @@ impl RuntimeManager {
         // The handle is always available before any store is constructed.
         native_bridge_common::io_runtime::set_io_handle(io_runtime.handle().clone());
 
-        let io_monitor = RuntimeMonitor::new(&io_runtime.handle());
+        let io_monitor = RuntimeMonitor::new(io_runtime.handle());
 
         let mut cpu_runtime_builder = Builder::new_multi_thread();
         cpu_runtime_builder

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_index_optimizer.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_index_optimizer.rs
@@ -97,7 +97,7 @@ impl PhysicalOptimizerRule for ScopedPageIndexOptimizer {
             let predicate = parquet.filter();
 
             // Predicate column NAMES — empty when there's no pushed-down filter.
-            let mut predicate_names: Vec<String> = predicate
+            let predicate_names: Vec<String> = predicate
                 .as_ref()
                 .map(|p| {
                     let mut names: Vec<String> = collect_columns(p)
@@ -279,7 +279,6 @@ mod tests {
     /// schema even when `parquet.filter()` is `None`.
     #[test]
     fn installs_factory_for_projection_only_scan() {
-        use datafusion::parquet::arrow::ProjectionMask;
         use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 
         let sch = schema(); // fields: a(0), b(1)
@@ -289,7 +288,8 @@ mod tests {
         let parquet = parquet_for(&sch);
         let config =
             FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), Arc::new(parquet))
-                .with_projection(Some(vec![0])) // project `a` only
+                .with_projection_indices(Some(vec![0])) // project `a` only
+                .unwrap()
                 .build();
         let plan = DataSourceExec::from_data_source(config);
 
@@ -347,6 +347,8 @@ mod tests {
     /// page-index cache filled — proving the rule installs a working scoped reader
     /// on the vanilla listing path.
     #[tokio::test]
+    // test-only: guard serializes global-cache tests; held across .await intentionally
+    #[allow(clippy::await_holding_lock)]
     async fn end_to_end_listing_scan_fills_scoped_cache() {
         use arrow::array::{Int32Array, StringArray};
         use arrow::record_batch::RecordBatch;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/scoped_page_index_reader.rs
@@ -263,6 +263,8 @@ impl AsyncFileReader for ScopedPageIndexReader {
 
 #[cfg(test)]
 mod tests {
+    // test-only: guard serializes global-cache tests; held across .await intentionally
+    #![allow(clippy::await_holding_lock)]
     use super::*;
     use arrow::array::{Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
@@ -295,7 +297,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(32)
+            .set_max_row_group_row_count(Some(32))
             .set_data_page_row_count_limit(8)
             .set_write_batch_size(8)
             .set_statistics_enabled(EnabledStatistics::Page)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -21,9 +21,7 @@ use datafusion::{
     execution::cache::{CacheAccessor, DefaultListFilesCache},
     execution::context::SessionContext,
     execution::memory_pool::MemoryPool,
-    execution::runtime_env::RuntimeEnvBuilder,
     execution::SessionStateBuilder,
-    physical_plan::ExecutionPlan,
     prelude::*,
 };
 use log::error;
@@ -71,6 +69,8 @@ pub struct SessionContextHandle {
     pub(crate) prepared_plan: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
     /// Phantom reservation holding pool capacity for untracked memory.
     /// Dropped when the handle is closed, releasing the capacity.
+    // Held purely for its RAII drop side-effect (releases pool capacity); never read.
+    #[allow(dead_code)]
     pub(crate) phantom_reservation: Option<datafusion::execution::memory_pool::MemoryReservation>,
 }
 
@@ -153,6 +153,11 @@ pub(crate) fn widen_schema_from_plan(
 
 /// Creates a SessionContext with per-query RuntimeEnv and registers the default
 /// ListingTable provider for parquet scans.
+///
+/// # Safety
+/// `runtime_ptr` and `shard_view_ptr` must be valid, non-null pointers to a live
+/// `DataFusionRuntime` and `ShardView` respectively (borrowed for the duration of
+/// the call), and `plan_bytes` must reference a valid byte slice.
 pub async unsafe fn create_session_context(
     runtime_ptr: i64,
     shard_view_ptr: i64,
@@ -206,7 +211,7 @@ pub async unsafe fn create_session_context(
 
     // Acquire memory budget from cached parquet metadata (zero I/O).
     // On cache miss (first query for this shard), skip — subsequent queries benefit.
-    let phantom_reservation = try_acquire_budget(runtime, &global_pool, &shard_view, &query_config);
+    let phantom_reservation = try_acquire_budget(runtime, &global_pool, shard_view, &query_config);
     let effective_partitions = phantom_reservation
         .as_ref()
         .map(|b| b.target_partitions)
@@ -433,6 +438,13 @@ pub unsafe fn close_session_context(ptr: i64) {
 /// Creates a SessionContext configured for indexed execution with filter delegation.
 /// Registers the `delegated_predicate` UDF and stores the tree shape + predicate count
 /// for use during execution.
+///
+/// # Safety
+/// `runtime_ptr` and `shard_view_ptr` must be valid, non-null pointers to a live
+/// `DataFusionRuntime` and `ShardView` respectively (borrowed for the duration of
+/// the call), and `plan_bytes` must reference a valid byte slice.
+// Real FFM-facing API; argument count mirrors the Java-provided indexed-execution inputs.
+#[allow(clippy::too_many_arguments)]
 pub async unsafe fn create_session_context_indexed(
     runtime_ptr: i64,
     shard_view_ptr: i64,
@@ -539,10 +551,10 @@ fn substrait_has_fetch_rel(plan_bytes: &[u8]) -> bool {
     fn rel_has_fetch(rel: &substrait::proto::Rel) -> bool {
         match rel.rel_type.as_ref() {
             Some(RelType::Fetch(f)) => f.count_mode.is_some(),
-            Some(RelType::Sort(s)) => s.input.as_ref().map_or(false, |r| rel_has_fetch(r)),
-            Some(RelType::Project(p)) => p.input.as_ref().map_or(false, |r| rel_has_fetch(r)),
-            Some(RelType::Filter(f)) => f.input.as_ref().map_or(false, |r| rel_has_fetch(r)),
-            Some(RelType::Aggregate(a)) => a.input.as_ref().map_or(false, |r| rel_has_fetch(r)),
+            Some(RelType::Sort(s)) => s.input.as_ref().is_some_and(|r| rel_has_fetch(r)),
+            Some(RelType::Project(p)) => p.input.as_ref().is_some_and(|r| rel_has_fetch(r)),
+            Some(RelType::Filter(f)) => f.input.as_ref().is_some_and(|r| rel_has_fetch(r)),
+            Some(RelType::Aggregate(a)) => a.input.as_ref().is_some_and(|r| rel_has_fetch(r)),
             // TODO: enumerate remaining rel types explicitly and panic on unknown ones.
             Some(other) => {
                 native_bridge_common::log_debug!(
@@ -560,7 +572,7 @@ fn substrait_has_fetch_rel(plan_bytes: &[u8]) -> bool {
     };
     plan.relations.iter().any(|pr| match pr.rel_type.as_ref() {
         Some(substrait::proto::plan_rel::RelType::Root(rr)) => {
-            rr.input.as_ref().map_or(false, |r| rel_has_fetch(r))
+            rr.input.as_ref().is_some_and(rel_has_fetch)
         }
         Some(substrait::proto::plan_rel::RelType::Rel(r)) => rel_has_fetch(r),
         None => false,
@@ -576,7 +588,6 @@ fn try_acquire_budget(
     config: &DatafusionQueryConfig,
 ) -> Option<crate::query_budget::QueryMemoryBudget> {
     use datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData;
-    use datafusion::execution::cache::CacheAccessor;
     use parquet::arrow::parquet_to_arrow_schema;
 
     let first_meta = shard_view.object_metas.first()?;
@@ -946,9 +957,7 @@ mod tests {
     /// another shard's store and failed with "No such file or directory".
     #[tokio::test]
     async fn test_per_query_object_store_registry_is_isolated() {
-        use datafusion::execution::object_store::{
-            DefaultObjectStoreRegistry, ObjectStoreRegistry,
-        };
+        use datafusion::execution::object_store::DefaultObjectStoreRegistry;
         use object_store::memory::InMemory;
         use object_store::ObjectStore;
         use url::Url;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/shard_table_provider.rs
@@ -106,7 +106,14 @@ impl TableProvider for ShardTableProvider {
                 });
                 pf = pf.with_statistics(file_stats);
                 if let Some(ref plan) = file_info.access_plan {
-                    pf = pf.with_extensions(Arc::new(plan.clone()));
+                    // Must stay on deprecated `with_extensions`: DataFusion's Parquet opener
+                    // retrieves the ParquetAccessPlan via the legacy `insert_dyn` keying;
+                    // `with_extension` keys by concrete type and the opener would not find it,
+                    // silently dropping row selection. See parquet_bridge.rs for details.
+                    #[allow(deprecated)]
+                    {
+                        pf = pf.with_extensions(Arc::new(plan.clone()));
+                    }
                 }
                 pf
             })

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -80,6 +80,7 @@ pub struct PartitionGateRepr {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct CacheGroupRepr {
     pub hit_count: i64,
     pub miss_count: i64,
@@ -89,34 +90,12 @@ pub struct CacheGroupRepr {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct CacheStatsRepr {
     pub metadata_cache: CacheGroupRepr,
     pub statistics_cache: CacheGroupRepr,
     pub column_index_cache: CacheGroupRepr,
     pub offset_index_cache: CacheGroupRepr,
-}
-
-impl Default for CacheGroupRepr {
-    fn default() -> Self {
-        Self {
-            hit_count: 0,
-            miss_count: 0,
-            entry_count: 0,
-            memory_bytes: 0,
-            size_limit_bytes: 0,
-        }
-    }
-}
-
-impl Default for CacheStatsRepr {
-    fn default() -> Self {
-        Self {
-            metadata_cache: CacheGroupRepr::default(),
-            statistics_cache: CacheGroupRepr::default(),
-            column_index_cache: CacheGroupRepr::default(),
-            offset_index_cache: CacheGroupRepr::default(),
-        }
-    }
 }
 
 #[repr(C)]
@@ -342,7 +321,7 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let monitor = RuntimeMonitor::new(&rt.handle());
+        let monitor = RuntimeMonitor::new(rt.handle());
         let result = pack_runtime_metrics(&monitor, rt.handle());
         assert_eq!(result.workers_count, 2);
     }
@@ -354,7 +333,7 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let monitor = RuntimeMonitor::new(&rt.handle());
+        let monitor = RuntimeMonitor::new(rt.handle());
         let result = pack_runtime_metrics(&monitor, rt.handle());
         assert_eq!(result.workers_count, 3);
         assert!(result.total_polls_count >= 0);
@@ -452,7 +431,7 @@ mod tests {
         // A buffer smaller than 680 bytes should be rejected by df_stats.
         // We can't call df_stats directly without a runtime manager,
         // but we verify the constant is correct.
-        assert!(layout::BUFFER_BYTE_SIZE > 0);
+        const { assert!(layout::BUFFER_BYTE_SIZE > 0) };
     }
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/tiered_storage_integration_tests.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/tiered_storage_integration_tests.rs
@@ -34,7 +34,7 @@ use opensearch_tiered_storage::types::{FileLocation, TieredFileEntry};
 
 // ── Helpers ─────────────────────────────────────────────────────────────────────
 
-const BLOCK_SIZE: usize = 1 * 1024 * 1024;
+const BLOCK_SIZE: usize = 1024 * 1024;
 const DISK_BYTES: usize = 8 * 1024 * 1024;
 const BUFFER_POOL: usize = 8 * 1024 * 1024;
 const SUBMIT_QUEUE: usize = 8 * 1024 * 1024;
@@ -233,7 +233,7 @@ async fn setup_df_session(
     ctx.runtime_env()
         .register_object_store(&url, store.clone() as Arc<dyn ObjectStore>);
 
-    let table_url = ListingTableUrl::parse(&format!("file:///{}", file_path)).unwrap();
+    let table_url = ListingTableUrl::parse(format!("file:///{}", file_path)).unwrap();
     let format = Arc::new(ParquetFormat::default());
     let listing_options = ListingOptions::new(format).with_file_extension(".parquet");
 
@@ -314,7 +314,10 @@ fn metadata_routed_to_metadata_cache_data_to_data_cache() {
         );
 
         // Data read (get_ranges) → data cache
-        let data = store.get_ranges(&path, &[0u64..4096]).await.unwrap();
+        let data = store
+            .get_ranges(&path, std::slice::from_ref(&(0u64..4096)))
+            .await
+            .unwrap();
         assert_eq!(data[0].len(), 4096);
 
         // Confirm data in data cache, NOT metadata cache
@@ -399,7 +402,10 @@ fn evict_prefix_clears_both_caches_on_shard_delete() {
     );
 
     block_on(async {
-        let _data = store.get_ranges(&path, &[0u64..4096]).await.unwrap();
+        let _data = store
+            .get_ranges(&path, std::slice::from_ref(&(0u64..4096)))
+            .await
+            .unwrap();
 
         let footer_key = range_cache_key("delete.parquet", footer_start, file_size);
         let data_key = range_cache_key("delete.parquet", 0, 4096);
@@ -523,7 +529,9 @@ fn data_pressure_does_not_evict_metadata() {
             let start = (i * 1024) as u64;
             let end = start + 102400;
             if end <= file_size {
-                let _ = store.get_ranges(&path, &[start..end]).await;
+                let _ = store
+                    .get_ranges(&path, std::slice::from_ref(&(start..end)))
+                    .await;
             }
         }
 
@@ -667,7 +675,10 @@ fn get_range_and_get_ranges_share_same_cache_key() {
 
     block_on(async {
         // Read first 4KB via get_ranges (data path → data_cache)
-        let via_ranges = store.get_ranges(&path, &[0u64..4096]).await.unwrap();
+        let via_ranges = store
+            .get_ranges(&path, std::slice::from_ref(&(0u64..4096)))
+            .await
+            .unwrap();
 
         // Read same range via get_range (metadata path → metadata_cache)
         let via_range = store.get_range(&path, 0u64..4096).await.unwrap();
@@ -718,7 +729,7 @@ fn metadata_cache_full_reads_still_succeed_via_local_fs() {
         false,
     ));
     let metadata_cache = Arc::new(FoyerCache::new(
-        1 * 1024 * 1024,
+        1024 * 1024,
         meta_dir.path(),
         BLOCK_SIZE,
         BUFFER_POOL,
@@ -833,7 +844,11 @@ fn warmup_put_metadata_then_datafusion_query_from_cache() {
         let footer_start = file_size.saturating_sub(64 * 1024);
         let footer_key = range_cache_key("warm.parquet", footer_start, file_size);
         if let Some(footer_bytes) = cache.get(&footer_key).await {
-            store.put_metadata("warm.parquet", &[footer_start..file_size], &[footer_bytes]);
+            store.put_metadata(
+                "warm.parquet",
+                std::slice::from_ref(&(footer_start..file_size)),
+                &[footer_bytes],
+            );
         }
 
         // Verify metadata is now in metadata_cache
@@ -1211,7 +1226,7 @@ fn metadata_foyer_capacity_breach_graceful_degradation() {
         false,
     ));
     let metadata_cache = Arc::new(FoyerCache::new(
-        1 * 1024 * 1024,
+        1024 * 1024,
         meta_dir.path(),
         BLOCK_SIZE,
         BUFFER_POOL,
@@ -1466,7 +1481,10 @@ fn get_opts_probe_does_not_pollute_metadata_foyer() {
         );
 
         // Contrast: reading via get_ranges DOES populate data cache
-        let data2 = store.get_ranges(&path, &[100u64..4196]).await.unwrap();
+        let data2 = store
+            .get_ranges(&path, std::slice::from_ref(&(100u64..4196)))
+            .await
+            .unwrap();
         assert_eq!(data2[0].len(), 4096);
         let data2_key = range_cache_key("nopollute.parquet", 100, 4196);
         assert!(
@@ -1733,7 +1751,7 @@ fn restart_with_file_deleted_query_succeeds_from_foyer_only() {
         let footer_bytes = bytes::Bytes::copy_from_slice(&file_bytes[footer_start as usize..]);
         store.put_metadata(
             "restart_full.parquet",
-            &[footer_start..file_size],
+            std::slice::from_ref(&(footer_start..file_size)),
             &[footer_bytes],
         );
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/approx_distinct_safe.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/approx_distinct_safe.rs
@@ -13,7 +13,7 @@
 //! TODO: Evaluate if DF's UDAF extension points (e.g. AccumulatorArgs overrides or
 //!       custom PhysicalOptimizerRule to inject CastExec) can avoid same-name overrides.
 
-use datafusion::arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+use datafusion::arrow::array::{ArrayRef, StringArray, StringViewArray};
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::common::{downcast_value, Result};
 use datafusion::execution::context::SessionContext;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/internal_pattern.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/internal_pattern.rs
@@ -309,7 +309,7 @@ pub struct InternalPatternAccumulator {
 }
 
 impl InternalPatternAccumulator {
-    pub fn new(arg0_is_list: bool, config: AggConfig) -> Self {
+    fn new(arg0_is_list: bool, config: AggConfig) -> Self {
         Self {
             arg0_is_list,
             config,
@@ -402,7 +402,7 @@ impl Accumulator for InternalPatternAccumulator {
 
     fn evaluate(&mut self) -> Result<ScalarValue> {
         if self.buffer.is_empty() {
-            return Ok(empty_list_struct_scalar()?);
+            return empty_list_struct_scalar();
         }
         let mut parser = BrainLogParser::with_thresholds(
             self.config.variable_count_threshold,
@@ -433,7 +433,7 @@ impl Accumulator for InternalPatternAccumulator {
 /// `LogPatternAggFunction.value()`'s ordering.
 fn sorted_pattern_entries(stats: HashMap<String, PatternEntry>) -> Vec<PatternEntry> {
     let mut entries: Vec<PatternEntry> = stats.into_values().collect();
-    entries.sort_by(|a, b| b.pattern_count.cmp(&a.pattern_count));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.pattern_count));
     entries
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/take.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/take.rs
@@ -238,7 +238,7 @@ impl TakeAccumulator {
     /// The Calcite plan materializes the literal `n` as a constant column —
     /// every row carries the same value, so reading row 0 is sufficient.
     fn resolve_limit_from(&mut self, n_col: &ArrayRef) -> Result<()> {
-        if self.limit.is_some() || n_col.len() == 0 {
+        if self.limit.is_some() || n_col.is_empty() {
             return Ok(());
         }
         let scalar = ScalarValue::try_from_array(n_col, 0)?;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conv.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conv.rs
@@ -21,7 +21,7 @@ use datafusion::logical_expr::{
 };
 
 use super::json_common::StringArrayView;
-use super::{coerce_args, udf_identity, CoerceMode};
+use super::{coerce_args, CoerceMode};
 
 pub fn register_all(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(ConvUdf::new()));

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/numeric_conversion.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/numeric_conversion.rs
@@ -339,6 +339,9 @@ fn convert_mstime(s: &str) -> Option<f64> {
 }
 
 #[cfg(test)]
+// clippy::approx_constant — the `3.14` literals below are arbitrary decimal parse fixtures,
+// not intended approximations of PI; using std::f64::consts::PI would change the assertions.
+#[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/tonumber.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/tonumber.rs
@@ -216,7 +216,7 @@ fn parse_with_base(s: Option<&str>, base: Option<i32>) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{Array, AsArray, Int32Array, StringArray};
+    use datafusion::arrow::array::{Array, AsArray, StringArray};
     use datafusion::arrow::datatypes::Field;
 
     fn invoke_scalar(value: Option<&str>, base: Option<i32>) -> Option<f64> {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/tostring.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/conversion/tostring.rs
@@ -313,8 +313,8 @@ fn format_commas_f64(v: f64) -> String {
     if frac != "00" {
         out.push('.');
         // Trim a trailing '0' when exactly one digit would be meaningful, e.g. `.50 → .5`.
-        if frac.ends_with('0') {
-            out.push_str(&frac[..frac.len() - 1]);
+        if let Some(stripped) = frac.strip_suffix('0') {
+            out.push_str(stripped);
         } else {
             out.push_str(frac);
         }
@@ -330,7 +330,7 @@ fn insert_thousands_separators(digits: &str, out: &mut String) {
     for (i, b) in bytes.iter().enumerate() {
         let from_right = len - i;
         out.push(*b as char);
-        if from_right > 1 && (from_right - 1) % 3 == 0 {
+        if from_right > 1 && (from_right - 1).is_multiple_of(3) {
             out.push(',');
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/date_format.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/date_format.rs
@@ -11,8 +11,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use chrono::{TimeZone, Utc};
 use datafusion::arrow::array::{
     Array, ArrayRef, AsArray, StringBuilder, TimestampMicrosecondArray,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
@@ -12,8 +12,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use chrono::{DateTime, Datelike, NaiveTime, TimeZone, Timelike, Utc};
 use datafusion::arrow::array::{
     Array, ArrayRef, AsArray, Int64Builder, StringArray, Time32MillisecondArray, Time32SecondArray,
@@ -284,7 +282,7 @@ fn extract_for_unit(unit: &str, dt: DateTime<Utc>) -> Option<i64> {
         "DAY" => Some(dd),
         "WEEK" => Some(dt.iso_week().week() as i64),
         "MONTH" => Some(mo),
-        "QUARTER" => Some(((mo - 1) / 3 + 1) as i64),
+        "QUARTER" => Some((mo - 1) / 3 + 1),
         "YEAR" => Some(yy),
         "DOW" => Some(dt.weekday().number_from_monday() as i64),
         "DOY" => Some(dt.ordinal() as i64),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/from_unixtime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/from_unixtime.rs
@@ -11,8 +11,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, TimestampMicrosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::{exec_err, plan_err, Result, ScalarValue};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/json_extract_all.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/json_extract_all.rs
@@ -203,9 +203,7 @@ impl Slot {
     fn extend(&mut self, next: Option<String>) {
         match self {
             Slot::Single(first) => {
-                let mut v = Vec::with_capacity(2);
-                v.push(first.take());
-                v.push(next);
+                let v = vec![first.take(), next];
                 *self = Slot::List(v);
             }
             Slot::List(v) => v.push(next),
@@ -301,9 +299,10 @@ fn build_path(path: &[String]) -> String {
         if segment == ARRAY_MARKER {
             s.push_str(ARRAY_MARKER);
         } else {
-            if !s.is_empty() && !s.ends_with(ARRAY_MARKER) {
-                s.push('.');
-            } else if s.ends_with(ARRAY_MARKER) {
+            // Separate field names with `.`; the leading segment gets none.
+            // (Both a plain field boundary and an array-marker boundary need a
+            // separator, which together is exactly "s is non-empty".)
+            if !s.is_empty() {
                 s.push('.');
             }
             s.push_str(segment);
@@ -526,7 +525,7 @@ mod tests {
         let udf = JsonExtractAllUdf::new();
         for variant in [DataType::Utf8, DataType::LargeUtf8, DataType::Utf8View] {
             assert_eq!(
-                udf.coerce_types(&[variant.clone()]).unwrap(),
+                udf.coerce_types(std::slice::from_ref(&variant)).unwrap(),
                 vec![variant.clone()],
                 "CoerceMode::Utf8 should pass {variant:?} through unchanged"
             );

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/makedate.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/makedate.rs
@@ -11,8 +11,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use chrono::{Datelike, NaiveDate};
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, Date32Builder};
 use datafusion::arrow::datatypes::{DataType, Float64Type};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/maketime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/maketime.rs
@@ -17,8 +17,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, Time64NanosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, Float64Type, TimeUnit};
 use datafusion::common::{exec_err, plan_err, Result, ScalarValue};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -37,7 +37,6 @@ macro_rules! udf_identity {
         }
     };
 }
-pub(crate) use udf_identity;
 
 /// Input-type categories for UDF argument slots. Each mode declares a canonical
 /// arrow target type plus the set of sources that coerce to it; invalid sources

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mvappend.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mvappend.rs
@@ -38,8 +38,8 @@ use datafusion::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, BooleanBuilder, Decimal128Array, Decimal128Builder,
     Float32Array, Float32Builder, Float64Array, Float64Builder, GenericListArray, Int16Array,
     Int16Builder, Int32Array, Int32Builder, Int64Array, Int64Builder, Int8Array, Int8Builder,
-    ListArray, ListBuilder, StringArray, StringBuilder, StringViewArray, StringViewBuilder,
-    UInt16Array, UInt16Builder, UInt32Array, UInt32Builder, UInt64Array, UInt64Builder, UInt8Array,
+    ListBuilder, StringArray, StringBuilder, StringViewArray, StringViewBuilder, UInt16Array,
+    UInt16Builder, UInt32Array, UInt32Builder, UInt64Array, UInt64Builder, UInt8Array,
     UInt8Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field};
@@ -405,7 +405,7 @@ fn append_string_scalar<B: StrAppend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::AsArray;
+    use datafusion::arrow::array::{AsArray, ListArray};
     use datafusion::common::ScalarValue;
 
     fn run(args: Vec<ColumnarValue>, n: usize) -> ArrayRef {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mvzip.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mvzip.rs
@@ -29,8 +29,8 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Float32Array, Float64Array, GenericListArray,
-    Int16Array, Int32Array, Int64Array, Int8Array, ListArray, ListBuilder, StringArray,
-    StringBuilder, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    Int16Array, Int32Array, Int64Array, Int8Array, ListArray, ListBuilder, StringBuilder,
+    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion::common::{plan_err, ScalarValue};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/os_week.rs
@@ -24,8 +24,6 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
 
-use super::udf_identity;
-
 pub fn register_all(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(OsWeekUdf::new()));
     ctx.register_udf(ScalarUDF::from(OsYearweekUdf::new()));
@@ -284,7 +282,7 @@ fn os_year_number(date: NaiveDate, mode: i32) -> i32 {
 
 /// `(firstDayOfWeek, minimalDaysInFirstWeek)` for MySQL modes 0..7.
 fn week_params(mode: u32) -> (Weekday, u32) {
-    let first = if mode % 2 == 0 {
+    let first = if mode.is_multiple_of(2) {
         Weekday::Sun
     } else {
         Weekday::Mon

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/pattern_parser.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/pattern_parser.rs
@@ -28,12 +28,11 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, ArrayRef, GenericListArray, ListArray, ListBuilder, MapBuilder, MapFieldNames,
-    StringArray, StringBuilder, StructArray,
+    Array, ArrayRef, ListArray, ListBuilder, MapBuilder, MapFieldNames, StringArray, StringBuilder,
+    StructArray,
 };
-use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer};
 use datafusion::arrow::datatypes::{DataType, Field, Fields};
-use datafusion::common::{plan_err, ScalarValue};
+use datafusion::common::plan_err;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{
@@ -41,7 +40,6 @@ use datafusion::logical_expr::{
 };
 
 use crate::patterns::{eval_field, eval_samples, PatternResult};
-use crate::udf::udf_identity;
 
 pub const NAME: &str = "pattern_parser";
 
@@ -229,7 +227,7 @@ pub struct PatternParserGetFieldUdf {
 }
 
 impl PatternParserGetFieldUdf {
-    pub fn new(field: PatternField) -> Self {
+    fn new(field: PatternField) -> Self {
         Self {
             field,
             signature: Signature::user_defined(Volatility::Immutable),
@@ -449,7 +447,7 @@ fn build_struct_array(results: &[PatternResult]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{Array, AsArray, BooleanArray};
+    use datafusion::arrow::array::Array;
 
     #[test]
     fn struct_data_type_has_pattern_and_tokens_fields() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/range_bucket.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/range_bucket.rs
@@ -39,7 +39,7 @@
 //! 5. `bin_index = floor((value - first_bin_start) / width)`
 //! 6. `bin_start = bin_index * width + first_bin_start`; `bin_end = bin_start
 //!    + width`; label via the same integer/float formatter as span_bucket
-//!    and width_bucket.
+//!      and width_bucket.
 
 use std::sync::Arc;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/reduce_eval.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/reduce_eval.rs
@@ -95,8 +95,8 @@ fn eval_approx_distinct(state_col: &ArrayRef) -> Result<ColumnarValue> {
             order_bys: &[],
             name: "x",
             is_distinct: false,
-            exprs: &[expr.clone()],
-            expr_fields: &[field.clone()],
+            exprs: std::slice::from_ref(&expr),
+            expr_fields: std::slice::from_ref(&field),
             is_reversed: false,
         })?;
         let state_array: ArrayRef = Arc::new(BinaryArray::from(vec![binary.value(i)]));
@@ -114,7 +114,6 @@ mod tests {
     use super::*;
     use datafusion::arrow::array::BinaryArray;
     use datafusion::functions_aggregate::approx_distinct::approx_distinct_udaf;
-    use datafusion::logical_expr::Accumulator;
 
     #[test]
     fn test_reduce_eval_approx_distinct() {
@@ -133,8 +132,8 @@ mod tests {
                 order_bys: &[],
                 name: "x",
                 is_distinct: false,
-                exprs: &[expr.clone()],
-                expr_fields: &[field.clone()],
+                exprs: std::slice::from_ref(&expr),
+                expr_fields: std::slice::from_ref(&field),
                 is_reversed: false,
             })
             .unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/str_to_date.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/str_to_date.rs
@@ -11,8 +11,6 @@
 
 use std::sync::Arc;
 
-use super::udf_identity;
-
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, TimestampMicrosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::{exec_err, plan_err, Result, ScalarValue};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/strftime.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/strftime.rs
@@ -19,8 +19,6 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
 
-use super::udf_identity;
-
 pub fn register_all(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(StrftimeUdf::new()));
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/time_format.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/time_format.rs
@@ -11,8 +11,6 @@
 //! (%d→"00", %Y→"0000"); date-only name tokens (%W, %a, %M, %D, %j, %w, %U/%u,
 //! %V/%v, %X/%x, %b) cause the whole render to collapse to NULL.
 
-use super::udf_identity;
-
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::{plan_err, Result};
 use datafusion::execution::context::SessionContext;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udwf/internal_pattern.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udwf/internal_pattern.rs
@@ -22,7 +22,7 @@
 //! resulting {@code array_element(map_extract(...), 1)} chain to one of the
 //! per-field scalar UDFs.
 
-use datafusion::arrow::array::{ArrayRef, AsArray, StringArray, StringBuilder};
+use datafusion::arrow::array::{ArrayRef, StringArray, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::common::Result;
 use datafusion::execution::context::SessionContext;
@@ -289,6 +289,7 @@ fn read_f64_at(arr: &ArrayRef, i: usize) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::arrow::array::AsArray;
     use std::sync::Arc;
 
     #[test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/tests/budget_accuracy_test.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/tests/budget_accuracy_test.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow_array::{Float64Array, Int64Array, RecordBatch, StringArray};
-use datafusion::common::DataFusionError;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
@@ -127,7 +126,7 @@ async fn measure_actual_bytes(
     plan: Arc<dyn ExecutionPlan>,
     ctx: Arc<datafusion::execution::TaskContext>,
 ) -> (usize, usize, usize) {
-    let num_partitions = plan.properties().output_partitioning().partition_count();
+    let _num_partitions = plan.properties().output_partitioning().partition_count();
     let streams = execute_stream_partitioned(plan, ctx).unwrap();
 
     let total_bytes = Arc::new(AtomicUsize::new(0));
@@ -244,16 +243,8 @@ async fn validate_budget_accuracy_inner(
         measure_actual_bytes(physical_plan, ctx.task_ctx()).await;
 
     // Compute actual average batch size (this is what flows through channels)
-    let avg_batch_bytes = if actual_batches > 0 {
-        actual_total_bytes / actual_batches
-    } else {
-        0
-    };
-    let actual_avg_row_bytes = if actual_rows > 0 {
-        actual_total_bytes / actual_rows
-    } else {
-        0
-    };
+    let avg_batch_bytes = actual_total_bytes.checked_div(actual_batches).unwrap_or(0);
+    let actual_avg_row_bytes = actual_total_bytes.checked_div(actual_rows).unwrap_or(0);
 
     // Formula prediction
     let predicted_avg_row_bytes = estimate_avg_row_bytes(schema);
@@ -450,13 +441,13 @@ async fn budget_accuracy_metadata_based_is_tighter() {
 
     let tmp = TempDir::new().unwrap();
     let schema = create_parquet_data(tmp.path(), 100_000, 4);
-    let dir = format!("file://{}/", tmp.path().to_str().unwrap());
+    let _dir = format!("file://{}/", tmp.path().to_str().unwrap());
 
     // Read parquet metadata from the first file
     let first_file = std::fs::read_dir(tmp.path())
         .unwrap()
         .filter_map(|e| e.ok())
-        .find(|e| e.path().extension().map_or(false, |ext| ext == "parquet"))
+        .find(|e| e.path().extension().is_some_and(|ext| ext == "parquet"))
         .unwrap();
     let reader =
         SerializedFileReader::new(std::fs::File::open(first_file.path()).unwrap()).unwrap();

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/ffm.rs
@@ -268,6 +268,10 @@ pub unsafe extern "C" fn foyer_update_persist_interval(ptr: i64, new_secs: u64) 
 /// # Safety
 /// - `ptr` must be a valid handle from [`foyer_create_cache`], not yet destroyed.
 /// - `prefix_ptr` must point to `prefix_len` consecutive valid UTF-8 bytes.
+// clippy::not_unsafe_ptr_arg_deref — this is a `#[no_mangle] extern "C"` FFM entry point
+// called from the JVM; the pointer contract is documented in the `# Safety` section above.
+// Marking it `unsafe fn` has no effect for C-ABI callers, so allow the raw-pointer deref.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[ffm_safe]
 #[no_mangle]
 pub extern "C" fn foyer_evict_prefix(ptr: i64, prefix_ptr: *const u8, prefix_len: u64) -> i64 {

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/foyer/foyer_cache.rs
@@ -67,7 +67,7 @@ fn build_io_engine_config(choice: &str) -> Box<dyn IoEngineConfig> {
         }
         "psync" => {
             native_bridge_common::log_info!("[block-cache] io_engine=psync forced by config");
-            return PsyncIoEngineConfig::new().boxed();
+            PsyncIoEngineConfig::new().boxed()
         }
         other => {
             if other != "auto" {
@@ -150,6 +150,7 @@ impl Drop for ActiveBytesGuard<'_> {
 /// 1. By the independent periodic persist task every `persist_interval_secs` seconds
 ///    (when `used_bytes` has changed since the last write — zero-write when idle).
 /// 2. Unconditionally in `Drop` (graceful shutdown).
+///
 /// On crash (`Drop` not called), only the Foyer disk data is recovered;
 /// key_index starts empty (same as before this feature was added).
 ///
@@ -296,6 +297,9 @@ impl FoyerCache {
     /// # Panics
     /// Panics if the Tokio runtime cannot be created or if Foyer fails to
     /// build the cache (e.g. insufficient disk space or invalid path).
+    // clippy::too_many_arguments — each parameter is a distinct required cache-construction
+    // knob (sizes, dir, intervals, thresholds); bundling into a struct only relocates the list.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         disk_bytes: usize,
         disk_dir: impl Into<PathBuf>,
@@ -419,6 +423,18 @@ impl FoyerCache {
             let sweep_threshold_atomic_clone = Arc::clone(&instance.sweep_threshold_ratio);
             let sweep_disk_bytes = disk_bytes;
 
+            // clippy::never_loop + derived lints — the inner loop currently only exits via
+            // `return`, so the outer restart/backoff scaffolding below (restart_count, backoff
+            // sleep, the "exited unexpectedly" log) is unreachable today. Kept intentionally
+            // as-is (restart-on-unexpected-exit intent); allow rather than restructure. The
+            // extra lints suppress the unreachable-code / unused-var noise that follows from it.
+            #[allow(
+                clippy::never_loop,
+                unused_variables,
+                unused_mut,
+                unreachable_code,
+                unused_labels
+            )]
             instance._runtime.spawn(async move {
                 native_bridge_common::log_info!(
                     "[block-cache] sweep task started: interval={}s", sweep_interval_secs
@@ -489,6 +505,16 @@ impl FoyerCache {
             let persist_dir = instance.cache_dir.clone();
             let persist_interval = Duration::from_secs(persist_interval_secs);
 
+            // clippy::never_loop + derived lints — see the sweep task above: the inner loop exits
+            // only via `return`, so the outer restart/backoff scaffolding is unreachable today.
+            // Kept intentionally as-is; allow rather than restructure.
+            #[allow(
+                clippy::never_loop,
+                unused_variables,
+                unused_mut,
+                unreachable_code,
+                unused_labels
+            )]
             instance._runtime.spawn(async move {
                 native_bridge_common::log_info!(
                     "[block-cache] persist task started: interval={}s",

--- a/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
+++ b/sandbox/plugins/block-cache-foyer/src/main/rust/src/tests.rs
@@ -38,8 +38,8 @@ const IO_ENGINE: &str = "auto";
 /// `lru_eviction_retains_keys_in_key_index`, etc.) create their own caches with
 /// explicit sizes and are unaffected by these constants.
 const TEST_CACHE_DISK_BYTES: usize = 4 * 1024 * 1024; // 4 MB disk capacity
-const TEST_CACHE_BLOCK_SIZE: usize = 1 * 1024 * 1024; // 1 MB block size (must be ≤ disk)
-const TEST_BUFFER_POOL_SIZE: usize = 1 * 1024 * 1024; // 1 MB buffer pool (≥ block_size)
+const TEST_CACHE_BLOCK_SIZE: usize = 1024 * 1024; // 1 MB block size (must be ≤ disk)
+const TEST_BUFFER_POOL_SIZE: usize = 1024 * 1024; // 1 MB buffer pool (≥ block_size)
 const TEST_SUBMIT_QUEUE_SIZE: usize = 2 * 1024 * 1024; // 2 MB submit queue (≥ 2× buffer pool)
 
 fn test_cache() -> (FoyerCache, TempDir) {
@@ -238,8 +238,8 @@ fn clear_updates_removed_count_and_removed_bytes() {
     let (cache, _dir) = test_cache();
 
     // Two files, one range each: 0-100 = 100 bytes, 0-200 = 200 bytes → total 300 bytes, 2 entries.
-    put_range(&cache, "/data/a.parquet", 0, 100, &vec![0u8; 100]);
-    put_range(&cache, "/data/b.parquet", 0, 200, &vec![0u8; 200]);
+    put_range(&cache, "/data/a.parquet", 0, 100, &[0u8; 100]);
+    put_range(&cache, "/data/b.parquet", 0, 200, &[0u8; 200]);
 
     let removed_count_before = cache
         .stats
@@ -648,7 +648,7 @@ fn lru_eviction_retains_keys_in_key_index() {
     // Writes 8 × 256KB = 2MB total into a 1MB cache to trigger LRU eviction pressure.
     let dir = TempDir::new().unwrap();
     let cache = FoyerCache::new(
-        1 * 1024 * 1024,
+        1024 * 1024,
         dir.path(),
         256 * 1024,
         256 * 1024,
@@ -893,8 +893,8 @@ fn evict_prefix_updates_removed_bytes_and_used_bytes() {
     let (cache, _dir) = test_cache();
 
     // Two ranges: 0-100 = 100 bytes, 100-300 = 200 bytes → total 300 bytes.
-    put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
-    put_range(&cache, "/data/file.parquet", 100, 300, &vec![0u8; 200]);
+    put_range(&cache, "/data/file.parquet", 0, 100, &[0u8; 100]);
+    put_range(&cache, "/data/file.parquet", 100, 300, &[0u8; 200]);
     std::thread::sleep(std::time::Duration::from_millis(100));
 
     let used_before = cache
@@ -945,7 +945,7 @@ fn evict_prefix_updates_removed_bytes_and_used_bytes() {
 #[test]
 fn evict_prefix_on_nonexistent_prefix_does_not_change_stats() {
     let (cache, _dir) = test_cache();
-    put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
+    put_range(&cache, "/data/file.parquet", 0, 100, &[0u8; 100]);
 
     let removed_before = cache
         .stats
@@ -1296,12 +1296,8 @@ fn ffm_snapshot_stats_valid_ptr_returns_zero_and_fills_buffer() {
 
     // A freshly created cache has no hits, misses, evictions, used bytes, or active reads.
     // Sections 0 and 1 are identical (Foyer is currently single-tier).
-    for i in 0..20 {
-        assert_eq!(
-            out[i], 0,
-            "out[{i}] should be 0 for a fresh cache, got {}",
-            out[i]
-        );
+    for (i, &val) in out.iter().enumerate() {
+        assert_eq!(val, 0, "out[{i}] should be 0 for a fresh cache, got {val}");
     }
 
     let destroy_rc = unsafe { foyer_destroy_cache(ptr) };
@@ -1835,7 +1831,7 @@ fn persist_task_last_persisted_reset_forces_persist_after_recovery() {
             0,
             false,
         );
-        put_range(&cache1, "/data/reset_test.parquet", 0, 100, &vec![0u8; 100]);
+        put_range(&cache1, "/data/reset_test.parquet", 0, 100, &[0u8; 100]);
         // Drop writes key_index.json with used_bytes=100.
     }
     assert!(
@@ -1970,11 +1966,11 @@ fn sweep_once_processes_exactly_one_shard() {
 
     // Inject one unique stale key per shard directly via raw shard access.
     // Each key is unique so it hashes to a predictable shard via the raw write.
-    for i in 0..shard_count {
+    for (i, shard) in shards.iter().enumerate() {
         let prefix = format!("shard_test_{}", i);
         let key = format!("{}\x1F0-100", prefix);
         // Direct shard write bypasses DashMap's hashing — we control exactly which shard gets the key.
-        shards[i].write().insert(
+        shard.write().insert(
             prefix,
             dashmap::SharedValue::new({
                 let mut s = std::collections::HashSet::new();
@@ -2460,9 +2456,8 @@ fn sweep_threshold_disabled_never_skips() {
     );
 
     // used_bytes = 0 (empty cache)
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "threshold=0.0: should never skip even when cache is empty"
     );
 
@@ -2471,9 +2466,8 @@ fn sweep_threshold_disabled_never_skips() {
         TEST_CACHE_DISK_BYTES as i64,
         std::sync::atomic::Ordering::Relaxed,
     );
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "threshold=0.0: should never skip even when cache is 100% full"
     );
 }
@@ -2501,9 +2495,8 @@ fn sweep_threshold_skips_when_usage_below_threshold() {
         .stats
         .used_bytes
         .store(0, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "usage=0% < threshold=75%: sweep must be skipped"
     );
 
@@ -2513,21 +2506,19 @@ fn sweep_threshold_skips_when_usage_below_threshold() {
         .stats
         .used_bytes
         .store(half, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "usage=50% < threshold=75%: sweep must be skipped"
     );
 
     // usage = 74.9% → below 75% → skip
-    let below = ((TEST_CACHE_DISK_BYTES as f64 * 0.749) as i64);
+    let below = (TEST_CACHE_DISK_BYTES as f64 * 0.749) as i64;
     cache
         .stats
         .used_bytes
         .store(below, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "usage=74.9% < threshold=75%: sweep must be skipped"
     );
 }
@@ -2551,26 +2542,24 @@ fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
     );
 
     // usage = exactly 75% → NOT below → do NOT skip
-    let exact = ((TEST_CACHE_DISK_BYTES as f64 * 0.75) as i64);
+    let exact = (TEST_CACHE_DISK_BYTES as f64 * 0.75) as i64;
     cache
         .stats
         .used_bytes
         .store(exact, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "usage=75% == threshold=75%: sweep must NOT be skipped"
     );
 
     // usage = 90% → above 75% → do NOT skip
-    let above = ((TEST_CACHE_DISK_BYTES as f64 * 0.90) as i64);
+    let above = (TEST_CACHE_DISK_BYTES as f64 * 0.90) as i64;
     cache
         .stats
         .used_bytes
         .store(above, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "usage=90% > threshold=75%: sweep must NOT be skipped"
     );
 
@@ -2579,9 +2568,8 @@ fn sweep_threshold_runs_when_usage_at_or_above_threshold() {
         TEST_CACHE_DISK_BYTES as i64,
         std::sync::atomic::Ordering::Relaxed,
     );
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "usage=100% > threshold=75%: sweep must NOT be skipped"
     );
 }
@@ -2605,14 +2593,13 @@ fn sweep_threshold_one_skips_unless_completely_full() {
     );
 
     // usage = 99.9% → still below 100% → skip
-    let almost_full = ((TEST_CACHE_DISK_BYTES as f64 * 0.999) as i64);
+    let almost_full = (TEST_CACHE_DISK_BYTES as f64 * 0.999) as i64;
     cache
         .stats
         .used_bytes
         .store(almost_full, std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "threshold=1.0, usage=99.9%: sweep must be skipped"
     );
 
@@ -2621,9 +2608,8 @@ fn sweep_threshold_one_skips_unless_completely_full() {
         TEST_CACHE_DISK_BYTES as i64,
         std::sync::atomic::Ordering::Relaxed,
     );
-    assert_eq!(
-        cache.should_skip_sweep(),
-        false,
+    assert!(
+        !cache.should_skip_sweep(),
         "threshold=1.0, usage=100%: sweep must NOT be skipped"
     );
 }
@@ -2652,9 +2638,8 @@ fn sweep_threshold_negative_used_bytes_treated_as_zero() {
         .used_bytes
         .store(-100, std::sync::atomic::Ordering::Relaxed);
     // usage = max(−100, 0) / disk = 0 / disk = 0.0 < 0.5 → skip
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "negative used_bytes must be clamped to 0; ratio 0.0 < threshold 0.5 → skip"
     );
 }
@@ -2686,9 +2671,8 @@ fn sweep_once_ignores_threshold_guard() {
         .insert("data/file.parquet\x1F0-100".to_string());
 
     // usage = 0 → should_skip_sweep() is true (below 99% threshold)
-    assert_eq!(
+    assert!(
         cache.should_skip_sweep(),
-        true,
         "precondition: threshold guard would skip"
     );
 
@@ -2809,8 +2793,8 @@ fn recovery_used_bytes_initialized_from_snapshot() {
             false,
         );
         // 3 ranges: 100 + 200 + 300 = 600 bytes total.
-        put_range(&cache, "/data/f.parquet", 0, 100, &vec![0u8; 100]);
-        put_range(&cache, "/data/f.parquet", 100, 300, &vec![0u8; 200]);
+        put_range(&cache, "/data/f.parquet", 0, 100, &[0u8; 100]);
+        put_range(&cache, "/data/f.parquet", 100, 300, &[0u8; 200]);
         put_range(&cache, "/data/f.parquet", 300, 600, &vec![0u8; 300]);
         // Drop persists.
     }
@@ -3167,7 +3151,7 @@ fn persist_task_does_not_fire_when_cache_idle() {
             false,
         );
         // Single put to trigger the first persist.
-        put_range(&cache, "/data/idle.parquet", 0, 100, &vec![0u8; 100]);
+        put_range(&cache, "/data/idle.parquet", 0, 100, &[0u8; 100]);
 
         // Wait for the first persist (sentinel → current triggers it).
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
@@ -3290,7 +3274,7 @@ fn persist_task_not_spawned_when_interval_is_zero() {
             0, // disabled
             false,
         );
-        put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
+        put_range(&cache, "/data/file.parquet", 0, 100, &[0u8; 100]);
 
         // Wait 2 seconds — file must NOT appear (no persist task).
         std::thread::sleep(std::time::Duration::from_millis(2000));
@@ -3412,13 +3396,7 @@ fn graceful_shutdown_snapshot_is_valid_json_with_correct_content() {
             512,
             &vec![0u8; 256],
         );
-        put_range(
-            &cache,
-            "/data/nodes/0/shard2.parquet",
-            0,
-            128,
-            &vec![0u8; 128],
-        );
+        put_range(&cache, "/data/nodes/0/shard2.parquet", 0, 128, &[0u8; 128]);
         // Drop writes key_index.json.
     }
 
@@ -3465,7 +3443,7 @@ fn no_tmp_file_left_after_graceful_shutdown() {
             0,
             false,
         );
-        put_range(&cache, "/data/file.parquet", 0, 100, &vec![0u8; 100]);
+        put_range(&cache, "/data/file.parquet", 0, 100, &[0u8; 100]);
         // Drop writes and renames.
     }
     assert!(
@@ -3559,10 +3537,10 @@ fn no_tmp_file_on_clean_startup() {
     );
 }
 
-/// Stale entries in the recovered snapshot (keys that Foyer did not recover due
-/// to LRU eviction before the last persist) are cleaned up by sweep_once().
-/// The cache is usable throughout — stale keys don't cause panics or incorrect
-/// behavior; they just occupy key_index until swept.
+// Stale entries in the recovered snapshot (keys that Foyer did not recover due
+// to LRU eviction before the last persist) are cleaned up by sweep_once().
+// The cache is usable throughout — stale keys don't cause panics or incorrect
+// behavior; they just occupy key_index until swept.
 // ─── 10k-scale key_index tests ────────────────────────────────────────────────
 // These tests build a 10k-entry key_index in-process (no OS cluster, no fd pressure).
 
@@ -3773,7 +3751,7 @@ fn key_index_clear_with_10k_entries() {
     }
 
     // Persist first so there's a file to delete.
-    key_index_store::save(&dir.path(), &cache.key_index).unwrap();
+    key_index_store::save(dir.path(), &cache.key_index).unwrap();
     assert!(
         dir.path()
             .join(key_index_store::KEY_INDEX_FILENAME)

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -14,7 +14,7 @@
 use std::slice;
 use std::str;
 
-use native_bridge_common::{ffm_safe, log_debug};
+use native_bridge_common::ffm_safe;
 
 use crate::field_config::FieldConfig;
 use crate::merge;
@@ -302,6 +302,14 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
     Ok(0)
 }
 
+/// Returns the total native bytes used by writers whose path starts with the
+/// given prefix.
+///
+/// # Safety
+///
+/// If `prefix_len > 0`, `prefix_ptr` must point to at least `prefix_len`
+/// initialized bytes of valid UTF-8 that remain live for the duration of the
+/// call. A null pointer or non-positive length is treated as an empty prefix.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_get_filtered_native_bytes_used(
     prefix_ptr: *const u8,
@@ -761,6 +769,15 @@ pub unsafe extern "C" fn parquet_merge_files(
 }
 
 /// Frees the heap-allocated arrays returned by `parquet_merge_files`.
+///
+/// # Safety
+///
+/// Each pointer argument must be either `0` or a value previously returned by
+/// `parquet_merge_files` and not yet freed. The corresponding length argument
+/// (`mapping_len` for `mapping_ptr`, `gen_count` for the three `gen_*` arrays)
+/// must exactly match the length the array was originally allocated with.
+/// Passing mismatched lengths, freed pointers, or pointers not produced by
+/// `parquet_merge_files` is undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_free_merge_result(
     mapping_ptr: i64,
@@ -774,20 +791,29 @@ pub unsafe extern "C" fn parquet_free_merge_result(
         let mapping_bytes = mapping_len as usize * std::mem::size_of::<i64>();
         // Java released merge mapping — free from pool
         crate::memory::merge_pool().shrink(mapping_bytes);
-        let _ = Box::from_raw(slice::from_raw_parts_mut(
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
             mapping_ptr as *mut i64,
             mapping_len as usize,
         ));
     }
     let n = gen_count as usize;
     if gen_keys_ptr != 0 && n > 0 {
-        let _ = Box::from_raw(slice::from_raw_parts_mut(gen_keys_ptr as *mut i64, n));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            gen_keys_ptr as *mut i64,
+            n,
+        ));
     }
     if gen_offsets_ptr != 0 && n > 0 {
-        let _ = Box::from_raw(slice::from_raw_parts_mut(gen_offsets_ptr as *mut i32, n));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            gen_offsets_ptr as *mut i32,
+            n,
+        ));
     }
     if gen_sizes_ptr != 0 && n > 0 {
-        let _ = Box::from_raw(slice::from_raw_parts_mut(gen_sizes_ptr as *mut i32, n));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            gen_sizes_ptr as *mut i32,
+            n,
+        ));
     }
 }
 
@@ -901,13 +927,20 @@ pub unsafe extern "C" fn parquet_read_as_json(
 // ---------------------------------------------------------------------------
 
 /// Frees the heap-allocated row ID mapping array returned as part of `parquet_finalize_writer`.
+///
+/// # Safety
+///
+/// `mapping_ptr` must be either `0` or a pointer previously returned by
+/// `parquet_finalize_writer` and not yet freed, and `mapping_len` must exactly
+/// match the length the array was originally allocated with. Any other
+/// combination is undefined behavior.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_free_row_id_mapping(mapping_ptr: i64, mapping_len: i64) {
     if mapping_ptr != 0 && mapping_len > 0 {
         let mapping_bytes = mapping_len as usize * std::mem::size_of::<i64>();
         // Java released write mapping — free from pool
         crate::memory::write_pool().shrink(mapping_bytes);
-        let _ = Box::from_raw(slice::from_raw_parts_mut(
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
             mapping_ptr as *mut i64,
             mapping_len as usize,
         ));
@@ -998,6 +1031,12 @@ pub extern "C" fn parquet_register_overcommit_callbacks(
 
 /// Get pool stats: writes 6 i64s to out_buf.
 /// Layout: [write_limit, write_used, write_peak, merge_limit, merge_used, merge_peak]
+///
+/// # Safety
+///
+/// `out_buf` must be non-null and point to a writable buffer with capacity for
+/// at least as many `i64` values as `crate::memory::get_stats()` returns (6).
+/// The buffer must remain valid for the duration of the call.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_get_pool_stats(out_buf: *mut i64) {
     let stats = crate::memory::get_stats();

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -55,6 +55,9 @@ pub struct MergeContext {
 impl MergeContext {
     /// Creates a new merge context: builds union schemas, opens the output
     /// writer, and spawns the background IO task.
+    // Each argument is a distinct, required merge configuration input; grouping
+    // them into a struct would only shift the argument list elsewhere.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         arrow_schemas: Vec<ArrowSchema>,
         parquet_descriptors: &[SchemaDescriptor],

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/sorted.rs
@@ -49,6 +49,9 @@ pub fn merge_sorted(
 }
 
 /// Performs a streaming k-way merge using the provided memory reservation.
+// Each argument is a distinct, required merge parameter; bundling them into a
+// struct would only move the argument list to the call site.
+#[allow(clippy::too_many_arguments)]
 pub fn merge_sorted_with_pool(
     input_files: &[String],
     output_path: &str,

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/native_settings.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/native_settings.rs
@@ -84,7 +84,7 @@ impl NativeSettings {
     pub fn has_field_configs(&self) -> bool {
         self.field_configs
             .as_ref()
-            .map_or(false, |configs| !configs.is_empty())
+            .is_some_and(|configs| !configs.is_empty())
     }
 
     pub fn get_sort_in_memory_threshold_bytes(&self) -> u64 {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/rate_limited_writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/rate_limited_writer.rs
@@ -127,12 +127,10 @@ impl<W: Write> RateLimitedWriter<W> {
 
         let min_pause_check_bytes = Self::calculate_min_pause_check_bytes(mb_per_sec);
 
-        let mut config = self.rate_limiter_config.write().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to acquire write lock: {}", e),
-            )
-        })?;
+        let mut config = self
+            .rate_limiter_config
+            .write()
+            .map_err(|e| std::io::Error::other(format!("Failed to acquire write lock: {}", e)))?;
 
         config.mb_per_sec = mb_per_sec;
         config.min_pause_check_bytes = min_pause_check_bytes;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
@@ -594,7 +594,6 @@ fn test_get_filtered_writer_memory_usage_with_writers() {
     let (_schema2, schema_ptr2) = create_writer_and_assert_success(&filename2);
     let result = NativeParquetWriter::get_filtered_writer_memory_usage(prefix);
     assert!(result.is_ok());
-    assert!(result.unwrap() >= 0);
     close_writer_and_cleanup_schema(&filename1, schema_ptr1);
     close_writer_and_cleanup_schema(&filename2, schema_ptr2);
 }
@@ -786,8 +785,8 @@ fn test_concurrent_writes_different_files() {
         schema_ptrs.push(schema_ptr);
     }
 
-    for i in 0..file_count {
-        let filename = filenames[i].clone();
+    for filename in &filenames {
+        let filename = filename.clone();
         let success_count = Arc::clone(&success_count);
 
         let handle = thread::spawn(move || {
@@ -827,7 +826,7 @@ fn test_bloom_filter_false_propagates_through_settings_store() {
 
     let stored = SETTINGS_STORE.get(index_name).unwrap();
     assert_eq!(stored.bloom_filter_enabled, Some(false));
-    assert_eq!(stored.get_bloom_filter_enabled(), false);
+    assert!(!stored.get_bloom_filter_enabled());
     drop(stored);
 
     let (_temp_dir, filename) = get_temp_file_path("bloom_test.parquet");
@@ -850,7 +849,7 @@ fn test_bloom_filter_false_propagates_through_settings_store() {
         "bloom_filter_enabled should remain false after create_writer, but got: {:?}",
         stored_after.bloom_filter_enabled
     );
-    assert_eq!(stored_after.get_bloom_filter_enabled(), false);
+    assert!(!stored_after.get_bloom_filter_enabled());
     drop(stored_after);
 
     close_writer_and_cleanup_schema(&filename, schema_ptr);
@@ -875,9 +874,8 @@ fn test_bloom_filter_default_when_no_settings() {
     assert!(result.is_ok());
 
     let stored = SETTINGS_STORE.get(index_name).unwrap();
-    assert_eq!(
-        stored.get_bloom_filter_enabled(),
-        false,
+    assert!(
+        !stored.get_bloom_filter_enabled(),
         "Default bloom_filter_enabled should be false when no settings exist"
     );
     drop(stored);
@@ -1045,11 +1043,13 @@ fn test_chunked_writer_single_chunk_row_ids_sequential() {
     let index_name = "test-chunked-single";
 
     // Configure with large threshold so everything fits in one chunk
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024); // 10MB — won't chunk
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024), // 10MB — won't chunk
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     // Create writer with sort on "age" ascending
@@ -1118,11 +1118,13 @@ fn test_chunked_writer_multi_chunk_row_ids_sequential() {
     let index_name = "test-chunked-multi";
 
     // Configure with tiny threshold to force multiple chunks
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Very small — forces chunking
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Very small — forces chunking
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -1205,11 +1207,13 @@ fn test_chunked_writer_multi_chunk_descending_sort() {
     let (_temp_dir, filename) = get_temp_file_path("chunked_desc.parquet");
     let index_name = "test-chunked-desc";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![true]; // descending
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![true], // descending
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -1270,11 +1274,13 @@ fn test_chunked_writer_multiple_write_calls() {
     let (_temp_dir, filename) = get_temp_file_path("chunked_multi_write.parquet");
     let index_name = "test-chunked-multi-write";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(128); // Small enough to force chunking
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(128), // Small enough to force chunking
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     // First batch: row_ids 0..4
@@ -1351,11 +1357,13 @@ fn test_chunked_writer_empty_finalize() {
     let (_temp_dir, filename) = get_temp_file_path("chunked_empty.parquet");
     let index_name = "test-chunked-empty";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     // Just create the writer with the schema, don't write data
@@ -1395,11 +1403,13 @@ fn test_chunked_writer_permutation_is_invertible() {
     let (_temp_dir, filename) = get_temp_file_path("chunked_invertible.parquet");
     let index_name = "test-chunked-invertible";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let original_ages = vec![55, 22, 88, 11, 44, 77, 33, 66, 99, 0];
@@ -1461,11 +1471,13 @@ fn test_chunked_writer_large_dataset_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("chunked_large.parquet");
     let index_name = "test-chunked-large";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(256); // Force many chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(256), // Force many chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let num_rows = 50i32;
@@ -1559,11 +1571,13 @@ fn test_chunked_writer_generation_in_metadata_single_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("gen_single.parquet");
     let index_name = "test-gen-single";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 42i64;
@@ -1606,11 +1620,13 @@ fn test_chunked_writer_generation_in_metadata_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("gen_multi.parquet");
     let index_name = "test-gen-multi";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Force multiple chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Force multiple chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 7i64;
@@ -1671,11 +1687,13 @@ fn test_chunked_writer_generation_zero() {
     let (_temp_dir, filename) = get_temp_file_path("gen_zero.parquet");
     let index_name = "test-gen-zero";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -1711,11 +1729,13 @@ fn test_chunked_writer_generation_large_value() {
     let (_temp_dir, filename) = get_temp_file_path("gen_large.parquet");
     let index_name = "test-gen-large";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024); // Large threshold — single chunk
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024), // Large threshold — single chunk
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 999_999i64;
@@ -1835,11 +1855,13 @@ fn test_chunked_writer_crc32_single_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("crc_single.parquet");
     let index_name = "test-crc-single";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024); // Single chunk
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024), // Single chunk
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -1887,11 +1909,13 @@ fn test_chunked_writer_crc32_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("crc_multi.parquet");
     let index_name = "test-crc-multi";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Force multiple chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Force multiple chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -1947,11 +1971,13 @@ fn test_chunked_writer_crc32_differs_for_different_data() {
     let index_name1 = "test-crc-diff1";
     let index_name2 = "test-crc-diff2";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name1.to_string(), settings.clone());
     SETTINGS_STORE.insert(index_name2.to_string(), settings);
 
@@ -2023,11 +2049,13 @@ fn test_chunked_writer_batch_slicing_large_batch() {
     // Set threshold to 1 byte — every batch will exceed it and trigger slicing.
     // With 1 byte threshold, rows_per_slice = max(1, 1/bytes_per_row) = 1,
     // so each row becomes its own chunk.
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(1); // Extremely small — forces per-row slicing
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(1), // Extremely small — forces per-row slicing
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -2108,11 +2136,13 @@ fn test_chunked_writer_batch_slicing_two_rows_per_slice() {
 
     // We need a threshold that allows ~2 rows. A single Int32 + Utf8 + Int64 row
     // is roughly 40-80 bytes in Arrow memory. Set threshold to allow ~2 rows.
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(100); // ~2 rows fit
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(100), // ~2 rows fit
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -2193,11 +2223,13 @@ fn test_chunked_writer_batch_slicing_descending() {
     let (_temp_dir, filename) = get_temp_file_path("slice_desc.parquet");
     let index_name = "test-slice-desc";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![true]; // descending
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(1); // Force per-row slicing
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![true], // descending
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(1), // Force per-row slicing
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -2252,11 +2284,13 @@ fn test_chunked_writer_batch_slicing_multiple_writes() {
     let (_temp_dir, filename) = get_temp_file_path("slice_multi_write.parquet");
     let index_name = "test-slice-multi-write";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(1); // Force slicing on every batch
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(1), // Force slicing on every batch
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -2361,11 +2395,13 @@ fn test_chunked_writer_no_row_id_single_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("no_rowid_single.parquet");
     let index_name = "test-no-rowid-single";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_no_row_id_schema_ptr();
@@ -2414,11 +2450,13 @@ fn test_chunked_writer_no_row_id_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("no_rowid_multi.parquet");
     let index_name = "test-no-rowid-multi";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Force multiple chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Force multiple chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_no_row_id_schema_ptr();
@@ -2476,11 +2514,13 @@ fn test_chunked_writer_no_row_id_batch_slicing() {
     let (_temp_dir, filename) = get_temp_file_path("no_rowid_slice.parquet");
     let index_name = "test-no-rowid-slice";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![true]; // descending
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(1); // Force per-row slicing
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![true], // descending
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(1), // Force per-row slicing
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_no_row_id_schema_ptr();
@@ -2612,11 +2652,13 @@ fn test_multi_column_sort_age_asc_score_desc() {
     let (_temp_dir, filename) = get_temp_file_path("multi_sort_asc_desc.parquet");
     let index_name = "test-multi-sort-asc-desc";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string(), "score".to_string()];
-    settings.reverse_sorts = vec![false, true]; // age ASC, score DESC
-    settings.nulls_first = vec![false, false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string(), "score".to_string()],
+        reverse_sorts: vec![false, true], // age ASC, score DESC
+        nulls_first: vec![false, false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_multi_sort_schema_ptr();
@@ -2682,11 +2724,13 @@ fn test_multi_column_sort_age_desc_score_asc() {
     let (_temp_dir, filename) = get_temp_file_path("multi_sort_desc_asc.parquet");
     let index_name = "test-multi-sort-desc-asc";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string(), "score".to_string()];
-    settings.reverse_sorts = vec![true, false]; // age DESC, score ASC
-    settings.nulls_first = vec![false, false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string(), "score".to_string()],
+        reverse_sorts: vec![true, false], // age DESC, score ASC
+        nulls_first: vec![false, false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_multi_sort_schema_ptr();
@@ -2731,11 +2775,13 @@ fn test_multi_column_sort_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("multi_sort_chunked.parquet");
     let index_name = "test-multi-sort-chunked";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string(), "score".to_string()];
-    settings.reverse_sorts = vec![false, false]; // both ASC
-    settings.nulls_first = vec![false, false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Force multiple chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string(), "score".to_string()],
+        reverse_sorts: vec![false, false], // both ASC
+        nulls_first: vec![false, false],
+        sort_in_memory_threshold_bytes: Some(64), // Force multiple chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_multi_sort_schema_ptr();
@@ -2808,11 +2854,13 @@ fn test_multi_column_sort_batch_slicing() {
     let (_temp_dir, filename) = get_temp_file_path("multi_sort_slice.parquet");
     let index_name = "test-multi-sort-slice";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string(), "score".to_string()];
-    settings.reverse_sorts = vec![false, true]; // age ASC, score DESC
-    settings.nulls_first = vec![false, false];
-    settings.sort_in_memory_threshold_bytes = Some(1); // Per-row slicing
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string(), "score".to_string()],
+        reverse_sorts: vec![false, true], // age ASC, score DESC
+        nulls_first: vec![false, false],
+        sort_in_memory_threshold_bytes: Some(1), // Per-row slicing
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_multi_sort_schema_ptr();
@@ -2914,11 +2962,13 @@ fn test_nulls_first_true_ascending() {
     let (_temp_dir, filename) = get_temp_file_path("nulls_first_true.parquet");
     let index_name = "test-nulls-first-true";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false]; // ASC
-    settings.nulls_first = vec![true]; // NULLs first
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false], // ASC
+        nulls_first: vec![true],    // NULLs first
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_nullable_schema_ptr();
@@ -2953,11 +3003,13 @@ fn test_nulls_first_false_ascending() {
     let (_temp_dir, filename) = get_temp_file_path("nulls_first_false.parquet");
     let index_name = "test-nulls-first-false";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false]; // ASC
-    settings.nulls_first = vec![false]; // NULLs last
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false], // ASC
+        nulls_first: vec![false],   // NULLs last
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_nullable_schema_ptr();
@@ -3036,11 +3088,13 @@ fn test_nulls_first_with_row_id_and_permutation() {
     let (_temp_dir, filename) = get_temp_file_path("nulls_first_rowid.parquet");
     let index_name = "test-nulls-first-rowid";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false]; // ASC
-    settings.nulls_first = vec![true]; // NULLs first
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false], // ASC
+        nulls_first: vec![true],    // NULLs first
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_nullable_with_row_id_schema_ptr();
@@ -3104,11 +3158,13 @@ fn test_nulls_last_with_row_id_and_permutation() {
     let (_temp_dir, filename) = get_temp_file_path("nulls_last_rowid.parquet");
     let index_name = "test-nulls-last-rowid";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false]; // ASC
-    settings.nulls_first = vec![false]; // NULLs last
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false], // ASC
+        nulls_first: vec![false],   // NULLs last
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_nullable_with_row_id_schema_ptr();
@@ -3170,11 +3226,13 @@ fn test_empty_batch_write_does_not_corrupt_sorted_writer() {
     let (_temp_dir, filename) = get_temp_file_path("empty_batch.parquet");
     let index_name = "test-empty-batch";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -3224,11 +3282,13 @@ fn test_only_empty_batches_produces_empty_output() {
     let (_temp_dir, filename) = get_temp_file_path("only_empty.parquet");
     let index_name = "test-only-empty";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -3267,11 +3327,13 @@ fn test_memory_usage_ipc_writer_reports_chunk_row_ids() {
     let (_temp_dir, filename) = get_temp_file_path("mem_ipc.parquet");
     let index_name = "test-mem-ipc";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Force chunking
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Force chunking
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -3349,11 +3411,13 @@ fn test_memory_usage_path_prefix_filtering() {
     let (_temp_dir2, filename2) = get_temp_file_path("mem_prefix_b.parquet");
     let index_name = "test-mem-prefix";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     // Create writer 1
@@ -3406,7 +3470,7 @@ fn test_memory_usage_path_prefix_filtering() {
     let mem2 = NativeParquetWriter::get_filtered_writer_memory_usage(prefix2).unwrap();
 
     // Writer 1 had data written (and chunks flushed), writer 2 did not
-    assert!(mem1 >= 0, "Writer 1 memory should be reported");
+    assert!(mem1 > 0, "Writer 1 memory should be reported");
     assert_eq!(mem2, 0, "Writer 2 should have 0 memory (no data written)");
 
     // Cleanup
@@ -3446,17 +3510,20 @@ fn test_write_data_no_ipc_writer() {
 /// - Row IDs are sequential 0..N
 /// - The permutation mapping is a valid permutation (bijection of 0..N)
 /// - The mapping correctly maps each original row to its output position
+///
 /// It does NOT assert a specific tie-breaking order.
 #[test]
 fn test_sort_all_identical_keys_produces_valid_permutation() {
     let (_temp_dir, filename) = get_temp_file_path("identical_keys.parquet");
     let index_name = "test-identical-keys";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -3568,13 +3635,15 @@ fn test_writer_properties_honored_empty_path() {
     let (_temp_dir, filename) = get_temp_file_path("props_empty.parquet");
     let index_name = "test-props-empty";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
-    settings.compression_type = Some("SNAPPY".to_string());
-    settings.bloom_filter_enabled = Some(false);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        compression_type: Some("SNAPPY".to_string()),
+        bloom_filter_enabled: Some(false),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 99i64;
@@ -3622,13 +3691,15 @@ fn test_writer_properties_honored_single_chunk_snappy_no_bloom() {
     let (_temp_dir, filename) = get_temp_file_path("props_single_snappy.parquet");
     let index_name = "test-props-single-snappy";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024); // Large — single chunk
-    settings.compression_type = Some("SNAPPY".to_string());
-    settings.bloom_filter_enabled = Some(false);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024), // Large — single chunk
+        compression_type: Some("SNAPPY".to_string()),
+        bloom_filter_enabled: Some(false),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 55i64;
@@ -3696,16 +3767,18 @@ fn test_writer_properties_honored_single_chunk_zstd_with_bloom() {
     let (_temp_dir, filename) = get_temp_file_path("props_single_zstd.parquet");
     let index_name = "test-props-single-zstd";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
-    settings.compression_type = Some("ZSTD".to_string());
-    settings.compression_level = Some(3);
-    settings.bloom_filter_enabled = Some(true);
-    settings.bloom_filter_fpp = Some(0.05);
-    settings.bloom_filter_ndv = Some(50_000);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        compression_type: Some("ZSTD".to_string()),
+        compression_level: Some(3),
+        bloom_filter_enabled: Some(true),
+        bloom_filter_fpp: Some(0.05),
+        bloom_filter_ndv: Some(50_000),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 12i64;
@@ -3761,13 +3834,15 @@ fn test_writer_properties_honored_multi_chunk_snappy_no_bloom() {
     let (_temp_dir, filename) = get_temp_file_path("props_multi_snappy.parquet");
     let index_name = "test-props-multi-snappy";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Tiny — forces multiple chunks
-    settings.compression_type = Some("SNAPPY".to_string());
-    settings.bloom_filter_enabled = Some(false);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Tiny — forces multiple chunks
+        compression_type: Some("SNAPPY".to_string()),
+        bloom_filter_enabled: Some(false),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 77i64;
@@ -3838,16 +3913,18 @@ fn test_writer_properties_honored_multi_chunk_zstd_with_bloom() {
     let (_temp_dir, filename) = get_temp_file_path("props_multi_zstd.parquet");
     let index_name = "test-props-multi-zstd";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Tiny — forces multiple chunks
-    settings.compression_type = Some("ZSTD".to_string());
-    settings.compression_level = Some(5);
-    settings.bloom_filter_enabled = Some(true);
-    settings.bloom_filter_fpp = Some(0.01);
-    settings.bloom_filter_ndv = Some(200_000);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Tiny — forces multiple chunks
+        compression_type: Some("ZSTD".to_string()),
+        compression_level: Some(5),
+        bloom_filter_enabled: Some(true),
+        bloom_filter_fpp: Some(0.01),
+        bloom_filter_ndv: Some(200_000),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let writer_generation = 33i64;
@@ -3914,13 +3991,15 @@ fn test_writer_properties_honored_single_chunk_uncompressed() {
     let (_temp_dir, filename) = get_temp_file_path("props_single_uncompressed.parquet");
     let index_name = "test-props-single-uncompressed";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
-    settings.compression_type = Some("UNCOMPRESSED".to_string());
-    settings.bloom_filter_enabled = Some(true);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        compression_type: Some("UNCOMPRESSED".to_string()),
+        bloom_filter_enabled: Some(true),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -3966,13 +4045,15 @@ fn test_writer_properties_honored_multi_chunk_uncompressed() {
     let (_temp_dir, filename) = get_temp_file_path("props_multi_uncompressed.parquet");
     let index_name = "test-props-multi-uncompressed";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Tiny — forces multiple chunks
-    settings.compression_type = Some("UNCOMPRESSED".to_string());
-    settings.bloom_filter_enabled = Some(true);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Tiny — forces multiple chunks
+        compression_type: Some("UNCOMPRESSED".to_string()),
+        bloom_filter_enabled: Some(true),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -4035,11 +4116,13 @@ fn test_writer_properties_defaults_single_chunk() {
     let index_name = "test-props-defaults-single";
 
     // Use defaults — only configure sort
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(10 * 1024 * 1024);
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(10 * 1024 * 1024),
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();
@@ -4089,11 +4172,13 @@ fn test_writer_properties_defaults_multi_chunk() {
     let (_temp_dir, filename) = get_temp_file_path("props_defaults_multi.parquet");
     let index_name = "test-props-defaults-multi";
 
-    let mut settings = NativeSettings::default();
-    settings.sort_columns = vec!["age".to_string()];
-    settings.reverse_sorts = vec![false];
-    settings.nulls_first = vec![false];
-    settings.sort_in_memory_threshold_bytes = Some(64); // Tiny — forces multiple chunks
+    let settings = NativeSettings {
+        sort_columns: vec!["age".to_string()],
+        reverse_sorts: vec![false],
+        nulls_first: vec![false],
+        sort_in_memory_threshold_bytes: Some(64), // Tiny — forces multiple chunks
+        ..Default::default()
+    };
     SETTINGS_STORE.insert(index_name.to_string(), settings);
 
     let (_schema, schema_ptr) = create_row_id_schema_ptr();

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
@@ -28,6 +28,15 @@ use crate::writer_properties_builder::WriterPropertiesBuilder;
 use crate::{log_debug, log_error, log_info};
 use native_bridge_common::memory_pool::{MemoryReservation, PoolBehavior};
 
+/// Boxed error alias used throughout the writer's fallible internal helpers.
+type WriterError = Box<dyn std::error::Error>;
+
+/// Output of finalizing sorted chunks: (chunk paths, per-chunk row IDs, per-chunk CRCs).
+type FinishChunksResult = (Vec<String>, Vec<Vec<i64>>, Vec<u32>);
+
+/// Output of `finalize_sorted_chunks`: (whole-file CRC32, optional row ID mapping).
+type FinalizeChunksResult = (u32, Option<Vec<i64>>);
+
 /// Result from finalizing a writer: Parquet metadata + whole-file CRC32 + optional sort permutation.
 #[derive(Debug)]
 pub struct FinalizeResult {
@@ -100,6 +109,9 @@ struct SortingChunkedWriter {
 }
 
 impl SortingChunkedWriter {
+    // Each argument is a distinct, required writer-configuration input; grouping
+    // them into a struct would only shift the argument list to the caller.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         base_path: String,
         schema: Arc<arrow::datatypes::Schema>,
@@ -288,8 +300,7 @@ impl SortingChunkedWriter {
             self.chunk_row_ids.push(ids);
 
             // Rewrite ___row_id to sequential 0..N so the chunk file is self-consistent
-            let sequential_ids =
-                Int64Array::from_iter_values((0..sorted_batch.num_rows() as i64).map(|x| x));
+            let sequential_ids = Int64Array::from_iter_values(0..sorted_batch.num_rows() as i64);
             let mut columns = sorted_batch.columns().to_vec();
             columns[idx] = Arc::new(sequential_ids);
             RecordBatch::try_new(self.schema.clone(), columns)?
@@ -328,7 +339,7 @@ impl SortingChunkedWriter {
     fn finish(
         mut self,
         reservation: &mut MemoryReservation,
-    ) -> Result<(Vec<String>, Vec<Vec<i64>>, Vec<u32>), Box<dyn std::error::Error>> {
+    ) -> Result<FinishChunksResult, WriterError> {
         if self.current_rows > 0 {
             self.flush_and_sort_chunk(reservation)?;
         }
@@ -336,7 +347,7 @@ impl SortingChunkedWriter {
         if let Some(mut writer) = self.current_ipc_writer.take() {
             writer.finish()?;
         }
-        let _ = std::fs::remove_file(&self.ipc_staging_path());
+        let _ = std::fs::remove_file(self.ipc_staging_path());
         Ok((self.completed_chunks, self.chunk_row_ids, self.chunk_crcs))
     }
 
@@ -709,6 +720,9 @@ impl NativeParquetWriter {
     /// Finalize pre-sorted Parquet chunks: k-way merge them into the final file.
     /// Chunks are already sorted (done eagerly during write), so no sort needed here.
     /// For single chunk, just rename. For empty, write empty Parquet.
+    // Each argument is a distinct, required finalization input; grouping them
+    // into a struct would only shift the argument list to the caller.
+    #[allow(clippy::too_many_arguments)]
     fn finalize_sorted_chunks(
         chunk_paths: &[String],
         chunk_row_ids: &[Vec<i64>],
@@ -721,7 +735,7 @@ impl NativeParquetWriter {
         writer_generation: i64,
         schema: Arc<arrow::datatypes::Schema>,
         reservation: &mut MemoryReservation,
-    ) -> Result<(u32, Option<Vec<i64>>), Box<dyn std::error::Error>> {
+    ) -> Result<FinalizeChunksResult, WriterError> {
         if chunk_paths.is_empty() {
             log_info!("finalize_sorted_chunks: no chunks, writing empty Parquet file");
             let config = SETTINGS_STORE
@@ -811,8 +825,8 @@ impl NativeParquetWriter {
             // Reserve 2× mapping: merge_output.mapping (alive) + flat_mapping (about to allocate)
             reservation.request(mapping_bytes * 2)?;
             let mut flat_mapping = vec![0i64; total];
-            for i in 0..total {
-                flat_mapping[i] = i as i64;
+            for (i, slot) in flat_mapping.iter_mut().enumerate() {
+                *slot = i as i64;
             }
             let mut pos = 0usize;
             for chunk_ids in chunk_row_ids {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -427,7 +427,7 @@ impl WriterPropertiesBuilder {
     fn parse_compression_type(compression_type: &str, level: i32) -> Result<Compression, String> {
         match compression_type.to_uppercase().as_str() {
             "ZSTD" => Ok(Compression::ZSTD(
-                ZstdLevel::try_new(level).unwrap_or(ZstdLevel::default()),
+                ZstdLevel::try_new(level).unwrap_or_default(),
             )),
             "SNAPPY" => Ok(Compression::SNAPPY),
             "GZIP" => Ok(Compression::GZIP(
@@ -1023,7 +1023,7 @@ mod tests {
     #[test]
     fn test_bloom_filter_default_is_false() {
         let config = NativeSettings::default();
-        assert_eq!(config.get_bloom_filter_enabled(), false);
+        assert!(!config.get_bloom_filter_enabled());
         let schema = schema_with(vec![("test_col", ArrowDataType::Utf8)]);
         let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
         let col_path = parquet::schema::types::ColumnPath::from("test_col");

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_integration_tests.rs
@@ -784,8 +784,8 @@ fn test_default_settings_ascending_nulls_first() {
     let vals = read_col_i64(&output, "v");
     assert_eq!(vals.len() as i64, total);
     // First total_nulls rows must all be None
-    for i in 0..total_nulls as usize {
-        assert_eq!(vals[i], None, "expected null at row {}", i);
+    for (i, val) in vals.iter().enumerate().take(total_nulls as usize) {
+        assert_eq!(*val, None, "expected null at row {}", i);
     }
     // Remaining rows must be exactly 0, 1, 2, ..., total_nonnulls-1
     for i in 0..total_nonnulls as usize {

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/sort_types_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/sort_types_tests.rs
@@ -93,7 +93,7 @@ fn test_merge_sort_by_int64() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, false)]));
 
     // File A: [1, 3, 5]  File B: [2, 4, 6]  File C: [0, 7, 8]
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![1, 3, 5]))],
@@ -152,7 +152,7 @@ fn test_merge_sort_by_int64_with_nulls() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, true)]));
 
     // Each file pre-sorted: nulls last, then ascending
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![Some(1), Some(5), None]))],
@@ -203,7 +203,7 @@ fn test_merge_sort_by_int64_with_nulls() {
 fn test_merge_sort_by_int32() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int32, false)]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int32Array::from(vec![10, 30]))],
@@ -259,7 +259,7 @@ fn test_merge_sort_by_float64() {
         false,
     )]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Float64Array::from(vec![1.1, 3.3, 5.5]))],
@@ -315,7 +315,7 @@ fn test_merge_sort_by_float64_with_nulls() {
         true,
     )]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Float64Array::from(vec![
@@ -381,7 +381,7 @@ fn test_merge_sort_by_float32() {
         false,
     )]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Float32Array::from(vec![1.0f32, 3.0]))],
@@ -437,7 +437,7 @@ fn test_merge_sort_by_float32_with_nulls() {
         true,
     )]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Float32Array::from(vec![
@@ -495,7 +495,7 @@ fn test_merge_sort_by_float32_with_nulls() {
 fn test_merge_sort_by_string() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Utf8, false)]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(StringArray::from(vec!["apple", "cherry", "fig"]))],
@@ -550,7 +550,7 @@ fn test_merge_sort_by_string() {
 fn test_merge_sort_by_string_with_nulls() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Utf8, true)]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(StringArray::from(vec![
@@ -620,7 +620,7 @@ fn test_merge_sort_descending() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, false)]));
 
     // Each file sorted descending
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![8, 5, 2]))],
@@ -683,7 +683,7 @@ fn test_merge_sort_multi_column_string_and_int() {
     // File A: (alpha,1), (alpha,3), (beta,1)
     // File B: (alpha,2), (beta,2), (beta,3)
     // Sorted by (category ASC, priority ASC)
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![
@@ -750,7 +750,7 @@ fn test_merge_sort_with_nulls_first() {
 
     // Each file pre-sorted with nulls first, then ascending
     // File A: [null, 2, 5]  File B: [null, 1, 4]
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![None, Some(2), Some(5)]))],
@@ -800,7 +800,7 @@ fn test_merge_sort_with_nulls_first() {
 fn test_merge_sort_with_nulls_last() {
     let schema = Arc::new(Schema::new(vec![Field::new("val", DataType::Int64, true)]));
 
-    let batches = vec![
+    let batches = [
         RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![Some(1), Some(3), None]))],

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/writer_integration_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/writer_integration_tests.rs
@@ -151,8 +151,8 @@ fn test_concurrent_writes_different_files() {
         schema_ptrs.push(schema_ptr);
     }
 
-    for i in 0..file_count {
-        let filename = filenames[i].clone();
+    for filename in &filenames {
+        let filename = filename.clone();
         let success_count = Arc::clone(&success_count);
         let handle = thread::spawn(move || {
             for _ in 0..2 {
@@ -414,7 +414,7 @@ use std::fs::File;
 fn read_column_compression(path: &str, col_name: &str) -> Compression {
     let reader = SerializedFileReader::new(File::open(path).unwrap()).unwrap();
     let meta = reader.metadata();
-    let schema = meta.file_metadata().schema_descr();
+    let _schema = meta.file_metadata().schema_descr();
     let rg = meta.row_group(0);
     for i in 0..rg.num_columns() {
         let col = rg.column(i);


### PR DESCRIPTION
### Description

Follow-up to #22369 (rustfmt). Wires `cargo clippy --workspace --all-targets -- -D warnings` into the sandbox native (Rust) workspace CI, and clears the workspace to **zero** clippy warnings so the gate passes.

**Workflow (`sandbox-check.yml`):**
- Adds the `clippy` component to the Rust toolchain setup.
- Adds a **"Run Rust clippy"** step. It runs with `working-directory: sandbox/libs/dataformat-native/rust` (not `--manifest-path` from the repo root) so the crate's `.cargo/config.toml` — which sets `--cfg tokio_unstable`, required by the tokio `RuntimeMetrics` calls in `stats.rs` / `merge/metrics.rs` — is honored. cargo only reads `.cargo/config.toml` relative to the working directory, so running from the repo root fails to compile.

**Code changes** (the bulk of the diff is mechanical clippy cleanup):
- Fix deny-by-default lints that were aborting the lint build before any warnings could be seen: `not_unsafe_ptr_arg_deref` (FFI `extern "C"` entry points), `never_loop`, `absurd_extreme_comparisons`, `approx_constant`, `mut_from_ref`.
- Migrate deprecated parquet/arrow APIs: `with_page_index` → `with_page_index_policy`, `set_max_row_group_size` → `set_max_row_group_row_count`.
- Repair stale benchmarks that no longer matched current API signatures (they already failed `cargo check --benches` on `main`).
- The remainder is unused-import/`mut` removal, doc-comment formatting, and idiomatic simplifications.

**Intentional `#[allow(deprecated)]` (please note during review):**
Two `PartitionedFile::with_extensions` calls — in `indexed_table/parquet_bridge.rs` and `shard_table_provider.rs` — are deliberately kept on the deprecated API. The `with_extension` replacement keys the extension by its concrete type, but DataFusion's Parquet opener retrieves the `ParquetAccessPlan` via the legacy `insert_dyn` keying; switching silently drops row selection and returns wrong rows (caught by the `boolean_algebra` e2e suite). Each site has a comment explaining the deferral.

**Verification:**
- `cargo clippy --workspace --all-targets -- -D warnings` — passes (0 warnings).
- `cargo fmt --all -- --check` — clean.
- Test suite passes. (Two pre-existing `local_exec_test` failures exist on `main`, unrelated to this change.)

Clippy config/enforcement is modeled on Apache DataFusion's and arrow-rs's lint setup.

### Check List
- [x] Functionality includes tests (N/A — CI/lint only; existing tests validate the code changes)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.