### PR TITLE
Fixing the flaky test for ScriptScoreQueryIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -70,9 +70,9 @@ import java.util.function.Function;
 
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.idsQuery;
-import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
 import static org.opensearch.index.query.QueryBuilders.scriptScoreQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFirstHit;
@@ -268,7 +268,9 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         indexRandomForConcurrentSearch("bulk-test-index");
 
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
-        SearchResponse resp = client().prepareSearch("bulk-test-index").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        SearchResponse resp = client().prepareSearch("bulk-test-index")
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script))
+            .get();
         assertNoFailures(resp);
         assertEquals(3, resp.getHits().getTotalHits().value());
         for (var hit : resp.getHits().getHits()) {
@@ -290,7 +292,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         // The per-doc path (newInstance) returns a fixed score of 2.0.
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
         SearchResponse resp = client().prepareSearch("bulk-test-minscore")
-            .setQuery(scriptScoreQuery(matchAllQuery(), script).setMinScore(1.5f))
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script).setMinScore(1.5f))
             .get();
         assertNoFailures(resp);
         assertEquals(2, resp.getHits().getTotalHits().value());
@@ -309,15 +311,18 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         indexRandomForConcurrentSearch("bulk-test-boost");
 
         float boost = 3.0f;
-        // First query without boost to get the base score
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
-        SearchResponse baseResp = client().prepareSearch("bulk-test-boost").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        // Use a term filter to match only our specific doc, avoiding random docs from indexRandomForConcurrentSearch
+        SearchResponse baseResp = client().prepareSearch("bulk-test-boost")
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script))
+            .get();
         assertNoFailures(baseResp);
+        assertEquals(1, baseResp.getHits().getTotalHits().value());
         float baseScore = baseResp.getHits().getHits()[0].getScore();
 
         // Query with boost — score should be base * boost
         SearchResponse resp = client().prepareSearch("bulk-test-boost")
-            .setQuery(scriptScoreQuery(matchAllQuery(), script).boost(boost))
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script).boost(boost))
             .get();
         assertNoFailures(resp);
         assertEquals(1, resp.getHits().getTotalHits().value());
@@ -335,7 +340,9 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
 
         // "fallback_score" source triggers null from bulkScorer() → falls back to per-doc scoring (returns 2.0)
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "fallback_score", Collections.emptyMap());
-        SearchResponse resp = client().prepareSearch("bulk-test-fallback").setQuery(scriptScoreQuery(matchAllQuery(), script)).get();
+        SearchResponse resp = client().prepareSearch("bulk-test-fallback")
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script))
+            .get();
         assertNoFailures(resp);
         assertEquals(1, resp.getHits().getTotalHits().value());
         assertEquals(2.0f, resp.getHits().getHits()[0].getScore(), 0.001f);
@@ -354,7 +361,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         // path (newInstance → execute() returns 2.0). Verify explain returns the per-doc score.
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
         SearchResponse resp = client().prepareSearch("bulk-test-explain")
-            .setQuery(scriptScoreQuery(matchAllQuery(), script))
+            .setQuery(scriptScoreQuery(termQuery("field1", "foo"), script))
             .setExplain(true)
             .get();
         assertNoFailures(resp);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing the flaky test for ScriptScoreQueryIT introduced in PR: https://github.com/opensearch-project/OpenSearch/pull/22423 .

Fix ensure that we fetch the document which was ingested and scores are compared for that test only.

### Tested using
```
./gradlew :server:internalClusterTest -Dtests.iters=20 -Dtests.class="*.ScriptScoreQueryIT" -Dtests.method="testBulkScoring*"
```
and failing seed

```
./gradlew ':server:internalClusterTest' --tests 'org.opensearch.search.query.ScriptScoreQueryIT' -Dtests.method='testBulkScoringWithBoost {p0={"search.concurrent_segment_search.enabled":"true"}}' -Dtests.seed=714BC37BA2B32A8F
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
