### PR TITLE
perf: optimize bucket counting and tracking in LongKeyedBucketOrds

### DIFF
--- a/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/bucket/terms/LongKeyedBucketOrdsBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/bucket/terms/LongKeyedBucketOrdsBenchmark.java
@@ -182,4 +182,17 @@ public class LongKeyedBucketOrdsBenchmark {
             bh.consume(ords);
         }
     }
+
+    @Benchmark
+    public void benchmarkBucketsInOrdAndMaxOwning(Blackhole bh) {
+        try (LongKeyedBucketOrds ords = LongKeyedBucketOrds.build(bigArrays, CardinalityUpperBound.MANY)) {
+            for (long i = 0; i < 50_000; i++) {
+                ords.add(i % 100, i % DISTINCT_VALUES);
+            }
+            for (long j = 0; j < 10_000; j++) {
+                bh.consume(ords.bucketsInOrd(j % 100));
+                bh.consume(ords.maxOwningBucketOrd());
+            }
+        }
+    }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -52,8 +52,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
         return cardinality.map(estimate -> estimate < 2 ? new FromSingle(bigArrays) : new FromMany(bigArrays));
     }
 
-    private LongKeyedBucketOrds() {
-    }
+    private LongKeyedBucketOrds() {}
 
     /**
      * Add the {@code owningBucketOrd, value} pair. Return the ord for
@@ -108,7 +107,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
     public interface BucketOrdsEnum {
         /**
          * Advance to the next value.
-         * 
+         *
          * @return {@code true} if there *is* a next value,
          *         {@code false} if there isn't
          */
@@ -250,8 +249,10 @@ public abstract class LongKeyedBucketOrds implements Releasable {
             // performance.
             long ord = ords.add(owningBucketOrd, value);
             if (ord >= 0) {
-                maxOwningBucketOrd = Math.max(maxOwningBucketOrd, owningBucketOrd);
-                bucketOrdsCounts = bigArrays.grow(bucketOrdsCounts, owningBucketOrd + 1);
+                if (owningBucketOrd > maxOwningBucketOrd) {
+                    maxOwningBucketOrd = owningBucketOrd;
+                    bucketOrdsCounts = bigArrays.grow(bucketOrdsCounts, owningBucketOrd + 1);
+                }
                 bucketOrdsCounts.increment(owningBucketOrd, 1);
             }
             return ord;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -52,7 +52,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
         return cardinality.map(estimate -> estimate < 2 ? new FromSingle(bigArrays) : new FromMany(bigArrays));
     }
 
-    private LongKeyedBucketOrds() {}
+    private LongKeyedBucketOrds() {
+    }
 
     /**
      * Add the {@code owningBucketOrd, value} pair. Return the ord for
@@ -107,6 +108,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
     public interface BucketOrdsEnum {
         /**
          * Advance to the next value.
+         * 
          * @return {@code true} if there *is* a next value,
          *         {@code false} if there isn't
          */
@@ -157,7 +159,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public long add(long owningBucketOrd, long value) {
-            // This is in the critical path for collecting most aggs. Be careful of performance.
+            // This is in the critical path for collecting most aggs. Be careful of
+            // performance.
             assert owningBucketOrd == 0;
             return ords.add(value);
         }
@@ -243,12 +246,13 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public long add(long owningBucketOrd, long value) {
-            // This is in the critical path for collecting most aggs. Be careful of performance.
+            // This is in the critical path for collecting most aggs. Be careful of
+            // performance.
             long ord = ords.add(owningBucketOrd, value);
             if (ord >= 0) {
                 maxOwningBucketOrd = Math.max(maxOwningBucketOrd, owningBucketOrd);
                 bucketOrdsCounts = bigArrays.grow(bucketOrdsCounts, owningBucketOrd + 1);
-                bucketOrdsCounts.set(owningBucketOrd, bucketOrdsCounts.get(owningBucketOrd) + 1);
+                bucketOrdsCounts.increment(owningBucketOrd, 1);
             }
             return ord;
         }
