### PR TITLE
Fix Arrow buffer leak on coordinator query and ingest pool 

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSink.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSink.java
@@ -27,8 +27,16 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 public interface ExchangeSink {
 
     /**
-     * Ingest an Arrow batch into this sink. The sink takes ownership of the
+     * Ingest an Arrow batch into this sink. On normal return the sink has taken ownership of the
      * batch and is responsible for releasing it when no longer needed.
+     *
+     * <p><b>All-or-nothing ownership.</b> Ownership transfers only on normal return. If this method
+     * throws, it must NOT have taken ownership of {@code batch} — neither the root nor any of its
+     * child vectors — so the caller still owns {@code batch} in full and is responsible for closing
+     * it exactly once. Implementations that begin consuming/transferring buffers before they might
+     * throw must either complete the transfer or roll it back before propagating, so the caller can
+     * safely {@code batch.close()} without risking a double-release. (Callers such as
+     * {@code Stitcher.finish} rely on this to free the batch on the feed-throws path.)
      */
     void feed(VectorSchemaRoot batch);
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/RowProducingSink.java
@@ -10,6 +10,8 @@ package org.opensearch.analytics.exec;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.ExchangeSource;
 import org.opensearch.analytics.spi.ExchangeSink;
 
@@ -43,6 +45,8 @@ import java.util.List;
 // close, partial buffering on early exit). Revisit the locking as part of that (e.g. tryLock with
 // timeout); the current single-monitor synchronization is correct but worth reconsidering then.
 public class RowProducingSink implements ExchangeSink, ExchangeSource {
+
+    private static final Logger logger = LogManager.getLogger(RowProducingSink.class);
 
     /**
      * Default maximum number of rows this sink will accept before rejecting
@@ -104,10 +108,24 @@ public class RowProducingSink implements ExchangeSink, ExchangeSource {
     @Override
     public synchronized void close() {
         closed = true;
-        for (VectorSchemaRoot batch : batches) {
-            batch.close();
+        // Guard each close individually: Arrow's VectorSchemaRoot.close() throws
+        // (IllegalStateException) when a vector's buffers were already released — e.g. a batch
+        // the consumer drained and closed via readResult(), or one whose vectors were shared with
+        // another close path. An unguarded loop would abort on the first such throw and abandon
+        // every batch after it, stranding their off-heap buffers on the (long-lived, when
+        // coordinator.buffer_limit=0) coordinator allocator. clear() runs regardless so the sink
+        // does not retain references to freed roots.
+        try {
+            for (VectorSchemaRoot batch : batches) {
+                try {
+                    batch.close();
+                } catch (RuntimeException e) {
+                    logger.warn("RowProducingSink: batch close failed during sink close; continuing to release the rest", e);
+                }
+            }
+        } finally {
+            batches.clear();
         }
-        batches.clear();
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
@@ -36,6 +36,7 @@ import org.opensearch.analytics.spi.DataConsumer;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.tasks.TaskCancelledException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -388,7 +389,23 @@ public final class LateMaterializationStageExecution extends AbstractStageExecut
                 outerListener.onFailure(failure);
             }
         });
+        // Publish the stitcher BEFORE any shard dispatch so onTerminalTransition (which may fire on a
+        // concurrent cancel thread) can always find it and close its pre-allocated output VSR. The
+        // Stitcher constructor already allocated that VSR on the coordinator allocator, so any window
+        // where the field is still null but output exists would leak it on a racing terminal.
         this.stitcher = stitcher;
+        // Close the publication race: if a terminal transition already fired while we were between
+        // Stitcher construction and the assignment above, its onTerminalTransition saw a null field
+        // and skipped the close. Re-check here and release output now that the field is published.
+        // state is an AtomicReference, so this read pairs with the CAS in transitionTo: either that
+        // CAS-then-read-stitcher saw our published field (and closed output), or our set-then-read-state
+        // sees the terminal here — output is freed exactly once on this racing-cancel path. Settle the
+        // task listener too (NotifyOnceListener makes a duplicate fire from the cancel path a no-op).
+        if (getState().isTerminal()) {
+            stitcher.close();
+            outerListener.onFailure(new TaskCancelledException("late materialization stage terminated before fetch dispatch"));
+            return;
+        }
 
         for (Map.Entry<Integer, ShardFetchPlan> entry : plansByUgsi.entrySet()) {
             int ugsi = entry.getKey();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
@@ -399,8 +399,14 @@ public final class LateMaterializationStageExecution extends AbstractStageExecut
         // and skipped the close. Re-check here and release output now that the field is published.
         // state is an AtomicReference, so this read pairs with the CAS in transitionTo: either that
         // CAS-then-read-stitcher saw our published field (and closed output), or our set-then-read-state
-        // sees the terminal here — output is freed exactly once on this racing-cancel path. Settle the
-        // task listener too (NotifyOnceListener makes a duplicate fire from the cancel path a no-op).
+        // sees the terminal here — output is freed exactly once on this racing-cancel path.
+        //
+        // We must also settle outerListener: the task body owns firing the per-task listener (see
+        // LocalStageTask), and a stage cancel does NOT fire it independently — so returning without
+        // firing would strand the task. This mirrors the K==0 branch below, which likewise settles
+        // the listener directly. onComplete (which also fires outerListener) can no longer run here
+        // because no shards are dispatched, and LocalTaskRunner wraps outerListener in a
+        // NotifyOnceListener regardless, so this can never double-fire.
         if (getState().isTerminal()) {
             stitcher.close();
             outerListener.onFailure(new TaskCancelledException("late materialization stage terminated before fetch dispatch"));

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
@@ -287,6 +287,25 @@ public final class LateMaterializationStageExecution extends AbstractStageExecut
         return List.of(new LocalStageTask(new StageTaskId(getStageId(), 0), this::drainAndClose));
     }
 
+    /**
+     * Releases the stitcher's pre-allocated output VSR on any terminal transition. The stitcher
+     * allocates {@code output} on the coordinator allocator up front and only frees it when
+     * {@link Stitcher#finish} runs (all shards reported). If the stage terminates — via cancel,
+     * timeout, or an upstream failure — while a shard's fetch stream is still outstanding, that
+     * countdown never reaches zero and {@code finish} never runs, pinning {@code output}'s buffers
+     * on the long-lived coordinator allocator. Closing here guarantees release; it is a no-op when
+     * {@code finish} already emitted (ownership transferred to {@code parentSink}, and
+     * {@link Stitcher#close} / {@code VectorSchemaRoot#close} are idempotent), and when no stitcher
+     * was ever created (K=0 or a pre-stitch failure).
+     */
+    @Override
+    protected void onTerminalTransition(State terminal) {
+        Stitcher s = this.stitcher;
+        if (s != null) {
+            s.close();
+        }
+    }
+
     /** Drained {@code ___row_id} per row, indexed by sort-order position. Populated by Phase A. */
     private long[] drainedRowIds;
 
@@ -398,7 +417,9 @@ public final class LateMaterializationStageExecution extends AbstractStageExecut
     }
 
     /** Stashed for the {@code onComplete} closure to read {@link Stitcher#surfaceableFailure()}. */
-    private Stitcher stitcher;
+    // volatile: set on the drain thread in scatterFetchAndStitch, read by onTerminalTransition
+    // which may fire on a different thread (cancel / timeout / upstream failure).
+    private volatile Stitcher stitcher;
 
     /**
      * Per-shard streaming response listener: forwards each Arrow batch to the

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
@@ -195,7 +195,14 @@ public final class Stitcher {
                     outputDisposed = true;
                 }
                 ownershipTransferred = true;
-                parentSink.close();
+                // Guard the sink close like the failure branch below: feed() already transferred
+                // ownership of output, so a close-time failure must not propagate out of finish()
+                // (it runs on a shard's GatherListener callback thread) — log and swallow it.
+                try {
+                    parentSink.close();
+                } catch (Exception e) {
+                    logger.warn("[Stitcher] parentSink.close() failed after emit for {} rows", totalRows, e);
+                }
                 logger.debug("[Stitcher] emitted rows={}", totalRows);
             } else {
                 try {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
@@ -15,6 +15,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.exec.VectorUtils;
 import org.opensearch.analytics.planner.rel.OpenSearchLateMaterialization;
 import org.opensearch.analytics.spi.ExchangeSink;
@@ -201,7 +202,7 @@ public final class Stitcher {
                 try {
                     parentSink.close();
                 } catch (Exception e) {
-                    logger.warn("[Stitcher] parentSink.close() failed after emit for {} rows", totalRows, e);
+                    logger.warn(new ParameterizedMessage("[Stitcher] parentSink.close() failed after emit for {} rows", totalRows), e);
                 }
                 logger.debug("[Stitcher] emitted rows={}", totalRows);
             } else {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
@@ -76,6 +76,14 @@ public final class Stitcher {
     private final ConcurrentLinkedQueue<Exception> failures = new ConcurrentLinkedQueue<>();
     private final Runnable onComplete;
     private final Object outputLock = new Object();
+    /**
+     * Guards the output VSR's disposition, mutated only under {@link #outputLock}. Set once, either
+     * to {@code true} when {@link #finish} hands output to {@code parentSink} (ownership transferred
+     * — this stitcher must not close it), or left {@code false} so exactly one of {@link #finish}'s
+     * finally or {@link #close} frees it. Prevents a double-close race between the last shard's
+     * {@code finish} and a concurrent terminal-transition {@code close}.
+     */
+    private boolean outputDisposed = false;
 
     public Stitcher(
         BufferAllocator allocator,
@@ -169,21 +177,65 @@ public final class Stitcher {
     }
 
     private void finish() {
+        // Ownership of the output VSR transfers to parentSink only once feed() returns normally
+        // (see ExchangeSink#feed — the sink then owns and releases it). Until then this stitcher
+        // owns output's buffers, which live on the coordinator allocator; if setRowCount /
+        // sanitizeNullViewSlots / feed throws before the hand-off, the finally must free them or
+        // they leak onto the long-lived coordinator allocator (the pool never goes back down).
+        boolean ownershipTransferred = false;
         try {
             if (failures.isEmpty()) {
                 output.setRowCount(totalRows);
                 VectorUtils.sanitizeNullViewSlots(output);
                 parentSink.feed(output);
+                // Mark disposed under the lock BEFORE anything else can observe it, so a concurrent
+                // close() (from the stage's terminal transition) sees ownership has moved and won't
+                // close the VSR parentSink now owns.
+                synchronized (outputLock) {
+                    outputDisposed = true;
+                }
+                ownershipTransferred = true;
                 parentSink.close();
                 logger.debug("[Stitcher] emitted rows={}", totalRows);
             } else {
-                output.close();
                 try {
                     parentSink.close();
                 } catch (Exception ignore) {}
             }
         } finally {
+            if (ownershipTransferred == false) {
+                closeOutputOnce();
+            }
             onComplete.run();
+        }
+    }
+
+    /**
+     * Releases the pre-allocated output VSR if it was never emitted. Idempotent and safe to call
+     * from the owning LM stage's terminal / cancel path to cover the window where {@link #finish}
+     * never runs — e.g. a shard's fetch stream neither completes nor fails (dropped listener, node
+     * lost mid-fetch, task cancelled before the stream terminates), so {@link #pendingShards} never
+     * reaches zero. Without this, {@code output}'s buffers stay pinned on the coordinator allocator
+     * for the node's lifetime. A no-op once ownership has transferred to {@code parentSink} via
+     * {@link #finish}, and a no-op on repeated calls.
+     */
+    public void close() {
+        closeOutputOnce();
+    }
+
+    /**
+     * Closes {@code output} at most once, and never after ownership transferred to {@code parentSink}.
+     * The {@code outputDisposed} flag is read-and-set under {@link #outputLock} so the last shard's
+     * {@link #finish} and a concurrent terminal-transition {@link #close} cannot double-close (or
+     * close a VSR the sink now owns).
+     */
+    private void closeOutputOnce() {
+        synchronized (outputLock) {
+            if (outputDisposed) {
+                return;
+            }
+            outputDisposed = true;
+            output.close();
         }
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/RowProducingSinkTests.java
@@ -8,8 +8,10 @@
 
 package org.opensearch.analytics.exec;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -221,6 +223,58 @@ public class RowProducingSinkTests extends OpenSearchTestCase {
         assertEquals("late batch must be closed, not buffered", 0, allocator.getAllocatedMemory());
         assertEquals("late batch must not count toward rows", 0, sink.getRowCount());
         assertFalse("nothing retained from a post-close feed", sink.readResult().iterator().hasNext());
+    }
+
+    // ─── close() releases the whole set even when a batch throws (coordinator leak fix) ──
+
+    /**
+     * Regression for the coordinator-allocator leak: {@code close()} must free EVERY buffered
+     * batch even if one batch's {@code close()} throws. Arrow throws
+     * {@code IllegalStateException("RefCnt has gone negative")} when a batch's underlying buffer was
+     * over-released — the real production condition where a batch's vectors were shared with, and
+     * already released by, another close path (e.g. the ordinal-appending sink shares field vectors
+     * by reference). The pre-fix loop aborted on the first such throw and abandoned every batch
+     * after it, stranding their off-heap buffers on the long-lived coordinator allocator (the
+     * "query pool never goes down" symptom). Here the FIRST buffered batch is rigged to throw on
+     * close; the two after it must still be released.
+     */
+    public void testCloseReleasesAllBatchesWhenOneThrows() {
+        RowProducingSink sink = new RowProducingSink();
+
+        VectorSchemaRoot poison = makeVsr(List.of("id"), new Object[][] { { "1" } });
+        VectorSchemaRoot b2 = makeVsr(List.of("id"), new Object[][] { { "2" } });
+        VectorSchemaRoot b3 = makeVsr(List.of("id"), new Object[][] { { "3" } });
+        sink.feed(poison);
+        sink.feed(b2);
+        sink.feed(b3);
+
+        // Over-release the first batch's data buffer so its close() throws "RefCnt has gone
+        // negative" mid-loop — the exact throw that used to strand b2 and b3.
+        FieldVector v = poison.getVector(0);
+        for (ArrowBuf buf : v.getBuffers(false)) {
+            buf.getReferenceManager().release();
+        }
+        long before = allocator.getAllocatedMemory();
+        assertTrue("b2/b3 (and the poison's remaining bufs) hold memory before sink close", before > 0);
+
+        sink.close(); // must not propagate; must release the tail
+
+        assertEquals("close() must release every batch despite the mid-loop throw", 0, allocator.getAllocatedMemory());
+        assertFalse("no batches retained after close", sink.readResult().iterator().hasNext());
+    }
+
+    /**
+     * {@code close()} is idempotent: a second call after the batches are already freed must not
+     * throw and must leave the allocator at zero. Guards the terminal-path double-close.
+     */
+    public void testCloseIsIdempotent() {
+        RowProducingSink sink = new RowProducingSink();
+        sink.feed(makeVsr(List.of("id"), new Object[][] { { "1" } }));
+
+        sink.close();
+        assertEquals(0, allocator.getAllocatedMemory());
+        sink.close(); // must not throw
+        assertEquals(0, allocator.getAllocatedMemory());
     }
 
     // ─── Helpers ────────────────────────────────────────────────────────

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/StitcherTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/StitcherTests.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stage;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.analytics.planner.rel.OpenSearchLateMaterialization;
+import org.opensearch.analytics.spi.ExchangeSink;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Leak-focused tests for {@link Stitcher}. The stitcher pre-allocates its {@code output}
+ * VectorSchemaRoot on the supplied allocator (in production, the coordinator allocator when
+ * {@code analytics.coordinator.buffer_limit=0}) and holds it for the whole fetch-and-stitch.
+ * These tests assert {@code allocator.getAllocatedMemory() == 0} after every terminal path —
+ * success, feed-throws mid-emit, and the "finish never runs" cancel path — so a regression that
+ * strands {@code output} on the coordinator allocator (the "query pool never goes down" symptom)
+ * is caught.
+ */
+public class StitcherTests extends OpenSearchTestCase {
+
+    private BufferAllocator allocator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        allocator = new RootAllocator();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        super.tearDown();
+    }
+
+    /** Single-column output; the response batch adds the ___row_id helper the stitcher skips. */
+    private List<Field> outputFields() {
+        return List.of(new Field("val", FieldType.nullable(ArrowType.Utf8.INSTANCE), null));
+    }
+
+    /** A fetch response batch: [___row_id, val], as the data node returns for LM fetch. */
+    private VectorSchemaRoot responseBatch(Object[] rowIds, Object[] vals) {
+        List<Field> fields = List.of(
+            new Field(OpenSearchLateMaterialization.ROW_ID_FIELD, FieldType.nullable(ArrowType.Utf8.INSTANCE), null),
+            new Field("val", FieldType.nullable(ArrowType.Utf8.INSTANCE), null)
+        );
+        VectorSchemaRoot vsr = VectorSchemaRoot.create(new Schema(fields), allocator);
+        vsr.allocateNew();
+        int rows = vals.length;
+        VarCharVector rid = (VarCharVector) vsr.getVector(0);
+        VarCharVector val = (VarCharVector) vsr.getVector(1);
+        for (int r = 0; r < rows; r++) {
+            rid.setSafe(r, rowIds[r].toString().getBytes(StandardCharsets.UTF_8));
+            val.setSafe(r, vals[r].toString().getBytes(StandardCharsets.UTF_8));
+        }
+        rid.setValueCount(rows);
+        val.setValueCount(rows);
+        vsr.setRowCount(rows);
+        return vsr;
+    }
+
+    /** ExchangeSink that takes ownership on feed() and closes what it receives on close(). */
+    private static final class OwningSink implements ExchangeSink {
+        private final List<VectorSchemaRoot> received = new ArrayList<>();
+        boolean closed = false;
+
+        @Override
+        public void feed(VectorSchemaRoot batch) {
+            received.add(batch);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            for (VectorSchemaRoot b : received) {
+                b.close();
+            }
+            received.clear();
+        }
+    }
+
+    /** ExchangeSink whose feed() always throws — simulates the emit-time failure window. */
+    private static final class ThrowingSink implements ExchangeSink {
+        @Override
+        public void feed(VectorSchemaRoot batch) {
+            throw new IllegalStateException("downstream feed rejected");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Success path: the single shard reports one batch, {@code shardComplete} triggers
+     * {@code finish}, and the output is fed to the sink. Closing the sink (owner) releases the
+     * output. Baseline that the happy path leaves nothing stranded.
+     */
+    public void testSuccessPathTransfersOwnershipAndLeavesNoLeak() {
+        OwningSink sink = new OwningSink();
+        AtomicInteger completes = new AtomicInteger();
+        Stitcher stitcher = new Stitcher(allocator, outputFields(), 1, 1, sink, completes::incrementAndGet);
+
+        VectorSchemaRoot resp = responseBatch(new Object[] { "0" }, new Object[] { "a" });
+        stitcher.acceptBatch(resp, new int[] { 0 }, 0);
+        resp.close(); // listener owns the response batch; stitcher only copied out of it
+        stitcher.shardComplete();
+
+        assertEquals("onComplete fired once", 1, completes.get());
+        assertTrue("sink took ownership and was closed by finish", sink.closed);
+        assertEquals("output released once the owning sink closed it", 0, allocator.getAllocatedMemory());
+
+        // A defensive stage-terminal close() must be a no-op after ownership transferred.
+        stitcher.close();
+        assertEquals(0, allocator.getAllocatedMemory());
+    }
+
+    /**
+     * Emit-time failure window: {@code parentSink.feed(output)} throws before ownership transfers.
+     * The pre-fix code left {@code output} unclosed (finally ran only {@code onComplete}); the fix
+     * closes it in {@code finish}'s finally. Assert the allocator returns to zero.
+     */
+    public void testFeedThrowDuringFinishDoesNotLeakOutput() {
+        ThrowingSink sink = new ThrowingSink();
+        AtomicInteger completes = new AtomicInteger();
+        Stitcher stitcher = new Stitcher(allocator, outputFields(), 1, 1, sink, completes::incrementAndGet);
+
+        VectorSchemaRoot resp = responseBatch(new Object[] { "0" }, new Object[] { "a" });
+        stitcher.acceptBatch(resp, new int[] { 0 }, 0);
+        resp.close();
+
+        // finish() runs on shardComplete; feed() throws inside it. The throw still propagates (as it
+        // did before the fix — the caller surfaces it), but the finally must free output first.
+        expectThrows(IllegalStateException.class, stitcher::shardComplete);
+
+        assertEquals("onComplete still fires via finish's finally", 1, completes.get());
+        assertEquals("output freed despite feed() throwing before ownership transfer", 0, allocator.getAllocatedMemory());
+    }
+
+    /**
+     * "finish never runs" window: a shard's fetch stream neither completes nor fails (dropped
+     * listener / node lost / cancelled before terminal), so {@code pendingShards} never reaches
+     * zero and {@code finish} is never called. The stage's terminal transition calls
+     * {@code Stitcher.close()}, which must release the pre-allocated output.
+     */
+    public void testCloseReleasesOutputWhenFinishNeverRuns() {
+        OwningSink sink = new OwningSink();
+        // Two shards pending; only one reports, so finish() never fires on its own.
+        Stitcher stitcher = new Stitcher(allocator, outputFields(), 2, 2, sink, () -> {});
+
+        VectorSchemaRoot resp = responseBatch(new Object[] { "0" }, new Object[] { "a" });
+        stitcher.acceptBatch(resp, new int[] { 0 }, 0);
+        resp.close();
+        assertTrue("output holds buffers while stitch is in flight", allocator.getAllocatedMemory() > 0);
+
+        // Stage terminal (cancel/timeout) → close() the stitcher.
+        stitcher.close();
+
+        assertEquals("stage-terminal close() frees the never-emitted output", 0, allocator.getAllocatedMemory());
+
+        // Idempotent: a late shardComplete (if it ever arrived) or a second close must not throw.
+        stitcher.close();
+        assertEquals(0, allocator.getAllocatedMemory());
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -355,16 +355,26 @@ public class VSRManager implements AutoCloseable {
 
     @Override
     public void close() {
+        // vsrPool.close() MUST run even if awaitPendingWrite / writer.flush() throws: a failed or
+        // timed-out background write (IOException from awaitPendingWrite) previously skipped it,
+        // stranding the pool's per-VSR child allocators (their off-heap Arrow buffers leaked onto
+        // the ingest pool for the node's lifetime — "Memory was leaked by query"). Release the pool
+        // in a finally so the buffers are reclaimed regardless of the drain/flush outcome.
         try {
             awaitPendingWrite(ROTATION_TIMEOUT, true);
             if (writer != null) {
                 writer.flush();
             }
-            vsrPool.close();
-            managedVSR.set(null);
         } catch (Exception e) {
             logger.error("Error during close for {}: {}", fileName, e.getMessage());
             throw new RuntimeException("Failed to close VSRManager: " + e.getMessage(), e);
+        } finally {
+            try {
+                vsrPool.close();
+            } catch (Exception e) {
+                logger.error("Error releasing VSR pool during close for {}: {}", fileName, e.getMessage());
+            }
+            managedVSR.set(null);
         }
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -476,4 +476,9 @@ public class VSRManager implements AutoCloseable {
     Future<?> getPendingWrite() {
         return pendingWrite;
     }
+
+    /** Visible for testing — injects a pending background write future to exercise close() paths. */
+    void setPendingWrite(Future<?> future) {
+        this.pendingWrite = future;
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -153,6 +153,45 @@ public class VSRManagerTests extends ParquetBaseTests {
         manager.flush();
     }
 
+    /**
+     * Regression for the ingest-pool leak: when {@code close()} fails to drain a background write
+     * (awaitPendingWrite throws {@code IOException("Background VSR write failed...")}), it must still
+     * release the VSR pool. The pre-fix close() called {@code vsrPool.close()} only after
+     * awaitPendingWrite/flush, so a background-write failure skipped it and stranded the per-VSR
+     * child allocators' off-heap buffers on the ingest pool for the node's lifetime ("Memory was
+     * leaked by query"). Here we buffer data into the active VSR, inject an already-failed
+     * pendingWrite so close() takes the throwing path, and assert the pool drains to zero.
+     */
+    public void testCloseReleasesPoolWhenBackgroundWriteFailed() throws Exception {
+        String filePath = createTempDir().resolve("bgwrite-fail.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
+
+        // Materialize buffers on the active VSR's child allocator so the pool holds bytes.
+        ManagedVSR active = manager.getActiveManagedVSR();
+        IntVector vec = (IntVector) active.getVector("val");
+        for (int i = 0; i < 1000; i++) {
+            vec.setSafe(i, i);
+        }
+        active.setRowCount(1000);
+        assertTrue("pool holds buffers before close", bufferPool.getTotalAllocatedBytes() > 0);
+
+        // Inject an already-failed background write so close()'s awaitPendingWrite throws — the exact
+        // condition (Background VSR write failed) that used to skip vsrPool.close().
+        java.util.concurrent.CompletableFuture<Object> failed = new java.util.concurrent.CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("simulated native write failure"));
+        java.lang.reflect.Field pw = VSRManager.class.getDeclaredField("pendingWrite");
+        pw.setAccessible(true);
+        pw.set(manager, failed);
+
+        RuntimeException thrown = expectThrows(RuntimeException.class, manager::close);
+        assertTrue(
+            "close still surfaces the background-write failure",
+            thrown.getMessage() != null && thrown.getMessage().contains("Failed to close VSRManager")
+        );
+
+        assertEquals("VSR pool must be released even when the background write failed", 0, bufferPool.getTotalAllocatedBytes());
+    }
+
     public void testMaybeRotateAtThreshold() throws Exception {
         String filePath = createTempDir().resolve("rotate.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -179,9 +179,7 @@ public class VSRManagerTests extends ParquetBaseTests {
         // condition (Background VSR write failed) that used to skip vsrPool.close().
         java.util.concurrent.CompletableFuture<Object> failed = new java.util.concurrent.CompletableFuture<>();
         failed.completeExceptionally(new RuntimeException("simulated native write failure"));
-        java.lang.reflect.Field pw = VSRManager.class.getDeclaredField("pendingWrite");
-        pw.setAccessible(true);
-        pw.set(manager, failed);
+        manager.setPendingWrite(failed);
 
         RuntimeException thrown = expectThrows(RuntimeException.class, manager::close);
         assertTrue(


### PR DESCRIPTION
### Description

Fixes three off-heap Arrow buffer leaks that let native memory pools (`POOL_QUERY`, `POOL_INGEST`) retain buffers after work finished, so the pool "never goes down" and eventually rejects new allocations. Two were surfaced from heap-dump analysis of a node whose coordinator query pool held ~332 MB with no active queries; the third from a production `Memory was leaked by query` log during ingest.

With `analytics.coordinator.buffer_limit=0` (the default) per-query allocator isolation is off, so every query allocates directly on the long-lived `coordinator` allocator and buffers are reclaimed only by explicit `VectorSchemaRoot.close()` / pool-close calls. Any missed close on any terminal path strands buffers for the node's lifetime.

**1. `RowProducingSink.close()` — unguarded release loop (analytics-engine)**
The batch-release loop was unguarded despite its javadoc promising per-batch guarding. When a batch's `close()` threw `IllegalStateException` ("RefCnt has gone negative" — a batch whose vectors were shared with, and already released by, another close path), the loop aborted and every batch after it leaked. The failure was invisible because the caller wraps `close()` in `runQuietly`. Fix: guard each `close()` individually and `clear()` in a `finally`, matching the documented contract.

**2. `Stitcher` output VSR — coordinator leak on failure/cancel (analytics-engine)**
The pre-allocated output VSR (on the coordinator allocator) was freed only inside `finish()`, and the success branch skipped `output.close()` assuming `parentSink.feed()` always takes ownership. If `feed()`/`sanitizeNullViewSlots` threw before ownership transferred, output leaked; if a shard's fetch stream never terminated, `finish()` never ran at all. Fix: an ownership guard so `finish()`'s `finally` frees output unless the sink took it, plus a race-safe `Stitcher.close()` wired into `LateMaterializationStageExecution.onTerminalTransition` for the cancel/timeout path where `finish()` never runs.

**3. `VSRManager.close()` — ingest pool leak on background-write failure (parquet-data-format)**
`close()` called `vsrPool.close()` only after `awaitPendingWrite()` and `writer.flush()` succeeded. When a background VSR write failed or timed out, `awaitPendingWrite` threw `IOException("Background VSR write failed…")` and `close()` rethrew before releasing the pool, stranding the per-VSR child allocators (surfacing as `Memory was leaked by query … Outstanding child allocators: Allocator(pool-<file>-vsr-N)`). Fix: move `vsrPool.close()` into a `finally` so the pool is released regardless of drain/flush outcome; the original failure is still surfaced.

### Testing

Each fix has a leak-assertion test (`allocator.getAllocatedMemory()` / `ArrowBufferPool.getTotalAllocatedBytes() == 0` after the terminal path). Every test was verified to **fail against the pre-fix code** with a real `Memory was leaked by query` error and pass after the fix:
- `RowProducingSinkTests.testCloseReleasesAllBatchesWhenOneThrows` (+ idempotency)
- `StitcherTests` — success, feed-throws-mid-emit, and finish-never-runs paths
- `VSRManagerTests.testCloseReleasesPoolWhenBackgroundWriteFailed`

### Related Issues
<!-- List any related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
