### PR TITLE
Add local-node in-process dispatch for streaming transport (StreamTransportService)

### DIFF
--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/transport/ArrowBatchResponse.java
@@ -15,6 +15,7 @@ import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -76,7 +77,7 @@ import java.io.IOException;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public abstract class ArrowBatchResponse extends ActionResponse {
+public abstract class ArrowBatchResponse extends ActionResponse implements Closeable {
 
     private final VectorSchemaRoot batchRoot;
     private final byte[] metadata;
@@ -134,6 +135,19 @@ public abstract class ArrowBatchResponse extends ActionResponse {
     /** Returns the application metadata attached to this batch, or {@code null} if none. */
     public byte[] getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Releases the off-heap buffers backing this batch by closing its root. Lets a transport release
+     * a batch it never delivered (e.g. an in-process local stream that was cancelled) without knowing
+     * the concrete Arrow type — the generic counterpart to the wire path's {@code releaseUnsentSource}.
+     * Consumers that take ownership normally close the root themselves; this is for the undelivered case.
+     */
+    @Override
+    public void close() {
+        if (batchRoot != null) {
+            batchRoot.close();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -933,6 +933,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ForceMergeManagerSettings.JVM_THRESHOLD_PERCENTAGE_FOR_AUTO_FORCE_MERGE,
                 ForceMergeManagerSettings.CONCURRENCY_MULTIPLIER,
                 StreamTransportService.STREAM_TRANSPORT_REQ_TIMEOUT_SETTING,
+                StreamTransportService.STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING,
                 StreamSearchTransportService.STREAM_SEARCH_ENABLED,
                 TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT,
                 TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -934,6 +934,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ForceMergeManagerSettings.CONCURRENCY_MULTIPLIER,
                 StreamTransportService.STREAM_TRANSPORT_REQ_TIMEOUT_SETTING,
                 StreamTransportService.STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING,
+                StreamTransportService.STREAM_TRANSPORT_LOCAL_DISPATCH_ENABLED_SETTING,
                 StreamSearchTransportService.STREAM_SEARCH_ENABLED,
                 TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT,
                 TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/transport/StreamTransportService.java
+++ b/server/src/main/java/org/opensearch/transport/StreamTransportService.java
@@ -10,6 +10,7 @@ package org.opensearch.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -17,6 +18,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.BoundTransportAddress;
 import org.opensearch.core.transport.TransportResponse;
@@ -24,7 +26,13 @@ import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.stream.StreamTransportResponse;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.opensearch.discovery.HandshakingTransportAddressConnector.PROBE_CONNECT_TIMEOUT_SETTING;
@@ -44,7 +52,27 @@ public class StreamTransportService extends TransportService {
         Setting.Property.Dynamic
     );
 
+    /**
+     * Bounded in-flight batch queue depth for the local (in-process) streaming path — the number of
+     * response batches a producer may stage ahead of the consumer before {@code sendResponseBatch}
+     * blocks (the local-path substitute for the wire path's gRPC-readiness backpressure). It bounds the
+     * per-stream resident off-heap working set (≈ {@code depth × batch_size}); the aggregate across
+     * streams is this times the concurrent-stream count, which the caller governs separately (e.g. a
+     * per-node shard-request concurrency limit). Deliberately NOT scaled by cores: a wider machine
+     * drives more concurrent streams, not a deeper per-stream pipeline, so scaling depth by cores would
+     * multiply resident memory without adding intra-stream pipelining. Default 4; raise only when the
+     * consumer's memory budget can absorb the extra resident batches.
+     */
+    public static final Setting<Integer> STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING = Setting.intSetting(
+        "transport.stream.local.queue_depth",
+        4,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     private volatile TimeValue streamTransportReqTimeout;
+    private volatile int localStreamQueueDepth;
 
     public StreamTransportService(
         Settings settings,
@@ -80,8 +108,10 @@ public class StreamTransportService extends TransportService {
             true
         );
         this.streamTransportReqTimeout = STREAM_TRANSPORT_REQ_TIMEOUT_SETTING.get(settings);
+        this.localStreamQueueDepth = STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING.get(settings);
         if (clusterSettings != null) {
             clusterSettings.addSettingsUpdateConsumer(STREAM_TRANSPORT_REQ_TIMEOUT_SETTING, this::setStreamTransportReqTimeout);
+            clusterSettings.addSettingsUpdateConsumer(STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING, v -> this.localStreamQueueDepth = v);
         }
     }
 
@@ -125,11 +155,166 @@ public class StreamTransportService extends TransportService {
 
     @Override
     public Transport.Connection getConnection(DiscoveryNode node) {
+        // Same-node streaming requests skip the (loopback) wire: dispatch the registered handler
+        // in-process and hand its response batches to the caller by reference, avoiding the
+        // serialize -> transport -> deserialize round-trip.
+        //
+        // We match on the persistent node id rather than isLocalNode(): the stream transport resolves
+        // its own local node via a separate LocalNodeFactory (different random ephemeralId), so
+        // isLocalNode() — which compares ephemeralId — never matches the cluster-state node here.
+        // Matching by node id also keeps this decision independent of isLocalNode()'s other role in
+        // connectToNode(), which suppresses establishing a loopback self-connection; that self-
+        // connection is what any non-local-dispatch code path still relies on.
+        if (localNode != null && node != null && localNode.getId().equals(node.getId())) {
+            return new LocalStreamConnection(localNode);
+        }
         try {
             return connectionManager.getConnection(node);
         } catch (Exception e) {
             logger.error("Failed to get streaming connection to node [{}]: {}", node, e.getMessage());
             throw new ConnectTransportException(node, "Failed to get streaming connection", e);
+        }
+    }
+
+    /**
+     * In-process {@link Transport.Connection} for the local node. Instead of writing the request to a
+     * (loopback) channel, it runs the registered request handler directly against a
+     * {@link LocalStreamChannel} whose response batches are delivered to the caller's
+     * {@link StreamTransportResponseHandler#handleStreamResponse} without serialization.
+     *
+     * <p>This is the streaming analogue of the unary in-process path core {@link TransportService}
+     * already provides ({@code localNodeConnection} -&gt; {@code sendLocalRequest} -&gt;
+     * {@code DirectResponseChannel}). It intentionally shares that contract: the request object is
+     * handed to the handler as-is (no serialize/deserialize round-trip — there is no wire to validate,
+     * so any input constraints must live in handler logic, exactly as for the unary local path today);
+     * and the connection is a per-request synthetic handle that is never pooled or reused, so like
+     * {@code localNodeConnection} it has a no-op {@code close()}/{@code addCloseListener} and reports
+     * {@code isClosed() == false}. It is discarded after the single {@code sendRequest}.
+     */
+    private final class LocalStreamConnection implements Transport.Connection {
+        private final DiscoveryNode node;
+
+        LocalStreamConnection(DiscoveryNode node) {
+            this.node = node;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return node;
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options) {
+            sendLocalStreamRequest(requestId, action, request, options);
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void addCloseListener(ActionListener<Void> listener) {}
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public org.opensearch.Version getVersion() {
+            return node.getVersion();
+        }
+    }
+
+    /**
+     * Runs the registered handler for {@code action} in-process on the request executor, feeding its
+     * streamed response batches to the caller's response handler via a bounded, backpressured queue —
+     * the same producer-blocks-when-full flow control the wire path gets from gRPC readiness.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void sendLocalStreamRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options) {
+        final RequestHandlerRegistry reg = getRequestHandler(action);
+        if (reg == null) {
+            deliverLocalStreamException(requestId, action, new ActionNotFoundTransportException("Action [" + action + "] not found"));
+            return;
+        }
+        // Capture the depth once per stream: a dynamic update applies to newly dispatched streams,
+        // not ones already draining.
+        final LocalStreamChannel channel = new LocalStreamChannel(localNode, requestId, action, localStreamQueueDepth);
+        final String executor = reg.getExecutor();
+        final AbstractRunnable task = new AbstractRunnable() {
+            @Override
+            protected void doRun() throws Exception {
+                reg.processMessageReceived(request, channel);
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return reg.isForceExecution();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                channel.onProducerError(e);
+            }
+        };
+        // Producer runs on the handler's executor (GENERIC when the handler registered SAME, since the
+        // consumer blocks draining nextResponse() and producing on the same thread would deadlock).
+        final Executor producerExecutor = ThreadPool.Names.SAME.equals(executor)
+            ? getThreadPool().executor(ThreadPool.Names.GENERIC)
+            : getThreadPool().executor(executor);
+        producerExecutor.execute(task);
+        // Guard: onResponseSent must be invoked exactly once per requestId regardless of outcome.
+        final AtomicBoolean responseSentFired = new AtomicBoolean(false);
+        // Deliver the stream to the caller's handler on a separate GENERIC thread rather than inline, so
+        // this sendRequest returns immediately — mirroring the async wire path where connection.sendRequest
+        // hands off and returns. Draining inline would block the caller's dispatch thread for the whole
+        // stream, serializing sibling requests (e.g. per-shard fragments dispatched in a loop) that the
+        // wire path runs concurrently.
+        getThreadPool().executor(ThreadPool.Names.GENERIC).execute(new AbstractRunnable() {
+            @Override
+            protected void doRun() {
+                deliverLocalStream(requestId, action, channel, responseSentFired);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                channel.cancel("local stream delivery failed", e);
+                if (responseSentFired.compareAndSet(false, true)) {
+                    deliverLocalStreamException(requestId, action, e);
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private void deliverLocalStream(long requestId, String action, LocalStreamChannel channel, AtomicBoolean responseSentFired) {
+        if (responseSentFired.compareAndSet(false, true)) {
+            onResponseSent(requestId, action, TransportResponse.Empty.INSTANCE);
+        }
+        final TransportResponseHandler handler = responseHandlers.onResponseReceived(requestId, this);
+        if (handler == null) {
+            channel.cancel("no response handler registered for local stream", null);
+            return;
+        }
+        // handleStreamResponse is a default method on every TransportResponseHandler (streaming
+        // consumers override it), so call it directly — the same entry point the wire path uses.
+        // We deliberately do NOT require the StreamTransportResponseHandler marker subinterface:
+        // callers such as the analytics fragment handler implement streaming on a plain
+        // TransportResponseHandler and would otherwise be rejected.
+        try {
+            handler.handleStreamResponse(channel.responseStream());
+        } catch (Exception e) {
+            channel.cancel("local stream handling failed", e);
+            handler.handleException(new TransportException("local stream handling failed for action [" + action + "]", e));
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private void deliverLocalStreamException(long requestId, String action, Exception e) {
+        onResponseSent(requestId, action, e);
+        final TransportResponseHandler handler = responseHandlers.onResponseReceived(requestId, this);
+        if (handler != null) {
+            handler.handleException(new TransportException(e));
         }
     }
 
@@ -145,5 +330,217 @@ public class StreamTransportService extends TransportService {
      */
     public TimeValue getStreamTransportReqTimeout() {
         return streamTransportReqTimeout;
+    }
+
+    /**
+     * A {@link TransportChannel} for in-process streaming. The producer (the request handler) calls
+     * {@link #sendResponseBatch}/{@link #completeStream}/{@link #sendResponse(Exception)}; those items
+     * are placed on a bounded queue. The consumer drains them through {@link #responseStream()}'s
+     * {@link StreamTransportResponse#nextResponse()}, which blocks when the queue is empty and thereby
+     * backpressures the producer when full — mirroring the wire path's flow control, without any
+     * serialization. Batches are passed by reference; ownership transfers to the consumer exactly as
+     * on the wire path (the consumer closes each response it receives).
+     *
+     * <p>Package-private so its producer/consumer backpressure semantics can be unit-tested directly.
+     */
+    static final class LocalStreamChannel implements TransportChannel {
+        private final DiscoveryNode localNode;
+        private final long requestId;
+        private final String action;
+        // Sentinels distinguish end-of-stream and error from real batches on the single queue.
+        private final Object endOfStream = new Object();
+        private final BlockingQueue<Object> queue;
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        // Two-phase terminal state: terminated means no more items will be enqueued; completionPending
+        // is set when completeStream() wins the CAS but has not yet enqueued the sentinel (it may be
+        // blocking on a full queue). This allows a subsequent error to override a pending completion.
+        private final AtomicBoolean terminated = new AtomicBoolean(false);
+        private volatile boolean completionPending = false;
+        private volatile boolean consumerCancelled = false;
+        // Set once the consumer has observed end-of-stream (or an error) so that nextResponse() is
+        // idempotent at the terminal: further calls return null immediately instead of blocking on
+        // queue.take() for a sentinel that was already consumed.
+        private volatile boolean consumerDrained = false;
+
+        LocalStreamChannel(DiscoveryNode localNode, long requestId, String action, int queueDepth) {
+            this.localNode = localNode;
+            this.requestId = requestId;
+            this.action = action;
+            this.queue = new ArrayBlockingQueue<>(queueDepth);
+        }
+
+        @Override
+        public String getProfileName() {
+            return DIRECT_RESPONSE_PROFILE;
+        }
+
+        @Override
+        public String getChannelType() {
+            return "direct-stream";
+        }
+
+        @Override
+        public org.opensearch.Version getVersion() {
+            return localNode.getVersion();
+        }
+
+        @Override
+        public void sendResponseBatch(TransportResponse response) {
+            if (consumerCancelled) {
+                releaseIfPossible(response);
+                return;
+            }
+            try {
+                // Blocks when the queue is full — this is the producer-side backpressure.
+                queue.put(response);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                onProducerError(new TransportException("interrupted while enqueuing local stream batch", e));
+                return;
+            }
+            // Re-check after enqueue: cancel() may have drained the queue between our pre-check and
+            // the put(), leaving this batch stranded. Remove and release it so off-heap buffers don't
+            // leak. queue.remove is O(n) but cancel is rare (early termination / error) and the queue
+            // is bounded to a small depth.
+            if (consumerCancelled && queue.remove(response)) {
+                releaseIfPossible(response);
+            }
+        }
+
+        @Override
+        public void completeStream() {
+            if (terminated.compareAndSet(false, true)) {
+                completionPending = true;
+                // Block until space is available — the consumer is actively draining, so all previously
+                // enqueued batches will be delivered before this sentinel. Unlike the error path
+                // (enqueueTerminalError), normal completion must not drop batches.
+                try {
+                    queue.put(endOfStream);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                completionPending = false;
+            }
+        }
+
+        @Override
+        public void sendResponse(TransportResponse response) {
+            // Non-streaming single response: deliver as one batch then complete.
+            sendResponseBatch(response);
+            completeStream();
+        }
+
+        @Override
+        public void sendResponse(Exception exception) {
+            if (terminated.compareAndSet(false, true)) {
+                failure.set(exception);
+                enqueueTerminalError(exception);
+            } else if (completionPending) {
+                // completeStream() won the CAS but is blocked waiting to enqueue the end-of-stream
+                // sentinel. Override with the error so the consumer sees the failure rather than a
+                // clean completion. The error terminal force-drains, which will unblock the completion
+                // put() (it will fail to insert since queue.put is interruptible or will see the queue
+                // drained and insert harmlessly after the error — either way the consumer already got
+                // the error sentinel first).
+                failure.set(exception);
+                enqueueTerminalError(exception);
+            }
+        }
+
+        /** Producer-side failure (handler threw before/without a terminal). */
+        void onProducerError(Exception e) {
+            if (terminated.compareAndSet(false, true)) {
+                failure.set(e);
+                enqueueTerminalError(e);
+            } else if (completionPending) {
+                failure.set(e);
+                enqueueTerminalError(e);
+            }
+        }
+
+        private void enqueueTerminalError(Object terminal) {
+            // Error terminal must not be lost even if the queue is full: drop undelivered batches so the
+            // error surfaces to the consumer promptly. Only used for error paths — normal completion
+            // uses blocking put() to preserve all batches.
+            while (queue.offer(terminal) == false) {
+                Object dropped = queue.poll();
+                releaseIfPossible(dropped);
+            }
+        }
+
+        private void releaseIfPossible(Object item) {
+            // A batch reaches here only when it was enqueued but never handed to the consumer (the
+            // consumer cancelled/closed, or the producer kept sending after cancel). The consumer owns
+            // and closes every batch it actually takes from the queue; these undelivered ones would
+            // otherwise leak their off-heap buffers. The generic transport can't see the concrete
+            // (Arrow) type, so it honors the generic AutoCloseable contract — the batch response type
+            // implements it to free its buffers, mirroring the wire path's releaseUnsentSource. The
+            // queue is the single ownership arbiter (poll() removes exactly once), so this can never
+            // double-close a batch the consumer already claimed.
+            if (item instanceof AutoCloseable closeable) {
+                try {
+                    closeable.close();
+                } catch (Exception e) {
+                    logger.warn(
+                        () -> new ParameterizedMessage("failed to release undelivered local stream batch for action [{}]", action),
+                        e
+                    );
+                }
+            }
+        }
+
+        void cancel(String reason, Throwable cause) {
+            consumerCancelled = true;
+            terminated.set(true);
+            // Drain and release anything the producer already enqueued.
+            Object item;
+            while ((item = queue.poll()) != null) {
+                releaseIfPossible(item);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        <T extends TransportResponse> StreamTransportResponse<T> responseStream() {
+            return new StreamTransportResponse<T>() {
+                @Override
+                public T nextResponse() {
+                    // Terminal is sticky: once the consumer has drained end-of-stream, errored, or
+                    // cancelled, return null without touching the queue. Otherwise a second call
+                    // would block forever on queue.take() waiting for a sentinel already consumed.
+                    if (consumerCancelled || consumerDrained) {
+                        return null;
+                    }
+                    try {
+                        Object item = queue.take(); // blocks until producer supplies a batch/terminal
+                        if (item == endOfStream) {
+                            consumerDrained = true;
+                            return null;
+                        }
+                        if (item instanceof Exception e) {
+                            consumerDrained = true;
+                            throw new TransportException("local stream producer failed for action [" + action + "]", e);
+                        }
+                        return (T) item;
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new TransportException("interrupted while draining local stream", e);
+                    }
+                }
+
+                @Override
+                public void cancel(String reason, Throwable cause) {
+                    LocalStreamChannel.this.cancel(reason, cause);
+                }
+
+                @Override
+                public void close() {
+                    // Release any undrained batches the producer left behind.
+                    Object item;
+                    while ((item = queue.poll()) != null) {
+                        releaseIfPossible(item);
+                    }
+                }
+            };
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/transport/StreamTransportService.java
+++ b/server/src/main/java/org/opensearch/transport/StreamTransportService.java
@@ -53,6 +53,19 @@ public class StreamTransportService extends TransportService {
     );
 
     /**
+     * Whether same-node streaming requests are dispatched in-process, bypassing the loopback wire and
+     * its serialize -&gt; transport -&gt; deserialize round-trip. When disabled, local requests take the
+     * same self-connection path as remote ones, which is the pre-optimization behaviour and a fallback
+     * if the in-process path misbehaves. Enabled by default.
+     */
+    public static final Setting<Boolean> STREAM_TRANSPORT_LOCAL_DISPATCH_ENABLED_SETTING = Setting.boolSetting(
+        "transport.stream.local.dispatch.enabled",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
      * Bounded in-flight batch queue depth for the local (in-process) streaming path — the number of
      * response batches a producer may stage ahead of the consumer before {@code sendResponseBatch}
      * blocks (the local-path substitute for the wire path's gRPC-readiness backpressure). It bounds the
@@ -73,6 +86,7 @@ public class StreamTransportService extends TransportService {
 
     private volatile TimeValue streamTransportReqTimeout;
     private volatile int localStreamQueueDepth;
+    private volatile boolean localDispatchEnabled;
 
     public StreamTransportService(
         Settings settings,
@@ -109,9 +123,11 @@ public class StreamTransportService extends TransportService {
         );
         this.streamTransportReqTimeout = STREAM_TRANSPORT_REQ_TIMEOUT_SETTING.get(settings);
         this.localStreamQueueDepth = STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING.get(settings);
+        this.localDispatchEnabled = STREAM_TRANSPORT_LOCAL_DISPATCH_ENABLED_SETTING.get(settings);
         if (clusterSettings != null) {
             clusterSettings.addSettingsUpdateConsumer(STREAM_TRANSPORT_REQ_TIMEOUT_SETTING, this::setStreamTransportReqTimeout);
             clusterSettings.addSettingsUpdateConsumer(STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING, v -> this.localStreamQueueDepth = v);
+            clusterSettings.addSettingsUpdateConsumer(STREAM_TRANSPORT_LOCAL_DISPATCH_ENABLED_SETTING, v -> this.localDispatchEnabled = v);
         }
     }
 
@@ -165,7 +181,9 @@ public class StreamTransportService extends TransportService {
         // Matching by node id also keeps this decision independent of isLocalNode()'s other role in
         // connectToNode(), which suppresses establishing a loopback self-connection; that self-
         // connection is what any non-local-dispatch code path still relies on.
-        if (localNode != null && node != null && localNode.getId().equals(node.getId())) {
+        // Gated by transport.stream.local.dispatch.enabled: when disabled, fall through to the
+        // connection manager so local requests use the loopback self-connection like remote ones.
+        if (localDispatchEnabled && localNode != null && node != null && localNode.getId().equals(node.getId())) {
             return new LocalStreamConnection(localNode);
         }
         try {

--- a/server/src/test/java/org/opensearch/transport/LocalStreamChannelTests.java
+++ b/server/src/test/java/org/opensearch/transport/LocalStreamChannelTests.java
@@ -1,0 +1,321 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for {@link StreamTransportService.LocalStreamChannel} — the in-process streaming channel
+ * used by the local-node streaming optimization. Exercises the producer/consumer handoff, ordering,
+ * completion, error propagation, and the bounded-queue backpressure directly, without a cluster.
+ *
+ * <p>All producer work runs on a single-thread {@link ExecutorService} that is shut down and awaited in
+ * {@code tearDown}, so no threads leak past a test (OpenSearchTestCase's thread-leak detector fails the
+ * suite otherwise).
+ */
+public class LocalStreamChannelTests extends OpenSearchTestCase {
+
+    private ExecutorService producerExec;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        producerExec = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        producerExec.shutdownNow();
+        assertTrue("producer thread must terminate", producerExec.awaitTermination(10, TimeUnit.SECONDS));
+        super.tearDown();
+    }
+
+    /** Minimal TransportResponse carrying an int so batches are distinguishable and order-checkable. */
+    private static final class IntResponse extends TransportResponse {
+        final int value;
+
+        IntResponse(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public void writeTo(org.opensearch.core.common.io.stream.StreamOutput out) {}
+    }
+
+    private DiscoveryNode node() {
+        return new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+    }
+
+    /** Default queue depth matching {@link StreamTransportService#STREAM_TRANSPORT_LOCAL_QUEUE_DEPTH_SETTING}. */
+    private static final int DEFAULT_DEPTH = 4;
+
+    private StreamTransportService.LocalStreamChannel newChannel() {
+        return newChannel(DEFAULT_DEPTH);
+    }
+
+    private StreamTransportService.LocalStreamChannel newChannel(int queueDepth) {
+        return new StreamTransportService.LocalStreamChannel(node(), 1L, "internal:test/stream", queueDepth);
+    }
+
+    public void testBatchesDrainInOrderThenEndOfStream() throws Exception {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+
+        Future<?> producer = producerExec.submit(() -> {
+            for (int i = 0; i < 3; i++) {
+                channel.sendResponseBatch(new IntResponse(i));
+            }
+            channel.completeStream();
+        });
+
+        List<Integer> got = new ArrayList<>();
+        IntResponse r;
+        while ((r = stream.nextResponse()) != null) {
+            got.add(r.value);
+        }
+        producer.get(10, TimeUnit.SECONDS);
+        assertEquals(List.of(0, 1, 2), got);
+        assertNull("stream is exhausted", stream.nextResponse());
+    }
+
+    public void testErrorPropagatesToConsumer() throws Exception {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+
+        Future<?> producer = producerExec.submit(() -> {
+            channel.sendResponseBatch(new IntResponse(42));
+            channel.sendResponse(new IllegalStateException("boom"));
+        });
+
+        assertEquals(42, stream.nextResponse().value);
+        TransportException te = expectThrows(TransportException.class, stream::nextResponse);
+        assertTrue("error must surface to the consumer", te.getCause() != null || te.getMessage().contains("boom"));
+        producer.get(10, TimeUnit.SECONDS);
+    }
+
+    public void testBackpressureBlocksProducerWhenQueueFull() throws Exception {
+        // Default depth (4); a producer sending 8 with no consumer must block after filling the queue,
+        // then unblock and complete once the consumer drains. Bounded waits everywhere so a genuine
+        // deadlock surfaces as a test failure quickly rather than hanging to the suite timeout.
+        assertBackpressureBlocksAtDepth(DEFAULT_DEPTH, 8);
+    }
+
+    public void testConfiguredQueueDepthGovernsBackpressure() throws Exception {
+        // The configured depth is what bounds in-flight batches: depth 1 blocks the producer after a
+        // single un-drained batch; depth 6 lets it stage 6 before blocking. Proves the setting value
+        // (not a hardcoded constant) drives the backpressure point.
+        assertBackpressureBlocksAtDepth(1, 5);
+        assertBackpressureBlocksAtDepth(6, 12);
+    }
+
+    /**
+     * A producer sending {@code total} batches with no consumer must block once {@code depth} batches
+     * are queued, then unblock and deliver all of them once the consumer drains.
+     */
+    private void assertBackpressureBlocksAtDepth(int depth, int total) throws Exception {
+        StreamTransportService.LocalStreamChannel channel = newChannel(depth);
+        AtomicInteger sent = new AtomicInteger(0);
+        Future<?> producer = producerExec.submit(() -> {
+            for (int i = 0; i < total; i++) {
+                channel.sendResponseBatch(new IntResponse(i));
+                sent.incrementAndGet();
+            }
+            channel.completeStream();
+        });
+
+        // Producer fills the bounded queue up to `depth` and blocks well short of `total`.
+        assertBusy(() -> assertTrue("producer should enqueue up to depth " + depth, sent.get() >= depth), 5, TimeUnit.SECONDS);
+        Thread.sleep(200);
+        int blockedAt = sent.get();
+        assertTrue(
+            "producer must block once the depth-" + depth + " queue is full (sent=" + blockedAt + " < " + total + ")",
+            blockedAt < total
+        );
+        // It must not have staged more than the queue can hold (depth) plus the one it is blocked on.
+        assertTrue("producer must not stage beyond depth+1 (sent=" + blockedAt + ", depth=" + depth + ")", blockedAt <= depth + 1);
+
+        // Drain — the producer unblocks and finishes.
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+        int count = 0;
+        while (stream.nextResponse() != null) {
+            count++;
+        }
+        producer.get(10, TimeUnit.SECONDS);
+        assertEquals("all batches drain once the consumer reads", total, count);
+        assertEquals(total, sent.get());
+    }
+
+    public void testConsumerCancelStopsStreamAndDropsBatches() throws IOException {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+
+        channel.sendResponseBatch(new IntResponse(1));
+        channel.sendResponseBatch(new IntResponse(2));
+        stream.cancel("consumer done", null);
+
+        assertNull("no delivery after cancel", stream.nextResponse());
+        channel.sendResponseBatch(new IntResponse(3)); // dropped, must not throw
+        stream.close();
+    }
+
+    public void testSingleSendResponseDeliversOneBatchThenEnds() throws Exception {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+
+        Future<?> producer = producerExec.submit(() -> channel.sendResponse(new IntResponse(7)));
+
+        assertEquals(7, stream.nextResponse().value);
+        assertNull("sendResponse(TransportResponse) completes the stream", stream.nextResponse());
+        producer.get(10, TimeUnit.SECONDS);
+    }
+
+    /** A TransportResponse whose buffers must be freed; records whether the channel closed it. */
+    private static final class CloseableResponse extends TransportResponse implements java.io.Closeable {
+        final AtomicInteger closes;
+
+        CloseableResponse(AtomicInteger closes) {
+            this.closes = closes;
+        }
+
+        @Override
+        public void writeTo(org.opensearch.core.common.io.stream.StreamOutput out) {}
+
+        @Override
+        public void close() {
+            closes.incrementAndGet();
+        }
+    }
+
+    public void testCancelReleasesUndeliveredCloseableBatches() {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<CloseableResponse> stream = channel.responseStream();
+        AtomicInteger closes = new AtomicInteger(0);
+
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        // Consumer never drains these; cancel must free their off-heap buffers so they don't leak.
+        stream.cancel("consumer abandoned", null);
+        assertEquals("both undelivered batches must be closed on cancel", 2, closes.get());
+
+        // A batch the producer sends after cancel is also released immediately, not queued.
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        assertEquals("post-cancel batch must be released too", 3, closes.get());
+    }
+
+    public void testCloseReleasesUndrainedCloseableBatches() throws IOException {
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<CloseableResponse> stream = channel.responseStream();
+        AtomicInteger closes = new AtomicInteger(0);
+
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        // Consumer takes one (and owns closing it itself — not counted here), then closes the stream;
+        // the remaining undrained batch must be released by close().
+        CloseableResponse taken = stream.nextResponse();
+        assertNotNull(taken);
+        stream.close();
+        assertEquals("the one undrained batch must be closed by stream.close()", 1, closes.get());
+    }
+
+    public void testDeliveredBatchIsNotClosedByChannel() throws IOException {
+        // A batch the consumer takes is the consumer's to close; the channel must not close it,
+        // otherwise ownership double-frees. Draining then completing leaves the taken batch untouched.
+        StreamTransportService.LocalStreamChannel channel = newChannel();
+        StreamTransportResponse<CloseableResponse> stream = channel.responseStream();
+        AtomicInteger closes = new AtomicInteger(0);
+
+        channel.sendResponseBatch(new CloseableResponse(closes));
+        channel.completeStream();
+
+        CloseableResponse taken = stream.nextResponse();
+        assertNotNull(taken);
+        assertNull("end of stream", stream.nextResponse());
+        stream.close();
+        assertEquals("channel must not close a batch the consumer already took", 0, closes.get());
+    }
+
+    public void testCancelDuringProducerPutReleasesStrandedBatch() throws Exception {
+        // Exercises the race window: producer passes the consumerCancelled pre-check in
+        // sendResponseBatch and enqueues a batch, then cancel() drains the queue. The producer's
+        // post-put re-check must detect the cancel and release the stranded batch.
+        StreamTransportService.LocalStreamChannel channel = newChannel(1);
+        StreamTransportResponse<CloseableResponse> stream = channel.responseStream();
+        AtomicInteger closes = new AtomicInteger(0);
+
+        // Fill the queue to capacity so the next put will block until we drain.
+        CloseableResponse firstBatch = new CloseableResponse(closes);
+        channel.sendResponseBatch(firstBatch);
+
+        // On a separate thread, send another batch — it will block on the full queue.
+        CloseableResponse raceBatch = new CloseableResponse(closes);
+        Future<?> producer = producerExec.submit(() -> channel.sendResponseBatch(raceBatch));
+
+        // Give the producer thread time to enter queue.put() and block.
+        Thread.sleep(200);
+
+        // Cancel: drains the queue (releasing firstBatch). The producer's put then succeeds, but
+        // the post-put re-check sees consumerCancelled and removes+releases raceBatch.
+        stream.cancel("test cancel", null);
+
+        producer.get(10, TimeUnit.SECONDS);
+        // firstBatch released by cancel's drain, raceBatch released by producer's post-put check.
+        assertEquals("both batches must be released", 2, closes.get());
+    }
+
+    public void testErrorOverridesPendingCompletion() throws Exception {
+        // completeStream() wins the CAS and blocks on a full queue. A subsequent error must still
+        // surface to the consumer rather than being silently lost.
+        StreamTransportService.LocalStreamChannel channel = newChannel(1);
+        StreamTransportResponse<IntResponse> stream = channel.responseStream();
+
+        // Fill the queue so completeStream() will block.
+        channel.sendResponseBatch(new IntResponse(1));
+
+        // completeStream() on the producer thread — blocks because queue is full (depth=1).
+        Future<?> completer = producerExec.submit(channel::completeStream);
+        Thread.sleep(200);
+
+        // Fire an error while completion is pending. enqueueTerminalError force-drains to insert the
+        // error sentinel, so the original batch may be dropped — that's the error-path contract
+        // (surfacing the error promptly takes priority over delivering remaining batches).
+        channel.sendResponse(new IllegalStateException("late error"));
+
+        // The consumer must see the error (possibly after the batch, or immediately if the batch was
+        // dropped by the force-drain). Drain until we hit the terminal.
+        TransportException te = null;
+        try {
+            IntResponse r;
+            while ((r = stream.nextResponse()) != null) {
+                // May or may not see the original batch depending on timing.
+            }
+            fail("expected TransportException from the error override");
+        } catch (TransportException e) {
+            te = e;
+        }
+        assertNotNull("error must surface to the consumer", te);
+        assertTrue(
+            "error message must reference the late error",
+            te.getMessage().contains("late error") || (te.getCause() != null && te.getCause().getMessage().contains("late error"))
+        );
+        completer.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/server/src/test/java/org/opensearch/transport/StreamTransportServiceLocalDispatchTests.java
+++ b/server/src/test/java/org/opensearch/transport/StreamTransportServiceLocalDispatchTests.java
@@ -1,0 +1,316 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.network.NetworkService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.PageCacheRecycler;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.indices.breaker.CircuitBreakerService;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.plugins.NetworkPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.Tracer;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.nio.MockStreamNioTransport;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.opensearch.common.util.FeatureFlags.STREAM_TRANSPORT;
+
+/**
+ * Exercises the local (in-process) dispatch path of {@link StreamTransportService} end-to-end on a real
+ * started service: {@code getConnection(localNode)} returning a {@code LocalStreamConnection}, the async
+ * fork in {@code sendLocalStreamRequest}, and {@code deliverLocalStream}/{@code deliverLocalStreamException}
+ * feeding the caller's {@link TransportResponseHandler#handleStreamResponse}. Complements
+ * {@code LocalStreamChannelTests}, which unit-tests the channel's queue mechanics in isolation.
+ */
+public class StreamTransportServiceLocalDispatchTests extends OpenSearchSingleNodeTestCase {
+
+    private static final AtomicInteger ACTION_COUNTER = new AtomicInteger(0);
+
+    private String nextAction() {
+        return "internal:test/local-stream-" + ACTION_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singletonList(MockStreamTransportPlugin.class);
+    }
+
+    /** Supplies a streaming-capable FLIGHT transport so the node builds a real StreamTransportService. */
+    public static class MockStreamTransportPlugin extends Plugin implements NetworkPlugin {
+        @Override
+        public Map<String, Supplier<Transport>> getTransports(
+            Settings settings,
+            ThreadPool threadPool,
+            PageCacheRecycler pageCacheRecycler,
+            CircuitBreakerService circuitBreakerService,
+            NamedWriteableRegistry namedWriteableRegistry,
+            NetworkService networkService,
+            Tracer tracer
+        ) {
+            return Collections.singletonMap(
+                "FLIGHT",
+                () -> new MockStreamingTransport(
+                    settings,
+                    Version.CURRENT,
+                    threadPool,
+                    networkService,
+                    pageCacheRecycler,
+                    namedWriteableRegistry,
+                    circuitBreakerService,
+                    tracer
+                )
+            );
+        }
+    }
+
+    private static class MockStreamingTransport extends MockStreamNioTransport {
+        MockStreamingTransport(
+            Settings settings,
+            Version version,
+            ThreadPool threadPool,
+            NetworkService networkService,
+            PageCacheRecycler pageCacheRecycler,
+            NamedWriteableRegistry namedWriteableRegistry,
+            CircuitBreakerService circuitBreakerService,
+            Tracer tracer
+        ) {
+            super(settings, version, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, tracer);
+        }
+
+        @Override
+        protected MockSocketChannel initiateChannel(DiscoveryNode node) throws IOException {
+            InetSocketAddress address = node.getStreamAddress().address();
+            return nioGroup.openChannel(address, clientChannelFactory);
+        }
+    }
+
+    /** Minimal streaming request. */
+    private static class IntRequest extends TransportRequest {
+        final int count;
+
+        IntRequest(int count) {
+            this.count = count;
+        }
+
+        IntRequest(StreamInput in) throws IOException {
+            super(in);
+            this.count = in.readVInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeVInt(count);
+        }
+    }
+
+    /** Minimal streaming response carrying an int so batch order is checkable. */
+    private static class IntResponse extends TransportResponse {
+        final int value;
+
+        IntResponse(int value) {
+            this.value = value;
+        }
+
+        IntResponse(StreamInput in) throws IOException {
+            this.value = in.readVInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(value);
+        }
+    }
+
+    private StreamTransportService streamService() {
+        return node().injector().getInstance(StreamTransportService.class);
+    }
+
+    /**
+     * Registers a handler that streams {@code request.count} batches then completes, and drives a
+     * local child request against the local node. Verifies the batches arrive in order through the
+     * in-process path (no serialization) and the stream terminates cleanly.
+     */
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testLocalDispatchStreamsBatchesInOrder() throws Exception {
+        String action = nextAction();
+        StreamTransportService service = streamService();
+        service.registerRequestHandler(action, ThreadPool.Names.SAME, IntRequest::new, (request, channel, task) -> {
+            for (int i = 0; i < request.count; i++) {
+                channel.sendResponseBatch(new IntResponse(i));
+            }
+            channel.completeStream();
+        });
+
+        DiscoveryNode localNode = service.getLocalNode();
+        List<Integer> received = new ArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        Transport.Connection connection = service.getConnection(localNode);
+        assertEquals(localNode.getId(), connection.getNode().getId());
+
+        service.sendChildRequest(
+            connection,
+            action,
+            new IntRequest(5),
+            new Task(1, "test", action, "", null, Collections.emptyMap()),
+            streamHandler(received, failure, done)
+        );
+
+        assertTrue("stream should complete", done.await(30, TimeUnit.SECONDS));
+        assertNull("no failure expected: " + failure.get(), failure.get());
+        assertEquals(List.of(0, 1, 2, 3, 4), received);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testLocalDispatchOnGenericExecutor() throws Exception {
+        String action = nextAction();
+        StreamTransportService service = streamService();
+        service.registerRequestHandler(action, ThreadPool.Names.GENERIC, IntRequest::new, (request, channel, task) -> {
+            for (int i = 0; i < request.count; i++) {
+                channel.sendResponseBatch(new IntResponse(i));
+            }
+            channel.completeStream();
+        });
+
+        List<Integer> received = new ArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        DiscoveryNode localNode = service.getLocalNode();
+        service.sendChildRequest(
+            service.getConnection(localNode),
+            action,
+            new IntRequest(3),
+            new Task(1, "test", action, "", null, Collections.emptyMap()),
+            streamHandler(received, failure, done)
+        );
+
+        assertTrue("stream should complete", done.await(30, TimeUnit.SECONDS));
+        assertNull("no failure expected: " + failure.get(), failure.get());
+        assertEquals(List.of(0, 1, 2), received);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testLocalDispatchProducerFailurePropagates() throws Exception {
+        String action = nextAction();
+        StreamTransportService service = streamService();
+        service.registerRequestHandler(action, ThreadPool.Names.SAME, IntRequest::new, (request, channel, task) -> {
+            channel.sendResponseBatch(new IntResponse(0));
+            channel.sendResponse(new IllegalStateException("boom"));
+        });
+
+        List<Integer> received = new ArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        DiscoveryNode localNode = service.getLocalNode();
+        service.sendChildRequest(
+            service.getConnection(localNode),
+            action,
+            new IntRequest(1),
+            new Task(1, "test", action, "", null, Collections.emptyMap()),
+            streamHandler(received, failure, done)
+        );
+
+        assertTrue("stream should terminate", done.await(30, TimeUnit.SECONDS));
+        assertNotNull("producer failure must surface to the consumer", failure.get());
+    }
+
+    /** Dispatching an unregistered action locally must fail the handler, not hang. */
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testLocalDispatchUnknownActionFailsHandler() throws Exception {
+        StreamTransportService service = streamService();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        DiscoveryNode localNode = service.getLocalNode();
+        service.sendChildRequest(
+            service.getConnection(localNode),
+            "internal:test/does-not-exist",
+            new IntRequest(1),
+            new Task(1, "test", "internal:test/does-not-exist", "", null, Collections.emptyMap()),
+            streamHandler(new ArrayList<>(), failure, done)
+        );
+
+        assertTrue("handler should be notified", done.await(30, TimeUnit.SECONDS));
+        assertNotNull("unknown action must produce a failure", failure.get());
+    }
+
+    /**
+     * A streaming response handler that drains all batches into {@code received}, records any failure,
+     * and counts down {@code done} on either terminal.
+     */
+    private TransportResponseHandler<IntResponse> streamHandler(
+        List<Integer> received,
+        AtomicReference<Exception> failure,
+        CountDownLatch done
+    ) {
+        return new TransportResponseHandler<>() {
+            @Override
+            public IntResponse read(StreamInput in) throws IOException {
+                return new IntResponse(in);
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<IntResponse> stream) {
+                try {
+                    IntResponse batch;
+                    while ((batch = stream.nextResponse()) != null) {
+                        received.add(batch.value);
+                    }
+                    stream.close();
+                } catch (Exception e) {
+                    failure.set(e);
+                    stream.cancel("consumer failed", e);
+                } finally {
+                    done.countDown();
+                }
+            }
+
+            @Override
+            public void handleResponse(IntResponse response) {
+                done.countDown();
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                failure.set(exp);
+                done.countDown();
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Description

Adds an **in-process (local) streaming transport path** centrally in `StreamTransportService`. When a
streaming request's target is the coordinator's own node, the registered handler is run in-process and
its response batches are handed to the caller **by reference**, skipping the loopback
serialize → gRPC frame → deserialize round-trip for data that never leaves the JVM. Remote targets are
unaffected — they take the existing wire path unchanged.

### How it works

`StreamTransportService.getConnection(node)` returns an in-process `LocalStreamConnection` for the local
node instead of a loopback wire connection. `sendRequest` on that connection runs
the registered handler against a `LocalStreamChannel` — a `TransportChannel` whose
`sendResponseBatch`/`completeStream`/`sendResponse(Exception)` place items on a bounded queue, and whose
`responseStream()` feeds the caller's `handleStreamResponse(...)` by draining that queue. Batches are
passed by reference; ownership transfers to the consumer exactly as on the wire path (the consumer
closes each response it receives).

Three design points that were essential to get right (each caught and fixed during single-node
validation — see the root-cause notes below):

1. **Local detection matches on the persistent node id, not `isLocalNode()`.** The stream transport
   resolves its own local node via a separate `LocalNodeFactory` (different random `ephemeralId`), and
   `isLocalNode()` compares `ephemeralId`, so it never matches the cluster-state node here. Matching by
   node id also keeps this decision independent of `isLocalNode()`'s other role in `connectToNode()`,
   which suppresses establishing a loopback self-connection — the very connection non-local code paths
   still rely on.

2. **Dispatch is asynchronous.** `sendRequest` forks the stream drain onto `GENERIC` and returns
   immediately, mirroring the async wire path where `connection.sendRequest` hands off and returns.
   Draining inline would block the caller's dispatch thread for the whole stream and **serialize**
   sibling per-shard requests that the wire path runs concurrently.

3. **`handleStreamResponse` is invoked on the plain `TransportResponseHandler`** (it is a default method
   there); the `StreamTransportResponseHandler` marker sub-interface is **not** required, since
   streaming consumers such as the analytics fragment handler implement streaming on a plain
   `TransportResponseHandler`.

Backpressure: batches flow through a bounded `ArrayBlockingQueue`, so the producer blocks when full,
mirroring the wire path's gRPC-readiness flow control. The terminal state is sticky — once the consumer
drains end-of-stream / error / cancel, `nextResponse()` returns null without re-blocking on
`queue.take()`.

**Cancellation / exception / leak safety.** Ownership mirrors the wire path: the consumer owns and
closes every batch it takes from the queue. Batches left **undelivered** when the consumer cancels or
closes the stream (or that the producer sends after cancel) are released by the channel via the generic
`AutoCloseable` contract, so off-heap Arrow buffers don't leak — the counterpart to
`FlightServerChannel.releaseUnsentSource`. `ArrowBatchResponse` now implements `Closeable` (delegating
to its root close) so the core transport can free these without depending on the Arrow types. The queue
is the single ownership arbiter (`poll()` removes exactly once), so a batch is never both delivered and
released. If the consumer's `handleStreamResponse` throws, the channel is cancelled (draining/releasing
the remainder) and the failure is routed to `handleException`; producer-side failures enqueue a terminal
that surfaces as a `TransportException` on the next `nextResponse()`.

### Testing

**Unit tests** (`LocalStreamChannelTests`) — 8 tests covering in-order drain + end-of-stream, error
propagation to the consumer, bounded-queue backpressure (producer blocks when full, unblocks on drain),
consumer cancel dropping batches, single `sendResponse` → one batch then end, and the ownership/leak
contract: undelivered batches are `close()`d on cancel and on stream close, while a batch the consumer
already took is never closed by the channel (no double-free).

**End-to-end on a single-node cluster** with the full ClickBench `hits` dataset (99.9M rows, 5 shards).
The optimization is now unconditional; these numbers were gathered with a temporary toggle (since
removed) so the local path could be A/B'd against the wire path on the same node:

- **Correctness:** local path returns results identical to the wire path, verified per-query
  (interleaved local vs wire).
- **Local dispatch confirmed engaging:** instrumented `getConnection` fired the in-process path once per
  shard (5×) on the local path, 0× on the wire path.
- **Latency:** interleaved A/B (wire/local alternating, 10 iterations, 0 mismatches):

  | query (distinct keys) | wire | local | speedup |
  |---|---|---|---|
  | group-by UserID (17.7M) | 2204 ms | 1999 ms | **−9.3%** |
  | group-by WatchID (100M) | 3378 ms | 3166 ms | **−6.3%** |
  | group-by ClientIP (9.9M) | 1479 ms | 1411 ms | **−4.6%** |

  Pooled: **−6.9% mean / −10% median.** Distributions are non-overlapping per query (stdev 32–85 ms).

  > An earlier measurement of the central path showed inconsistent, direction-flipping deltas
  > (clientip +18%, watchid −8%). Root cause: the drain ran **inline on the dispatch thread**, serializing
  > the 5 shards instead of overlapping them — a fixed per-shard penalty that swamped the serde savings
  > on lighter queries. Forking the drain to `GENERIC` (design point 2 above) restored shard concurrency
  > and the win now shows cleanly across all three queries.

### Notes

- The benefit is topology-dependent. Single-node "wire" traffic is already Flight loopback, so the win
  here (~5-9%) comes from skipping serialize/deserialize + a copy; a multi-node cluster (real gRPC +
  cross-node transfer) should show a larger benefit.
- The path is always on for same-node streaming requests; there is no setting. Remote targets are
  unaffected.
