### PR TITLE
Improve bitmap query planning

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/Bitmap64DocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/Bitmap64DocValuesQuery.java
@@ -62,51 +62,62 @@ public class Bitmap64DocValuesQuery extends Query implements Accountable {
         return new ConstantScoreWeight(this, boost) {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-                SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
-                final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+                // This query verifies candidate docs via doc values, so its real cost is a full segment scan.
+                final long cost = context.reader().maxDoc();
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
+                        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
 
-                final TwoPhaseIterator iterator;
+                        final TwoPhaseIterator iterator;
 
-                if (singleton != null) {
-                    iterator = new TwoPhaseIterator(singleton) {
-                        @Override
-                        public boolean matches() throws IOException {
-                            long value = singleton.longValue();
-                            return value >= min && value <= max && bitmap.contains(value);
-                        }
-
-                        @Override
-                        public float matchCost() {
-                            return 5;
-                        }
-                    };
-                } else {
-                    iterator = new TwoPhaseIterator(values) {
-                        @Override
-                        public boolean matches() throws IOException {
-                            int count = values.docValueCount();
-                            for (int i = 0; i < count; i++) {
-                                final long value = values.nextValue();
-                                if (value < min) {
-                                    continue;
-                                } else if (value > max) {
-                                    return false;
-                                } else if (bitmap.contains(value)) {
-                                    return true;
+                        if (singleton != null) {
+                            iterator = new TwoPhaseIterator(singleton) {
+                                @Override
+                                public boolean matches() throws IOException {
+                                    long value = singleton.longValue();
+                                    return value >= min && value <= max && bitmap.contains(value);
                                 }
-                            }
-                            return false;
+
+                                @Override
+                                public float matchCost() {
+                                    return 5;
+                                }
+                            };
+                        } else {
+                            iterator = new TwoPhaseIterator(values) {
+                                @Override
+                                public boolean matches() throws IOException {
+                                    int count = values.docValueCount();
+                                    for (int i = 0; i < count; i++) {
+                                        final long value = values.nextValue();
+                                        if (value < min) {
+                                            continue;
+                                        } else if (value > max) {
+                                            return false;
+                                        } else if (bitmap.contains(value)) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                }
+
+                                @Override
+                                public float matchCost() {
+                                    return 5;
+                                }
+                            };
                         }
 
-                        @Override
-                        public float matchCost() {
-                            return 5;
-                        }
-                    };
-                }
+                        return new ConstantScoreScorer(score(), scoreMode, iterator);
+                    }
 
-                final Scorer scorer = new ConstantScoreScorer(score(), scoreMode, iterator);
-                return new Weight.DefaultScorerSupplier(scorer);
+                    @Override
+                    public long cost() {
+                        return cost;
+                    }
+                };
             }
 
             @Override

--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -63,48 +63,59 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
         return new ConstantScoreWeight(this, boost) {
             @Override
             public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-                SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
-                final NumericDocValues singleton = DocValues.unwrapSingleton(values);
-                final TwoPhaseIterator iterator;
-                if (singleton != null) {
-                    iterator = new TwoPhaseIterator(singleton) {
-                        @Override
-                        public boolean matches() throws IOException {
-                            long value = singleton.longValue();
-                            return value >= min && value <= max && bitmap.contains((int) value);
-                        }
-
-                        @Override
-                        public float matchCost() {
-                            return 5; // 2 comparisons, possible lookup in the bitmap
-                        }
-                    };
-                } else {
-                    iterator = new TwoPhaseIterator(values) {
-                        @Override
-                        public boolean matches() throws IOException {
-                            int count = values.docValueCount();
-                            for (int i = 0; i < count; i++) {
-                                final long value = values.nextValue();
-                                if (value < min) {
-                                    continue;
-                                } else if (value > max) {
-                                    return false; // values are sorted, terminate
-                                } else if (bitmap.contains((int) value)) {
-                                    return true;
+                // This query verifies candidate docs via doc values, so its real cost is a full segment scan.
+                final long cost = context.reader().maxDoc();
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
+                        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+                        final TwoPhaseIterator iterator;
+                        if (singleton != null) {
+                            iterator = new TwoPhaseIterator(singleton) {
+                                @Override
+                                public boolean matches() throws IOException {
+                                    long value = singleton.longValue();
+                                    return value >= min && value <= max && bitmap.contains((int) value);
                                 }
-                            }
-                            return false;
-                        }
 
-                        @Override
-                        public float matchCost() {
-                            return 5; // 2 comparisons, possible lookup in the bitmap
+                                @Override
+                                public float matchCost() {
+                                    return 5; // 2 comparisons, possible lookup in the bitmap
+                                }
+                            };
+                        } else {
+                            iterator = new TwoPhaseIterator(values) {
+                                @Override
+                                public boolean matches() throws IOException {
+                                    int count = values.docValueCount();
+                                    for (int i = 0; i < count; i++) {
+                                        final long value = values.nextValue();
+                                        if (value < min) {
+                                            continue;
+                                        } else if (value > max) {
+                                            return false; // values are sorted, terminate
+                                        } else if (bitmap.contains((int) value)) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                }
+
+                                @Override
+                                public float matchCost() {
+                                    return 5; // 2 comparisons, possible lookup in the bitmap
+                                }
+                            };
                         }
-                    };
-                }
-                final Scorer scorer = new ConstantScoreScorer(score(), scoreMode, iterator);
-                return new DefaultScorerSupplier(scorer);
+                        return new ConstantScoreScorer(score(), scoreMode, iterator);
+                    }
+
+                    @Override
+                    public long cost() {
+                        return cost;
+                    }
+                };
             }
 
             @Override

--- a/server/src/test/java/org/opensearch/search/query/Bitmap64DocValuesQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/Bitmap64DocValuesQueryTests.java
@@ -212,10 +212,11 @@ public class Bitmap64DocValuesQueryTests extends OpenSearchTestCase {
 
             Bitmap64DocValuesQuery query = new Bitmap64DocValuesQuery("product_id", bitmap);
             Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
-            ScorerSupplier supplier = weight.scorerSupplier(reader.leaves().get(0));
+org.apache.lucene.index.LeafReaderContext leaf = reader.leaves().get(0);
+ScorerSupplier supplier = weight.scorerSupplier(leaf);
 
-            assertNotNull(supplier);
-            assertEquals(reader.maxDoc(), supplier.cost());
+assertNotNull(supplier);
+assertEquals(leaf.reader().maxDoc(), supplier.cost());
         } finally {
             if (reader != null) {
                 reader.close();

--- a/server/src/test/java/org/opensearch/search/query/Bitmap64DocValuesQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/Bitmap64DocValuesQueryTests.java
@@ -17,7 +17,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -186,6 +189,40 @@ public class Bitmap64DocValuesQueryTests extends OpenSearchTestCase {
 
         reader.close();
         dir.close();
+    }
+
+    public void testScorerSupplierCostReflectsFullSegmentScan() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+        IndexReader reader = null;
+        try {
+            addDoc(writer, 1L);
+            addDoc(writer, 2L);
+            addDoc(writer, 3L);
+            addDoc(writer, 4L);
+
+            writer.commit();
+
+            reader = DirectoryReader.open(dir);
+            IndexSearcher searcher = newSearcher(reader);
+
+            Roaring64NavigableMap bitmap = new Roaring64NavigableMap();
+            bitmap.add(1L);
+            bitmap.add(4L);
+
+            Bitmap64DocValuesQuery query = new Bitmap64DocValuesQuery("product_id", bitmap);
+            Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+            ScorerSupplier supplier = weight.scorerSupplier(reader.leaves().get(0));
+
+            assertNotNull(supplier);
+            assertEquals(reader.maxDoc(), supplier.cost());
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+            writer.close();
+            dir.close();
+        }
     }
 
     public void testNullFieldThrowsException() {

--- a/server/src/test/java/org/opensearch/search/query/BitmapDocValuesQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/BitmapDocValuesQueryTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.opensearch.test.OpenSearchTestCase;
@@ -44,9 +45,15 @@ public class BitmapDocValuesQueryTests extends OpenSearchTestCase {
 
     @After
     public void closeAllTheReaders() throws IOException {
-        reader.close();
-        w.close();
-        dir.close();
+        if (reader != null) {
+            reader.close();
+        }
+        if (w != null) {
+            w.close();
+        }
+        if (dir != null) {
+            dir.close();
+        }
     }
 
     public void testScore() throws IOException {
@@ -113,5 +120,38 @@ public class BitmapDocValuesQueryTests extends OpenSearchTestCase {
         Set<Integer> actual = new HashSet<>(getMatchingValues(weight, searcher.getIndexReader()));
         Set<Integer> expected = Set.of(2, 3);
         assertEquals(expected, actual);
+    }
+
+    public void testScorerSupplierCostReflectsFullSegmentScan() throws IOException {
+        Document d = new Document();
+        d.add(new IntField("product_id", 1, Field.Store.NO));
+        w.addDocument(d);
+
+        d = new Document();
+        d.add(new IntField("product_id", 2, Field.Store.NO));
+        w.addDocument(d);
+
+        d = new Document();
+        d.add(new IntField("product_id", 3, Field.Store.NO));
+        w.addDocument(d);
+
+        d = new Document();
+        d.add(new IntField("product_id", 4, Field.Store.NO));
+        w.addDocument(d);
+
+        w.commit();
+        reader = DirectoryReader.open(w);
+        searcher = newSearcher(reader);
+
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(1);
+        bitmap.add(4);
+        BitmapDocValuesQuery query = new BitmapDocValuesQuery("product_id", bitmap);
+
+        Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        ScorerSupplier supplier = weight.scorerSupplier(reader.leaves().get(0));
+
+        assertNotNull(supplier);
+        assertEquals(reader.maxDoc(), supplier.cost());
     }
 }


### PR DESCRIPTION
Improve planner behavior for bitmap-backed terms queries on doc-values fields by making the bitmap doc-values scorer advertise a full-segment scan cost. This helps Lucene avoid choosing the bitmap query as the lead iterator when more selective clauses are available, which reduces the chance of inefficient execution plans. Add regression coverage for both the 32-bit and 64-bit bitmap doc-values query paths.

Related Issues
Resolves #22458

Check List
 Functionality includes testing.
 API changes companion pull request created, if applicable.
 Public documentation issue/PR created, if applicable.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.