### PR TITLE
Add bulkscorer script processing interface in ScriptScore query so that underline ScriptEngines can take advantage of bulk scoring.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -34,6 +34,13 @@ package org.opensearch.search.query;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.util.Bits;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -42,20 +49,28 @@ import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.script.MockScriptPlugin;
+import org.opensearch.script.ScoreScript;
 import org.opensearch.script.Script;
+import org.opensearch.script.ScriptContext;
+import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptType;
+import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.idsQuery;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
 import static org.opensearch.index.query.QueryBuilders.scriptScoreQuery;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
@@ -83,7 +98,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singleton(CustomScriptPlugin.class);
+        return Arrays.asList(CustomScriptPlugin.class, BulkScoringScriptPlugin.class);
     }
 
     public static class CustomScriptPlugin extends MockScriptPlugin {
@@ -237,5 +252,240 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         // to make sure we test the intended code path
         SearchResponse resp = client().prepareSearch("test-index").setQuery(scriptScoreQuery).setProfile(true).get();
         assertNoFailures(resp);
+    }
+
+    // ===== BulkScoringLeafFactory integration tests =====
+
+    public void testBulkScoringProducesCorrectScores() throws Exception {
+        assertAcked(
+            prepareCreate("bulk-test-index").setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setMapping("field1", "type=text")
+        );
+        client().prepareIndex("bulk-test-index").setId("1").setSource("field1", "foo").get();
+        client().prepareIndex("bulk-test-index").setId("2").setSource("field1", "foo").get();
+        client().prepareIndex("bulk-test-index").setId("3").setSource("field1", "foo").get();
+        refresh();
+        indexRandomForConcurrentSearch("bulk-test-index");
+
+        Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
+        SearchResponse resp = client().prepareSearch("bulk-test-index").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        assertNoFailures(resp);
+        assertEquals(3, resp.getHits().getTotalHits().value());
+        for (var hit : resp.getHits().getHits()) {
+            assertTrue("Score should be positive from bulk scorer, got: " + hit.getScore(), hit.getScore() > 0f);
+        }
+    }
+
+    public void testBulkScoringBypassedWithMinScore() throws Exception {
+        assertAcked(
+            prepareCreate("bulk-test-minscore").setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setMapping("field1", "type=text")
+        );
+        client().prepareIndex("bulk-test-minscore").setId("1").setSource("field1", "foo").get();
+        client().prepareIndex("bulk-test-minscore").setId("2").setSource("field1", "foo").get();
+        refresh();
+        indexRandomForConcurrentSearch("bulk-test-minscore");
+
+        // When minScore is set, ScriptScoreQuery bypasses bulk scoring and uses per-doc ScriptScorer.
+        // The per-doc path (newInstance) returns a fixed score of 2.0.
+        Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
+        SearchResponse resp = client().prepareSearch("bulk-test-minscore")
+            .setQuery(scriptScoreQuery(matchAllQuery(), script).setMinScore(1.5f))
+            .get();
+        assertNoFailures(resp);
+        assertEquals(2, resp.getHits().getTotalHits().value());
+        for (var hit : resp.getHits().getHits()) {
+            assertEquals(2.0f, hit.getScore(), 0.001f);
+        }
+    }
+
+    public void testBulkScoringWithBoost() throws Exception {
+        assertAcked(
+            prepareCreate("bulk-test-boost").setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setMapping("field1", "type=text")
+        );
+        client().prepareIndex("bulk-test-boost").setId("1").setSource("field1", "foo").get();
+        refresh();
+        indexRandomForConcurrentSearch("bulk-test-boost");
+
+        float boost = 3.0f;
+        // First query without boost to get the base score
+        Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
+        SearchResponse baseResp = client().prepareSearch("bulk-test-boost").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        assertNoFailures(baseResp);
+        float baseScore = baseResp.getHits().getHits()[0].getScore();
+
+        // Query with boost — score should be base * boost
+        SearchResponse resp = client().prepareSearch("bulk-test-boost")
+            .setQuery(scriptScoreQuery(matchAllQuery(), script).boost(boost))
+            .get();
+        assertNoFailures(resp);
+        assertEquals(1, resp.getHits().getTotalHits().value());
+        assertEquals(baseScore * boost, resp.getHits().getHits()[0].getScore(), 0.001f);
+    }
+
+    public void testBulkScoringFallbackWhenReturnsNull() throws Exception {
+        assertAcked(
+            prepareCreate("bulk-test-fallback").setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setMapping("field1", "type=text")
+        );
+        client().prepareIndex("bulk-test-fallback").setId("1").setSource("field1", "foo").get();
+        refresh();
+        indexRandomForConcurrentSearch("bulk-test-fallback");
+
+        // "fallback_score" source triggers null from bulkScorer() → falls back to per-doc scoring (returns 2.0)
+        Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "fallback_score", Collections.emptyMap());
+        SearchResponse resp = client().prepareSearch("bulk-test-fallback").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        assertNoFailures(resp);
+        assertEquals(1, resp.getHits().getTotalHits().value());
+        assertEquals(2.0f, resp.getHits().getHits()[0].getScore(), 0.001f);
+    }
+
+    public void testBulkScoringExplainUsesPerDocPath() throws Exception {
+        assertAcked(
+            prepareCreate("bulk-test-explain").setSettings(Settings.builder().put("index.number_of_shards", 1))
+                .setMapping("field1", "type=text")
+        );
+        client().prepareIndex("bulk-test-explain").setId("1").setSource("field1", "foo").get();
+        refresh();
+        indexRandomForConcurrentSearch("bulk-test-explain");
+
+        // The bulk scorer produces score = (docId + 1) * boost, but explain always uses the per-doc
+        // path (newInstance → execute() returns 2.0). Verify explain returns the per-doc score.
+        Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
+        SearchResponse resp = client().prepareSearch("bulk-test-explain")
+            .setQuery(scriptScoreQuery(matchAllQuery(), script))
+            .setExplain(true)
+            .get();
+        assertNoFailures(resp);
+        assertEquals(1, resp.getHits().getTotalHits().value());
+        assertNotNull(resp.getHits().getHits()[0].getExplanation());
+        assertTrue(resp.getHits().getHits()[0].getExplanation().getDescription().contains("script score function, computed with script:"));
+    }
+
+    // ===== Bulk Scoring Script Plugin =====
+
+    public static class BulkScoringScriptPlugin extends Plugin implements ScriptPlugin {
+        @Override
+        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+            return new BulkScoringScriptEngine();
+        }
+    }
+
+    /**
+     * A minimal script engine that produces a {@link ScoreScript.BulkScoringLeafFactory}.
+     * <p>
+     * Source "bulk_score": bulk scorer assigns score = (segment-local docId + 1) * boost.
+     * Source "fallback_score": bulkScorer() returns null, falling back to per-doc scoring with score = 2.0.
+     */
+    public static class BulkScoringScriptEngine implements ScriptEngine {
+
+        public static final String NAME = "bulk_test";
+
+        @Override
+        public String getType() {
+            return NAME;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T compile(String name, String source, ScriptContext<T> context, Map<String, String> params) {
+            if (context.equals(ScoreScript.CONTEXT) == false) {
+                throw new IllegalArgumentException("Unsupported context: " + context.name);
+            }
+
+            ScoreScript.Factory factory = (Map<String, Object> p, SearchLookup lookup, IndexSearcher indexSearcher) -> {
+                boolean useBulk = "bulk_score".equals(source);
+                return new BulkScoringLeafFactoryImpl(p, lookup, indexSearcher, useBulk);
+            };
+            return (T) factory;
+        }
+
+        @Override
+        public Set<ScriptContext<?>> getSupportedContexts() {
+            return Set.of(ScoreScript.CONTEXT);
+        }
+    }
+
+    private static class BulkScoringLeafFactoryImpl implements ScoreScript.BulkScoringLeafFactory {
+
+        private final Map<String, Object> params;
+        private final SearchLookup lookup;
+        private final IndexSearcher indexSearcher;
+        private final boolean useBulk;
+
+        BulkScoringLeafFactoryImpl(Map<String, Object> params, SearchLookup lookup, IndexSearcher indexSearcher, boolean useBulk) {
+            this.params = params;
+            this.lookup = lookup;
+            this.indexSearcher = indexSearcher;
+            this.useBulk = useBulk;
+        }
+
+        @Override
+        public boolean needs_score() {
+            return false;
+        }
+
+        @Override
+        public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
+            return new ScoreScript(params, lookup, indexSearcher, ctx) {
+                @Override
+                public double execute(ExplanationHolder explanation) {
+                    return 2.0;
+                }
+            };
+        }
+
+        @Override
+        public BulkScorer bulkScorer(LeafReaderContext context, BulkScorer subQueryBulkScorer, ScoreMode subQueryScoreMode, float boost)
+            throws IOException {
+            if (useBulk == false) {
+                return null;
+            }
+            return new SimpleBulkScorer(subQueryBulkScorer, boost);
+        }
+    }
+
+    /**
+     * A simple bulk scorer that drives the sub-query's bulk scorer to discover matched docs,
+     * then assigns each document a score of (docId + 1) * boost.
+     */
+    private static class SimpleBulkScorer extends BulkScorer {
+
+        private final BulkScorer subQueryBulkScorer;
+        private final float boost;
+
+        SimpleBulkScorer(BulkScorer subQueryBulkScorer, float boost) {
+            this.subQueryBulkScorer = subQueryBulkScorer;
+            this.boost = boost;
+        }
+
+        @Override
+        public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+            final float[] currentScore = new float[1];
+            Scorable scorable = new Scorable() {
+                @Override
+                public float score() {
+                    return currentScore[0];
+                }
+            };
+            collector.setScorer(scorable);
+
+            return subQueryBulkScorer.score(new LeafCollector() {
+                @Override
+                public void setScorer(Scorable scorer) {}
+
+                @Override
+                public void collect(int doc) throws IOException {
+                    currentScore[0] = (doc + 1) * boost;
+                    collector.collect(doc);
+                }
+            }, acceptDocs, min, max);
+        }
+
+        @Override
+        public long cost() {
+            return subQueryBulkScorer.cost();
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -137,6 +137,15 @@ public class ScriptScoreQuery extends Query {
                     public BulkScorer bulkScorer() throws IOException {
                         if (minScore == null) {
                             final BulkScorer subQueryBulkScorer = subQueryScorerSupplier.bulkScorer();
+                            if (subQueryBulkScorer == null) {
+                                return null;
+                            }
+                            if (scriptBuilder instanceof ScoreScript.BulkScoringLeafFactory bulkFactory) {
+                                final BulkScorer custom = bulkFactory.bulkScorer(context, subQueryBulkScorer, subQueryScoreMode, boost);
+                                if (custom != null) {
+                                    return custom;
+                                }
+                            }
                             return new ScriptScoreBulkScorer(subQueryBulkScorer, subQueryScoreMode, makeScoreScript(context), boost);
                         } else {
                             return super.bulkScorer();

--- a/server/src/main/java/org/opensearch/script/ScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScript.java
@@ -32,9 +32,11 @@
 package org.opensearch.script;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
 import org.opensearch.Version;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.index.fielddata.ScriptDocValues;
@@ -271,6 +273,57 @@ public abstract class ScoreScript {
         boolean needs_score();
 
         ScoreScript newInstance(LeafReaderContext ctx) throws IOException;
+    }
+
+    /**
+     * Extension of {@link LeafFactory} that allows a script engine to provide a custom
+     * {@link BulkScorer} for batch scoring. When implemented, {@code ScriptScoreQuery} will
+     * delegate to the returned bulk scorer instead of scoring documents one at a time.
+     * This enables optimizations such as batched I/O prefetch and vectorized distance computation.
+     *
+     * <p><b>Score mode contract:</b> The returned {@link BulkScorer} fully replaces the default
+     * {@code ScriptScoreBulkScorer}. It is responsible for honoring all scoring semantics including
+     * score validation (non-negative, non-NaN) and applying the boost factor. The caller does not
+     * apply any additional score transformations on top of the returned scorer's output.
+     *
+     * <p><b>Explain contract:</b> The {@code explain()} path in {@code ScriptScoreQuery} always uses
+     * the per-document scoring path via {@link #newInstance(LeafReaderContext)}. Implementations must
+     * ensure that the per-doc scorer and the bulk scorer produce consistent scores for the same
+     * document, so that explain output accurately reflects actual query scores.
+     *
+     * @opensearch.internal
+     */
+    public interface BulkScoringLeafFactory extends LeafFactory {
+
+        /**
+         * Create a BulkScorer that scores documents in batches for improved I/O efficiency.
+         *
+         * <p><b>Contract:</b>
+         * <ul>
+         *   <li>{@code subQueryBulkScorer} is guaranteed non-null by the caller.</li>
+         *   <li>If this method returns {@code null}, the caller falls back to the default per-document
+         *       scoring path. The {@code subQueryBulkScorer} remains unconsumed and will be used by
+         *       the fallback scorer.</li>
+         *   <li>If this method returns a non-null {@link BulkScorer}, the caller uses it exclusively
+         *       for this segment. The implementation takes ownership of {@code subQueryBulkScorer}
+         *       and is responsible for driving or discarding it.</li>
+         *   <li>The returned scorer must produce valid scores: non-negative, non-NaN, with the
+         *       provided {@code boost} applied.</li>
+         * </ul>
+         *
+         * @param context            the leaf reader context for this segment
+         * @param subQueryBulkScorer the sub-query's BulkScorer that drives document iteration (never null)
+         * @param subQueryScoreMode  the score mode of the sub-query
+         * @param boost              the boost factor to apply to scores
+         * @return a BulkScorer, or null to fall back to default per-document scoring
+         * @throws IOException if an I/O error occurs
+         */
+        BulkScorer bulkScorer(
+            final LeafReaderContext context,
+            final BulkScorer subQueryBulkScorer,
+            final ScoreMode subQueryScoreMode,
+            float boost
+        ) throws IOException;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
@@ -39,18 +39,22 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Bits;
 import org.opensearch.Version;
 import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.lucene.search.function.ScriptScoreQuery;
@@ -64,7 +68,9 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -274,6 +280,287 @@ public class ScriptScoreQueryTests extends OpenSearchTestCase {
                 }
             };
         }
+    }
+
+    public void testBulkScoringLeafFactoryIsUsed() throws IOException {
+        Script script = new Script("bulk scoring script");
+        List<Integer> collectedDocs = new ArrayList<>();
+
+        ScoreScript.BulkScoringLeafFactory factory = newBulkFactory(
+            script,
+            false,
+            explanation -> 2.0,
+            (context, subQueryBulkScorer, subQueryScoreMode, boost) -> {
+                return new BulkScorer() {
+                    @Override
+                    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                        Scorable scorable = new Scorable() {
+                            float score = 5.0f;
+
+                            @Override
+                            public float score() {
+                                return score;
+                            }
+                        };
+                        collector.setScorer(scorable);
+                        collector.collect(0);
+                        collectedDocs.add(0);
+                        return DocIdSetIterator.NO_MORE_DOCS;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 1;
+                    }
+                };
+            }
+        );
+
+        ScriptScoreQuery query = new ScriptScoreQuery(Queries.newMatchAllQuery(), script, factory, null, "index", 0, Version.CURRENT);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        List<Integer> searchCollectedDocs = new ArrayList<>();
+        LeafCollector collector = new LeafCollector() {
+            Scorable scorer;
+
+            @Override
+            public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+            }
+
+            @Override
+            public void collect(int doc) throws IOException {
+                searchCollectedDocs.add(doc);
+            }
+        };
+        bulkScorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+
+        assertThat(collectedDocs.size(), equalTo(1));
+        assertThat(searchCollectedDocs.size(), equalTo(1));
+        assertThat(searchCollectedDocs.get(0), equalTo(0));
+    }
+
+    public void testBulkScoringLeafFactoryReturnsNullFallsBackToDefault() throws IOException {
+        Script script = new Script("bulk scoring returns null");
+
+        ScoreScript.BulkScoringLeafFactory factory = newBulkFactory(
+            script,
+            false,
+            explanation -> 3.0,
+            (context, subQueryBulkScorer, subQueryScoreMode, boost) -> null
+        );
+
+        ScriptScoreQuery query = new ScriptScoreQuery(Queries.newMatchAllQuery(), script, factory, null, "index", 0, Version.CURRENT);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        List<Float> scores = new ArrayList<>();
+        LeafCollector collector = new LeafCollector() {
+            Scorable scorer;
+
+            @Override
+            public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+            }
+
+            @Override
+            public void collect(int doc) throws IOException {
+                scores.add(scorer.score());
+            }
+        };
+        bulkScorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+
+        assertThat(scores.size(), equalTo(1));
+        assertThat(scores.get(0), equalTo(3.0f));
+    }
+
+    public void testBulkScoringLeafFactorySkippedWhenMinScoreSet() throws IOException {
+        Script script = new Script("bulk scoring with minScore");
+        boolean[] bulkScorerCalled = new boolean[] { false };
+
+        ScoreScript.BulkScoringLeafFactory factory = newBulkFactory(
+            script,
+            false,
+            explanation -> 5.0,
+            (context, subQueryBulkScorer, subQueryScoreMode, boost) -> {
+                bulkScorerCalled[0] = true;
+                return new BulkScorer() {
+                    @Override
+                    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) {
+                        return DocIdSetIterator.NO_MORE_DOCS;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+                };
+            }
+        );
+
+        float minScore = 1.0f;
+        ScriptScoreQuery query = new ScriptScoreQuery(Queries.newMatchAllQuery(), script, factory, minScore, "index", 0, Version.CURRENT);
+
+        searcher.search(query, 10);
+        assertFalse("BulkScoringLeafFactory.bulkScorer() should not be called when minScore is set", bulkScorerCalled[0]);
+    }
+
+    public void testBulkScoringLeafFactoryWithBoost() throws IOException {
+        Script script = new Script("bulk scoring with boost");
+        float queryBoost = 2.5f;
+        float[] receivedBoost = new float[] { 0f };
+
+        ScoreScript.BulkScoringLeafFactory factory = newBulkFactory(
+            script,
+            false,
+            explanation -> 1.0,
+            (context, subQueryBulkScorer, subQueryScoreMode, boost) -> {
+                receivedBoost[0] = boost;
+                return null;
+            }
+        );
+
+        ScriptScoreQuery query = new ScriptScoreQuery(Queries.newMatchAllQuery(), script, factory, null, "index", 0, Version.CURRENT);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, queryBoost);
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        scorerSupplier.bulkScorer();
+
+        assertThat(receivedBoost[0], equalTo(queryBoost));
+    }
+
+    public void testBulkScoringReturnsNullWhenSubQueryBulkScorerIsNull() throws IOException {
+        Script script = new Script("bulk scoring with null sub-query bulk scorer");
+        boolean[] bulkScorerCalled = new boolean[] { false };
+
+        ScoreScript.BulkScoringLeafFactory factory = newBulkFactory(
+            script,
+            false,
+            explanation -> 1.0,
+            (context, subQueryBulkScorer, subQueryScoreMode, boost) -> {
+                bulkScorerCalled[0] = true;
+                return new BulkScorer() {
+                    @Override
+                    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) {
+                        return DocIdSetIterator.NO_MORE_DOCS;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+                };
+            }
+        );
+
+        ScriptScoreQuery query = new ScriptScoreQuery(new NullBulkScorerQuery(), script, factory, null, "index", 0, Version.CURRENT);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        assertNull("BulkScorer should be null when sub-query's bulkScorer() returns null", bulkScorer);
+        assertFalse("BulkScoringLeafFactory.bulkScorer() should not be called when sub-query bulk scorer is null", bulkScorerCalled[0]);
+    }
+
+    private static class NullBulkScorerQuery extends Query {
+
+        @Override
+        public String toString(String field) {
+            return getClass().getSimpleName();
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+            visitor.visitLeaf(this);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return this == obj;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+            return new Weight(this) {
+
+                @Override
+                public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                    return new ScorerSupplier() {
+                        @Override
+                        public Scorer get(long leadCost) throws IOException {
+                            return null;
+                        }
+
+                        @Override
+                        public BulkScorer bulkScorer() throws IOException {
+                            return null;
+                        }
+
+                        @Override
+                        public long cost() {
+                            return 0;
+                        }
+                    };
+                }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
+            };
+        }
+    }
+
+    @FunctionalInterface
+    interface BulkScorerProvider {
+        BulkScorer provide(LeafReaderContext context, BulkScorer subQueryBulkScorer, ScoreMode subQueryScoreMode, float boost)
+            throws IOException;
+    }
+
+    private ScoreScript.BulkScoringLeafFactory newBulkFactory(
+        Script script,
+        boolean needsScore,
+        Function<ScoreScript.ExplanationHolder, Double> function,
+        BulkScorerProvider bulkScorerProvider
+    ) {
+        SearchLookup lookup = mock(SearchLookup.class);
+        LeafSearchLookup leafLookup = mock(LeafSearchLookup.class);
+        IndexSearcher indexSearcher = mock(IndexSearcher.class);
+        when(lookup.getLeafSearchLookup(any())).thenReturn(leafLookup);
+        return new ScoreScript.BulkScoringLeafFactory() {
+            @Override
+            public BulkScorer bulkScorer(LeafReaderContext context, BulkScorer subQueryBulkScorer, ScoreMode subQueryScoreMode, float boost)
+                throws IOException {
+                return bulkScorerProvider.provide(context, subQueryBulkScorer, subQueryScoreMode, boost);
+            }
+
+            @Override
+            public boolean needs_score() {
+                return needsScore;
+            }
+
+            @Override
+            public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
+                return new ScoreScript(script.getParams(), lookup, indexSearcher, leafReaderContext) {
+                    @Override
+                    public double execute(ExplanationHolder explanation) {
+                        return function.apply(explanation);
+                    }
+                };
+            }
+        };
     }
 
     private ScoreScript.LeafFactory newFactory(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add bulkscorer script processing interface in ScriptScore query so that underline ScriptEngines can take advantage of bulk scoring.

### Related Issues
NA
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
