### PR TITLE
[Backport 2.19] Fix unbounded recursion in deserialization that can cause StackOverflowError (#22404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix case insensitive and escaped query on wildcard ([#16827](https://github.com/opensearch-project/OpenSearch/pull/16827))
 - Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
 - Prevent negative fielddata stats by guarding against stale removals after shard reallocation ([#21667](https://github.com/opensearch-project/OpenSearch/pull/21667))
+- Fix unbounded recursion in deserialization that can cause StackOverflowError ([#22404](https://github.com/opensearch-project/OpenSearch/pull/22404))
 
 ### Security
 

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -723,11 +723,24 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Maximum depth for recursive deserialization of nested generic values.
+     * Protects against StackOverflowError from deeply nested binary payloads.
+     */
+    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+
+    /**
      * Reads a value of unspecified type. If a collection is read then the collection will be mutable if it contains any entry but might
      * be immutable if it is empty.
      */
     @Nullable
     public Object readGenericValue() throws IOException {
+        return readGenericValue(0);
+    }
+
+    private Object readGenericValue(int depth) throws IOException {
+        if (depth > MAX_DESERIALIZATION_DEPTH) {
+            throw new IOException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded for binary deserialization");
+        }
         byte type = readByte();
         Writeable.Reader<?> r = Writeable.WriteableRegistry.getReader(type);
         if (r != null) {
@@ -752,13 +765,13 @@ public abstract class StreamInput extends InputStream {
             case 6:
                 return readByteArray();
             case 7:
-                return readArrayList();
+                return readArrayList(depth);
             case 8:
-                return readArray();
+                return readArray(depth);
             case 9:
-                return readLinkedHashMap();
+                return readLinkedHashMap(depth);
             case 10:
-                return readHashMap();
+                return readHashMap(depth);
             case 11:
                 return readByte();
             case 12:
@@ -782,9 +795,9 @@ public abstract class StreamInput extends InputStream {
             case 23:
                 return readZonedDateTime();
             case 24:
-                return readCollection(StreamInput::readGenericValue, LinkedHashSet::new, Collections.emptySet());
+                return readCollection(si -> si.readGenericValue(depth + 1), LinkedHashSet::new, Collections.emptySet());
             case 25:
-                return readCollection(StreamInput::readGenericValue, HashSet::new, Collections.emptySet());
+                return readCollection(si -> si.readGenericValue(depth + 1), HashSet::new, Collections.emptySet());
             case 26:
                 return readBigInteger();
             case 27:
@@ -812,14 +825,14 @@ public abstract class StreamInput extends InputStream {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private List readArrayList() throws IOException {
+    private List readArrayList(int depth) throws IOException {
         int size = readArraySize();
         if (size == 0) {
             return Collections.emptyList();
         }
         List list = new ArrayList(size);
         for (int i = 0; i < size; i++) {
-            list.add(readGenericValue());
+            list.add(readGenericValue(depth + 1));
         }
         return list;
     }
@@ -831,40 +844,40 @@ public abstract class StreamInput extends InputStream {
 
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
-    private Object[] readArray() throws IOException {
+    private Object[] readArray(int depth) throws IOException {
         int size8 = readArraySize();
         if (size8 == 0) {
             return EMPTY_OBJECT_ARRAY;
         }
         Object[] list8 = new Object[size8];
         for (int i = 0; i < size8; i++) {
-            list8[i] = readGenericValue();
+            list8[i] = readGenericValue(depth + 1);
         }
         return list8;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private Map readLinkedHashMap() throws IOException {
+    private Map readLinkedHashMap(int depth) throws IOException {
         int size9 = readArraySize();
         if (size9 == 0) {
             return Collections.emptyMap();
         }
         Map map9 = new LinkedHashMap(size9);
         for (int i = 0; i < size9; i++) {
-            map9.put(readString(), readGenericValue());
+            map9.put(readString(), readGenericValue(depth + 1));
         }
         return map9;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private Map readHashMap() throws IOException {
+    private Map readHashMap(int depth) throws IOException {
         int size10 = readArraySize();
         if (size10 == 0) {
             return Collections.emptyMap();
         }
         Map map10 = new HashMap(size10);
         for (int i = 0; i < size10; i++) {
-            map10.put(readString(), readGenericValue());
+            map10.put(readString(), readGenericValue(depth + 1));
         }
         return map10;
     }

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
@@ -304,13 +304,13 @@ public abstract class AbstractXContentParser implements XContentParser {
     @Override
     public List<Object> list() throws IOException {
         skipToListStart(this);
-        return readListUnsafe(this, SIMPLE_MAP_FACTORY);
+        return readListUnsafe(this, SIMPLE_MAP_FACTORY, 0);
     }
 
     @Override
     public List<Object> listOrderedMap() throws IOException {
         skipToListStart(this);
-        return readListUnsafe(this, ORDERED_MAP_FACTORY);
+        return readListUnsafe(this, ORDERED_MAP_FACTORY, 0);
     }
 
     private static final Supplier<Map<String, Object>> SIMPLE_MAP_FACTORY = HashMap::new;
@@ -328,12 +328,21 @@ public abstract class AbstractXContentParser implements XContentParser {
         Supplier<Map<String, Object>> mapFactory,
         Map<String, Object> map
     ) throws IOException {
+        return readMapEntries(parser, mapFactory, map, 0);
+    }
+
+    private static Map<String, Object> readMapEntries(
+        XContentParser parser,
+        Supplier<Map<String, Object>> mapFactory,
+        Map<String, Object> map,
+        int depth
+    ) throws IOException {
         assert parser.currentToken() == Token.FIELD_NAME : "Expected field name but saw [" + parser.currentToken() + "]";
         do {
             // Must point to field name
             String fieldName = parser.currentName();
             // And then the value...
-            Object value = readValueUnsafe(parser.nextToken(), parser, mapFactory);
+            Object value = readValueUnsafe(parser.nextToken(), parser, mapFactory, depth);
             map.put(fieldName, value);
         } while (parser.nextToken() == Token.FIELD_NAME);
         return map;
@@ -375,18 +384,25 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
     }
 
+    // Maximum depth for recursive deserialization of nested objects/arrays.
+    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+
     // read a list without bounds checks, assuming the current parser is always on an array start
-    private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
+    private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory, int depth)
+        throws IOException {
+        if (depth > MAX_DESERIALIZATION_DEPTH) {
+            throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+        }
         assert parser.currentToken() == Token.START_ARRAY;
         ArrayList<Object> list = new ArrayList<>();
         for (Token token = parser.nextToken(); token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {
-            list.add(readValueUnsafe(token, parser, mapFactory));
+            list.add(readValueUnsafe(token, parser, mapFactory, depth + 1));
         }
         return list;
     }
 
     public static Object readValue(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
-        return readValueUnsafe(parser.currentToken(), parser, mapFactory);
+        return readValueUnsafe(parser.currentToken(), parser, mapFactory, 0);
     }
 
     /**
@@ -395,8 +411,9 @@ public abstract class AbstractXContentParser implements XContentParser {
      * @param currentToken current token that the parser is at
      * @param parser       parser to read from
      * @param mapFactory   map factory to use for reading objects
+     * @param depth        current recursion depth
      */
-    private static Object readValueUnsafe(Token currentToken, XContentParser parser, Supplier<Map<String, Object>> mapFactory)
+    private static Object readValueUnsafe(Token currentToken, XContentParser parser, Supplier<Map<String, Object>> mapFactory, int depth)
         throws IOException {
         assert currentToken == parser.currentToken() : "Supplied current token ["
             + currentToken
@@ -411,11 +428,14 @@ public abstract class AbstractXContentParser implements XContentParser {
             case VALUE_BOOLEAN:
                 return parser.booleanValue();
             case START_OBJECT: {
+                if (depth > MAX_DESERIALIZATION_DEPTH) {
+                    throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+                }
                 final Map<String, Object> map = mapFactory.get();
-                return parser.nextToken() != Token.FIELD_NAME ? map : readMapEntries(parser, mapFactory, map);
+                return parser.nextToken() != Token.FIELD_NAME ? map : readMapEntries(parser, mapFactory, map, depth + 1);
             }
             case START_ARRAY:
-                return readListUnsafe(parser, mapFactory);
+                return readListUnsafe(parser, mapFactory, depth);
             case VALUE_EMBEDDED_OBJECT:
                 return parser.binaryValue();
             case VALUE_NULL:

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentContraints.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentContraints.java
@@ -32,9 +32,7 @@ public interface XContentContraints {
         System.getProperty(DEFAULT_MAX_NAME_LEN_PROPERTY, Integer.toString(Integer.MAX_VALUE) /* no limit */ )
     );
 
-    final int DEFAULT_MAX_DEPTH = Integer.parseInt(
-        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, Integer.toString(Integer.MAX_VALUE) /* no limit */ )
-    );
+    final int DEFAULT_MAX_DEPTH = Integer.parseInt(System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "100"));
 
     final int DEFAULT_CODEPOINT_LIMIT = Integer.parseInt(System.getProperty(DEFAULT_CODEPOINT_LIMIT_PROPERTY, "52428800" /* ~50 Mb */));
 }

--- a/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.io.stream;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class StreamInputMaxDepthTests extends OpenSearchTestCase {
+
+    public void testDeeplyNestedArrayListThrows() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 200; i++) {
+            out.writeByte((byte) 7);  // ArrayList type tag
+            out.writeVInt(1);         // size = 1
+        }
+        out.writeByte((byte) 0);      // String type
+        out.writeString("x");
+
+        StreamInput in = out.bytes().streamInput();
+        IOException ex = expectThrows(IOException.class, in::readGenericValue);
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Maximum nesting depth"));
+    }
+
+    public void testDeeplyNestedHashMapThrows() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 200; i++) {
+            out.writeByte((byte) 10); // HashMap type tag
+            out.writeVInt(1);         // size = 1
+            out.writeString("k");     // key
+        }
+        out.writeByte((byte) 0);      // String type
+        out.writeString("v");
+
+        StreamInput in = out.bytes().streamInput();
+        IOException ex = expectThrows(IOException.class, in::readGenericValue);
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Maximum nesting depth"));
+    }
+
+    public void testModerateNestingSucceeds() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        for (int i = 0; i < 50; i++) {
+            out.writeByte((byte) 7);  // ArrayList
+            out.writeVInt(1);
+        }
+        out.writeByte((byte) 0);      // String
+        out.writeString("leaf");
+
+        StreamInput in = out.bytes().streamInput();
+        Object result = in.readGenericValue();
+        assertNotNull(result);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class XContentParserMaxDepthTests extends OpenSearchTestCase {
+
+    public void testDeeplyNestedArrayThrows() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++)
+            sb.append('[');
+        for (int i = 0; i < 200; i++)
+            sb.append(']');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            expectThrows(Exception.class, parser::list);
+        }
+    }
+
+    public void testDeeplyNestedObjectThrows() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++)
+            sb.append("{\"a\":");
+        sb.append("1");
+        for (int i = 0; i < 200; i++)
+            sb.append('}');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            expectThrows(Exception.class, parser::map);
+        }
+    }
+
+    public void testModerateNestingSucceeds() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 50; i++)
+            sb.append('[');
+        sb.append("1");
+        for (int i = 0; i < 50; i++)
+            sb.append(']');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            assertNotNull(parser.list());
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -165,10 +166,26 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("Limit of mapping depth [1] has been exceeded"));
     }
 
-    public void testMappingDepthXContentLimit() throws Throwable {
-        createIndex(
-            "test1",
-            Settings.builder().put(MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey(), XContentContraints.DEFAULT_MAX_DEPTH).build()
+    public void testMappingDepthExceedsXContentLimit() throws Throwable {
+        final IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> createIndex(
+                "test1",
+                Settings.builder()
+                    .put(MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey(), XContentContraints.DEFAULT_MAX_DEPTH + 1)
+                    .build()
+            )
+        );
+
+        assertThat(
+            ex.getMessage(),
+            is(
+                "The provided value "
+                    + (XContentContraints.DEFAULT_MAX_DEPTH + 1)
+                    + " of the index setting 'index.mapping.depth.limit' exceeds per-JVM configured limit of "
+                    + XContentContraints.DEFAULT_MAX_DEPTH
+                    + ". Please change the setting value or increase per-JVM limit using 'opensearch.xcontent.depth.max' system property."
+            )
         );
     }
 


### PR DESCRIPTION
Manually backports #22404 to 2.19 due to conflicts.

---

* Fix unbounded recursion in deserialization that can cause StackOverflowError

  Add depth tracking to recursive deserialization in AbstractXContentParser (readListUnsafe/readValueUnsafe/readMapEntries) and StreamInput (readGenericValue/readArrayList/readArray/readLinkedHashMap/readHashMap).

  Both layers now enforce MAX_DESERIALIZATION_DEPTH=100, throwing a catchable exception instead of allowing StackOverflowError which kills the JVM.

  Additionally lower Jackson StreamReadConstraints maxNestingDepth from 1000 to 100 as defense-in-depth.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
