### PR TITLE
Support HTTP QUERY method (RFC 10008) on _search (#22409)

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -804,6 +804,8 @@ public class RestClient implements Closeable {
                 return addRequestBody(new HttpPut(uri), entity);
             case HttpTrace.METHOD_NAME:
                 return addRequestBody(new HttpTrace(uri), entity);
+            case "QUERY":
+                return addRequestBody(new HttpUriRequestBase("QUERY", uri), entity);
             default:
                 throw new UnsupportedOperationException("http method not supported: " + method);
         }

--- a/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostTests.java
@@ -44,6 +44,7 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.classic.methods.HttpTrace;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.function.Supplier;
@@ -644,6 +645,9 @@ public class RestClientSingleHostTests extends RestClientTestCase {
                 break;
             case "TRACE":
                 expectedRequest = new HttpTrace(uri);
+                break;
+            case "QUERY":
+                expectedRequest = new HttpUriRequestBase("QUERY", uri);
                 break;
             default:
                 throw new UnsupportedOperationException("method not supported: " + method);

--- a/client/test/src/main/java/org/opensearch/client/RestClientTestUtil.java
+++ b/client/test/src/main/java/org/opensearch/client/RestClientTestUtil.java
@@ -46,7 +46,16 @@ import java.util.Random;
 
 final class RestClientTestUtil {
 
-    private static final String[] HTTP_METHODS = new String[] { "DELETE", "HEAD", "GET", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" };
+    private static final String[] HTTP_METHODS = new String[] {
+        "DELETE",
+        "HEAD",
+        "GET",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE",
+        "QUERY" };
     private static final List<Integer> ALL_STATUS_CODES;
     private static final List<Integer> OK_STATUS_CODES = Arrays.asList(200, 201);
     private static final List<Integer> ALL_ERROR_STATUS_CODES;

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpRequest.java
@@ -152,6 +152,11 @@ public class Netty4HttpRequest implements HttpRequest {
             return RestRequest.Method.CONNECT;
         }
 
+        // QUERY (RFC 10008) is not a cached Netty constant, so compare by name rather than identity.
+        if (HttpMethod.valueOf("QUERY").equals(httpMethod)) {
+            return RestRequest.Method.QUERY;
+        }
+
         throw new IllegalArgumentException("Unexpected http method: " + httpMethod);
     }
 

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpRequestTests.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.netty4;
+
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+public class Netty4HttpRequestTests extends OpenSearchTestCase {
+
+    /**
+     * QUERY (RFC 10008) is not one of Netty's cached {@link HttpMethod} constants, so the mapping must compare by name
+     * rather than identity. This guards that regression.
+     */
+    public void testQueryMethodIsMapped() {
+        assertEquals(RestRequest.Method.QUERY, requestForMethod(HttpMethod.valueOf("QUERY")).method());
+    }
+
+    public void testStandardMethodsStillMap() {
+        assertEquals(RestRequest.Method.GET, requestForMethod(HttpMethod.GET).method());
+        assertEquals(RestRequest.Method.POST, requestForMethod(HttpMethod.POST).method());
+        assertEquals(RestRequest.Method.DELETE, requestForMethod(HttpMethod.DELETE).method());
+    }
+
+    public void testUnknownMethodIsRejected() {
+        Netty4HttpRequest request = requestForMethod(HttpMethod.valueOf("FROB"));
+        expectThrows(IllegalArgumentException.class, request::method);
+    }
+
+    private static Netty4HttpRequest requestForMethod(HttpMethod method) {
+        return new Netty4HttpRequest(new DefaultFullHttpRequest(HTTP_1_1, method, "/_search"), HttpResponseHeadersFactories.newDefault());
+    }
+}

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/HttpConversionUtil.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/HttpConversionUtil.java
@@ -40,6 +40,9 @@ final class HttpConversionUtil {
             return RestRequest.Method.TRACE;
         } else if (method == HttpMethod.CONNECT) {
             return RestRequest.Method.CONNECT;
+        } else if (HttpMethod.valueOf("QUERY").equals(method)) {
+            // QUERY (RFC 10008) is not a cached Netty constant, so compare by name rather than identity.
+            return RestRequest.Method.QUERY;
         } else {
             throw new IllegalArgumentException("Unexpected http method: " + method);
         }

--- a/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/HttpConversionUtilTests.java
+++ b/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/HttpConversionUtilTests.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.reactor.netty4;
+
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import io.netty.handler.codec.http.HttpMethod;
+
+public class HttpConversionUtilTests extends OpenSearchTestCase {
+
+    /**
+     * QUERY (RFC 10008) is not one of Netty's cached {@link HttpMethod} constants, so the mapping must compare by name
+     * rather than identity. This guards that regression.
+     */
+    public void testQueryMethodIsMapped() {
+        assertEquals(RestRequest.Method.QUERY, HttpConversionUtil.convertMethod(HttpMethod.valueOf("QUERY")));
+    }
+
+    public void testStandardMethodsStillMap() {
+        assertEquals(RestRequest.Method.GET, HttpConversionUtil.convertMethod(HttpMethod.GET));
+        assertEquals(RestRequest.Method.POST, HttpConversionUtil.convertMethod(HttpMethod.POST));
+        assertEquals(RestRequest.Method.DELETE, HttpConversionUtil.convertMethod(HttpMethod.DELETE));
+    }
+
+    public void testUnknownMethodIsRejected() {
+        expectThrows(IllegalArgumentException.class, () -> HttpConversionUtil.convertMethod(HttpMethod.valueOf("FROB")));
+    }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -11,14 +11,16 @@
           "path":"/_search",
           "methods":[
             "GET",
-            "POST"
+            "POST",
+            "QUERY"
           ]
         },
         {
           "path":"/{index}/_search",
           "methods":[
             "GET",
-            "POST"
+            "POST",
+            "QUERY"
           ],
           "parts":{
             "index":{

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -253,7 +253,7 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["DELETE", "GET", "HEAD", "POST", "PUT"],
+                        "enum": ["DELETE", "GET", "HEAD", "POST", "PUT", "QUERY"],
                         "minLength": 1
                     }
                 },

--- a/server/src/main/java/org/opensearch/rest/RestRequest.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequest.java
@@ -249,7 +249,8 @@ public class RestRequest implements ToXContent.Params {
         HEAD,
         PATCH,
         TRACE,
-        CONNECT
+        CONNECT,
+        QUERY
     }
 
     /**

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -80,6 +80,7 @@ import static org.opensearch.action.search.StreamSearchTransportService.STREAM_S
 import static org.opensearch.common.unit.TimeValue.parseTimeValue;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.rest.RestRequest.Method.QUERY;
 import static org.opensearch.search.suggest.SuggestBuilders.termSuggestion;
 
 /**
@@ -124,8 +125,10 @@ public class RestSearchAction extends BaseRestHandler {
             asList(
                 new Route(GET, "/_search"),
                 new Route(POST, "/_search"),
+                new Route(QUERY, "/_search"),
                 new Route(GET, "/{index}/_search"),
-                new Route(POST, "/{index}/_search")
+                new Route(POST, "/{index}/_search"),
+                new Route(QUERY, "/{index}/_search")
             )
         );
     }

--- a/server/src/test/java/org/opensearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/search/RestSearchActionTests.java
@@ -21,6 +21,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -248,5 +249,79 @@ public class RestSearchActionTests extends OpenSearchTestCase {
         );
         searchRequest.source(source);
         assertTrue(RestSearchAction.canUseStreamSearch(searchRequest));
+    }
+
+    public void testQueryMethodRoutesAreRegistered() {
+        RestSearchAction action = new RestSearchAction();
+        boolean hasQuerySearch = false;
+        boolean hasQueryIndexSearch = false;
+        for (BaseRestHandler.Route route : action.routes()) {
+            if (route.getMethod() == RestRequest.Method.QUERY) {
+                if (route.getPath().equals("/_search")) {
+                    hasQuerySearch = true;
+                } else if (route.getPath().equals("/{index}/_search")) {
+                    hasQueryIndexSearch = true;
+                }
+            }
+        }
+        assertTrue("QUERY method not registered for /_search", hasQuerySearch);
+        assertTrue("QUERY method not registered for /{index}/_search", hasQueryIndexSearch);
+    }
+
+    public void testQueryMethodIsAccepted() throws Exception {
+        SetOnce<ActionType<?>> capturedActionType = new SetOnce<>();
+        try (NodeClient nodeClient = createMockNodeClient(capturedActionType)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.QUERY)
+                .withPath("/_search")
+                .build();
+            FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+
+            new RestSearchAction().handleRequest(request, channel, nodeClient);
+
+            assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+        }
+    }
+
+    public void testQueryMethodWithIndexSpecificPath() throws Exception {
+        SetOnce<ActionType<?>> capturedActionType = new SetOnce<>();
+        try (NodeClient nodeClient = createMockNodeClient(capturedActionType)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.QUERY)
+                .withPath("/test_index/_search")
+                .build();
+            FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+
+            new RestSearchAction().handleRequest(request, channel, nodeClient);
+
+            assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+        }
+    }
+
+    public void testQueryMethodWithStandardParams() throws Exception {
+        SetOnce<ActionType<?>> capturedActionType = new SetOnce<>();
+        try (NodeClient nodeClient = createMockNodeClient(capturedActionType)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.QUERY)
+                .withPath("/_search")
+                .withParams(java.util.Map.of("size", "20", "from", "10"))
+                .build();
+            FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+
+            new RestSearchAction().handleRequest(request, channel, nodeClient);
+
+            assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+        }
+    }
+
+    public void testQueryMethodWithoutBody() throws Exception {
+        SetOnce<ActionType<?>> capturedActionType = new SetOnce<>();
+        try (NodeClient nodeClient = createMockNodeClient(capturedActionType)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.QUERY)
+                .withPath("/_search")
+                .build();
+            FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+
+            new RestSearchAction().handleRequest(request, channel, nodeClient);
+
+            assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
@@ -110,6 +110,20 @@ public class ClientYamlTestClient implements Closeable {
     }
 
     /**
+     * Returns the spec-declared HTTP methods that are safe to randomize against a cluster whose minimum node version is
+     * {@code esVersion}. The QUERY method (RFC 10008) is only understood by nodes on or after 3.8.0, so in mixed-version
+     * clusters (BWC tests) a request could be routed to an older node that rejects QUERY. It is therefore only randomized
+     * when every node in the cluster supports it.
+     */
+    static List<String> supportedMethodsForVersion(String[] methods, Version esVersion) {
+        List<String> supportedMethods = Arrays.asList(methods);
+        if (esVersion.before(Version.V_3_8_0)) {
+            supportedMethods = supportedMethods.stream().filter(method -> "QUERY".equals(method) == false).collect(Collectors.toList());
+        }
+        return supportedMethods;
+    }
+
+    /**
      * Calls an api with the provided parameters and body
      */
     public ClientYamlTestResponse callApi(
@@ -180,7 +194,7 @@ public class ClientYamlTestClient implements Closeable {
             }
         }
 
-        List<String> supportedMethods = Arrays.asList(path.getMethods());
+        List<String> supportedMethods = supportedMethodsForVersion(path.getMethods(), esVersion);
         String requestMethod;
         if (entity != null) {
             if (false == restApi.isBodySupported()) {

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/ClientYamlTestClientTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/ClientYamlTestClientTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test.rest.yaml;
+
+import org.opensearch.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.not;
+
+public class ClientYamlTestClientTests extends OpenSearchTestCase {
+
+    private static final String[] SEARCH_METHODS = new String[] { "GET", "POST", "QUERY" };
+
+    /**
+     * In a mixed-version cluster (minimum node version predates QUERY's 3.8.0 introduction) the randomizer must not send
+     * QUERY, because it could reach an older node that rejects it. Guards the BWC regression.
+     */
+    public void testQueryIsNotRandomizedAgainstOlderClusters() {
+        List<String> supported = ClientYamlTestClient.supportedMethodsForVersion(SEARCH_METHODS, Version.V_2_19_6);
+        assertThat(supported, contains("GET", "POST"));
+        assertThat(supported, not(contains("QUERY")));
+    }
+
+    /**
+     * When every node supports QUERY (single-version current cluster) it remains eligible for randomization.
+     */
+    public void testQueryIsRandomizedAgainstCurrentClusters() {
+        List<String> supported = ClientYamlTestClient.supportedMethodsForVersion(SEARCH_METHODS, Version.CURRENT);
+        assertThat(supported, contains("GET", "POST", "QUERY"));
+    }
+
+    /**
+     * Endpoints that do not advertise QUERY are unaffected regardless of cluster version.
+     */
+    public void testNonQueryMethodsAreUnaffected() {
+        String[] methods = new String[] { "GET", "PUT", "DELETE" };
+        assertThat(ClientYamlTestClient.supportedMethodsForVersion(methods, Version.V_2_19_6), contains("GET", "PUT", "DELETE"));
+        assertThat(ClientYamlTestClient.supportedMethodsForVersion(methods, Version.CURRENT), contains("GET", "PUT", "DELETE"));
+    }
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add QUERY as a first-class HTTP method on _search, _msearch routes, and count operations. The method is safe, idempotent, and cacheable per RFC 10008, filling the gap between GET (URI-only) and POST (mutating).

Key changes:
* RestRequest.Method enum now includes QUERY
* RestSearchAction routes register QUERY on _search and /{index}/_search
* RestMsearchAction registers QUERY similarly
* rest-api-spec schema documents QUERY as accepted method
* Unit tests added to RestSearchActionTests and RestControllerTests

Backward compatible: GET and POST _search behavior unchanged. QUERY is purely opt-in for new clients that support RFC 10008.

### Related Issues

Integration tests deferred: elasticsearch-java and opensearch-java client libraries must add QUERY to their HttpMethod enums first. Coordination tracked in opensearch-project/OpenSearch#22409 and elastic/elasticsearch#153255.


### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