@@ -316,13 +320,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public void close() {
-            try {
-                ords.close();
-            } finally {
-                if (bucketOrdsCounts != null) {
-                    bucketOrdsCounts.close();
-                }
-            }
+            ords.close();
+            bucketOrdsCounts.close();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -34,6 +34,7 @@ package org.opensearch.search.aggregations.bucket.terms;
 
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.LongArray;
 import org.opensearch.common.util.LongLongHash;
 import org.opensearch.common.util.ReorganizingLongHash;
 import org.opensearch.search.aggregations.CardinalityUpperBound;
@@ -229,16 +230,27 @@ public abstract class LongKeyedBucketOrds implements Releasable {
      * @opensearch.internal
      */
     public static class FromMany extends LongKeyedBucketOrds {
+        private final BigArrays bigArrays;
         private final LongLongHash ords;
+        private long maxOwningBucketOrd = -1;
+        private LongArray bucketOrdsCounts;
 
         public FromMany(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
             ords = new LongLongHash(2, bigArrays);
+            bucketOrdsCounts = bigArrays.newLongArray(1, true);
         }
 
         @Override
         public long add(long owningBucketOrd, long value) {
             // This is in the critical path for collecting most aggs. Be careful of performance.
-            return ords.add(owningBucketOrd, value);
+            long ord = ords.add(owningBucketOrd, value);
+            if (ord >= 0) {
+                maxOwningBucketOrd = Math.max(maxOwningBucketOrd, owningBucketOrd);
+                bucketOrdsCounts = bigArrays.grow(bucketOrdsCounts, owningBucketOrd + 1);
+                bucketOrdsCounts.set(owningBucketOrd, bucketOrdsCounts.get(owningBucketOrd) + 1);
+            }
+            return ord;
         }
 
         @Override
@@ -253,14 +265,10 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public long bucketsInOrd(long owningBucketOrd) {
-            // TODO it'd be faster to count the number of buckets in a list of these ords rather than one at a time
-            long count = 0;
-            for (long i = 0; i < ords.size(); i++) {
-                if (ords.getKey1(i) == owningBucketOrd) {
-                    count++;
-                }
+            if (owningBucketOrd >= bucketOrdsCounts.size()) {
+                return 0;
             }
-            return count;
+            return bucketOrdsCounts.get(owningBucketOrd);
         }
 
         @Override
@@ -270,12 +278,7 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public long maxOwningBucketOrd() {
-            // TODO this is fairly expensive to compute. Can we avoid needing it?
-            long max = -1;
-            for (long i = 0; i < ords.size(); i++) {
-                max = Math.max(max, ords.getKey1(i));
-            }
-            return max;
+            return maxOwningBucketOrd;
         }
 
         @Override
@@ -313,7 +316,13 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
         @Override
         public void close() {
-            ords.close();
+            try {
+                ords.close();
+            } finally {
+                if (bucketOrdsCounts != null) {
+                    bucketOrdsCounts.close();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
This PR optimizes `LongKeyedBucketOrds.FromMany` to replace $O(N)$ linear scans in `bucketsInOrd` and `maxOwningBucketOrd` with $O(1)$ operations:
1. Tracks `maxOwningBucketOrd` dynamically as a class field updated on insertions.
2. Caches bucket counts per `owningBucketOrd` in a `LongArray` managed by `BigArrays`, incrementing it incrementally.

### Tests and Verification
- **Unit Tests**: Running `./gradlew :server:test --tests "org.opensearch.search.aggregations.bucket.terms.LongKeyedBucketOrdsTests"` passed successfully.
- **Spotless Formatting**: Verified with `./gradlew spotlessJavaCheck`.
- **Microbenchmarking**: Microbenchmarks show a ~4x speedup in lookup operations (see the corresponding issue for details).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Related Issues
Resolves #22449 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
