### PR TITLE
Gradle plugin support for dependencies in plugin descriptor properties

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -113,8 +113,15 @@ class PluginBuildPlugin implements Plugin<Project> {
                     'customFolderName'    : extension1.customFolderName,
                     'extendedPlugins'     : extension1.extendedPlugins.join(','),
                     'hasNativeController' : extension1.hasNativeController,
-                    'requiresKeystore'    : extension1.requiresKeystore
+                    'requiresKeystore'    : extension1.requiresKeystore,
+                    'dependencies'        : extension1.dependencies
             ]
+
+            // Clear opensearch version if dependencies are specified
+            if (extension1.dependencies != null && !extension1.dependencies.trim().isEmpty()) {
+                properties.put('opensearchVersion', '');
+            }
+
             project.tasks.named('pluginProperties').configure {
                 expand(properties)
                 inputs.properties(properties)

--- a/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
@@ -53,6 +53,8 @@ public class PluginPropertiesExtension {
 
     private String customFolderName = "";
 
+    private String dependencies = "";
+
     /** Other plugins this plugin extends through SPI */
     private List<String> extendedPlugins = new ArrayList<>();
 
@@ -84,6 +86,14 @@ public class PluginPropertiesExtension {
 
     public void setCustomFolderName(String customFolderName) {
         this.customFolderName = customFolderName;
+    }
+
+    public String getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(String dependencies) {
+        this.dependencies = dependencies;
     }
 
     public String getName() {

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -59,3 +59,6 @@ extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+#
+# 'dependencies': any dependencies specified by the plugin
+dependencies=${dependencies}

--- a/buildSrc/src/test/java/org/opensearch/gradle/plugin/PluginBuildPluginTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/plugin/PluginBuildPluginTests.java
@@ -39,8 +39,8 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
-import org.junit.Ignore;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
@@ -72,7 +72,6 @@ public class PluginBuildPluginTests extends GradleUnitTestCase {
         });
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/47123")
     public void testApplyWithAfterEvaluate() {
         project.getExtensions().getExtraProperties().set("bwcVersions", Mockito.mock(BwcVersions.class));
         project.getPlugins().apply(PluginBuildPlugin.class);
@@ -88,5 +87,16 @@ public class PluginBuildPluginTests extends GradleUnitTestCase {
             "Task to generate notice not created: " + project.getTasks().stream().map(Task::getPath).collect(Collectors.joining(", ")),
             project.getTasks().findByName("generateNotice")
         );
+        Map<String, Object> taskProperties = project.getTasks().findByName("pluginProperties").getInputs().getProperties();
+        assertTrue(taskProperties.containsKey("description"));
+        assertTrue(taskProperties.containsKey("version"));
+        assertTrue(taskProperties.containsKey("name"));
+        assertTrue(taskProperties.containsKey("classname"));
+        assertTrue(taskProperties.containsKey("javaVersion"));
+        assertTrue(taskProperties.containsKey("opensearchVersion"));
+        assertTrue(taskProperties.containsKey("customFolderName"));
+        assertTrue(taskProperties.containsKey("extendedPlugins"));
+        assertTrue(taskProperties.containsKey("hasNativeController"));
+        assertTrue(taskProperties.containsKey("dependencies"));
     }
 }

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/tools/cli/plugin/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/tools/cli/plugin/InstallPluginCommandTests.java
@@ -290,7 +290,9 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
                 "java.version",
                 System.getProperty("java.specification.version"),
                 "classname",
-                "FakePlugin"
+                "FakePlugin",
+                "dependencies",
+                ""
             ),
             Arrays.stream(additionalProps)
         ).toArray(String[]::new);
@@ -313,7 +315,9 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
                 "java.version",
                 System.getProperty("java.specification.version"),
                 "classname",
-                "FakePlugin"
+                "FakePlugin",
+                "opensearch.version",
+                ""
             ),
             Arrays.stream(additionalProps)
         ).toArray(String[]::new);

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -291,19 +291,19 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         final String opensearchVersionString = propsMap.remove("opensearch.version");
         final String dependenciesValue = propsMap.remove("dependencies");
