### PR TITLE
Percolator: skip MemoryIndex verification for range queries on single-valued documents

### DIFF
--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
@@ -96,9 +96,11 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
@@ -114,14 +116,30 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
 
     static final byte FIELD_VALUE_SEPARATOR = 0;  // nul code point
     static final String EXTRACTION_COMPLETE = "complete";
+    /**
+     * The query's extraction is complete provided the percolated document contains at most one
+     * value for every field listed in {@link #EXTRACTION_RANGE_FIELDS_FIELD_NAME}: the only
+     * obstacle to full verification was range extraction, which is exact for single-valued
+     * fields. Whether the MemoryIndex verification can be skipped is decided per percolate
+     * request by inspecting the document (see {@code PercolatorFieldType#percolateQuery}).
+     */
+    static final String EXTRACTION_COMPLETE_SINGLE_VALUED = "complete_single_valued";
     static final String EXTRACTION_PARTIAL = "partial";
     static final String EXTRACTION_FAILED = "failed";
 
     static final String EXTRACTED_TERMS_FIELD_NAME = "extracted_terms";
     static final String EXTRACTION_RESULT_FIELD_NAME = "extraction_result";
+    static final String EXTRACTION_RANGE_FIELDS_FIELD_NAME = "extraction_range_fields";
     static final String QUERY_BUILDER_FIELD_NAME = "query_builder_field";
     static final String RANGE_FIELD_NAME = "range_field";
     static final String MINIMUM_SHOULD_MATCH_FIELD_NAME = "minimum_should_match_field";
+
+    /**
+     * Indices created on or after this version encode range-only-unverified queries as
+     * {@link #EXTRACTION_COMPLETE_SINGLE_VALUED} (plus the ranged field names in
+     * {@link #EXTRACTION_RANGE_FIELDS_FIELD_NAME}) instead of {@link #EXTRACTION_PARTIAL}.
+     */
+    static final Version SINGLE_VALUED_VERIFICATION_INDEX_VERSION = Version.V_3_8_0;
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
@@ -159,6 +177,8 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             fieldType.queryTermsField = extractedTermsField.fieldType();
             KeywordFieldMapper extractionResultField = createExtractQueryFieldBuilder(EXTRACTION_RESULT_FIELD_NAME, context);
             fieldType.extractionResultField = extractionResultField.fieldType();
+            KeywordFieldMapper extractionRangeFieldsField = createExtractQueryFieldBuilder(EXTRACTION_RANGE_FIELDS_FIELD_NAME, context);
+            fieldType.extractionRangeFieldsField = extractionRangeFieldsField.fieldType();
             BinaryFieldMapper queryBuilderField = createQueryBuilderFieldBuilder(context);
             fieldType.queryBuilderField = queryBuilderField.fieldType();
             // Range field is of type ip, because that matches closest with BinaryRange field. Otherwise we would
@@ -178,6 +198,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
                 queryShardContext,
                 extractedTermsField,
                 extractionResultField,
+                extractionRangeFieldsField,
                 queryBuilderField,
                 rangeFieldMapper,
                 minimumShouldMatchFieldMapper,
@@ -237,6 +258,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
 
         MappedFieldType queryTermsField;
         MappedFieldType extractionResultField;
+        MappedFieldType extractionRangeFieldsField;
         MappedFieldType queryBuilderField;
         MappedFieldType minimumShouldMatchField;
 
@@ -282,7 +304,31 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             // not know to which document the terms belong too and for certain queries we incorrectly emit candidate
             // matches as actual match.
             if (canUseMinimumShouldMatchField && indexReader.maxDoc() == 1) {
-                verifiedMatchesQuery = new TermQuery(new Term(extractionResultField.name(), EXTRACTION_COMPLETE));
+                BooleanQuery.Builder verifiedMatches = new BooleanQuery.Builder();
+                verifiedMatches.setMinimumNumberShouldMatch(1);
+                verifiedMatches.add(new TermQuery(new Term(extractionResultField.name(), EXTRACTION_COMPLETE)), BooleanClause.Occur.SHOULD);
+                // Queries whose only obstacle to full verification was range extraction
+                // (extraction_result: complete_single_valued) are verified as well, unless the
+                // document is multi-valued on one of the fields their ranges target: for those
+                // fields the candidate check packs the document's values into one [min, max]
+                // interval, which can intersect a stored range that contains none of the actual
+                // values. For single-valued fields the intersection check is exact.
+                BooleanQuery.Builder singleValuedMatches = new BooleanQuery.Builder();
+                singleValuedMatches.add(
+                    new TermQuery(new Term(extractionResultField.name(), EXTRACTION_COMPLETE_SINGLE_VALUED)),
+                    BooleanClause.Occur.FILTER
+                );
+                // Plain term queries (instead of a TermInSetQuery, which would require a rewrite
+                // before PercolateQuery creates the weight); a document has few multi-valued
+                // point fields at most.
+                for (BytesRef multiValuedPointField : multiValuedPointFields(indexReader)) {
+                    singleValuedMatches.add(
+                        new TermQuery(new Term(extractionRangeFieldsField.name(), multiValuedPointField)),
+                        BooleanClause.Occur.MUST_NOT
+                    );
+                }
+                verifiedMatches.add(singleValuedMatches.build(), BooleanClause.Occur.SHOULD);
+                verifiedMatchesQuery = verifiedMatches.build();
             } else {
                 verifiedMatchesQuery = new MatchNoDocsQuery("multiple or nested docs or CoveringQuery could not be used");
             }
