### PR TITLE
Add supportsWildcard capability to Attribute interface

### DIFF
--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/Attribute.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/Attribute.java
@@ -49,6 +49,19 @@ public interface Attribute extends Writeable {
     }
 
     /**
+     * Indicates whether this attribute supports the wildcard character ({@code *}) in its rule values.
+     * Attributes that perform prefix (wildcard) matching override their {@link #findAttributeMatches}
+     * implementation to use {@link org.opensearch.rule.storage.AttributeValueStore#getMatches} which
+     * is wildcard-aware. Defaults to {@code true} because the framework's default
+     * {@code findAttributeMatches} uses {@code getMatches}. Attributes that match via
+     * {@link org.opensearch.rule.storage.AttributeValueStore#getExactMatch} should override this
+     * to return {@code false} if they do not intend to honor wildcards.
+     */
+    default boolean supportsWildcard() {
+        return true;
+    }
+
+    /**
      * Ensure that `validateAttribute` is called in the constructor of attribute implementations
      * to prevent potential serialization issues.
      */

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/RuleAttributeTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/RuleAttributeTests.java
@@ -36,6 +36,10 @@ public class RuleAttributeTests extends OpenSearchTestCase {
         assertTrue(RuleAttribute.INDEX_PATTERN.getWeightedSubfields().isEmpty());
     }
 
+    public void testIndexPatternSupportsWildcard() {
+        assertTrue(RuleAttribute.INDEX_PATTERN.supportsWildcard());
+    }
+
     public void testFromXContentParseAttributeValues_success() throws IOException {
         String json = "{ \"index_pattern\": [\"val1\", \"val2\"] }";
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(null, null, json)) {


### PR DESCRIPTION
### Description
Adds a `supportsWildcard()` default method to the `Attribute` interface, returning `true`. This declares the capability contract: the framework's default `findAttributeMatches` implementation uses `getMatches`, which is wildcard-aware (trailing `*` = prefix match, no `*` = exact match, per #22461). Attributes that match via `getExactMatch` and do not honor wildcards can override to return `false`.

This is the core-side preparation for enabling wildcard support in `principal.username`/`principal.role` rules. The matching-side change (switching `PrincipalAttribute.findAttributeMatches` from `getExactMatch` to `getMatches`) will be a companion PR in opensearch-project/security.

### Related Issues
Resolves #22456

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.