### PR TITLE
[Transport-gRPC] Wire gRPC call cancellation into search task cancellation

### DIFF
--- a/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/SearchCancellationIT.java
+++ b/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/SearchCancellationIT.java
@@ -81,7 +81,7 @@ public class SearchCancellationIT extends GrpcTransportBaseIT {
                 // deadline) would -- the gRPC analogue of the HTTP client's Cancellable.cancel().
                 cancellableContext.run(() -> asyncStub.search(searchRequest, new NoopObserver()));
 
-                // Wait until the search is actually executing in the query phase (event, not a sleep).
+                // Wait until the search is actually executing in the query phase
                 assertTrue(
                     "search did not reach the query phase",
                     SearchBlockPlugin.blockEntered.await(SAFETY_TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/SearchCancellationIT.java
+++ b/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/SearchCancellationIT.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksAction;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.protobufs.SearchRequest;
+import org.opensearch.protobufs.SearchRequestBody;
+import org.opensearch.protobufs.SearchResponse;
+import org.opensearch.protobufs.services.SearchServiceGrpc;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.grpc.ssl.NettyGrpcClient;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * Integration test verifying that cancelling a gRPC search call causes the server to cancel the underlying
+ * search task, instead of running it to completion. This is the gRPC counterpart to the HTTP behavior in
+ * {@code RestCancellableNodeClient} (exercised by {@code SearchRestCancellationIT}).
+ * <p>
+ * The fix's contract is narrow: an abandoned gRPC call must trigger a {@code CancelTasks} for that search's
+ * task. This test asserts exactly that, and nothing more -- that {@code CancelTasks} then cancels the task is
+ * core behavior already covered by {@code server}'s {@code SearchCancellationIT}. It is fully event-driven
+ * (latches on the search entering the query phase and on the cancellation being issued), so it does not
+ * depend on timing; the timeouts are only safety nets so a regression fails fast rather than hanging.
+ */
+public class SearchCancellationIT extends GrpcTransportBaseIT {
+
+    private static final long SAFETY_TIMEOUT_SECONDS = 30;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // GrpcPlugin provides the transport; SearchBlockPlugin holds a search in the query phase and signals
+        // when the cancellation is issued for its task.
+        return Arrays.asList(GrpcPlugin.class, SearchBlockPlugin.class);
+    }
+
+    public void testGrpcClientCancellationCancelsSearchTask() throws Exception {
+        String indexName = "test-grpc-cancellation";
+        createTestIndex(indexName);
+        indexTestDocument(indexName, "1", DEFAULT_DOCUMENT_SOURCE);
+
+        SearchBlockPlugin.reset();
+
+        try (NettyGrpcClient client = createGrpcClient()) {
+            SearchServiceGrpc.SearchServiceStub asyncStub = SearchServiceGrpc.newStub(client.getChannel());
+            SearchRequest searchRequest = SearchRequest.newBuilder()
+                .addIndex(indexName)
+                .setSearchRequestBody(SearchRequestBody.newBuilder().setSize(10).build())
+                .build();
+
+            try (Context.CancellableContext cancellableContext = Context.current().withCancellation()) {
+                // Bind the RPC to a cancellable context so we can abandon it mid-flight, as a real client (or a
+                // deadline) would -- the gRPC analogue of the HTTP client's Cancellable.cancel().
+                cancellableContext.run(() -> asyncStub.search(searchRequest, new NoopObserver()));
+
+                // Wait until the search is actually executing in the query phase (event, not a sleep).
+                assertTrue(
+                    "search did not reach the query phase",
+                    SearchBlockPlugin.blockEntered.await(SAFETY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                );
+                SearchBlockPlugin.expectedTaskId = SearchBlockPlugin.coordinatorTaskId;
+                assertNotNull("coordinator task id was not captured", SearchBlockPlugin.expectedTaskId);
+
+                // Abandon the call.
+                cancellableContext.cancel(Status.CANCELLED.withDescription("client cancelled").asRuntimeException());
+
+                // The fix must translate that into a CancelTasks for the search task. Without it, this latch never
+                // fires and the await returns false, failing the test.
+                assertTrue(
+                    "gRPC cancellation was not propagated to a task cancellation",
+                    SearchBlockPlugin.cancelObserved.await(SAFETY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                );
+            } finally {
+                // Release the (now cancelled) search so it can unwind and the node shuts down cleanly.
+                SearchBlockPlugin.releaseBlock();
+            }
+        }
+    }
+
+    /** A gRPC observer that ignores all signals; the test drives cancellation out-of-band via the context. */
+    private static class NoopObserver implements StreamObserver<SearchResponse> {
+        @Override
+        public void onNext(SearchResponse value) {}
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {}
+    }
+
+    /**
+     * Test plugin that (1) blocks every shard-level query phase until released, holding a search in flight
+     * independent of the query DSL, and (2) installs an action filter that signals when a {@code CancelTasks}
+     * targeting the blocked search's coordinator task is issued.
+     */
+    public static class SearchBlockPlugin extends Plugin implements ActionPlugin {
+        static volatile CountDownLatch blockEntered = new CountDownLatch(1);
+        static volatile CountDownLatch blockReleased = new CountDownLatch(1);
+        static volatile CountDownLatch cancelObserved = new CountDownLatch(1);
+        static volatile TaskId coordinatorTaskId;
+        static volatile TaskId expectedTaskId;
+
+        static void reset() {
+            blockEntered = new CountDownLatch(1);
+            blockReleased = new CountDownLatch(1);
+            cancelObserved = new CountDownLatch(1);
+            coordinatorTaskId = null;
+            expectedTaskId = null;
+        }
+
+        static void releaseBlock() {
+            blockReleased.countDown();
+        }
+
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            indexModule.addSearchOperationListener(new SearchOperationListener() {
+                @Override
+                public void onPreQueryPhase(SearchContext searchContext) {
+                    // Capture the coordinator task (parent of this shard task) and signal that the search is in flight.
+                    coordinatorTaskId = searchContext.getTask().getParentTaskId();
+                    blockEntered.countDown();
+                    try {
+                        // Hold the query phase open until the test releases it. The timeout is only a safety net;
+                        // correctness comes from releaseBlock(), not from elapsed time.
+                        if (blockReleased.await(SAFETY_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {
+                            throw new RuntimeException("search block was not released");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public List<ActionFilter> getActionFilters() {
+            return Collections.singletonList(new ActionFilter() {
+                @Override
+                public int order() {
+                    return 0;
+                }
+
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+                    Task task,
+                    String action,
+                    Request request,
+                    ActionRequestMetadata<Request, Response> actionRequestMetadata,
+                    ActionListener<Response> listener,
+                    ActionFilterChain<Request, Response> chain
+                ) {
+                    if (CancelTasksAction.NAME.equals(action) && request instanceof CancelTasksRequest) {
+                        TaskId cancelledTaskId = ((CancelTasksRequest) request).getTaskId();
+                        TaskId expected = expectedTaskId;
+                        if (expected != null && expected.equals(cancelledTaskId)) {
+                            cancelObserved.countDown();
+                        }
+                    }
+                    chain.proceed(task, action, request, listener);
+                }
+            });
+        }
+    }
+}

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/client/GrpcCancellableNodeClient.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/client/GrpcCancellableNodeClient.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.client;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.FilterClient;
+import org.opensearch.transport.client.OriginSettingClient;
+import org.opensearch.transport.client.node.NodeClient;
+
+import io.grpc.stub.ServerCallStreamObserver;
+
+import static org.opensearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
+
+/**
+ * A {@link Client} that cancels the task executed locally when the gRPC call it is bound to is cancelled
+ * before completion (for example when the client disconnects or the call deadline is exceeded).
+ * <p>
+ * This is the gRPC counterpart to {@code RestCancellableNodeClient}, which performs the same role for the
+ * HTTP transport by listening for channel closure. Without it, a cancelled gRPC request would leave its
+ * underlying task (such as a search) running server-side for its full duration, wasting resources on a
+ * result no client will read.
+ *
+ * @opensearch.internal
+ */
+public class GrpcCancellableNodeClient extends FilterClient {
+    private static final Logger logger = LogManager.getLogger(GrpcCancellableNodeClient.class);
+
+    private final NodeClient client;
+    private final ServerCallStreamObserver<?> serverCallObserver;
+
+    /**
+     * Creates a new GrpcCancellableNodeClient.
+     *
+     * @param client the node client used to execute the action locally
+     * @param serverCallObserver the gRPC response observer whose cancellation signal drives task cancellation
+     */
+    public GrpcCancellableNodeClient(NodeClient client, ServerCallStreamObserver<?> serverCallObserver) {
+        super(client);
+        this.client = client;
+        this.serverCallObserver = serverCallObserver;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+        ActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        // Execute locally so we can obtain the Task and cancel it if the gRPC call is abandoned.
+        Task task = client.executeLocally(action, request, listener);
+        final TaskId taskId = new TaskId(client.getLocalNodeId(), task.getId());
+
+        serverCallObserver.setOnCancelHandler(() -> {
+            logger.debug("gRPC call cancelled by client, cancelling task {}", taskId);
+            cancelTask(taskId);
+        });
+
+        // Guard against the race where the call is cancelled between executeLocally and setOnCancelHandler:
+        // if it is already cancelled the handler may never fire, so cancel the task explicitly.
+        if (serverCallObserver.isCancelled()) {
+            logger.debug("gRPC call already cancelled, cancelling task {}", taskId);
+            cancelTask(taskId);
+        }
+    }
+
+    /**
+     * Cancels the task associated with the abandoned gRPC call. Runs the cancellation as the tasks-origin
+     * system user, mirroring {@code RestCancellableNodeClient}.
+     *
+     * @param taskId the id of the task to cancel
+     */
+    protected void cancelTask(TaskId taskId) {
+        CancelTasksRequest req = new CancelTasksRequest().setTaskId(taskId).setReason("gRPC client cancelled the request");
+        // force the origin to execute the cancellation as a system user
+        new OriginSettingClient(client, TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.wrap(() -> {}));
+    }
+}

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/client/package-info.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/client/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Client wrappers for gRPC transport functionality.
+ *
+ * This package contains {@link org.opensearch.transport.client.Client} implementations that adapt
+ * OpenSearch actions to gRPC call semantics, such as cancelling the underlying task when a gRPC call
+ * is abandoned by the client.
+ *
+ * @opensearch.internal
+ */
+package org.opensearch.transport.grpc.client;

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
@@ -117,7 +117,7 @@ public class SearchServiceImpl extends SearchServiceGrpc.SearchServiceImplBase {
                 aggregationRegistry
             );
             SearchRequestActionListener listener = new SearchRequestActionListener(wrappedObserver, aggregateRegistry);
-            searchClientFor(responseObserver).search(searchRequest, listener);
+            getClientForSearch(responseObserver).search(searchRequest, listener);
         } catch (CircuitBreakingException e) {
             logger.debug("Circuit breaker tripped for gRPC search request: {}", e.getMessage());
             StatusRuntimeException grpcError = GrpcErrorHandler.convertToGrpcError(e);
@@ -142,7 +142,7 @@ public class SearchServiceImpl extends SearchServiceGrpc.SearchServiceImplBase {
      * @param responseObserver the gRPC response observer for this call
      * @return the client to execute the search request against
      */
-    private Client searchClientFor(StreamObserver<org.opensearch.protobufs.SearchResponse> responseObserver) {
+    private Client getClientForSearch(StreamObserver<org.opensearch.protobufs.SearchResponse> responseObserver) {
         if (client instanceof NodeClient && responseObserver instanceof ServerCallStreamObserver) {
             return new GrpcCancellableNodeClient(
                 (NodeClient) client,

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
@@ -15,6 +15,8 @@ import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.protobufs.services.SearchServiceGrpc;
 import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.node.NodeClient;
+import org.opensearch.transport.grpc.client.GrpcCancellableNodeClient;
 import org.opensearch.transport.grpc.listeners.CreatePitRequestActionListener;
 import org.opensearch.transport.grpc.listeners.DeletePitRequestActionListener;
 import org.opensearch.transport.grpc.listeners.SearchRequestActionListener;
@@ -30,6 +32,7 @@ import org.opensearch.transport.grpc.util.GrpcErrorHandler;
 import java.io.IOException;
 
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -114,7 +117,7 @@ public class SearchServiceImpl extends SearchServiceGrpc.SearchServiceImplBase {
                 aggregationRegistry
             );
             SearchRequestActionListener listener = new SearchRequestActionListener(wrappedObserver, aggregateRegistry);
-            client.search(searchRequest, listener);
+            searchClientFor(responseObserver).search(searchRequest, listener);
         } catch (CircuitBreakingException e) {
             logger.debug("Circuit breaker tripped for gRPC search request: {}", e.getMessage());
             StatusRuntimeException grpcError = GrpcErrorHandler.convertToGrpcError(e);
@@ -125,6 +128,28 @@ public class SearchServiceImpl extends SearchServiceGrpc.SearchServiceImplBase {
             StatusRuntimeException grpcError = GrpcErrorHandler.convertToGrpcError(e);
             responseObserver.onError(grpcError);
         }
+    }
+
+    /**
+     * Returns the client to execute the search against. When the underlying client is a {@link NodeClient} and the
+     * gRPC call exposes a cancellation signal (a {@link ServerCallStreamObserver}), the search is executed through a
+     * {@link GrpcCancellableNodeClient} so the underlying search task is cancelled if the client abandons the call.
+     * This mirrors how the HTTP transport cancels search tasks on channel close via {@code RestCancellableNodeClient},
+     * and prevents a cancelled/deadline-exceeded gRPC request from running server-side for its full duration.
+     * <p>
+     * Otherwise the plain client is returned, leaving existing behavior unchanged.
+     *
+     * @param responseObserver the gRPC response observer for this call
+     * @return the client to execute the search request against
+     */
+    private Client searchClientFor(StreamObserver<org.opensearch.protobufs.SearchResponse> responseObserver) {
+        if (client instanceof NodeClient && responseObserver instanceof ServerCallStreamObserver) {
+            return new GrpcCancellableNodeClient(
+                (NodeClient) client,
+                (ServerCallStreamObserver<org.opensearch.protobufs.SearchResponse>) responseObserver
+            );
+        }
+        return client;
     }
 
     /**

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/services/SearchServiceImpl.java
@@ -142,7 +142,9 @@ public class SearchServiceImpl extends SearchServiceGrpc.SearchServiceImplBase {
      * @param responseObserver the gRPC response observer for this call
      * @return the client to execute the search request against
      */
-    private Client getClientForSearch(StreamObserver<org.opensearch.protobufs.SearchResponse> responseObserver) {
+    // Visible for testing: package-private so the branch on client's type can be exercised directly, independent
+    // of SearchRequestProtoUtils#prepareRequest, which requires a NodeClient of its own.
+    Client getClientForSearch(StreamObserver<org.opensearch.protobufs.SearchResponse> responseObserver) {
         if (client instanceof NodeClient && responseObserver instanceof ServerCallStreamObserver) {
             return new GrpcCancellableNodeClient(
                 (NodeClient) client,

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/client/GrpcCancellableNodeClientTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/client/GrpcCancellableNodeClientTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport.grpc.client;
+
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.node.NodeClient;
+import org.junit.Before;
+
+import io.grpc.stub.ServerCallStreamObserver;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GrpcCancellableNodeClientTests extends OpenSearchTestCase {
+
+    private static final String LOCAL_NODE_ID = "local-node";
+    private static final long TASK_ID = 42L;
+
+    private NodeClient nodeClient;
+    private ServerCallStreamObserver<SearchResponse> serverCallObserver;
+    private Task task;
+    private SearchRequest searchRequest;
+    private ActionListener<SearchResponse> listener;
+    private GrpcCancellableNodeClient cancellableClient;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        nodeClient = mock(NodeClient.class);
+        serverCallObserver = mock(ServerCallStreamObserver.class);
+        task = mock(Task.class);
+        when(task.getId()).thenReturn(TASK_ID);
+        when(nodeClient.getLocalNodeId()).thenReturn(LOCAL_NODE_ID);
+        when(nodeClient.executeLocally(eq(SearchAction.INSTANCE), any(SearchRequest.class), any(ActionListener.class))).thenReturn(task);
+
+        searchRequest = new SearchRequest();
+        listener = mock(ActionListener.class);
+
+        // Spy so the actual cancellation dispatch (which requires a real thread context) can be stubbed
+        // while still exercising the real cancellation wiring in doExecute.
+        cancellableClient = spy(new GrpcCancellableNodeClient(nodeClient, serverCallObserver));
+        doNothing().when(cancellableClient).cancelTask(any(TaskId.class));
+    }
+
+    public void testExecuteLocallyIsUsedToCaptureTask() {
+        cancellableClient.doExecute(SearchAction.INSTANCE, searchRequest, listener);
+
+        // The task must be obtained via executeLocally (the plain Client.search discards it),
+        // and the caller's listener must be passed through untouched.
+        verify(nodeClient).executeLocally(eq(SearchAction.INSTANCE), eq(searchRequest), eq(listener));
+    }
+
+    public void testCancelHandlerCancelsTaskWhenCallIsCancelled() {
+        cancellableClient.doExecute(SearchAction.INSTANCE, searchRequest, listener);
+
+        // A cancel handler must be registered on the gRPC call, and firing it must cancel the captured task.
+        ArgumentCaptor<Runnable> handlerCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(serverCallObserver).setOnCancelHandler(handlerCaptor.capture());
+
+        // Not cancelled yet, so nothing should have been cancelled during setup.
+        verify(cancellableClient, never()).cancelTask(any(TaskId.class));
+
+        handlerCaptor.getValue().run();
+
+        verify(cancellableClient).cancelTask(new TaskId(LOCAL_NODE_ID, TASK_ID));
+    }
+
+    public void testTaskCancelledImmediatelyWhenCallAlreadyCancelled() {
+        // Simulate the race where the client cancels before the handler is registered.
+        when(serverCallObserver.isCancelled()).thenReturn(true);
+
+        cancellableClient.doExecute(SearchAction.INSTANCE, searchRequest, listener);
+
+        verify(cancellableClient).cancelTask(new TaskId(LOCAL_NODE_ID, TASK_ID));
+    }
+
+    public void testTaskNotCancelledWhenCallCompletesNormally() {
+        cancellableClient.doExecute(SearchAction.INSTANCE, searchRequest, listener);
+
+        // Handler registered but never fired, call not cancelled: the task must be left running.
+        verify(serverCallObserver).setOnCancelHandler(any(Runnable.class));
+        verify(cancellableClient, never()).cancelTask(any(TaskId.class));
+    }
+}

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/services/SearchServiceImplTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/services/SearchServiceImplTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.transport.grpc.services;
 
+import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.common.unit.TimeValue;
@@ -17,6 +18,7 @@ import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.protobufs.SearchRequestBody;
 import org.opensearch.search.SearchHits;
+import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.transport.grpc.proto.request.search.aggregation.AggregationBuilderProtoConverterRegistryImpl;
@@ -29,6 +31,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -143,6 +146,35 @@ public class SearchServiceImplTests extends OpenSearchTestCase {
 
         // Verify that client.search was called with any SearchRequest and any ActionListener
         verify(client).search(any(org.opensearch.action.search.SearchRequest.class), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSearchWiresCancellationForServerCallStreamObserver() throws IOException {
+        // A real gRPC unary call supplies a ServerCallStreamObserver, which exposes a cancellation signal.
+        ServerCallStreamObserver<org.opensearch.protobufs.SearchResponse> serverCallObserver = mock(ServerCallStreamObserver.class);
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(7L);
+        when(client.getLocalNodeId()).thenReturn("local-node");
+        when(
+            client.executeLocally(
+                eq(SearchAction.INSTANCE),
+                any(org.opensearch.action.search.SearchRequest.class),
+                any(ActionListener.class)
+            )
+        ).thenReturn(task);
+
+        org.opensearch.protobufs.SearchRequest request = createTestSearchRequest();
+        service.search(request, serverCallObserver);
+
+        // The search must be routed through the cancellable client: executed via executeLocally (to capture
+        // the task) rather than the plain client.search, with a cancel handler registered on the gRPC call.
+        verify(client).executeLocally(
+            eq(SearchAction.INSTANCE),
+            any(org.opensearch.action.search.SearchRequest.class),
+            any(ActionListener.class)
+        );
+        verify(client, never()).search(any(org.opensearch.action.search.SearchRequest.class), any());
+        verify(serverCallObserver).setOnCancelHandler(any(Runnable.class));
     }
 
     public void testCircuitBreakerCheckedBeforeProcessing() throws IOException {

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/services/SearchServiceImplTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/services/SearchServiceImplTests.java
@@ -20,6 +20,7 @@ import org.opensearch.protobufs.SearchRequestBody;
 import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.transport.grpc.proto.request.search.aggregation.AggregationBuilderProtoConverterRegistryImpl;
 import org.opensearch.transport.grpc.proto.request.search.query.AbstractQueryBuilderProtoUtils;
@@ -175,6 +176,34 @@ public class SearchServiceImplTests extends OpenSearchTestCase {
         );
         verify(client, never()).search(any(org.opensearch.action.search.SearchRequest.class), any());
         verify(serverCallObserver).setOnCancelHandler(any(Runnable.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetClientForSearchDoesNotWrapWhenClientIsNotNodeClient() {
+        // The cancellable path relies on NodeClient-specific behavior (executeLocally/getLocalNodeId), so it must
+        // not be used when the underlying client isn't a NodeClient -- even if the gRPC call exposes a
+        // cancellation signal. Exercised directly against getClientForSearch (rather than through search()) since
+        // SearchRequestProtoUtils.prepareRequest independently requires a NodeClient before this branch is ever
+        // reached in production, which would otherwise mask this branch behind an unrelated ClassCastException.
+        Client plainClient = mock(Client.class);
+        SearchServiceImpl plainClientService = new SearchServiceImpl(
+            plainClient,
+            queryUtils,
+            aggregationRegistry,
+            aggregateRegistry,
+            circuitBreakerService
+        );
+        ServerCallStreamObserver<org.opensearch.protobufs.SearchResponse> serverCallObserver = mock(ServerCallStreamObserver.class);
+
+        assertSame(plainClient, plainClientService.getClientForSearch(serverCallObserver));
+        verify(serverCallObserver, never()).setOnCancelHandler(any(Runnable.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetClientForSearchDoesNotWrapWhenObserverIsNotCancellable() {
+        // The other half of the branch: a NodeClient with a plain (non-cancellable) observer must also fall back
+        // to the plain client.
+        assertSame(client, service.getClientForSearch(responseObserver));
     }
 
     public void testCircuitBreakerCheckedBeforeProcessing() throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Cancels the server-side search task when a gRPC search call is cancelled (client cancels the RPC, disconnects, or the call deadline is exceeded), bringing the `transport-grpc` transport to parity with the HTTP transport.

**Problem**

Over the `transport-grpc` transport, a search whose client had already gone away kept running to completion server-side — we observed **17–30s** of wasted execution after cancellation, consuming CPU, memory, and search-thread-pool capacity for a result no client would read. A client that times out and retries can leave multiple orphaned searches running, amplifying load when the cluster is already slow.

**Observed impact (production)**

First caught during a segment merge — gRPC search requests spiked to **>10s**, driving up **p99**. Merges are just one trigger; this hurts during any period of elevated search latency (GC pauses, high load, expensive queries, cold caches, etc.). Whenever a search is slow enough that the client gives up (cancel, disconnect, or deadline), the abandoned request kept running across all shards, compounding the slowdown that made the client leave.

Representative slow log — a lookup over **256 shards** spending **17.3s almost entirely in the query phase** (`query=17318` of `took_millis=17319`), 0 hits:

```
took[17.3s], took_millis[17319], phase_took_millis[{expand=0, query=17318, fetch=0}], total_hits[0 hits], search_type[QUERY_THEN_FETCH], shards[{total:256, successful:256, skipped:0, failed:0}], source[{"from":0,"size":100,"query":{"bool":{"filter":[{"multi_match":{"query":"xyz","fields":["user_contactinfo.*^1.0"],"type":"best_fields","operator":"OR","analyzer":"phone_search_analyzer"}}],"must_not":[{"exists":{"field":"deleted_at"}}]}},"stored_fields":["uuid"],"sort":[{"email_address":{"order":"asc","missing":""}}]}], id[]
```

Since the time is spent almost entirely in the **query phase**, cancelling the coordinator task and its multi shard sub-tasks (what this change does) stops the work instead of letting it run the full 17.3s — relieving the p99 spike during merges and any other period of elevated latency.

**Root cause**

The HTTP path wraps the node client in `RestCancellableNodeClient`, which captures the search `Task` via `NodeClient.executeLocally(...)` and, on `HttpChannel` close, issues a `CancelTasksRequest` for it. The gRPC path (`SearchServiceImpl.search`) instead called `client.search(searchRequest, listener)`, which **discards the task**, and never wired anything to gRPC's cancellation signal — so gRPC search had no cancellation-on-client-disconnect behavior at all.

**Fix**

Mirror the HTTP design with a dedicated collaborator so the service handler stays focused and cancellation stays encapsulated:

- **`GrpcCancellableNodeClient`** (new) — a `FilterClient` that:
  - executes the action via `NodeClient.executeLocally(...)` to obtain the `Task`;
  - registers `ServerCallStreamObserver.setOnCancelHandler(...)` to issue a `CancelTasksRequest` for that task (as the tasks-origin system user, exactly like `RestCancellableNodeClient`);
  - guards the register-time race with an `isCancelled()` check so a call cancelled between `executeLocally` and handler registration is still cancelled.
- **`SearchServiceImpl`** — routes the search through `GrpcCancellableNodeClient` when the call exposes a cancellation signal (the observer is a `ServerCallStreamObserver` and the client is a `NodeClient`), and otherwise falls back to the existing path unchanged.
- Testing in progress on real server.

**Notes / scope**

- No behavior change on the happy path: `client.search(...)` already routes through `executeLocally` internally (discarding the task), so this only *retains* the task handle to enable cancellation.
- No new public API, request field, or setting. Users don't opt in — abandoned work simply stops.
- Cancellation flows through the existing `CancelTasks` machinery, which propagates the ban to shard-level child tasks on data nodes, so the actual query/fetch work stops — not just the coordinator.
- Scope is limited to the search endpoint; PIT/other gRPC endpoints are unchanged.

**Files changed**

| File | Change |
|---|---|
| `.../transport/grpc/client/GrpcCancellableNodeClient.java` | New: cancellation-aware `FilterClient` |
| `.../transport/grpc/client/package-info.java` | New: package docs |
| `.../transport/grpc/services/SearchServiceImpl.java` | Route search through the cancellable client when a cancellation signal is available |
| `.../transport/grpc/client/GrpcCancellableNodeClientTests.java` | New: unit tests |
| `.../transport/grpc/services/SearchServiceImplTests.java` | Added: delegation test |
| `.../transport/grpc/SearchCancellationIT.java` | New: integration test |


### Related Issues
Resolves #22428 

### Testing
- **Unit — `GrpcCancellableNodeClientTests`:** task is captured via `executeLocally`; firing the cancel handler cancels the captured task; an already-cancelled call cancels immediately; a normally-completing call leaves the task running.
- **Unit — `SearchServiceImplTests`:** with a `ServerCallStreamObserver`, the search is routed through the cancellable path (`executeLocally` + `setOnCancelHandler`, not `client.search`); existing tests unchanged.
- **Integration — `SearchCancellationIT`:** boots the real gRPC transport, holds a search in the query phase, cancels the gRPC call via a cancellable context, and asserts a `CancelTasks` is issued for the search task. Fully event-driven (latches, no `assertBusy`/sleeps). Verified it **fails** with the fix disabled and **passes** with it enabled.
- **Manual, end-to-end (local, via `grpcurl`):** on a node running the gRPC transport, ingest a large enough dataset that a search runs for several seconds (bulk-index many documents), then send an expensive gRPC search through `grpcurl` with a short call deadline (`-max-time`) so the client abandons the call while the search is still executing. With the fix, the server-side task is cancelled as soon as the deadline expires — confirmed via the DEBUG cancel log and the tasks API showing the search task `cancelled=true` and then unwinding — instead of running to natural completion. Without the fix, the same request keeps running server-side for the query's full duration after `grpcurl` has already returned.
- **Real cluster (expensive query):** the same approach applies on a live cluster — issue an expensive/slow gRPC search (e.g. a costly aggregation or regexp/wildcard query spanning many shards) so it runs long enough to observe, cancel the call (deadline, disconnect, or explicit cancel), and confirm via the tasks API that the search task and its shard sub-tasks are cancelled and stop promptly rather than running to completion.


Run (automated):
```
./gradlew :modules:transport-grpc:test \
  --tests "org.opensearch.transport.grpc.client.GrpcCancellableNodeClientTests" \
  --tests "org.opensearch.transport.grpc.services.SearchServiceImplTests"
./gradlew :modules:transport-grpc:internalClusterTest \
  --tests "org.opensearch.transport.grpc.SearchCancellationIT"
```

Manual reproduction (local, `grpcurl`):
```
# 1. Start a node with the gRPC auxiliary transport enabled (binds :9400)
./gradlew :run -Dtests.opensearch.aux.transport.types=transport-grpc

# 2. Bulk-index enough documents that a search takes several seconds to run
#    (repeat the bulk to grow the dataset until a query is reliably slow)

# 3. Fire an expensive search with a short call deadline so grpcurl gives up
#    while the search is still executing server-side
grpcurl -plaintext -max-time 2 \
  -d '{"index":["my-index"], ... expensive query ...}' \
  localhost:9400 org.opensearch.protobufs.services.SearchService/Search

# 4. Confirm the server cancelled the task instead of running to completion:
#    - the node log shows the DEBUG cancel line from GrpcCancellableNodeClient
#    - GET _tasks?actions=*search* shows the search task cancelled=true, then gone
```

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. — N/A (no API/proto changes)
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. — N/A (no user-facing API/setting; internal behavior parity)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).