### PR TITLE
Fix duplicate elements left by CollectionUtils.sortAndDedup

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
@@ -123,8 +123,13 @@ public class CollectionUtils {
 
         do {
             T old = oldArray.next(); // get the next item and advance iter
-            if (comparator.compare(cmp, old) != 0 && (cmp = deduped.next()) != old) {
-                deduped.set(old);
+            if (comparator.compare(cmp, old) != 0) {
+                // a new unique value: advance the write cursor and only copy when it isn't already in place
+                if (deduped.next() != old) {
+                    deduped.set(old);
+                }
+                // remember the value we just retained, not the (possibly stale) value under the write cursor
+                cmp = old;
             }
         } while (oldArray.hasNext());
         // in place update

--- a/server/src/test/java/org/opensearch/common/util/CollectionUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/util/CollectionUtilsTests.java
@@ -102,7 +102,22 @@ public class CollectionUtilsTests extends OpenSearchTestCase {
         assertDeduped(List.of(-1, 0, 2, 1, -1, 19, -1), Comparator.naturalOrder(), 5);
         // test sorted array
         assertDeduped(List.of(-1, 0, 1, 2, 19, 19), Comparator.naturalOrder(), 5);
-        // test sorted
+        // multiple consecutive duplicate runs: every run after the first previously survived because the
+        // last-retained value was tracked incorrectly, leaving spurious duplicates
+        assertDeduped(List.of(0, 0, 1, 1), Comparator.naturalOrder(), 2);
+        assertDeduped(List.of(2, 2, 2, 3, 3), Comparator.naturalOrder(), 2);
+        assertDeduped(List.of(0, 0, 1, 1, 2, 2), Comparator.naturalOrder(), 3);
+        assertDeduped(List.of(1, 1, 2, 3, 3, 3), Comparator.naturalOrder(), 3);
+        // duplicate runs followed by a trailing unique value
+        assertDeduped(List.of(0, 0, 1, 1, 2), Comparator.naturalOrder(), 3);
+        // unsorted input with several duplicate groups
+        assertDeduped(List.of(5, 1, 5, 1, 3, 3), Comparator.naturalOrder(), 3);
+        // reverse comparator across multiple runs
+        assertDeduped(List.of(1, 1, 2, 2, 3, 3), Comparator.reverseOrder(), 3);
+        // distinct object references that are equal by the comparator (values outside the Integer autobox
+        // cache): dedup must still collapse them -- equality is decided by the comparator, not by reference
+        assertDeduped(List.of(1000, 1000, 2000, 2000), Comparator.naturalOrder(), 2);
+        assertDeduped(List.of(1000, 1000, 1000, 2000, 2000), Comparator.naturalOrder(), 2);
     }
 
     public void testEmptyPartition() {


### PR DESCRIPTION
### Description

`CollectionUtils.sortAndDedup(List, Comparator)` can leave duplicate elements in the list. After it retains a new unique value it updates its "last retained value" tracker from the wrong source, so once the input contains two or more consecutive runs of equal values, every run after the first survives.

```java
T cmp = deduped.next(); // meant to hold the last retained value
...
do {
    T old = oldArray.next();
    // cmp is reassigned from the write cursor (deduped.next()), not from the retained value `old`
    if (comparator.compare(cmp, old) != 0 && (cmp = deduped.next()) != old) {
        deduped.set(old);
    }
} while (oldArray.hasNext());
```

When a new unique `old` is found, `cmp` is assigned `deduped.next()` — the value currently under the write cursor — instead of `old`, the value actually being kept. `cmp` then goes stale and the next comparison is made against the wrong value.

Example:
- `sortAndDedup([0, 0, 1, 1], naturalOrder())` returns `[0, 1, 1]` (expected `[0, 1]`)
- `sortAndDedup([2, 2, 2, 3, 3], naturalOrder())` returns `[2, 3, 3]` (expected `[2, 3]`)

It triggers whenever a sorted run of ≥2 equal values is followed by another run of ≥2 equal values.

### Impact

`BinaryFieldMapper` calls this to dedup a document's multi-valued `binary` doc-values before serialization:

```java
// server/src/main/java/org/opensearch/index/mapper/BinaryFieldMapper.java:294
CollectionUtils.sortAndDedup(bytesList, Arrays::compareUnsigned);
```

A document whose binary field holds values like `{aa, aa, bb, bb}` is stored as `[aa, bb, bb]` — duplicated, oversized stored doc-values.

### Root cause / fix

The sibling `BytesRefUtils.sortAndDedup` uses the standard adjacent `previous`/`current` compare and is correct. Track the retained value directly instead of the write-cursor value:

```java
if (comparator.compare(cmp, old) != 0) {
    // a new unique value: advance the write cursor and only copy when it isn't already in place
    if (deduped.next() != old) {
        deduped.set(old);
    }
    cmp = old; // remember the value we just retained
}
```

This keeps the original in-place write and the reference-equality skip (avoids a redundant `set` when the value is already in position); it only corrects which value `cmp` tracks. This is the only `ListIterator`-based dedup in the class, and `BinaryFieldMapper` is its only production caller.

### Test

Extended `CollectionUtilsTests.testSortAndDedup` with multiple-consecutive-run cases (`[0,0,1,1]`, `[2,2,2,3,3]`, `[0,0,1,1,2,2]`, runs followed by a trailing unique, unsorted multi-group input, and a reverse comparator). The existing `assertDeduped` helper already exercises both `ArrayList` and `LinkedList` and asserts that adjacent elements differ. The new cases fail before the fix (spurious duplicates survive) and pass after. `:libs:opensearch-core` precommit and the `CollectionUtilsTests` suite are green locally.

### Related Issues

No linked issue — found by reading the code.

### Check List
- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
