### PR TITLE
Fix dissect leading delimiter byte offset for multi-byte characters

### DIFF
--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectParser.java
@@ -120,6 +120,7 @@ public final class DissectParser {
     private final List<DissectPair> matchPairs;
     private final String pattern;
     private String leadingDelimiter = "";
+    private final int leadingDelimiterByteLength;
     private final int maxMatches;
     private final int maxResults;
     private final int appendCount;
@@ -133,6 +134,8 @@ public final class DissectParser {
         while (matcher.find()) {
             leadingDelimiter = matcher.group(1);
         }
+        // precompute the leading delimiter's UTF-8 byte length; parse() indexes into the input byte[] with it
+        this.leadingDelimiterByteLength = leadingDelimiter.getBytes(StandardCharsets.UTF_8).length;
         List<DissectPair> matchPairs = new ArrayList<>();
         matcher = KEY_DELIMITER_FIELD_PATTERN.matcher(pattern.substring(leadingDelimiter.length()));
         while (matcher.find()) {
@@ -225,8 +228,8 @@ public final class DissectParser {
             DissectPair dissectPair = it.next();
             DissectKey key = dissectPair.getKey();
             byte[] delimiter = dissectPair.getDelimiter().getBytes(StandardCharsets.UTF_8);
-            // start dissection after the first delimiter
-            int i = leadingDelimiter.length();
+            // start dissection after the leading delimiter, measured in bytes to stay aligned with the input byte[]
+            int i = leadingDelimiterByteLength;
             int valueStart = i;
             int lookAheadMatches;
             // start walking the input string byte by byte, look ahead for matches where needed

--- a/libs/dissect/src/test/java/org/opensearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/opensearch/dissect/DissectParserTests.java
@@ -350,6 +350,20 @@ public class DissectParserTests extends OpenSearchTestCase {
         assertMatch(",%{a} %{b}", ",,foo bar", Arrays.asList("a", "b"), Arrays.asList(",foo", "bar"));
     }
 
+    public void testLeadingDelimiterMultiByte() {
+        // A non-ASCII leading delimiter has to be measured in bytes, not chars, when seeding the value
+        // cursor. Otherwise the first value starts partway into the delimiter's bytes and comes back
+        // corrupted. Exercises 2-byte, 3-byte and 4-byte (surrogate pair) leading delimiters, single and
+        // multiple keys, a repeated delimiter, and a multi-byte value.
+        assertMatch("»%{a}", "»foo", Arrays.asList("a"), Arrays.asList("foo"));
+        assertMatch("»%{a} %{b}", "»foo bar", Arrays.asList("a", "b"), Arrays.asList("foo", "bar"));
+        assertMatch("€%{a},%{b}", "€foo,bar", Arrays.asList("a", "b"), Arrays.asList("foo", "bar"));
+        assertMatch("子%{a}", "子foo", Arrays.asList("a"), Arrays.asList("foo"));
+        assertMatch("😀%{a}", "😀foo", Arrays.asList("a"), Arrays.asList("foo"));
+        assertMatch("»%{a}", "»子", Arrays.asList("a"), Arrays.asList("子"));
+        assertMatch("»»%{a} %{b}", "»»foo bar", Arrays.asList("a", "b"), Arrays.asList("foo", "bar"));
+    }
+
     /**
      * Runtime errors
      */


### PR DESCRIPTION
### Description

`DissectParser.parse` seeds the value cursor with `leadingDelimiter.length()` — a **char** count — but uses it to index into the `input` **byte array** (`input = inputString.getBytes(UTF_8)`). When the leading delimiter contains a non-ASCII character its char length is smaller than its byte length, so the first value starts partway into the delimiter's bytes and comes back corrupted. Nothing is thrown — it silently returns the wrong value.

```java
byte[] input = inputString.getBytes(StandardCharsets.UTF_8); // byte domain
...
int i = leadingDelimiter.length();   // char count used as an index into input[]
int valueStart = i;
```

Example — pattern `»%{a}`, input `»foo` (`»` = U+00BB = 2 bytes):
- `leadingDelimiter.length()` is `1`, so `valueStart = 1` — one byte into the 2-byte `»`.
- the first value becomes `copyOfRange(input, 1, …)` = `[BB, 66, 6F, 6F]`, which decodes to `"�foo"`.
- result is `{a="�foo"}`; expected `{a="foo"}`.

**Root cause.** The between-key delimiters in the same method are already handled in the byte domain — `delimiter = dissectPair.getDelimiter().getBytes(UTF_8)`, indexed against `input.length`. Only the *leading* delimiter measured its offset with `String.length()`. `testLogstashSpecs` already relies on multi-byte between-key delimiters (`»`, `€`) working, so multi-byte delimiters are a supported case — the leading position was just overlooked.

**Fix.** Measure the leading delimiter in bytes, matching the rest of the method:

```java
int i = leadingDelimiter.getBytes(StandardCharsets.UTF_8).length;
```

One line; `StandardCharsets` is already imported. This is the only place in `parse` where a char length indexed the byte array — lines 137/221/222 operate on `String`s in the char domain and are correct. Reachable via the `dissect` ingest processor with any pattern whose leading delimiter contains a non-ASCII character.

**Test.** Added `testLeadingDelimiterMultiByte` next to the existing `testLeadingDelimiter`, covering 2-byte (`»`), 3-byte (`€`, `子`) and 4-byte / surrogate-pair (`😀`) leading delimiters, single and multiple keys, a repeated delimiter, and a multi-byte value. It fails before the fix (`Expected: "foo" but: was "�foo"`) and passes after. The `:libs:opensearch-dissect` test suite plus `precommit` (spotless, checkstyle, forbiddenApis, licenseHeaders) are green locally.

### Related Issues

No linked issue — found by reading the code.

### Check List
- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
