### PR TITLE
Fix NPE when creating a match-all composable index template without an inline template

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
@@ -118,13 +118,14 @@ public class PutComposableIndexTemplateAction extends ActionType<AcknowledgedRes
             if (indexTemplate == null) {
                 validationException = addValidationError("an index template is required", validationException);
             } else {
-                if (indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
-                    if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
-                        validationException = addValidationError(
-                            "global composable templates may not specify the setting " + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
-                            validationException
-                        );
-                    }
+                if (indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)
+                    && indexTemplate.template() != null
+                    && indexTemplate.template().settings() != null
+                    && IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
+                    validationException = addValidationError(
+                        "global composable templates may not specify the setting " + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
+                        validationException
+                    );
                 }
                 if (indexTemplate.priority() != null && indexTemplate.priority() < 0) {
                     validationException = addValidationError("index template priority must be >= 0", validationException);

--- a/server/src/test/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializingTestCase<PutComposableIndexTemplateAction.Request> {
     @Override
@@ -82,6 +83,25 @@ public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializ
         assertThat(validationErrors.size(), is(1));
         String error = validationErrors.get(0);
         assertThat(error, is("global composable templates may not specify the setting " + IndexMetadata.SETTING_INDEX_HIDDEN));
+    }
+
+    public void testPutGlobalTemplateWithoutInlineTemplateSucceeds() {
+        ComposableIndexTemplate globalTemplate = new ComposableIndexTemplate(List.of("*"), null, List.of("ct"), null, null, null, null);
+
+        PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request("test");
+        request.indexTemplate(globalTemplate);
+
+        assertThat(request.validate(), is(nullValue()));
+    }
+
+    public void testPutGlobalTemplateWithoutSettingsSucceeds() {
+        Template template = new Template(null, null, null);
+        ComposableIndexTemplate globalTemplate = new ComposableIndexTemplate(List.of("*"), template, null, null, null, null, null);
+
+        PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request("test");
+        request.indexTemplate(globalTemplate);
+
+        assertThat(request.validate(), is(nullValue()));
     }
 
     public void testPutIndexTemplateV2RequestMustContainTemplate() {


### PR DESCRIPTION
### Description

Fixes a `NullPointerException` when creating a composable index template with a match-all pattern (`*`) in `index_patterns` and without an inline `template` block:

```
PUT /_index_template/my-catch-all
{
  "index_patterns": ["*"],
  "priority": 0,
  "composed_of": ["my-defaults"]
}
```

```
{
  "error": {
    "type": "null_pointer_exception",
    "reason": "Cannot invoke \"org.opensearch.cluster.metadata.Template.settings()\" because the return value of \"org.opensearch.cluster.metadata.ComposableIndexTemplate.template()\" is null"
  },
  "status": 500
}
```

`Request#validate()` checked the `index.hidden` restriction for global templates by calling `indexTemplate.template().settings()` without null checks. Since the `template` block is optional, both `template()` and its `settings()` can be null, which caused the NPE. With this change, the `index.hidden` validation only runs when an inline template with settings is actually present, so a match-all, `composed_of`-only template can be created.

The same bug existed in Elasticsearch and was fixed in 7.10.3 (elastic/elasticsearch#67310).

Added unit tests covering a global template without an inline template and one with an inline template but null settings.

### Related Issues

Resolves #22420 

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).