### PR TITLE
fix: correct typos in comments and documentation

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -216,7 +216,7 @@ It's typically easier to wait until the console stops scrolling, and then run `c
 ```bash
 curl localhost:9200
 ```
-The expected reponse should be
+The expected response should be
 ```
 {
   "name" : "runTask-0",

--- a/buildSrc/src/main/java/org/opensearch/gradle/ExportOpenSearchBuildResourcesTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/ExportOpenSearchBuildResourcesTask.java
@@ -58,8 +58,8 @@ import java.util.Set;
 /**
  * Export OpenSearch build resources to configurable paths
  * <p>
- * Wil overwrite existing files and create missing directories.
- * Useful for resources that that need to be passed to other processes trough the filesystem or otherwise can't be
+ * Will overwrite existing files and create missing directories.
+ * Useful for resources that need to be passed to other processes through the filesystem or otherwise can't be
  * consumed from the classpath.
  */
 public class ExportOpenSearchBuildResourcesTask extends DefaultTask {

--- a/buildSrc/src/main/java/org/opensearch/gradle/VersionProperties.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/VersionProperties.java
@@ -58,7 +58,7 @@ public class VersionProperties {
 
     public static String getBundledJdk(final String platform, final String arch) {
         switch (platform) {
-            case "darwin": // fall trough
+            case "darwin": // fall through
             case "mac":
                 return bundledJdkDarwin;
             case "freebsd":

--- a/libs/core/src/main/java/org/opensearch/core/compress/CompressorRegistry.java
+++ b/libs/core/src/main/java/org/opensearch/core/compress/CompressorRegistry.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 /**
  * A registry that wraps a static Map singleton which holds a mapping of unique String names (typically the
- * compressor header as a string) to registerd {@link Compressor} implementations.
+ * compressor header as a string) to registered {@link Compressor} implementations.
  * <p>
  * This enables plugins, modules, extensions to register their own compression implementations through SPI
  *

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -140,7 +140,7 @@ public class StemmerTokenFilterFactoryTests extends OpenSearchTokenStreamTestCas
             assertAnalyzesTo(analyzer, "horses", new String[] { "horse" });
             assertAnalyzesTo(analyzer, "cameras", new String[] { "camera" });
 
-            // The orginal s stemmer gives up on stemming oes words because English has no fixed rule for the stem
+            // The original s stemmer gives up on stemming oes words because English has no fixed rule for the stem
             // (see https://howtospell.co.uk/making-O-words-plural )
             // This stemmer removes the es but retains e for a small number of exceptions
             assertAnalyzesTo(analyzer, "mosquitoes", new String[] { "mosquito" });

--- a/server/src/internalClusterTest/java/org/opensearch/merge/MergeStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/merge/MergeStatsIT.java
@@ -103,12 +103,12 @@ public class MergeStatsIT extends RemoteStoreBaseIntegTestCase {
                 // nodes and updated by different callbacks in the warmer flow, so they only
                 // reconcile once the async warmer push has fully completed on both sides.
                 assertEquals(
-                    "Expected sent size by node 2 to be equal to recieved size by node 1.",
+                    "Expected sent size by node 2 to be equal to received size by node 1.",
                     allNodesStats.get(0).getIndices().getMerge().getWarmerStats().getTotalReceivedSize(),
                     allNodesStats.get(1).getIndices().getMerge().getWarmerStats().getTotalSentSize()
                 );
                 assertEquals(
-                    "Expected sent size by node 1 to be equal to recieved size by node 2.",
+                    "Expected sent size by node 1 to be equal to received size by node 2.",
                     allNodesStats.get(0).getIndices().getMerge().getWarmerStats().getTotalSentSize(),
                     allNodesStats.get(1).getIndices().getMerge().getWarmerStats().getTotalReceivedSize()
                 );
@@ -168,12 +168,12 @@ public class MergeStatsIT extends RemoteStoreBaseIntegTestCase {
 
             for (int shard = 0; shard <= 1; shard++) {
                 assertEquals(
-                    "Expected sent size by primary shard to be equal to recieved size by replica shard.",
+                    "Expected sent size by primary shard to be equal to received size by replica shard.",
                     shardsSentAndReceivedSize.get("[" + indices[0] + "][" + shard + "][R]").get("RECEIVED"),
                     shardsSentAndReceivedSize.get("[" + indices[0] + "][" + shard + "][P]").get("SENT")
                 );
                 assertEquals(
-                    "Expected sent size by replica shard to be equal to recieved size by primary shard.",
+                    "Expected sent size by replica shard to be equal to received size by primary shard.",
                     shardsSentAndReceivedSize.get("[" + indices[0] + "][" + shard + "][R]").get("SENT"),
                     shardsSentAndReceivedSize.get("[" + indices[0] + "][" + shard + "][P]").get("RECEIVED")
                 );

--- a/server/src/main/java/org/opensearch/common/util/CuckooFilter.java
+++ b/server/src/main/java/org/opensearch/common/util/CuckooFilter.java
@@ -321,7 +321,7 @@ public class CuckooFilter implements Writeable {
 
     /**
      * Low-level insert method. Attempts to write the fingerprint into an empty entry
-     * at this bucket's position.  Returns true if that was sucessful, false if all entries
+     * at this bucket's position.  Returns true if that was successful, false if all entries
      * were occupied.
      * <p>
      * If the fingerprint already exists in one of the entries, it will not duplicate the

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureMemoryManager.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureMemoryManager.java
@@ -50,7 +50,7 @@ import java.util.function.ToLongFunction;
  * <p>
  * MemoryManager attempts to increase of decrease the shard limits in case the shard utilization goes below operating_factor.lower or
  * goes above operating_factor.upper of current shard limits. MemoryManager attempts to update the new shard limit such that the new value
- * remains withing the operating_factor.optimal range of current shard utilization.
+ * remains within the operating_factor.optimal range of current shard utilization.
  *
  * @opensearch.internal
  */

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/NonPruningSortedSetOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/NonPruningSortedSetOrdinalsIndexFieldData.java
@@ -221,7 +221,7 @@ public class NonPruningSortedSetOrdinalsIndexFieldData extends SortedSetOrdinals
 
         @Override
         public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
-            // explictly disable pruning
+            // explicitly disable pruning
             return delegate.getComparator(numHits, Pruning.NONE);
         }
 

--- a/server/src/main/java/org/opensearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/opensearch/transport/TransportMessageListener.java
@@ -93,7 +93,7 @@ public interface TransportMessageListener {
 
     /**
      * Called for every response received
-     * @param requestId the request id for this reponse
+     * @param requestId the request id for this response
      * @param context the response context or null if the context was already processed ie. due to a timeout.
      */
     default void onResponseReceived(long requestId, Transport.ResponseContext context) {}

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -753,7 +753,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         assertEquals(1, testListener.getPhaseCurrent(expandPhase.getSearchPhaseNameOptional().get()));
 
         action.executeNextPhase(expandPhase, fetchPhase);
-        action.onPhaseDone(); /* finish phase since we don't have reponse being sent */
+        action.onPhaseDone(); /* finish phase since we don't have response being sent */
 
         assertThat(testListener.getPhaseMetric(expandPhase.getSearchPhaseNameOptional().get()), greaterThanOrEqualTo(delay));
         assertEquals(1, testListener.getPhaseTotal(expandPhase.getSearchPhaseNameOptional().get()));

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
@@ -494,7 +494,7 @@ public class IndicesServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     /**
-     * Tests that teh {@link MapperService} created by {@link IndicesService#createIndexMapperService(IndexMetadata)} contains
+     * Tests that the {@link MapperService} created by {@link IndicesService#createIndexMapperService(IndexMetadata)} contains
      * custom types and similarities registered by plugins
      */
     public void testStandAloneMapperServiceWithPlugins() throws IOException {


### PR DESCRIPTION
## Description

This PR fixes 12 misspellings found in comments and documentation across the codebase:

| File | Typo | Fix |
|------|------|-----|
| IndicesServiceTests.java | `teh` | `the` |
| MergeStatsIT.java (4x) | `recieved` | `received` |
| TransportMessageListener.java | `reponse` | `response` |
| AbstractSearchAsyncActionTests.java | `reponse` | `response` |
| DEVELOPER_GUIDE.md | `reponse` | `response` |
| CuckooFilter.java | `sucessful` | `successful` |
| CompressorRegistry.java | `registerd` | `registered` |
| NonPruningSortedSetOrdinalsIndexFieldData.java | `explictly` | `explicitly` |
| ShardIndexingPressureMemoryManager.java | `withing` | `within` |
| ExportOpenSearchBuildResourcesTask.java | `Wil`, `trough` | `Will`, `through` |
| VersionProperties.java | `trough` | `through` |
| StemmerTokenFilterFactoryTests.java | `orginal` | `original` |

All changes are in comments and documentation only - no code logic changes.

Signed-off-by: Akanksha Trehan <akankshatrehun@gmail.com>