-        if (opensearchVersionString == null && dependenciesValue == null) {
+        if (isBlank(opensearchVersionString) && isBlank(dependenciesValue)) {
             throw new IllegalArgumentException(
                 "Either [opensearch.version] or [dependencies] property must be specified for the plugin [" + name + "]"
             );
         }
-        if (opensearchVersionString != null && dependenciesValue != null) {
+        if (!isBlank(opensearchVersionString) && !isBlank(dependenciesValue)) {
             throw new IllegalArgumentException(
                 "Only one of [opensearch.version] or [dependencies] property can be specified for the plugin [" + name + "]"
             );
         }
 
         final List<SemverRange> opensearchVersionRanges = new ArrayList<>();
-        if (opensearchVersionString != null) {
+        if (!isBlank(opensearchVersionString)) {
             opensearchVersionRanges.add(SemverRange.fromString(opensearchVersionString));
         } else {
             Map<String, String> dependenciesMap;
@@ -597,5 +597,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append("Folder name: ")
             .append(customFolderName);
         return information.toString();
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
     }
 }

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -175,6 +175,68 @@ public class PluginInfoTests extends OpenSearchTestCase {
         );
     }
 
+    public void testReadFromPropertiesOpenSearchVersionEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "opensearch.version",
+            "",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(
+            e.getMessage(),
+            containsString("Either [opensearch.version] or [dependencies] property must be specified for the plugin ")
+        );
+    }
+
+    public void testReadFromPropertiesDependenciesEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "dependencies",
+            "",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(
+            e.getMessage(),
+            containsString("Either [opensearch.version] or [dependencies] property must be specified for the plugin ")
+        );
+    }
+
+    public void testReadFromPropertiesOpenSearchVersionAndDependenciesEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "opensearch.version",
+            "",
+            "dependencies",
+            "",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(
+            e.getMessage(),
+            containsString("Either [opensearch.version] or [dependencies] property must be specified for the plugin ")
+        );
+    }
+
     public void testReadFromPropertiesWithDependenciesAndOpenSearchVersion() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(
@@ -199,6 +261,62 @@ public class PluginInfoTests extends OpenSearchTestCase {
             e.getMessage(),
             containsString("Only one of [opensearch.version] or [dependencies] property can be specified for the plugin")
         );
+    }
+
+    public void testReadFromPropertiesDependenciesEmptyOpenSearchVersionNotEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "opensearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin",
+            "dependencies",
+            ""
+        );
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals("my_plugin", info.getName());
+        assertEquals("fake desc", info.getDescription());
+        assertEquals("1.0", info.getVersion());
+        assertEquals("FakePlugin", info.getClassname());
+        assertEquals(Version.CURRENT.toString(), info.getOpenSearchVersionRanges().get(0).toString());
+        assertThat(info.getExtendedPlugins(), empty());
+    }
+
+    public void testReadFromPropertiesOpenSearchVersionEmptyDependenciesNotEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"~" + Version.CURRENT.toString() + "\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin",
+            "opensearch.version",
+            ""
+        );
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals("my_plugin", info.getName());
+        assertEquals("fake desc", info.getDescription());
+        assertEquals("1.0", info.getVersion());
+        assertEquals("FakePlugin", info.getClassname());
+        assertEquals("~" + Version.CURRENT.toString(), info.getOpenSearchVersionRanges().get(0).toString());
+        assertThat(info.getExtendedPlugins(), empty());
     }
 
     public void testReadFromPropertiesJavaVersionMissing() throws Exception {
@@ -630,7 +748,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
     }
 
-    public void testhMultipleOpenSearchRangesInDependencies() throws Exception {
+    public void testMultipleOpenSearchRangesInDependencies() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(
             pluginDir,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
this is #17178 rebased and split in two commits, with better commit messages. all credits for the actual commit content go to @abseth-amzn (who doesn't seem to be working on OpenSearch anymore, thus the original PR has been abandoned for a long time).

the rest is copy & paste from the commit message:
PR #11441 added support for semver ranges in dependencies of plugins.
this now updates `opensearchplugin` (from
`org.opensearch.gradle:build-tools`) to support `dependencies` property
when building plugins. since most plugins do not create the
`plugin-descriptor.properties` file manually but instead use this gradle
plugin for it this means that so far `dependencies` was not really used.

`dependencies` also allows depending on `opensearch` (i.e. the core) and
it allows depending on a semver range - thus this finally allows
decoupling plugin releases from OpenSearch releases, i.e. plugins using
this instead of specifying an `opensearch.version` do not need a new
release for every new OpenSearch minor/patch release.

for existing plugins updating to the new gradle plugin version will just
generate an empty `dependencies` entry. so far, this would have then
caused the plugin to fail to load, however the previous commit has
modified this behaviour.
an alternative would be to not generate the entry at all if no
dependencies are specified, but then `dependencies` would be handled
differently to all other entries in the properties file. since the
gradle plugin is generally only updated together with the OpenSearch
version which the plugins support this should be ok to do (it's unlikely
that a plugin will use the gradle plugin 3.8.0 and generate a plugin
release for e.g. 3.7.0).

---

plugin info: support empty `dependencies`

so far, if a plugin provides a `plugin-descriptor.properties` with an
empty `dependencies` entry this will fail if `opensearch.version` is
also specified. however, an empty `dependencies` entry should not fail
this - it should behave as if it were not present.

### Related Issues
resolves #13187
related to #11441

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
