### PR TITLE
Return 400 for user-facing planner validation errors

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -122,7 +122,7 @@ public class FieldStorageResolver {
         for (String fieldName : fieldNames) {
             FieldStorageInfo info = fieldStorage.get(fieldName);
             if (info == null) {
-                throw new IllegalStateException("Field [" + fieldName + "] not found in field storage for index");
+                throw new IllegalArgumentException("Field [" + fieldName + "] not found in field storage for index");
             }
             result.add(info);
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -283,7 +283,7 @@ public class OpenSearchFilterRule extends RelOptRule {
             }
             ScalarFunction scalarFunc = ScalarFunction.fromSqlOperatorWithFallback(scalarFunctionCall.getOperator());
             if (scalarFunc == null) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                     "Unrecognized scalar function ["
                         + scalarFunctionCall.getOperator().getName()
                         + "] in call ["

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -94,7 +94,7 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
         // cleanly — aliases legitimately span such indices next to populated ones — and resolving
         // any field against it alone fails with the standard "not found" error.
         FieldStorageResolver resolver = newMappinglessResolver();
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> resolver.resolve(List.of("name")));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> resolver.resolve(List.of("name")));
         assertTrue("expected 'not found' error, got: " + ex.getMessage(), ex.getMessage().contains("not found in field storage"));
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -978,7 +978,7 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(table), predicate);
         PlannerContext context = buildContext("parquet", Map.of("name", Map.of("type", "keyword", "index", true)));
 
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> runPlanner(filter, context));
         assertTrue(
             "Message must name the unrecognized scalar function",
             exception.getMessage().contains("Unrecognized scalar function [FAKE_UDF]")


### PR DESCRIPTION
## Description

Changes two specific `IllegalStateException` throws to `IllegalArgumentException` in the analytics engine planner. These are error paths triggered by user-caused issues that should return HTTP 400 (actionable error) rather than 500 (redacted internal error).

### Changes

| File | Error | Rationale |
|------|-------|-----------|
| `FieldStorageResolver.java` | "Field [X] not found in field storage for index" | User's query references a field that doesn't exist in the index mapping (e.g., typo in field name). |
| `OpenSearchFilterRule.java` | "Unrecognized scalar function [X] in call [Y]" | User used an unsupported UDF in a WHERE clause. |