@@ -331,6 +377,26 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             return new Tuple<>(candidateQuery.build(), canUseMinimumShouldMatchField);
         }
 
+        /**
+         * Names of single-dimension point fields that carry more than one value in the percolated
+         * document. Only meaningful when the reader holds a single document (callers gate on
+         * {@code maxDoc() == 1}); range extractions on these fields cannot be trusted without
+         * MemoryIndex verification.
+         */
+        static List<BytesRef> multiValuedPointFields(IndexReader indexReader) throws IOException {
+            List<BytesRef> fields = new ArrayList<>();
+            LeafReader reader = indexReader.leaves().get(0).reader();
+            for (FieldInfo info : reader.getFieldInfos()) {
+                if (info.getPointIndexDimensionCount() == 1) {
+                    PointValues values = reader.getPointValues(info.name);
+                    if (values != null && values.size() > 1) {
+                        fields.add(new BytesRef(info.name));
+                    }
+                }
+            }
+            return fields;
+        }
+
         // This was extracted the method above, because otherwise it is difficult to test what terms are included in
         // the query in case a CoveringQuery is used (it does not have a getter to retrieve the clauses)
         Tuple<List<BytesRef>, Map<String, List<byte[]>>> extractTermsAndRanges(IndexReader indexReader) throws IOException {
@@ -367,6 +433,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
     private final Supplier<QueryShardContext> queryShardContext;
     private final KeywordFieldMapper queryTermsField;
     private final KeywordFieldMapper extractionResultField;
+    private final KeywordFieldMapper extractionRangeFieldsField;
     private final BinaryFieldMapper queryBuilderField;
     private final NumberFieldMapper minimumShouldMatchFieldMapper;
     private final RangeFieldMapper rangeFieldMapper;
@@ -380,6 +447,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         Supplier<QueryShardContext> queryShardContext,
         KeywordFieldMapper queryTermsField,
         KeywordFieldMapper extractionResultField,
+        KeywordFieldMapper extractionRangeFieldsField,
         BinaryFieldMapper queryBuilderField,
         RangeFieldMapper rangeFieldMapper,
         NumberFieldMapper minimumShouldMatchFieldMapper,
@@ -389,6 +457,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         this.queryShardContext = queryShardContext;
         this.queryTermsField = queryTermsField;
         this.extractionResultField = extractionResultField;
+        this.extractionRangeFieldsField = extractionRangeFieldsField;
         this.queryBuilderField = queryBuilderField;
         this.minimumShouldMatchFieldMapper = minimumShouldMatchFieldMapper;
         this.rangeFieldMapper = rangeFieldMapper;
@@ -447,7 +516,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         ParseContext.Document doc = context.doc();
         PercolatorFieldType pft = (PercolatorFieldType) this.fieldType();
         QueryAnalyzer.Result result;
-        Version indexVersion = context.mapperService().getIndexSettings().getIndexVersionCreated();
+        Version indexVersion = context.indexSettings().getIndexVersionCreated();
         result = QueryAnalyzer.analyze(query, indexVersion);
         if (result == QueryAnalyzer.Result.UNKNOWN) {
             doc.add(new Field(pft.extractionResultField.name(), EXTRACTION_FAILED, INDEXED_KEYWORD));
@@ -474,6 +543,18 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             }
         } else if (result.verified) {
             doc.add(new Field(extractionResultField.name(), EXTRACTION_COMPLETE, INDEXED_KEYWORD));
+        } else if (result.verifiedIfSingleValued && indexVersion.onOrAfter(SINGLE_VALUED_VERIFICATION_INDEX_VERSION)) {
+            // The only obstacle to full verification was range extraction, which is exact for
+            // single-valued fields. Record the ranged field names so that the percolate query can
+            // check them against the percolated document and skip the MemoryIndex verification
+            // when the document is single-valued on all of them.
+            doc.add(new Field(extractionResultField.name(), EXTRACTION_COMPLETE_SINGLE_VALUED, INDEXED_KEYWORD));
+            Set<String> rangeFieldNames = new HashSet<>();
+            for (QueryAnalyzer.QueryExtraction extraction : result.extractions) {
+                if (extraction.range != null && rangeFieldNames.add(extraction.range.fieldName)) {
+                    doc.add(new Field(extractionRangeFieldsField.name(), new BytesRef(extraction.range.fieldName), INDEXED_KEYWORD));
+                }
+            }
         } else {
             doc.add(new Field(extractionResultField.name(), EXTRACTION_PARTIAL, INDEXED_KEYWORD));
         }
