### PR TITLE
add remote store translog tracker getter

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
@@ -137,4 +137,8 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
     public Repository getRepository() {
         return repository;
     }
+
+    public RemoteTranslogTransferTracker getRemoteTranslogTransferTracker() {
+        return remoteTranslogTransferTracker;
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add getter method for remote translog transfer tracker in `RemoteBlobStoreInternalTranslogFactory` to enable external access to tracking metrics.

What does this change do and how does it modify current behavior?
No Change in any workflow. Adds a public getter method `getRemoteTranslogTransferTracker()` that returns the `RemoteTranslogTransferTracker` instance from `RemoteBlobStoreInternalTranslogFactory`

Why is this change needed and how does this address the problem being solved?
This is required for the plugins (`opensearch-storage-encryption`) which has its own factory implemention overriding the `RemoteFsTranslog`. So they would be able to use the same tracker instance which could be aggregated and shared. Otherwise the tracker used in overridden impl is not considered.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
