### PR TITLE
Fix negative os.cpu.percent on cgroup v2 containers

### DIFF
--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -246,6 +246,8 @@ grant {
   permission java.io.FilePermission "/sys/fs/cgroup/cpu", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpu/-", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpu.max", "read";
+  // cgroup v2: read by the JVM's container-aware OperatingSystemMXBean.getCpuLoad() (usage_usec/nr_periods)
+  permission java.io.FilePermission "/sys/fs/cgroup/cpu.stat", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpu.weight", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpuset.cpus", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpuset.cpus.effective", "read";


### PR DESCRIPTION
### Description

On containers that use **cgroup v2** (e.g. GKE nodes on 1.26+, which default to cgroup v2), `_cat/nodes` and `_nodes/stats` report `os.cpu.percent: -1` even though the JVM fully supports cgroup v2:

```
"os":{"cpu":{"percent":-1,"load_average":{...}}, ...}
```

`os.cpu.percent` is sourced from `com.sun.management.OperatingSystemMXBean.getCpuLoad()` (via `OsProbe.getSystemCpuPercent()` → `Probes.getLoadAndScaleToPercent`). On a container with a CPU quota (`cpu.max` = `"<quota> <period>"`), the JVM's container-aware `getCpuLoad()` takes the quota branch and reads **`/sys/fs/cgroup/cpu.stat`** (`usage_usec`, `nr_periods`) to compute the load.

**Root cause:** the bundled JDK performs that cgroup read through a plain `Files.lines(...)` with no `doPrivileged` wrapping (the old wrappers were dropped when the SecurityManager was removed in JEP 486). OpenSearch's agent-based policy (`FileInterceptor`) intercepts the file open and walks the caller protection-domain chain; with no `doPrivileged` frame to stop at, the OpenSearch frames (`OsProbe`/`Probes`) remain in the chain and must hold the `FilePermission`. `security.policy` granted `cpu.max` but **not `cpu.stat`**, so the read is denied, `getCpuLoad()` throws, `Probes.getLoadAndScaleToPercent` swallows the exception, and `os.cpu.percent` becomes `-1`.

This was verified by running `getCpuLoad()` standalone (no agent) on the same bundled JDK in the same container — it returns valid values — while the node process (agent + policy) returns `-1`.

**Fix:** grant read access to `/sys/fs/cgroup/cpu.stat`. This is the cgroup v2 sibling of the existing `cpu,cpuacct` grant used for the cgroup v1 process-CPU path.


### Related Issues
Resolves #19120

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