@@ -512,6 +593,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         return Arrays.<Mapper>asList(
             queryTermsField,
             extractionResultField,
+            extractionRangeFieldsField,
             queryBuilderField,
             minimumShouldMatchFieldMapper,
             rangeFieldMapper

--- a/modules/percolator/src/main/java/org/opensearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/QueryAnalyzer.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointRangeQuery;
@@ -181,9 +182,28 @@ final class QueryAnalyzer {
 
         @Override
         public QueryVisitor getSubVisitor(Occur occur, Query parent) {
-            if (parent instanceof ApproximateScoreQuery approximateScoreQuery
-                && approximateScoreQuery.getOriginalQuery() instanceof DateRangeIncludingNowQuery) {
-                terms.add(Result.UNKNOWN);
+            if (parent instanceof ApproximateScoreQuery approximateScoreQuery) {
+                if (approximateScoreQuery.getOriginalQuery() instanceof DateRangeIncludingNowQuery) {
+                    terms.add(Result.UNKNOWN);
+                    return QueryVisitor.EMPTY_VISITOR;
+                }
+                // ApproximateScoreQuery visits both the original query and its approximation
+                // through the returned sub visitor. The approximation matches the same documents
+                // as the original query but cannot be analyzed (its leaf would come out as
+                // UNKNOWN, making the whole result unverifiable). Analyze only the original
+                // query and swallow both visits.
+                ResultBuilder child = new ResultBuilder(version, true);
+                children.add(child);
+                approximateScoreQuery.getOriginalQuery().visit(child);
+                return QueryVisitor.EMPTY_VISITOR;
+            }
+            if (parent instanceof IndexOrDocValuesQuery indexOrDocValuesQuery) {
+                // Same for IndexOrDocValuesQuery: it visits both its index query and its doc
+                // values query, which match the same documents. The doc values query usually
+                // cannot be analyzed, so analyze only the index query and swallow both visits.
+                ResultBuilder child = new ResultBuilder(version, true);
+                children.add(child);
+                indexOrDocValuesQuery.getIndexQuery().visit(child);
                 return QueryVisitor.EMPTY_VISITOR;
             }
             this.verified = isVerified(parent);
@@ -266,8 +286,15 @@ final class QueryAnalyzer {
 
         byte[] interval = new byte[16];
         NumericUtils.subtract(16, 0, prepad(upperPoint), prepad(lowerPoint), interval);
+        // Not verified, because the candidate check for ranges packs the percolated document's
+        // values into one [min, max] interval per field, which can produce false candidate matches
+        // for multi-valued documents. It is exact for single-valued documents though, so the
+        // result is verifiedIfSingleValued and the decision is deferred to percolate time, when
+        // the document's fields can be inspected.
         return new Result(
             false,
+            false,
+            true,
             Collections.singleton(new QueryExtraction(new Range(query.getField(), lowerPoint, upperPoint, interval))),
             1
         );
@@ -299,6 +326,7 @@ final class QueryAnalyzer {
 
         int msm = 0;
         boolean verified = conjunctionsWithUnknowns.size() == conjunctions.size();
+        boolean verifiedIfSingleValued = verified;
         boolean matchAllDocs = true;
         Set<QueryExtraction> extractions = new HashSet<>();
         Set<String> seenRangeFields = new HashSet<>();
@@ -323,6 +351,11 @@ final class QueryAnalyzer {
                     if (seenRangeFields.contains(queryExtraction.range.fieldName)) {
                         resultMsm = Math.max(0, resultMsm - 1);
                         verified = false;
+                        // Multiple ranges on the same field collapse into a single candidate
+                        // clause, so a candidate match no longer implies that every range
+                        // matches — not even for single-valued documents
+                        // (e.g. field:[1,2] AND field:[5,6] candidate-matches value 1).
+                        verifiedIfSingleValued = false;
                     }
                 } else {
                     // In case that there are duplicate term query extractions we need to be careful with
@@ -333,6 +366,7 @@ final class QueryAnalyzer {
                     if (extractions.contains(queryExtraction)) {
                         resultMsm = Math.max(0, resultMsm - 1);
                         verified = false;
+                        verifiedIfSingleValued = false;
                     }
                 }
             }
@@ -348,14 +382,17 @@ final class QueryAnalyzer {
                 verified = false;
 
             }
+            if (result.verifiedIfSingleValued == false || result.minimumShouldMatch < result.extractions.size()) {
+                verifiedIfSingleValued = false;
+            }
             matchAllDocs &= result.matchAllDocs;
             extractions.addAll(result.extractions);
         }
 
         if (matchAllDocs) {
-            return new Result(matchAllDocs, verified);
+            return new Result(matchAllDocs, verified, verifiedIfSingleValued);
         } else {
-            return new Result(verified, extractions, msm);
+            return new Result(false, verified, verifiedIfSingleValued, extractions, msm);
         }
     }
 
@@ -369,6 +406,7 @@ final class QueryAnalyzer {
         // Keep track of the msm for each clause:
         List<Integer> clauses = new ArrayList<>(disjunctions.size());
         boolean verified = true;
+        boolean verifiedIfSingleValued = true;
         int numMatchAllClauses = 0;
         boolean hasRangeExtractions = false;
 
@@ -397,6 +435,11 @@ final class QueryAnalyzer {
                 || (subResult.extractions.size() > 1 && requiredShouldClauses > 1)) {
                 verified = false;
             }
+            if (subResult.verifiedIfSingleValued == false
+                || subResult.minimumShouldMatch > 1
+                || (subResult.extractions.size() > 1 && requiredShouldClauses > 1)) {
+                verifiedIfSingleValued = false;
+            }
             if (subResult.matchAllDocs) {
                 numMatchAllClauses++;
             }
@@ -404,6 +447,7 @@ final class QueryAnalyzer {
             for (QueryExtraction extraction : subResult.extractions) {
                 if (terms.add(extraction) == false) {
                     verified = false;
+                    verifiedIfSingleValued = false;
                     hasDuplicateTerms = true;
                 }
             }
@@ -436,10 +480,16 @@ final class QueryAnalyzer {
         } else {
             msm = 1;
         }
+        if (hasRangeExtractions && requiredShouldClauses > 1) {
+            // With range extractions present the combined msm is collapsed to 1 (see above),
+            // dropping the candidate bar below the actual `minimum_should_match`; a candidate
+            // match then no longer implies a real match, not even for single-valued documents.
+            verifiedIfSingleValued = false;
+        }
         if (matchAllDocs) {
-            return new Result(matchAllDocs, verified);
+            return new Result(matchAllDocs, verified, verifiedIfSingleValued);
         } else {
-            return new Result(verified, terms, msm);
+            return new Result(false, verified, verifiedIfSingleValued, terms, msm);
         }
     }
 
@@ -557,19 +607,42 @@ final class QueryAnalyzer {
 
         final Set<QueryExtraction> extractions;
         final boolean verified;
+        /**
+         * Whether a candidate match doesn't need to be verified provided the percolated document
+         * contains at most one value for every field targeted by a range extraction. Candidate
+         * matching packs the document's values into a single {@code [min, max]} interval per
+         * field, which is exact for single-valued fields but can produce false candidate matches
+         * for multi-valued ones (e.g. values {1, 10} intersect a stored range [4, 6] although no
+         * actual value falls inside it).
+         * <p>
+         * Invariant: {@code verified} implies {@code verifiedIfSingleValued}.
+         */
+        final boolean verifiedIfSingleValued;
         final int minimumShouldMatch;
         final boolean matchAllDocs;
 
-        Result(boolean matchAllDocs, boolean verified, Set<QueryExtraction> extractions, int minimumShouldMatch) {
+        Result(
+            boolean matchAllDocs,
+            boolean verified,
+            boolean verifiedIfSingleValued,
+            Set<QueryExtraction> extractions,
+            int minimumShouldMatch
+        ) {
             if (minimumShouldMatch > extractions.size()) {
                 throw new IllegalArgumentException(
                     "minimumShouldMatch can't be greater than the number of extractions: " + minimumShouldMatch + " > " + extractions.size()
                 );
             }
+            assert verified == false || verifiedIfSingleValued : "verified results are trivially verified for single-valued documents";
             this.matchAllDocs = matchAllDocs;
             this.extractions = extractions;
             this.verified = verified;
+            this.verifiedIfSingleValued = verifiedIfSingleValued;
             this.minimumShouldMatch = minimumShouldMatch;
+        }
+
+        Result(boolean matchAllDocs, boolean verified, Set<QueryExtraction> extractions, int minimumShouldMatch) {
+            this(matchAllDocs, verified, verified, extractions, minimumShouldMatch);
         }
 
         Result(boolean verified, Set<QueryExtraction> extractions, int minimumShouldMatch) {
@@ -580,14 +653,18 @@ final class QueryAnalyzer {
             this(matchAllDocs, verified, Collections.emptySet(), 0);
         }
 
+        Result(boolean matchAllDocs, boolean verified, boolean verifiedIfSingleValued) {
+            this(matchAllDocs, verified, verifiedIfSingleValued, Collections.emptySet(), 0);
+        }
+
         @Override
         public String toString() {
             return extractions.toString();
         }
 
         Result unverify() {
-            if (verified) {
-                return new Result(matchAllDocs, false, extractions, minimumShouldMatch);
+            if (verified || verifiedIfSingleValued) {
+                return new Result(matchAllDocs, false, false, extractions, minimumShouldMatch);
             } else {
                 return this;
             }

--- a/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
@@ -78,6 +78,7 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
@@ -122,8 +123,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -728,6 +731,71 @@ public class CandidateQueryTests extends OpenSearchSingleNodeTestCase {
         assertEquals(1, topDocs.totalHits.value());
         assertEquals(1, topDocs.scoreDocs.length);
         assertEquals(5, topDocs.scoreDocs[0].doc);
+    }
+
+    public void testRangeQueriesVerifiedForSingleValuedDocument() throws Exception {
+        List<ParseContext.Document> docs = new ArrayList<>();
+        addQuery(IntPoint.newRangeQuery("int_field", 0, 5), docs);                          // doc 0: complete_single_valued
+        addQuery(new TermQuery(new Term("string_field", "value")), docs);                   // doc 1: complete
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(IntPoint.newRangeQuery("int_field", 0, 5), Occur.MUST);
+        builder.add(new TermQuery(new Term("string_field", "value")), Occur.MUST_NOT);
+        addQuery(builder.build(), docs);                                                    // doc 2: partial
+        indexWriter.addDocuments(docs);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        shardSearcher.setQueryCache(null);
+
+        // Single-valued document: the range-only query is covered by the verified matches query,
+        // so its candidate match skips the MemoryIndex verification.
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new IntPoint("int_field", 3)), new WhitespaceAnalyzer());
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        PercolateQuery query = (PercolateQuery) fieldType.percolateQuery(
+            "_name",
+            queryStore,
+            Collections.singletonList(new BytesArray("{}")),
+            percolateSearcher,
+            false,
+            Version.CURRENT
+        );
+        TopDocs topDocs = shardSearcher.search(query, 10);
+        assertEquals(2L, topDocs.totalHits.value()); // the range query and the range + must_not query
+
+        Set<Integer> verifiedDocIds = searchDocIds(shardSearcher, query.getVerifiedMatchesQuery());
+        // the single-valued-verified range query and the fully verified term query; never the partial one
+        assertEquals(Set.of(0, 1), verifiedDocIds);
+
+        // Multi-valued document on the ranged field: the packed [-1, 10] interval intersects the
+        // stored [0, 5] range although no actual value falls inside it. The verified matches
+        // query must exclude the range query so that the false candidate match is rejected by
+        // the MemoryIndex verification.
+        memoryIndex = MemoryIndex.fromDocument(
+            Arrays.asList(new IntPoint("int_field", -1), new IntPoint("int_field", 10)),
+            new WhitespaceAnalyzer()
+        );
+        percolateSearcher = memoryIndex.createSearcher();
+        query = (PercolateQuery) fieldType.percolateQuery(
+            "_name",
+            queryStore,
+            Collections.singletonList(new BytesArray("{}")),
+            percolateSearcher,
+            false,
+            Version.CURRENT
+        );
+        topDocs = shardSearcher.search(query, 10);
+        assertEquals(0L, topDocs.totalHits.value());
+
+        verifiedDocIds = searchDocIds(shardSearcher, query.getVerifiedMatchesQuery());
+        assertEquals(Set.of(1), verifiedDocIds); // only the term query remains verified
+    }
+
+    private static Set<Integer> searchDocIds(IndexSearcher searcher, Query query) throws IOException {
+        Set<Integer> docIds = new HashSet<>();
+        for (ScoreDoc scoreDoc : searcher.search(query, 10).scoreDocs) {
+            docIds.add(scoreDoc.doc);
+        }
+        return docIds;
     }
 
     public void testDuelRangeQueries() throws Exception {

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorFieldMapperTests.java
@@ -129,6 +129,7 @@ import static org.opensearch.index.query.QueryBuilders.termQuery;
 import static org.opensearch.index.query.QueryBuilders.termsLookupQuery;
 import static org.opensearch.index.query.QueryBuilders.wildcardQuery;
 import static org.opensearch.percolator.PercolatorFieldMapper.EXTRACTION_COMPLETE;
+import static org.opensearch.percolator.PercolatorFieldMapper.EXTRACTION_COMPLETE_SINGLE_VALUED;
 import static org.opensearch.percolator.PercolatorFieldMapper.EXTRACTION_FAILED;
 import static org.opensearch.percolator.PercolatorFieldMapper.EXTRACTION_PARTIAL;
 import static org.hamcrest.Matchers.containsString;
@@ -316,7 +317,9 @@ public class PercolatorFieldMapperTests extends OpenSearchSingleNodeTestCase {
         ParseContext.Document document = parseContext.doc();
 
         PercolatorFieldMapper.PercolatorFieldType fieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
+        // multiple ranges on the same field cannot be verified, not even for single-valued documents
         assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(fieldType.extractionRangeFieldsField.name()).length, equalTo(0));
         List<IndexableField> fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.rangeField.name())));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
@@ -339,7 +342,14 @@ public class PercolatorFieldMapperTests extends OpenSearchSingleNodeTestCase {
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
-        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        // ranges on different fields are exact for single-valued documents: the query is encoded
+        // as complete_single_valued with the ranged field names recorded for the percolate-time check
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_COMPLETE_SINGLE_VALUED));
+        List<String> rangeFieldNames = Arrays.stream(document.getFields(fieldType.extractionRangeFieldsField.name()))
+            .map(f -> f.binaryValue().utf8ToString())
+            .sorted()
+            .collect(Collectors.toList());
+        assertThat(rangeFieldNames, equalTo(Arrays.asList("number_field1", "number_field2")));
         fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.rangeField.name())));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
@@ -351,6 +361,70 @@ public class PercolatorFieldMapperTests extends OpenSearchSingleNodeTestCase {
         fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.minimumShouldMatchField.name())));
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get(0).numericValue(), equalTo(2L));
+    }
+
+    public void testExtractRangesRecordsRangeFieldsOnce() throws Exception {
+        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        addQueryFieldMappings();
+        // a disjunction of two ranges on the same field is exact for single-valued documents,
+        // and the ranged field name is recorded only once
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(mapperService.fieldType("number_field1").rangeQuery(10, 20, true, true, null, null, null, context), Occur.SHOULD);
+        bq.add(mapperService.fieldType("number_field1").rangeQuery(30, 40, true, true, null, null, null, context), Occur.SHOULD);
+
+        DocumentMapper documentMapper = mapperService.documentMapper();
+        IndexMetadata build = IndexMetadata.builder("")
+            .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexSettings settings = new IndexSettings(build, Settings.EMPTY);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(
+            settings,
+            mapperService.documentMapperParser(),
+            documentMapper,
+            null,
+            null
+        );
+        fieldMapper.processQuery(bq.build(), parseContext);
+        ParseContext.Document document = parseContext.doc();
+
+        PercolatorFieldMapper.PercolatorFieldType fieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_COMPLETE_SINGLE_VALUED));
+        IndexableField[] rangeFieldNames = document.getFields(fieldType.extractionRangeFieldsField.name());
+        assertThat(rangeFieldNames.length, equalTo(1));
+        assertThat(rangeFieldNames[0].binaryValue().utf8ToString(), equalTo("number_field1"));
+    }
+
+    public void testExtractRangesOnOldIndexVersionUsesPartial() throws Exception {
+        // indices created before the single-valued verification encoding keep writing `partial`
+        Version oldVersion = Version.V_3_7_0;
+        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        addQueryFieldMappings();
+        Query rangeQuery = mapperService.fieldType("number_field1").rangeQuery(10, 20, true, true, null, null, null, context);
+
+        DocumentMapper documentMapper = mapperService.documentMapper();
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        IndexMetadata build = IndexMetadata.builder("")
+            .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, oldVersion))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexSettings settings = new IndexSettings(build, Settings.EMPTY);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(
+            settings,
+            mapperService.documentMapperParser(),
+            documentMapper,
+            null,
+            null
+        );
+        fieldMapper.processQuery(rangeQuery, parseContext);
+        ParseContext.Document document = parseContext.doc();
+
+        PercolatorFieldMapper.PercolatorFieldType oldFieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
+        assertThat(document.getField(oldFieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(oldFieldType.extractionRangeFieldsField.name()).length, equalTo(0));
     }
 
     public void testExtractTermsAndRanges_failed() throws Exception {

--- a/modules/percolator/src/test/java/org/opensearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/QueryAnalyzerTests.java
@@ -77,6 +77,8 @@ import org.opensearch.index.search.OpenSearchToParentBlockJoinQuery;
 import org.opensearch.lucene.queries.BlendedTermQuery;
 import org.opensearch.percolator.QueryAnalyzer.QueryExtraction;
 import org.opensearch.percolator.QueryAnalyzer.Result;
+import org.opensearch.search.approximate.ApproximatePointRangeQuery;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
@@ -1542,6 +1544,118 @@ public class QueryAnalyzerTests extends OpenSearchTestCase {
         assertThat(result.extractions, hasSize(3));
         assertFalse(result.verified);
         assertFalse(result.matchAllDocs);
+    }
+
+    public void testTermQuery_verifiedIfSingleValued() {
+        // fully verified results are trivially verified for single-valued documents
+        Result result = analyze(new TermQuery(new Term("_field", "_value")), Version.CURRENT);
+        assertTrue(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+    }
+
+    public void testPointRangeQuery_verifiedIfSingleValued() {
+        Result result = analyze(IntPoint.newRangeQuery("_field", 10, 20), Version.CURRENT);
+        assertFalse(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+        assertThat(result.minimumShouldMatch, equalTo(1));
+    }
+
+    public void testIndexOrDocValuesQuery_verifiedIfSingleValued() {
+        Query query = new IndexOrDocValuesQuery(
+            IntPoint.newRangeQuery("_field", 10, 20),
+            SortedNumericDocValuesField.newSlowRangeQuery("_field", 10, 20)
+        );
+        Result result = analyze(query, Version.CURRENT);
+        assertFalse(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+    }
+
+    public void testApproximateScoreQuery_verifiedIfSingleValued() {
+        // the exact shape produced by NumberFieldMapper.NumberType#rangeQuery for a searchable
+        // field with doc values
+        Query query = new ApproximateScoreQuery(
+            new IndexOrDocValuesQuery(
+                IntPoint.newRangeQuery("_field", 10, 20),
+                SortedNumericDocValuesField.newSlowRangeQuery("_field", 10, 20)
+            ),
+            new ApproximatePointRangeQuery(
+                "_field",
+                IntPoint.pack(10).bytes,
+                IntPoint.pack(20).bytes,
+                1,
+                ApproximatePointRangeQuery.INT_FORMAT
+            )
+        );
+        Result result = analyze(query, Version.CURRENT);
+        assertFalse(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+        assertThat(result.minimumShouldMatch, equalTo(1));
+        // the approximation query is not extracted separately
+        List<QueryAnalyzer.QueryExtraction> ranges = new ArrayList<>(result.extractions);
+        assertThat(ranges.size(), equalTo(1));
+        assertEquals("_field", ranges.get(0).range.fieldName);
+    }
+
+    public void testRangeConjunction_verifiedIfSingleValued() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(IntPoint.newRangeQuery("field1", 10, 20), Occur.MUST);
+        builder.add(LongPoint.newRangeQuery("field2", 10L, 20L), Occur.MUST);
+        builder.add(new TermQuery(new Term("field3", "value")), Occur.FILTER);
+        Result result = analyze(builder.build(), Version.CURRENT);
+        assertFalse(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+        assertThat(result.minimumShouldMatch, equalTo(3));
+    }
+
+    public void testRangesOnSameFieldConjunction_notVerifiedIfSingleValued() {
+        // candidate matching collapses ranges per field, so a candidate match on one range does
+        // not imply that both match, not even for single-valued documents
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(IntPoint.newRangeQuery("field1", 10, 20), Occur.MUST);
+        builder.add(IntPoint.newRangeQuery("field1", 15, 25), Occur.MUST);
+        Result result = analyze(builder.build(), Version.CURRENT);
+        assertFalse(result.verified);
+        assertFalse(result.verifiedIfSingleValued);
+    }
+
+    public void testRangeDisjunction_verifiedIfSingleValued() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(IntPoint.newRangeQuery("field1", 10, 20), Occur.SHOULD);
+        builder.add(new TermQuery(new Term("field2", "value")), Occur.SHOULD);
+        Result result = analyze(builder.build(), Version.CURRENT);
+        assertFalse(result.verified);
+        assertTrue(result.verifiedIfSingleValued);
+        assertThat(result.minimumShouldMatch, equalTo(1));
+    }
+
+    public void testRangeDisjunctionWithMinimumShouldMatch_notVerifiedIfSingleValued() {
+        // with ranges present the combined msm collapses to 1, dropping the candidate bar below
+        // minimum_should_match=2; a candidate match no longer implies a real match
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.setMinimumNumberShouldMatch(2);
+        builder.add(IntPoint.newRangeQuery("field1", 10, 20), Occur.SHOULD);
+        builder.add(new TermQuery(new Term("field2", "value")), Occur.SHOULD);
+        builder.add(new TermQuery(new Term("field3", "value")), Occur.SHOULD);
+        Result result = analyze(builder.build(), Version.CURRENT);
+        assertFalse(result.verified);
+        assertFalse(result.verifiedIfSingleValued);
+    }
+
+    public void testMustNotWithRange_notVerifiedIfSingleValued() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(IntPoint.newRangeQuery("field1", 10, 20), Occur.MUST);
+        builder.add(new TermQuery(new Term("field2", "value")), Occur.MUST_NOT);
+        Result result = analyze(builder.build(), Version.CURRENT);
+        assertFalse(result.verified);
+        assertFalse(result.verifiedIfSingleValued);
+    }
+
+    public void testUnverifyClearsVerifiedIfSingleValued() {
+        Result result = analyze(IntPoint.newRangeQuery("_field", 10, 20), Version.CURRENT);
+        assertTrue(result.verifiedIfSingleValued);
+        Result unverified = result.unverify();
+        assertFalse(unverified.verified);
+        assertFalse(unverified.verifiedIfSingleValued);
     }
 
 }


### PR DESCRIPTION
### Description
Skips MemoryIndex verification for percolator range queries when the percolated document is single-valued in every ranged field. Percolation results are bit-for-bit identical; only the number of MemoryIndex verifications drops.

**Problem.** Any percolator query containing a range clause is indexed as `extraction_result: partial`, so every candidate match is verified through the MemoryIndex (per candidate, per request: load the stored query from doc values, parse it, evaluate it). The conservatism only protects against multi-valued documents, where candidate matching is inexact because the document's values are packed into one `[min, max]` interval per field (values `{1, 10}` intersect a stored range `[4, 6]` although no actual value falls inside it). For single-valued fields the candidate check is exact — and single-valuedness is cheaply decidable at percolate time, when the engine is holding the document.

### Related Issues
Resolves #22437

**Changes.**
Index time: QueryAnalyzer.Result gains verifiedIfSingleValued (ranges set it; degenerate shapes - same-field range conjunctions and range-bearing disjunctions under minimum_should_match > 1 - drop it). Such queries are encoded as extraction_result:complete_single_valued with the ranged field names recorded in a new extraction_range_fields subfield, gated on the index-created version.

Percolate time: the verified-matches query additionally covers complete_single_valued queries, excluding those whose ranged fields are multi-valued in the percolated document (FieldInfos + PointValues.size() over one-dimensional point fields). PercolateQuery is unchanged.

**Backwards compatibility.** The new encoding is written only for indices created on/after `SINGLE_VALUED_VERIFICATION_INDEX_VERSION`; older indices keep writing `partial`. Mixed clusters degrade gracefully: nodes unaware of the marker keep verifying those queries through the MemoryIndex (correct, just not optimized), and the widened verified-matches query matches nothing for old stored queries. No wire-format changes, no user-facing mapping parameters, no change in match results.

**Testing.**
- Existing randomized duel tests (`CandidateQueryTests`) — random documents including multi-valued fields against random range-bearing queries, compared with ground-truth evaluation — pass unmodified while now exercising the skip path (also run with `-Dtests.iters=10`).
- New targeted test asserts the verified-matches query covers a range-only stored query for a single-valued document and excludes it when the document is multi-valued on the ranged field (where the packed interval produces a false candidate that verification must reject).
- New `QueryAnalyzerTests` cover flag propagation including both downgrade cases and the DSL wrapper shapes; `PercolatorFieldMapperTests` cover the new encoding, range-field-name dedup, and the index-version gate.
- Full module green: `:modules:percolator:test`, `:modules:percolator:precommit`, `:modules:percolator:internalClusterTest`, `:modules:percolator:yamlRestTest`.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
