### PR TITLE
Fix heap leak: WildcardMatchingQuery retains SearchLookup via query cache

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceValueFetcher.java
@@ -69,6 +69,11 @@ public abstract class SourceValueFetcher implements ValueFetcher {
         this.nullValue = nullValue;
     }
 
+    protected SourceValueFetcher(Set<String> sourcePaths, Object nullValue) {
+        this.sourcePaths = sourcePaths;
+        this.nullValue = nullValue;
+    }
+
     @Override
     public List<Object> fetchValues(SourceLookup lookup) {
         List<Object> values = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
@@ -51,8 +51,8 @@ import org.opensearch.index.fielddata.plain.NonPruningSortedSetOrdinalsIndexFiel
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
-import org.opensearch.search.lookup.LeafSearchLookup;
 import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -356,6 +356,35 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
 
                     try {
                         return normalizeValue(normalizer, name(), keywordValue);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            };
+        }
+
+        Supplier<ValueFetcher> valueFetcherSupplier(QueryShardContext context) {
+            if (hasDocValues()) {
+                IndexFieldData<?> ifd = context.getForField(this);
+                return () -> new DocValueFetcher(DocValueFormat.RAW, ifd);
+            }
+            Set<String> sourcePaths = context.sourcePath(name());
+            Object nv = nullValue;
+            int above = ignoreAbove;
+            NamedAnalyzer norm = normalizer();
+            String fieldName = name();
+            return () -> new SourceValueFetcher(sourcePaths, nv) {
+                @Override
+                protected String parseSourceValue(Object value) {
+                    String keywordValue = value.toString();
+                    if (keywordValue.length() > above) {
+                        return null;
+                    }
+                    if (norm == null) {
+                        return keywordValue;
+                    }
+                    try {
+                        return normalizeValue(norm, fieldName, keywordValue);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -753,7 +782,6 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
         private final Predicate<String> secondPhaseMatcher;
         private final String patternString; // For toString
         private final Supplier<ValueFetcher> valueFetcherSupplier;
-        private final SearchLookup searchLookup;
 
         WildcardMatchingQuery(String fieldName, Query firstPhaseQuery, String patternString) {
             this(fieldName, firstPhaseQuery, s -> true, patternString, (QueryShardContext) null, null);
@@ -772,10 +800,8 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             this.secondPhaseMatcher = Objects.requireNonNull(secondPhaseMatcher);
             this.patternString = Objects.requireNonNull(patternString);
             if (context != null) {
-                this.searchLookup = context.lookup();
-                this.valueFetcherSupplier = () -> fieldType.valueFetcher(context, context.lookup(), null);
+                this.valueFetcherSupplier = fieldType.valueFetcherSupplier(context);
             } else {
-                this.searchLookup = null;
                 this.valueFetcherSupplier = null;
             }
         }
@@ -785,15 +811,13 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             Query firstPhaseQuery,
             Predicate<String> secondPhaseMatcher,
             String patternString,
-            Supplier<ValueFetcher> valueFetcherSupplier,
-            SearchLookup searchLookup
+            Supplier<ValueFetcher> valueFetcherSupplier
         ) {
             this.fieldName = fieldName;
             this.firstPhaseQuery = firstPhaseQuery;
             this.secondPhaseMatcher = secondPhaseMatcher;
             this.patternString = patternString;
             this.valueFetcherSupplier = valueFetcherSupplier;
-            this.searchLookup = searchLookup;
         }
 
         @Override
@@ -825,14 +849,7 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
         public Query rewrite(IndexSearcher indexSearcher) throws IOException {
             Query rewriteFirstPhase = firstPhaseQuery.rewrite(indexSearcher);
             if (rewriteFirstPhase != firstPhaseQuery) {
-                return new WildcardMatchingQuery(
-                    fieldName,
-                    rewriteFirstPhase,
-                    secondPhaseMatcher,
-                    patternString,
-                    valueFetcherSupplier,
-                    searchLookup
-                );
+                return new WildcardMatchingQuery(fieldName, rewriteFirstPhase, secondPhaseMatcher, patternString, valueFetcherSupplier);
             }
             return this;
         }
@@ -852,17 +869,15 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
                         public Scorer get(long leadCost) throws IOException {
                             Scorer approximateScorer = firstPhaseSupplier.get(leadCost);
                             DocIdSetIterator approximation = approximateScorer.iterator();
-                            LeafSearchLookup leafSearchLookup = searchLookup.getLeafSearchLookup(context);
-                            // Create a new ValueFetcher per thread.
-                            // ValueFetcher.setNextReader is not thread safe.
+                            SourceLookup sourceLookup = new SourceLookup();
                             final ValueFetcher valueFetcher = valueFetcherSupplier.get();
                             valueFetcher.setNextReader(context);
 
                             TwoPhaseIterator twoPhaseIterator = new TwoPhaseIterator(approximation) {
                                 @Override
                                 public boolean matches() throws IOException {
-                                    leafSearchLookup.setDocument(approximation.docID());
-                                    List<?> values = valueFetcher.fetchValues(leafSearchLookup.source());
+                                    sourceLookup.setSegmentAndDocument(context, approximation.docID());
+                                    List<?> values = valueFetcher.fetchValues(sourceLookup);
                                     for (Object value : values) {
                                         if (secondPhaseMatcher.test(value.toString())) {
                                             return true;

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
@@ -225,6 +225,17 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         assertEquals(ft.existsQuery(null), actual);
     }
 
+    public void testWildcardMatchingQueryEquality() {
+        BooleanQuery bq = new BooleanQuery.Builder().build();
+        WildcardFieldMapper.WildcardMatchingQuery q1 = new WildcardFieldMapper.WildcardMatchingQuery("field", bq, "test*");
+        WildcardFieldMapper.WildcardMatchingQuery q2 = new WildcardFieldMapper.WildcardMatchingQuery("field", bq, "test*");
+        assertEquals(q1, q2);
+        assertEquals(q1.hashCode(), q2.hashCode());
+
+        WildcardFieldMapper.WildcardMatchingQuery q3 = new WildcardFieldMapper.WildcardMatchingQuery("field", bq, "other*");
+        assertNotEquals(q1, q3);
+    }
+
     public void testRegexpMatchAll() {
         // The following matches any string of length exactly 3. We do need to evaluate the predicate.
         String pattern = "...";


### PR DESCRIPTION
### Description

The `wildcard` field type builds a `WildcardMatchingQuery` for every wildcard, prefix, regexp and terms query. Lucene's query cache stores that query object as a key, in one node-wide LRU. A key lives until the cache evicts it, long after the search that created it.

The query held two request-scoped objects: a `SearchLookup`, and a lambda over the `QueryShardContext`. Both reach the shard's `IndexSearcher` and its segment readers. When a shard closed, its readers stayed reachable from the cache key, so its heap never came back. Each cached pattern pinned about 15 MB.

The fix follows two rules. The cache key must be light, and `equals()` must mean "same matches". The query now holds a `Supplier<ValueFetcher>` that captured only index-level data at construction time: the `IndexFieldData` handle when the field has doc values, or the `_source` paths when it does not. The scorer creates one `SourceLookup` and one `ValueFetcher` per segment. The query stays cacheable. The second rule also closes an older gap: two regexp queries that differed only in case sensitivity compared equal, so the cache served one for the other.

A cluster test with 200 distinct wildcard queries, 6 repetitions each, gave these counts:

| Metric | Before | After |
|--------|:---:|:---:|
| SearchLookup instances | 400 | **0** |
| QueryShardContext instances | 200 | **0** |
| Cache entries | 200 | 200 |
| Cache hits | 200 | 200 |

A rerun on the final commit, with all 200 patterns resident in the query cache (`indices.queries.cache.min_frequency: 1`, request cache off), showed 200 `WildcardMatchingQuery` instances and 0 `SearchLookup` and 0 `QueryShardContext` instances in a live heap histogram.

Resolves #22419

### Changes

Each item names the code that changed and what it does now.

- `WildcardFieldType#valueFetcherSupplier(QueryShardContext)` resolves the `IndexFieldData` handle or the `_source` paths once, at query construction. It returns a supplier whose lambdas capture only those locals. `fielddataBuilder` ignores the `SearchLookup` supplier it receives, so the `IndexFieldData` holds no shard state either.
- `WildcardMatchingQuery#createWeight` builds one `SourceLookup` and one `ValueFetcher` per scorer. Neither class is thread safe, and Lucene drives one scorer from one thread, so nothing is shared.
- `WildcardMatchingQuery#equals` and `hashCode` now include the `RegExp` syntax flags and match flags. The second-phase matcher is a lambda, so the key compares its inputs instead. Before this change, `/a|b/` with and without the case flag had the same field, approximation and pattern string, and compared equal.
- A `WildcardMatchingQuery` built without a `QueryShardContext` can be compared, hashed and rewritten, but not searched: `createWeight` throws `IllegalStateException`. The package-private constructor that built an accept-everything query is removed, together with its sentinel. Only tests used it, and it left a query whose second phase was not exact yet compared equal to a real one. The one member that exists only for tests sits under a marked block at the bottom of the class.
- `SourceValueFetcher` gains a protected constructor that takes the `_source` paths and the null value directly, so a fetcher can exist without a `QueryShardContext`.
- Tests: a `Directory` plus `LRUQueryCache` round trip checks that the cached query still runs its second phase and never calls the `QueryShardContext` again. Further tests cover fetcher resolution for both paths, flag-aware equality, and the failure on search without a context.

### Background
Wildcard field 101, a short illustrated explainer of how this field type indexes and queries, and why the query object must not hold shard-scoped state: [rendered page](https://htmlpreview.github.io/?https://gist.githubusercontent.com/bowenlan-amzn/2855f529a2b1877192cfe55767575d44/raw/wildcard-field-101.html) · [source](https://gist.github.com/bowenlan-amzn/2855f529a2b1877192cfe55767575d44)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] API changes companion pull request - N/A
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
