### PR TITLE
Fix unbounded recursion in deserialization that can cause StackOverflowError

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -723,11 +723,24 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Maximum depth for recursive deserialization of nested generic values.
+     * Protects against StackOverflowError from deeply nested binary payloads.
+     */
+    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+
+    /**
      * Reads a value of unspecified type. If a collection is read then the collection will be mutable if it contains any entry but might
      * be immutable if it is empty.
      */
     @Nullable
     public Object readGenericValue() throws IOException {
+        return readGenericValue(0);
+    }
+
+    private Object readGenericValue(int depth) throws IOException {
+        if (depth > MAX_DESERIALIZATION_DEPTH) {
+            throw new IOException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded for binary deserialization");
+        }
         byte type = readByte();
         Writeable.Reader<?> r = Writeable.WriteableRegistry.getReader(type);
         if (r != null) {
@@ -752,13 +765,13 @@ public abstract class StreamInput extends InputStream {
             case 6:
                 return readByteArray();
             case 7:
-                return readArrayList();
+                return readArrayList(depth);
             case 8:
-                return readArray();
+                return readArray(depth);
             case 9:
-                return readLinkedHashMap();
+                return readLinkedHashMap(depth);
             case 10:
-                return readHashMap();
+                return readHashMap(depth);
             case 11:
                 return readByte();
             case 12:
@@ -784,9 +797,9 @@ public abstract class StreamInput extends InputStream {
             case 23:
                 return readZonedDateTime();
             case 24:
-                return readCollection(StreamInput::readGenericValue, LinkedHashSet::new, Collections.emptySet());
+                return readCollection(si -> si.readGenericValue(depth + 1), LinkedHashSet::new, Collections.emptySet());
             case 25:
-                return readCollection(StreamInput::readGenericValue, HashSet::new, Collections.emptySet());
+                return readCollection(si -> si.readGenericValue(depth + 1), HashSet::new, Collections.emptySet());
             case 26:
                 return readBigInteger();
             case 27:
@@ -814,14 +827,14 @@ public abstract class StreamInput extends InputStream {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private List readArrayList() throws IOException {
+    private List readArrayList(int depth) throws IOException {
         int size = readArraySize();
         if (size == 0) {
             return Collections.emptyList();
         }
         List list = new ArrayList(size);
         for (int i = 0; i < size; i++) {
-            list.add(readGenericValue());
+            list.add(readGenericValue(depth + 1));
         }
         return list;
     }
@@ -833,40 +846,40 @@ public abstract class StreamInput extends InputStream {
 
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
-    private Object[] readArray() throws IOException {
+    private Object[] readArray(int depth) throws IOException {
         int size8 = readArraySize();
         if (size8 == 0) {
             return EMPTY_OBJECT_ARRAY;
         }
         Object[] list8 = new Object[size8];
         for (int i = 0; i < size8; i++) {
-            list8[i] = readGenericValue();
+            list8[i] = readGenericValue(depth + 1);
         }
         return list8;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private Map readLinkedHashMap() throws IOException {
+    private Map readLinkedHashMap(int depth) throws IOException {
         int size9 = readArraySize();
         if (size9 == 0) {
             return Collections.emptyMap();
         }
         Map map9 = new LinkedHashMap(size9);
         for (int i = 0; i < size9; i++) {
-            map9.put(readString(), readGenericValue());
+            map9.put(readString(), readGenericValue(depth + 1));
         }
         return map9;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private Map readHashMap() throws IOException {
+    private Map readHashMap(int depth) throws IOException {
         int size10 = readArraySize();
         if (size10 == 0) {
             return Collections.emptyMap();
         }
         Map map10 = new HashMap(size10);
         for (int i = 0; i < size10; i++) {
-            map10.put(readString(), readGenericValue());
+            map10.put(readString(), readGenericValue(depth + 1));
         }
         return map10;
     }

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
@@ -304,13 +304,13 @@ public abstract class AbstractXContentParser implements XContentParser {
     @Override
     public List<Object> list() throws IOException {
         skipToListStart(this);
-        return readListUnsafe(this, SIMPLE_MAP_FACTORY);
+        return readListUnsafe(this, SIMPLE_MAP_FACTORY, 0);
     }
 
     @Override
     public List<Object> listOrderedMap() throws IOException {
         skipToListStart(this);
-        return readListUnsafe(this, ORDERED_MAP_FACTORY);
+        return readListUnsafe(this, ORDERED_MAP_FACTORY, 0);
     }
 
     private static final Supplier<Map<String, Object>> SIMPLE_MAP_FACTORY = HashMap::new;
@@ -328,12 +328,21 @@ public abstract class AbstractXContentParser implements XContentParser {
         Supplier<Map<String, Object>> mapFactory,
         Map<String, Object> map
     ) throws IOException {
+        return readMapEntries(parser, mapFactory, map, 0);
+    }
+
+    private static Map<String, Object> readMapEntries(
+        XContentParser parser,
+        Supplier<Map<String, Object>> mapFactory,
+        Map<String, Object> map,
+        int depth
+    ) throws IOException {
         assert parser.currentToken() == Token.FIELD_NAME : "Expected field name but saw [" + parser.currentToken() + "]";
         do {
             // Must point to field name
             String fieldName = parser.currentName();
             // And then the value...
-            Object value = readValueUnsafe(parser.nextToken(), parser, mapFactory);
+            Object value = readValueUnsafe(parser.nextToken(), parser, mapFactory, depth);
             map.put(fieldName, value);
         } while (parser.nextToken() == Token.FIELD_NAME);
         return map;
@@ -375,18 +384,25 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
     }
 
+    // Maximum depth for recursive deserialization of nested objects/arrays.
+    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+
     // read a list without bounds checks, assuming the current parser is always on an array start
-    private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
+    private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory, int depth)
+        throws IOException {
+        if (depth > MAX_DESERIALIZATION_DEPTH) {
+            throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+        }
         assert parser.currentToken() == Token.START_ARRAY;
         ArrayList<Object> list = new ArrayList<>();
         for (Token token = parser.nextToken(); token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {
-            list.add(readValueUnsafe(token, parser, mapFactory));
+            list.add(readValueUnsafe(token, parser, mapFactory, depth + 1));
         }
         return list;
     }
 
     public static Object readValue(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
-        return readValueUnsafe(parser.currentToken(), parser, mapFactory);
+        return readValueUnsafe(parser.currentToken(), parser, mapFactory, 0);
     }
 
     /**
@@ -395,8 +411,9 @@ public abstract class AbstractXContentParser implements XContentParser {
      * @param currentToken current token that the parser is at
      * @param parser       parser to read from
      * @param mapFactory   map factory to use for reading objects
+     * @param depth        current recursion depth
      */
-    private static Object readValueUnsafe(Token currentToken, XContentParser parser, Supplier<Map<String, Object>> mapFactory)
+    private static Object readValueUnsafe(Token currentToken, XContentParser parser, Supplier<Map<String, Object>> mapFactory, int depth)
         throws IOException {
         assert currentToken == parser.currentToken() : "Supplied current token ["
             + currentToken
@@ -411,11 +428,14 @@ public abstract class AbstractXContentParser implements XContentParser {
             case VALUE_BOOLEAN:
                 return parser.booleanValue();
             case START_OBJECT: {
+                if (depth > MAX_DESERIALIZATION_DEPTH) {
+                    throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+                }
                 final Map<String, Object> map = mapFactory.get();
-                return parser.nextToken() != Token.FIELD_NAME ? map : readMapEntries(parser, mapFactory, map);
+                return parser.nextToken() != Token.FIELD_NAME ? map : readMapEntries(parser, mapFactory, map, depth + 1);
             }
             case START_ARRAY:
-                return readListUnsafe(parser, mapFactory);
+                return readListUnsafe(parser, mapFactory, depth);
             case VALUE_EMBEDDED_OBJECT:
                 return parser.binaryValue();
             case VALUE_NULL:

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
@@ -32,7 +32,7 @@ public interface XContentConstraints {
     );
 
     final int DEFAULT_MAX_DEPTH = Integer.parseInt(
-        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "1000" /* StreamReadConstraints.DEFAULT_MAX_DEPTH */)
+        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "100")
     );
 
     final int DEFAULT_CODEPOINT_LIMIT = Integer.parseInt(System.getProperty(DEFAULT_CODEPOINT_LIMIT_PROPERTY, "52428800" /* ~50 Mb */));

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
@@ -31,9 +31,7 @@ public interface XContentConstraints {
         System.getProperty(DEFAULT_MAX_NAME_LEN_PROPERTY, "50000" /* StreamReadConstraints.DEFAULT_MAX_NAME_LEN */)
     );
 
-    final int DEFAULT_MAX_DEPTH = Integer.parseInt(
-        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "100")
-    );
+    final int DEFAULT_MAX_DEPTH = Integer.parseInt(System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "100"));
 
     final int DEFAULT_CODEPOINT_LIMIT = Integer.parseInt(System.getProperty(DEFAULT_CODEPOINT_LIMIT_PROPERTY, "52428800" /* ~50 Mb */));
     final int DEFAULT_BUFFER_SIZE = Integer.parseInt(

--- a/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.io.stream;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class StreamInputMaxDepthTests extends OpenSearchTestCase {
+
+    public void testDeeplyNestedArrayListThrows() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 200; i++) {
+            out.writeByte((byte) 7);  // ArrayList type tag
+            out.writeVInt(1);         // size = 1
+        }
+        out.writeByte((byte) 0);      // String type
+        out.writeString("x");
+
+        StreamInput in = out.bytes().streamInput();
+        IOException ex = expectThrows(IOException.class, in::readGenericValue);
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Maximum nesting depth"));
+    }
+
+    public void testDeeplyNestedHashMapThrows() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 200; i++) {
+            out.writeByte((byte) 10); // HashMap type tag
+            out.writeVInt(1);         // size = 1
+            out.writeString("k");     // key
+        }
+        out.writeByte((byte) 0);      // String type
+        out.writeString("v");
+
+        StreamInput in = out.bytes().streamInput();
+        IOException ex = expectThrows(IOException.class, in::readGenericValue);
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Maximum nesting depth"));
+    }
+
+    public void testModerateNestingSucceeds() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 50; i++) {
+            out.writeByte((byte) 7);  // ArrayList
+            out.writeVInt(1);
+        }
+        out.writeByte((byte) 0);      // String
+        out.writeString("leaf");
+
+        StreamInput in = out.bytes().streamInput();
+        Object result = in.readGenericValue();
+        assertNotNull(result);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class XContentParserMaxDepthTests extends OpenSearchTestCase {
+
+    public void testDeeplyNestedArrayThrows() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) sb.append('[');
+        for (int i = 0; i < 200; i++) sb.append(']');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            expectThrows(Exception.class, parser::list);
+        }
+    }
+
+    public void testDeeplyNestedObjectThrows() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) sb.append("{\"a\":");
+        sb.append("1");
+        for (int i = 0; i < 200; i++) sb.append('}');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            expectThrows(Exception.class, parser::map);
+        }
+    }
+
+    public void testModerateNestingSucceeds() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 50; i++) sb.append('[');
+        sb.append("1");
+        for (int i = 0; i < 50; i++) sb.append(']');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            assertNotNull(parser.list());
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
@@ -20,8 +20,10 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedArrayThrows() throws IOException {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 200; i++) sb.append('[');
-        for (int i = 0; i < 200; i++) sb.append(']');
+        for (int i = 0; i < 200; i++)
+            sb.append('[');
+        for (int i = 0; i < 200; i++)
+            sb.append(']');
 
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
@@ -37,9 +39,11 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedObjectThrows() throws IOException {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 200; i++) sb.append("{\"a\":");
+        for (int i = 0; i < 200; i++)
+            sb.append("{\"a\":");
         sb.append("1");
-        for (int i = 0; i < 200; i++) sb.append('}');
+        for (int i = 0; i < 200; i++)
+            sb.append('}');
 
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
@@ -55,9 +59,11 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
 
     public void testModerateNestingSucceeds() throws IOException {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 50; i++) sb.append('[');
+        for (int i = 0; i < 50; i++)
+            sb.append('[');
         sb.append("1");
-        for (int i = 0; i < 50; i++) sb.append(']');
+        for (int i = 0; i < 50; i++)
+            sb.append(']');
 
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -190,8 +190,10 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
         assertThat(
             ex.getMessage(),
             is(
-                "The provided value 1001 of the index setting 'index.mapping.depth.limit' exceeds per-JVM configured limit of 1000. "
-                    + "Please change the setting value or increase per-JVM limit using 'opensearch.xcontent.depth.max' system property."
+                "The provided value " + (XContentConstraints.DEFAULT_MAX_DEPTH + 1)
+                    + " of the index setting 'index.mapping.depth.limit' exceeds per-JVM configured limit of "
+                    + XContentConstraints.DEFAULT_MAX_DEPTH
+                    + ". Please change the setting value or increase per-JVM limit using 'opensearch.xcontent.depth.max' system property."
             )
         );
     }

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -190,7 +190,8 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
         assertThat(
             ex.getMessage(),
             is(
-                "The provided value " + (XContentConstraints.DEFAULT_MAX_DEPTH + 1)
+                "The provided value "
+                    + (XContentConstraints.DEFAULT_MAX_DEPTH + 1)
                     + " of the index setting 'index.mapping.depth.limit' exceeds per-JVM configured limit of "
                     + XContentConstraints.DEFAULT_MAX_DEPTH
                     + ". Please change the setting value or increase per-JVM limit using 'opensearch.xcontent.depth.max' system property."


### PR DESCRIPTION
### Description
Fix unbounded recursion in deserialization that can cause StackOverflowError.
 Deeply nested JSON or binary payloads can trigger unbounded recursion in two deserialization paths, causing a `StackOverflowError` that kills the JVM rather than producing a catchable exception.
  
This PR adds depth tracking to:
  - **`AbstractXContentParser`** (`readListUnsafe`/`readValueUnsafe`/`readMapEntries`) — the XContent (JSON/YAML/CBOR/Smile) parsing layer
  - **`StreamInput`** (`readGenericValue`/`readArrayList`/`readArray`/`readLinkedHashMap`/`readHashMap`) — the binary transport/serialization layer
  
Both layers now enforce `MAX_DESERIALIZATION_DEPTH=100` (configurable via `-Dopensearch.xcontent.depth.max`), throwing a catchable `IOException` or `IllegalStateException` instead of allowing the JVM to crash.
  
Additionally lowers the Jackson `StreamReadConstraints` `maxNestingDepth` from 1000 to 100 as defense-in-depth, aligning all three layers to the same limit.
  
### Related Issues
- N/A
  
### Check List
  - [x] Functionality includes testing.
  - [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
  - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.