### PR TITLE
Match index_pattern rules exactly unless value ends in wildcard

### DIFF
--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
@@ -25,6 +25,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * ref: https://commons.apache.org/proper/commons-collections/javadocs/api-4.4/org/apache/commons/collections4/trie/PatriciaTrie.html
  */
 public class DefaultAttributeValueStore<K extends String, V> implements AttributeValueStore<K, V> {
+    /**
+     * Trailing character in a stored value that marks it as a prefix (wildcard) pattern. A stored value
+     * without this character is matched exactly.
+     */
+    private static final String WILDCARD = "*";
     private final PatriciaTrie<Set<V>> trie;
     private static final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private static final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
@@ -96,18 +101,30 @@ public class DefaultAttributeValueStore<K extends String, V> implements Attribut
         readLock.lock();
         try {
             List<MatchLabel<V>> results = new ArrayList<>();
-            StringBuilder prefixBuilder = new StringBuilder(key);
 
+            // Exact match: a value stored without a trailing wildcard matches the request key exactly.
+            // The empty key is reserved for "no constraint" rules and is handled separately below.
+            if (!key.isEmpty()) {
+                addMatches(results, trie.get(key), 1f);
+            }
+
+            // Prefix (wildcard) matches: a stored value of the form "<prefix>*" matches the request key
+            // when the key starts with <prefix>. Walk each prefix of the key from longest to shortest.
+            StringBuilder prefixBuilder = new StringBuilder(key);
             for (int i = key.length(); i >= 0; i--) {
-                Set<V> values = trie.get(prefixBuilder.toString());
+                Set<V> values = trie.get(prefixBuilder.toString() + WILDCARD);
                 if (values != null && !values.isEmpty()) {
-                    float score = (float) prefixBuilder.length() / key.length();
+                    float score = key.isEmpty() ? 0f : (float) prefixBuilder.length() / key.length();
                     addMatches(results, values, score);
                 }
                 if (!prefixBuilder.isEmpty()) {
                     prefixBuilder.deleteCharAt(prefixBuilder.length() - 1);
                 }
             }
+
+            // Rules that do not constrain this attribute are stored under the empty key and match anything.
+            addMatches(results, trie.get(""), 0f);
+
             return results;
         } finally {
             readLock.unlock();

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
@@ -103,22 +103,25 @@ public class DefaultAttributeValueStore<K extends String, V> implements Attribut
             List<MatchLabel<V>> results = new ArrayList<>();
 
             // Exact match: a value stored without a trailing wildcard matches the request key exactly.
-            // The empty key is reserved for "no constraint" rules and is handled separately below.
-            if (!key.isEmpty()) {
+            // A key that itself ends in the wildcard character is only a prefix (wildcard) value and is
+            // handled by the loop below; the empty key is reserved for "no constraint" rules.
+            if (!key.isEmpty() && !key.endsWith(WILDCARD)) {
                 addMatches(results, trie.get(key), 1f);
             }
 
             // Prefix (wildcard) matches: a stored value of the form "<prefix>*" matches the request key
             // when the key starts with <prefix>. Walk each prefix of the key from longest to shortest.
-            StringBuilder prefixBuilder = new StringBuilder(key);
-            for (int i = key.length(); i >= 0; i--) {
-                Set<V> values = trie.get(prefixBuilder.toString() + WILDCARD);
-                if (values != null && !values.isEmpty()) {
-                    float score = key.isEmpty() ? 0f : (float) prefixBuilder.length() / key.length();
-                    addMatches(results, values, score);
-                }
-                if (!prefixBuilder.isEmpty()) {
-                    prefixBuilder.deleteCharAt(prefixBuilder.length() - 1);
+            if (!key.isEmpty()) {
+                StringBuilder prefixBuilder = new StringBuilder(key);
+                for (int i = key.length(); i >= 0; i--) {
+                    Set<V> values = trie.get(prefixBuilder.toString() + WILDCARD);
+                    if (values != null && !values.isEmpty()) {
+                        float score = (float) prefixBuilder.length() / key.length();
+                        addMatches(results, values, score);
+                    }
+                    if (!prefixBuilder.isEmpty()) {
+                        prefixBuilder.deleteCharAt(prefixBuilder.length() - 1);
+                    }
                 }
             }
 

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
@@ -84,6 +84,13 @@ public class AttributeValueStoreTests extends OpenSearchTestCase {
         assertTrue(subjectUnderTest.getMatches("fo").isEmpty());
     }
 
+    public void testWildcardRequestKeyMatchesWildcardValueOnce() {
+        // A request key that is itself a wildcard expression ("fox*") must match a stored "fox*" value
+        // only once (via the prefix branch), not additionally via an exact match, to avoid inflating score.
+        subjectUnderTest.put("fox*", "lucy");
+        assertEquals(1, subjectUnderTest.getMatches("fox*").size());
+    }
+
     public void testClear() {
         subjectUnderTest.put("foo", "bar");
         subjectUnderTest.clear();

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
@@ -88,7 +88,49 @@ public class AttributeValueStoreTests extends OpenSearchTestCase {
         // A request key that is itself a wildcard expression ("fox*") must match a stored "fox*" value
         // only once (via the prefix branch), not additionally via an exact match, to avoid inflating score.
         subjectUnderTest.put("fox*", "lucy");
-        assertEquals(1, subjectUnderTest.getMatches("fox*").size());
+        List<MatchLabel<String>> matches = subjectUnderTest.getMatches("fox*");
+        assertEquals(1, matches.size());
+        assertEquals("lucy", matches.get(0).getFeatureValue());
+        // Stem "fox" (length 3) over request "fox*" (length 4) scores 0.75; without the exact-branch guard the
+        // exact hit on "fox*" would add a second 1.0 match and the caller's score summation would inflate it.
+        assertEquals(0.75f, matches.get(0).getMatchScore(), 0.0f);
+
+        // A wildcard request key must not exact-match a non-wildcard stored value of the same stem.
+        subjectUnderTest.put("fox", "exact");
+        assertEquals(Set.of("lucy"), extractFeatureValues(subjectUnderTest.getMatches("fox*")));
+    }
+
+    public void testExactAndWildcardValuesWithSameStemAreDistinct() {
+        // "fox" (exact) and "fox*" (prefix) are stored under distinct keys and matched independently.
+        subjectUnderTest.put("fox", "exact");
+        subjectUnderTest.put("fox*", "prefix");
+
+        // Request "fox" matches the exact value (score 1.0) and the wildcard stem (score 1.0).
+        assertEquals(Set.of("exact", "prefix"), extractFeatureValues(subjectUnderTest.getMatches("fox")));
+        // A longer request matches only the wildcard value.
+        assertEquals(Set.of("prefix"), extractFeatureValues(subjectUnderTest.getMatches("foxtail")));
+    }
+
+    public void testEmptyKeyValueMatchesEveryRequestAsNoConstraint() {
+        // Values stored under the empty key represent "no constraint" and must match any request key at score 0.
+        // This pins the explicit empty-key lookup in getMatches; without it, unconstrained-attribute rules stop matching.
+        subjectUnderTest.put("", "no_constraint");
+
+        List<MatchLabel<String>> matches = subjectUnderTest.getMatches("anything");
+        assertEquals(1, matches.size());
+        assertEquals("no_constraint", matches.get(0).getFeatureValue());
+        assertEquals(0f, matches.get(0).getMatchScore(), 0.0f);
+        assertEquals(Set.of("no_constraint"), extractFeatureValues(subjectUnderTest.getMatches("")));
+    }
+
+    public void testBareWildcardValueMatchesEveryNonEmptyRequest() {
+        // A bare "*" value (valid per RuleValidator) is reached via the shrinking-prefix loop at the empty prefix,
+        // so it matches every non-empty request key at score 0, but does not match an empty request key.
+        subjectUnderTest.put("*", "catch_all");
+
+        assertEquals(Set.of("catch_all"), extractFeatureValues(subjectUnderTest.getMatches("anything")));
+        assertEquals(0f, subjectUnderTest.getMatches("anything").get(0).getMatchScore(), 0.0f);
+        assertTrue(subjectUnderTest.getMatches("").isEmpty());
     }
 
     public void testClear() {

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/storage/AttributeValueStoreTests.java
@@ -64,8 +64,24 @@ public class AttributeValueStoreTests extends OpenSearchTestCase {
 
         assertTrue(subjectUnderTest.getMatches("foxtail").isEmpty());
 
-        subjectUnderTest.put("fox", "lucy");
+        // A wildcard value "fox*" prefix-matches the request "foxtail".
+        subjectUnderTest.put("fox*", "lucy");
         assertFalse(subjectUnderTest.getMatches("foxtail").isEmpty());
+    }
+
+    public void testExactValueDoesNotPrefixMatch() {
+        // A value stored without a trailing wildcard is matched exactly, not as a prefix.
+        subjectUnderTest.put("fox", "lucy");
+        assertTrue(subjectUnderTest.getMatches("foxtail").isEmpty());
+        assertTrue(extractFeatureValues(subjectUnderTest.getMatches("fox")).contains("lucy"));
+    }
+
+    public void testWildcardValuePrefixMatches() {
+        // A value stored with a trailing wildcard matches both the exact stem and longer values.
+        subjectUnderTest.put("fox*", "lucy");
+        assertTrue(extractFeatureValues(subjectUnderTest.getMatches("fox")).contains("lucy"));
+        assertTrue(extractFeatureValues(subjectUnderTest.getMatches("foxtail")).contains("lucy"));
+        assertTrue(subjectUnderTest.getMatches("fo").isEmpty());
     }
 
     public void testClear() {

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -29,10 +29,6 @@ import java.util.function.BiConsumer;
  */
 public class InMemoryRuleProcessingService {
 
-    /**
-     * Wildcard character which will be removed as we only support prefix based search rather than pattern match based
-     */
-    public static final String WILDCARD = "*";
     private final AttributeValueStoreFactory attributeValueStoreFactory;
     /**
      * Map of prioritized attributes
@@ -84,14 +80,14 @@ public class InMemoryRuleProcessingService {
     private void removeOperation(Map.Entry<Attribute, Set<String>> attributeEntry, Rule rule) {
         AttributeValueStore<String, String> valueStore = attributeValueStoreFactory.getAttributeValueStore(attributeEntry.getKey());
         for (String value : attributeEntry.getValue()) {
-            valueStore.remove(value.replace(WILDCARD, ""), rule.getFeatureValue());
+            valueStore.remove(value, rule.getFeatureValue());
         }
     }
 
     private void addOperation(Map.Entry<Attribute, Set<String>> attributeEntry, Rule rule) {
         AttributeValueStore<String, String> valueStore = attributeValueStoreFactory.getAttributeValueStore(attributeEntry.getKey());
         for (String value : attributeEntry.getValue()) {
-            valueStore.put(value.replace(WILDCARD, ""), rule.getFeatureValue());
+            valueStore.put(value, rule.getFeatureValue());
         }
     }
 

--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
@@ -95,13 +95,22 @@ public class InMemoryRuleProcessingServiceTests extends OpenSearchTestCase {
     }
 
     public void testEvaluateLabelForExactMatchWithLongestMatchingPrefixCase() {
-        sut.add(getRule(Set.of("test1", "change"), "test_id"));
-        sut.add(getRule(Set.of("test", "double"), "test_id1"));
+        sut.add(getRule(Set.of("test1*", "change"), "test_id"));
+        sut.add(getRule(Set.of("test*", "double"), "test_id1"));
 
         List<AttributeExtractor<String>> extractors = getAttributeExtractors(List.of("testing"));
         Optional<String> label = sut.evaluateLabel(extractors);
         assertTrue(label.isPresent());
         assertEquals("test_id1", label.get());
+    }
+
+    public void testEvaluateLabelForExactValueDoesNotPrefixMatch() {
+        // A value stored without a trailing wildcard is matched exactly, so a longer request does not match.
+        sut.add(getRule(Set.of("test", "change"), "test_id"));
+
+        List<AttributeExtractor<String>> extractors = getAttributeExtractors(List.of("testing"));
+        Optional<String> label = sut.evaluateLabel(extractors);
+        assertFalse(label.isPresent());
     }
 
     public void testEvaluateLabelForNoMatchWithLongestMatchingPrefixCase() {

--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
@@ -113,6 +113,34 @@ public class InMemoryRuleProcessingServiceTests extends OpenSearchTestCase {
         assertFalse(label.isPresent());
     }
 
+    public void testEvaluateLabelForLongestWildcardPrefixWins() {
+        // Two wildcard rules both prefix-match the request; the one with the longer matching prefix scores higher and wins.
+        sut.add(getRule(Set.of("test*"), "short_prefix"));
+        sut.add(getRule(Set.of("testi*"), "long_prefix"));
+
+        List<AttributeExtractor<String>> extractors = getAttributeExtractors(List.of("testing"));
+        Optional<String> label = sut.evaluateLabel(extractors);
+        assertTrue(label.isPresent());
+        assertEquals("long_prefix", label.get());
+    }
+
+    public void testRemoveExactValueLeavesSiblingWildcardValue() {
+        // Exact "my-index" and wildcard "my-index*" are stored under distinct keys; removing the exact rule must
+        // not remove the wildcard rule (the pre-fix code stripped '*', conflating the two keys).
+        Rule exactRule = getRule(Set.of("my-index"), "exact_group");
+        Rule wildcardRule = getRule(Set.of("my-index*"), "prefix_group");
+        sut.add(exactRule);
+        sut.add(wildcardRule);
+        sut.remove(exactRule);
+
+        // The wildcard rule still matches both the exact stem and a longer index.
+        assertEquals("prefix_group", sut.evaluateLabel(getAttributeExtractors(List.of("my-index"))).orElse(null));
+        assertEquals("prefix_group", sut.evaluateLabel(getAttributeExtractors(List.of("my-index-1"))).orElse(null));
+
+        sut.remove(wildcardRule);
+        assertFalse(sut.evaluateLabel(getAttributeExtractors(List.of("my-index-1"))).isPresent());
+    }
+
     public void testEvaluateLabelForNoMatchWithLongestMatchingPrefixCase() {
         sut.add(getRule(Set.of("key1", "change"), "test_id"));
         sut.add(getRule(Set.of("key12", "double"), "test_id1"));

--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/IndexPatternImplicitWildcardVerificationTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/IndexPatternImplicitWildcardVerificationTests.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rule;
+
+import org.opensearch.rule.attribute_extractor.AttributeExtractor;
+import org.opensearch.rule.autotagging.Attribute;
+import org.opensearch.rule.autotagging.AutoTaggingRegistry;
+import org.opensearch.rule.autotagging.FeatureType;
+import org.opensearch.rule.autotagging.Rule;
+import org.opensearch.rule.storage.AttributeValueStoreFactory;
+import org.opensearch.rule.storage.DefaultAttributeValueStore;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.opensearch.rule.attribute_extractor.AttributeExtractor.LogicalOperator.AND;
+
+/**
+ * Tests that an index_pattern rule matches by prefix only when its value ends in a wildcard,
+ * and matches exactly otherwise.
+ */
+public class IndexPatternImplicitWildcardVerificationTests extends OpenSearchTestCase {
+
+    public enum IndexFeatureType implements FeatureType {
+        INSTANCE;
+
+        static {
+            AutoTaggingRegistry.registerFeatureType(INSTANCE);
+        }
+
+        @Override
+        public String getName() {
+            return "index_verification_feature";
+        }
+
+        @Override
+        public Map<Attribute, Integer> getOrderedAttributes() {
+            return Map.of(RuleAttribute.INDEX_PATTERN, 1);
+        }
+    }
+
+    private InMemoryRuleProcessingService newService() {
+        AttributeValueStoreFactory factory = new AttributeValueStoreFactory(IndexFeatureType.INSTANCE, DefaultAttributeValueStore::new);
+        return new InMemoryRuleProcessingService(factory, IndexFeatureType.INSTANCE.getOrderedAttributes());
+    }
+
+    private Rule indexRule(String indexPattern, String group) {
+        return new Rule(
+            "rule_" + group,
+            "rule for " + indexPattern,
+            Map.of(RuleAttribute.INDEX_PATTERN, Set.of(indexPattern)),
+            IndexFeatureType.INSTANCE,
+            group,
+            "2025-02-24T07:42:10.123456Z"
+        );
+    }
+
+    private Optional<String> evaluateForIndex(InMemoryRuleProcessingService sut, String requestIndex) {
+        List<AttributeExtractor<String>> extractors = new ArrayList<>();
+        extractors.add(new AttributeExtractor<>() {
+            @Override
+            public Attribute getAttribute() {
+                return RuleAttribute.INDEX_PATTERN;
+            }
+
+            @Override
+            public Iterable<String> extract() {
+                return List.of(requestIndex);
+            }
+
+            @Override
+            public LogicalOperator getLogicalOperator() {
+                return AND;
+            }
+        });
+        return sut.evaluateLabel(extractors);
+    }
+
+    public void testExactIndexPatternDoesNotMatchLongerRequestIndex() {
+        InMemoryRuleProcessingService sut = newService();
+        sut.add(indexRule("my-index", "groupA"));
+
+        // Exact rule "my-index" must NOT match a longer index that merely shares the prefix.
+        assertFalse(evaluateForIndex(sut, "my-index-1").isPresent());
+    }
+
+    public void testExactIndexPatternMatchesExactRequestIndex() {
+        InMemoryRuleProcessingService sut = newService();
+        sut.add(indexRule("my-index", "groupA"));
+
+        Optional<String> label = evaluateForIndex(sut, "my-index");
+        assertTrue(label.isPresent());
+        assertEquals("groupA", label.get());
+    }
+
+    public void testWildcardIndexPatternMatchesByPrefix() {
+        InMemoryRuleProcessingService sut = newService();
+        sut.add(indexRule("my-index*", "groupA"));
+
+        Optional<String> exact = evaluateForIndex(sut, "my-index");
+        assertTrue(exact.isPresent());
+        assertEquals("groupA", exact.get());
+
+        Optional<String> prefixed = evaluateForIndex(sut, "my-index-1");
+        assertTrue(prefixed.isPresent());
+        assertEquals("groupA", prefixed.get());
+    }
+
+    public void testExactRuleWinsOverShorterPrefixRule() {
+        InMemoryRuleProcessingService sut = newService();
+        sut.add(indexRule("my-index", "groupExact"));
+        sut.add(indexRule("my*", "groupPrefix"));
+
+        // Request "my-index" matches the exact rule at score 1.0 and the shorter prefix "my*" at a lower
+        // score, so the exact rule wins.
+        Optional<String> exact = evaluateForIndex(sut, "my-index");
+        assertTrue(exact.isPresent());
+        assertEquals("groupExact", exact.get());
+    }
+
+    public void testExactRuleAndEqualStemWildcardRuleTie() {
+        InMemoryRuleProcessingService sut = newService();
+        sut.add(indexRule("my-index", "groupExact"));
+        sut.add(indexRule("my-index*", "groupPrefix"));
+
+        // Request "my-index" matches the exact rule (1.0) and the wildcard rule "my-index*" whose stem
+        // equals the request (also 1.0). The scores tie and cannot be broken, so no group is assigned.
+        assertFalse(evaluateForIndex(sut, "my-index").isPresent());
+
+        // A longer index matches only the wildcard rule.
+        Optional<String> longer = evaluateForIndex(sut, "my-index-1");
+        assertTrue(longer.isPresent());
+        assertEquals("groupPrefix", longer.get());
+    }
+}


### PR DESCRIPTION
### Description
An `index_pattern` rule value without a trailing `*` still matched request indices that merely shared it as a prefix — the trailing wildcard was always implied, so there was no way to write an exact-only index rule. For example, a rule for `index_pattern: ["my-index"]` also matched `my-index-1`, `my-index-archive`, etc. This contradicts the documentation, which states a plain value is matched exactly and only a value ending in `*` matches by prefix.

Root cause: the `*` was stripped at storage time (`InMemoryRuleProcessingService`) so `"my-index"` and `"my-index*"` became the same trie key, and `DefaultAttributeValueStore.getMatches` always walked prefixes.

This change stores values verbatim and makes `getMatches` wildcard-aware:
- A value stored without a trailing `*` is matched exactly.
- A value of the form `<prefix>*` matches request keys that start with `<prefix>` (scored by matched length, as before).
- The empty-key "no constraint" behavior is unchanged.

The change is confined to two production files to keep it easy to backport to affected versions.

**Behavior changes to note:**
- `index_pattern` rules without a trailing `*` stop prefix-matching after upgrade. Users relying on the implicit prefix behavior must append `*` to their rule values. No reindex or migration is needed — matching is in-memory and rebuilt on each rule sync.
- `principal.username`/`principal.role` rules **without** `*` are unaffected. However, an existing principal rule **containing** `*` (e.g. `username: ["dev*"]`) previously matched the stripped literal value (`dev`); with verbatim storage it matches nothing, since principal matches via `getExactMatch`. Honoring the wildcard for principal attributes will be handled in a follow-up (#22457).

### Related Issues
Resolves #22460

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
