### PR TITLE
Fix query cache heap leak from wildcard field queries

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
@@ -839,7 +839,9 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-            Weight firstPhaseWeight = firstPhaseQuery.createWeight(searcher, scoreMode, boost);
+            // Delegate to the searcher so the (cheap, stateless) first-phase query remains eligible for the
+            // query cache. Scores from the first phase are never used, since this weight produces constant scores.
+            Weight firstPhaseWeight = searcher.createWeight(firstPhaseQuery, ScoreMode.COMPLETE_NO_SCORES, 1f);
             return new ConstantScoreWeight(this, boost) {
                 @Override
                 public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
@@ -892,7 +894,12 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
 
                 @Override
                 public boolean isCacheable(LeafReaderContext leafReaderContext) {
-                    return true;
+                    // This weight references the shard-scoped SearchLookup and ValueFetcher through the
+                    // second-phase matching logic. Caching it would pin those (and everything they reference,
+                    // such as the QueryShardContext) in the query cache long after the search completes,
+                    // while equals/hashCode ignores them, so a cache hit could resurrect a stale lookup.
+                    // The rewritten first-phase query is cached independently via searcher.createWeight above.
+                    return searchLookup == null;
                 }
             };
         }

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
@@ -272,10 +272,10 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         );
 
         try (Directory dir = newDirectory()) {
-            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
-            iw.addDocument(appleTrigramDocument());
-            try (IndexReader reader = DirectoryReader.open(iw)) {
-                iw.close();
+            try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER))) {
+                iw.addDocument(appleTrigramDocument());
+            }
+            try (IndexReader reader = DirectoryReader.open(dir)) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 searcher.setQueryCache(null);
 
@@ -304,10 +304,10 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         );
 
         try (Directory dir = newDirectory()) {
-            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
-            iw.addDocument(appleTrigramDocument());
-            try (IndexReader reader = DirectoryReader.open(iw)) {
-                iw.close();
+            try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER))) {
+                iw.addDocument(appleTrigramDocument());
+            }
+            try (IndexReader reader = DirectoryReader.open(dir)) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 List<Query> cachedQueries = new ArrayList<>();
                 LRUQueryCache cache = new LRUQueryCache(1000, 1 << 20, leaf -> true, 1f) {
@@ -365,10 +365,10 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         context = null;
 
         try (Directory dir = newDirectory()) {
-            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
-            iw.addDocument(appleTrigramDocument());
-            try (IndexReader reader = DirectoryReader.open(iw)) {
-                iw.close();
+            try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER))) {
+                iw.addDocument(appleTrigramDocument());
+            }
+            try (IndexReader reader = DirectoryReader.open(dir)) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 LRUQueryCache cache = new LRUQueryCache(1000, 1 << 20, leaf -> true, 1f);
                 searcher.setQueryCache(cache);

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
@@ -8,14 +8,42 @@
 
 package org.opensearch.index.mapper;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LRUQueryCache;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.lookup.LeafSearchLookup;
