### PR TITLE
Update -PinstalledPlugins documentation to reflect opensearch-security plugin requirements

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -193,6 +193,12 @@ External plugins may also be fetched and installed from maven snapshots:
 ./gradlew run -PinstalledPlugins="['opensearch-job-scheduler', 'opensearch-sql-plugin']"
 ```
 
+In case when `opensearch-security` is required, provide the `crypto.standard` property explicitly:
+
+```bash
+./gradlew run -PinstalledPlugins="['opensearch-security']" -Pcrypto.standard=FIPS-140-3
+```
+
 You can specify a plugin version to pull to test a specific version in the org.opensearch.plugin groupId:
 ```bash
 ./gradlew run -PinstalledPlugins="['opensearch-job-scheduler:3.3.x.x']"

--- a/build.gradle
+++ b/build.gradle
@@ -262,8 +262,8 @@ tasks.register("verifyBwcTestsEnabled") {
 }
 
 tasks.register("branchConsistency") {
-  description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
-  group 'Verification'
+  description = 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
+  group = 'Verification'
   dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Update `-PinstalledPlugins` documentation to reflect `opensearch-security` plugin requirements. Running `./gradlew run -PinstalledPlugins="['opensearch-security']"` fails with:

```
» [2026-07-14T13:56:38,082][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [runTask-0] fatal error in thread [main], exiting
»  java.lang.NoClassDefFoundError: org/bouncycastle/jcajce/provider/BouncyCastleFipsProvider
»       at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
»       at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:2985)
»       at java.base/java.lang.Class.getConstructors(Class.java:2025)
»       at org.opensearch.plugins.PluginsService.loadPlugin(PluginsService.java:906)
»       at org.opensearch.plugins.PluginsService.loadBundle(PluginsService.java:874)
»       at org.opensearch.plugins.PluginsService.loadBundles(PluginsService.java:657)
»       at org.opensearch.plugins.PluginsService.<init>(PluginsService.java:227)
»       at org.opensearch.node.Node.<init>(Node.java:576)
»       at org.opensearch.node.Node.<init>(Node.java:504)
»       at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:264)
»       at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:264)
»       at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:426)
»       at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:168)
»       at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:159)
»       at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
»       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
»       at org.opensearch.cli.Command.main(Command.java:101)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:125)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:91)
»  Caused by: java.lang.ClassNotFoundException: org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
```

Setting `crypto.standard` explicitly eliminates the issue: `./gradlew run -PinstalledPlugins="['opensearch-security']" -Pcrypto.standard=FIPS-140-3` (since BC dependencies are going to be bundled).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