+import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.search.lookup.SourceLookup;
 
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class WildcardFieldTypeTests extends FieldTypeTestCase {
 
@@ -223,6 +251,179 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         pattern = "*";
         actual = ft.wildcardQuery(pattern, null, null);
         assertEquals(ft.existsQuery(null), actual);
+    }
+
+    public void testCacheabilityDependsOnSearchLookup() throws IOException {
+        BooleanQuery firstPhase = firstPhaseQueryForApple();
+
+        // A query built without a QueryShardContext holds no shard-scoped state and stays cacheable.
+        WildcardFieldMapper.WildcardMatchingQuery contextFreeQuery = new WildcardFieldMapper.WildcardMatchingQuery(
+            "field",
+            firstPhase,
+            "*apple*"
+        );
+        WildcardFieldMapper.WildcardMatchingQuery contextBoundQuery = new WildcardFieldMapper.WildcardMatchingQuery(
+            "field",
+            firstPhase,
+            s -> s.contains("apple"),
+            "*apple*",
+            mockedQueryShardContext(),
+            new WildcardFieldMapper.WildcardFieldType("field")
+        );
+
+        try (Directory dir = newDirectory()) {
+            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
+            iw.addDocument(appleTrigramDocument());
+            try (IndexReader reader = DirectoryReader.open(iw)) {
+                iw.close();
+                IndexSearcher searcher = new IndexSearcher(reader);
+                searcher.setQueryCache(null);
+
+                Weight contextFreeWeight = contextFreeQuery.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                assertTrue(contextFreeWeight.isCacheable(reader.leaves().get(0)));
+
+                // A query bound to a QueryShardContext captures the shard's SearchLookup. Caching its weight
+                // would pin that lookup (and everything reachable from it) in the query cache.
+                Weight contextBoundWeight = contextBoundQuery.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                assertFalse(contextBoundWeight.isCacheable(reader.leaves().get(0)));
+            }
+        }
+    }
+
+    public void testFirstPhaseQueryCachedIndependently() throws IOException {
+        QueryShardContext context = mockedQueryShardContext();
+        BooleanQuery firstPhase = firstPhaseQueryForApple();
+
+        WildcardFieldMapper.WildcardMatchingQuery query = new WildcardFieldMapper.WildcardMatchingQuery(
+            "field",
+            firstPhase,
+            s -> s.contains("apple"),
+            "*apple*",
+            context,
+            new WildcardFieldMapper.WildcardFieldType("field")
+        );
+
+        try (Directory dir = newDirectory()) {
+            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
+            iw.addDocument(appleTrigramDocument());
+            try (IndexReader reader = DirectoryReader.open(iw)) {
+                iw.close();
+                IndexSearcher searcher = new IndexSearcher(reader);
+                List<Query> cachedQueries = new ArrayList<>();
+                LRUQueryCache cache = new LRUQueryCache(1000, 1 << 20, leaf -> true, 1f) {
+                    @Override
+                    protected void onQueryCache(Query query, long ramBytesUsed) {
+                        super.onQueryCache(query, ramBytesUsed);
+                        cachedQueries.add(query);
+                    }
+                };
+                searcher.setQueryCache(cache);
+                searcher.setQueryCachingPolicy(new QueryCachingPolicy() {
+                    @Override
+                    public void onUse(Query query) {}
+
+                    @Override
+                    public boolean shouldCache(Query query) {
+                        return true;
+                    }
+                });
+
+                assertEquals(1, searcher.count(query));
+                // The first-phase trigram query (and its clauses) is cached; the outer two-phase query,
+                // which holds the shard-scoped SearchLookup, must not enter the cache.
+                assertTrue(cachedQueries.contains(firstPhase));
+                for (Query cached : cachedQueries) {
+                    assertFalse(cached instanceof WildcardFieldMapper.WildcardMatchingQuery);
+                }
+
+                assertEquals(1, searcher.count(query));
+                assertTrue(cache.getHitCount() > 0);
+            }
+        }
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/opensearch-project/OpenSearch/issues/22419">#22419</a>.
+     * Prior to the fix, the two-phase {@code WildcardMatchingQuery} declared itself cacheable while holding a
+     * reference to the shard-scoped {@link SearchLookup}. Once inserted into the query cache (whose entries
+     * outlive the search), the cache pinned the lookup and everything reachable from it on the heap, and since
+     * the query's equals/hashCode ignore the lookup, repeated wildcard searches accumulated distinct pinned
+     * object graphs until the node ran out of heap.
+     */
+    public void testSearchLookupNotPinnedByQueryCache() throws Exception {
+        QueryShardContext context = mockedQueryShardContext();
+        WeakReference<SearchLookup> lookupRef = new WeakReference<>(context.lookup());
+
+        Query query = new WildcardFieldMapper.WildcardMatchingQuery(
+            "field",
+            firstPhaseQueryForApple(),
+            s -> s.contains("apple"),
+            "*apple*",
+            context,
+            new WildcardFieldMapper.WildcardFieldType("field")
+        );
+        context = null;
+
+        try (Directory dir = newDirectory()) {
+            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.KEYWORD_ANALYZER));
+            iw.addDocument(appleTrigramDocument());
+            try (IndexReader reader = DirectoryReader.open(iw)) {
+                iw.close();
+                IndexSearcher searcher = new IndexSearcher(reader);
+                LRUQueryCache cache = new LRUQueryCache(1000, 1 << 20, leaf -> true, 1f);
+                searcher.setQueryCache(cache);
+                searcher.setQueryCachingPolicy(new QueryCachingPolicy() {
+                    @Override
+                    public void onUse(Query query) {}
+
+                    @Override
+                    public boolean shouldCache(Query query) {
+                        return true;
+                    }
+                });
+
+                assertEquals(1, searcher.count(query));
+                assertTrue("expected the first-phase query to be cached", cache.getCacheCount() > 0);
+
+                // Drop every reference to the query except whatever the cache retained. If the cache pinned
+                // the query (and, through it, the SearchLookup), the weak reference never clears and this
+                // assertion times out, reproducing the heap pinning reported in #22419.
+                query = null;
+                assertBusy(() -> {
+                    System.gc(); // GC is not deterministic, hence the polling
+                    assertNull("SearchLookup is still strongly reachable: the query cache is pinning shard state", lookupRef.get());
+                }, 5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private static BooleanQuery firstPhaseQueryForApple() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        for (String term : Set.of("app", "ppl", "ple")) {
+            builder.add(new TermQuery(new Term("field", term)), BooleanClause.Occur.FILTER);
+        }
+        return builder.build();
+    }
+
+    private static Document appleTrigramDocument() {
+        Document doc = new Document();
+        for (String term : Set.of("app", "ppl", "ple")) {
+            doc.add(new StringField("field", term, Field.Store.NO));
+        }
+        return doc;
+    }
+
+    private static QueryShardContext mockedQueryShardContext() {
+        QueryShardContext context = mock(QueryShardContext.class);
+        SearchLookup searchLookup = mock(SearchLookup.class);
+        LeafSearchLookup leafSearchLookup = mock(LeafSearchLookup.class);
+        SourceLookup sourceLookup = new SourceLookup();
+        sourceLookup.setSource(Map.of("field", "there is an apple here"));
+        when(leafSearchLookup.source()).thenReturn(sourceLookup);
+        when(searchLookup.getLeafSearchLookup(any())).thenReturn(leafSearchLookup);
+        when(context.lookup()).thenReturn(searchLookup);
+        when(context.sourcePath("field")).thenReturn(Set.of("field"));
+        return context;
     }
 
     public void testRegexpMatchAll() {


### PR DESCRIPTION
### Description
Fixes a heap exhaustion caused by `WildcardMatchingQuery` (the two-phase query behind the `wildcard` field type) being admitted to the LRU query cache while holding shard-scoped state.

When built from a `QueryShardContext`, the query captures the shard's `SearchLookup` and a `ValueFetcher` supplier for second-phase verification, but its weight unconditionally reported `isCacheable() == true`. Cache entries outlive the search, so each cached wildcard query pinned its captured object graph on the heap. Because `equals`/`hashCode` ignore the captured lookup, every unique pattern pinned a distinct graph, and the cache's RAM accounting (via `Query#visit`, which only sees the first-phase terms) missed the pinned state entirely, so memory-based eviction never triggered. Under steady wildcard query traffic this accumulates until the node runs out of heap.

Changes:
- The weight now reports `isCacheable() == false` whenever a `SearchLookup` was captured, keeping the stateful two-phase query out of the cache.
- The first-phase trigram query is created through `searcher.createWeight(firstPhaseQuery, ScoreMode.COMPLETE_NO_SCORES, 1f)` instead of `firstPhaseQuery.createWeight(...)`, so the cheap, stateless part of the query remains independently cacheable (its scores were never used; the outer weight is constant-score).

Tests:
- `testSearchLookupNotPinnedByQueryCache` — regression test for the reported leak: runs a context-bound query through an `LRUQueryCache`, retains only a `WeakReference` to the captured `SearchLookup`, releases the query, and asserts the reference clears under GC. On `main` it fails with `SearchLookup is still strongly reachable: the query cache is pinning shard state`; with this fix it passes.
- `testCacheabilityDependsOnSearchLookup` — the weight is cacheable without a `QueryShardContext` and not cacheable with one.
- `testFirstPhaseQueryCachedIndependently` — the first-phase query still enters the cache and serves hits, while the outer `WildcardMatchingQuery` never does.

Verified on a live node built from source (1 GB heap, 20k-doc single-segment `wildcard` index, 2000 unique patterns x 6 repetitions in filter context with `request_cache=false`, then forced GC + `jcmd GC.class_histogram`):

| After GC | main | with fix |
|---|---|---|
| Retained `SearchLookup` / `QueryShardContext` | 4000 / 2000 | 0 / 0 |
| Heap used | 134 MB | 47 MB (baseline) |
| Query cache entries / hits | 2000 / 0 | 2000 / 4000 |

On `main` the cache self-reported ~2.4 MB while actually pinning ~88 MB, even with a near-empty mapping — consistent with the tens-of-GB retention reported in the issue at production scale.

A follow-up restructuring `WildcardMatchingQuery` so the second phase does not capture shard-scoped state at all (making the full query safely cacheable again) is discussed in the linked issue.

### Related Issues
Resolves #22419

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
