### PR TITLE
Skip FFM upcalls for dead AND branches in bitmap tree prefetch

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -49,9 +49,7 @@
 //! before any expensive Collector leaf work. The refinement stage walks
 //! children in their *original* tree order, which is fine because Arrow
 //! kernels don't short-circuit internally and leaf identity is by
-//! `Arc::as_ptr`, not DFS position. See [`subtree_cost`] and the
-//! `collect_collector_leaves` doc for the identity mechanism that lets
-//! these two orderings coexist safely.
+//! `Arc::as_ptr`, not DFS position. See [`subtree_cost`].
 //!
 //! Plus [`CollectorLeafBitmaps`] — the default [`LeafBitmapSource`] impl that
 //! expands index-backed `RowGroupDocsCollector` output into RoaringBitmaps.
@@ -93,9 +91,6 @@ impl TreeEvaluator for BitmapTreeEvaluator {
     ) -> Result<TreePrefetch, String> {
         let mut per_leaf = Vec::new();
         let mut dfs_counter = 0usize;
-        // Root call passes `under_all_and_path = true` — root's (empty)
-        // ancestor chain is trivially all-AND, so if the root short-circuits
-        // to empty, the candidate set is empty and refinement won't run.
         let candidates = prefetch_node(
             tree,
             ctx,
@@ -105,7 +100,6 @@ impl TreeEvaluator for BitmapTreeEvaluator {
             page_prune_metrics,
             &mut dfs_counter,
             &mut per_leaf,
-            /* under_all_and_path */ true,
             stats_prune_tree,
             rg_index_to_pos,
         )?;
@@ -148,9 +142,7 @@ impl TreeEvaluator for BitmapTreeEvaluator {
 // It's used only to assign a stable `leaf_dfs_index` to each leaf so a
 // `LeafBitmapSource` implementation can identify which leaf it's being asked
 // about. We advance `dfs` on every leaf whether we actually evaluate it or
-// not (see the short-circuit branches in AND/OR) so downstream walkers that
-// reproduce the DFS order (`collect_collector_leaves`, `skip_dfs`) stay in
-// sync with this one.
+// not (see the short-circuit branches in AND/OR).
 //
 // Note: the stored per-leaf bitmap entries use `Arc::as_ptr(collector)` as
 // the key, not `leaf_dfs_index`. DFS position changes between
@@ -158,22 +150,12 @@ impl TreeEvaluator for BitmapTreeEvaluator {
 // walks in original order), but `Arc` identity is stable across both. See
 // the refinement-stage walker for the lookup.
 //
-// The `under_all_and_path` flag tracks whether every ancestor (up to root)
-// is an AND node. When true, an empty candidate result here propagates all
-// the way up — `TreeBitsetSource::prefetch_rg` returns `None`, the RG is
-// skipped entirely, and the refinement stage never runs. In that case we
-// can drop Collector bitmap materialisation in short-circuited branches
-// (no one will look them up). When false, some ancestor is OR or NOT,
-// which can recover from an empty subtree — refinement may still run and
-// will need the bitmaps in `out`, so we materialise them defensively.
-//
-// Propagation rule:
-//   - Root call: `under_all_and_path = true` (no ancestors).
-//   - Recurse into an AND child: pass the flag unchanged.
-//   - Recurse into an OR or NOT child: pass `false`.
-// The universe-saturation short-circuit in OR is NOT affected — saturation
-// produces a non-empty candidate set, so the RG is always read and
-// refinement always runs. Bitmaps must be materialised regardless.
+// Short-circuit contract:
+//   - AND dead branch: `skip_dfs_with_empty_bitmaps` — no FFM upcalls,
+//     empty entries in side-table so refinement doesn't panic.
+//   - OR saturated: `collect_collector_leaves` — real FFM upcalls needed
+//     because Predicate supersets shrink at refinement (OR still needs
+//     the real Collector bitmaps for correct results).
 
 fn prefetch_node(
     node: &ResolvedNode,
@@ -184,7 +166,6 @@ fn prefetch_node(
     page_prune_metrics: Option<&PagePruneMetrics>,
     dfs: &mut usize,
     out: &mut Vec<(usize, RoaringBitmap)>,
-    under_all_and_path: bool,
     stats_prune_tree: Option<&StatsPruneTree>,
     rg_index_to_pos: &HashMap<usize, usize>,
 ) -> Result<RoaringBitmap, String> {
@@ -199,11 +180,7 @@ fn prefetch_node(
                     "BitmapTree: skipping subtree for RG {} — pruned by RG-level stats",
                     ctx.rg_idx
                 );
-                if under_all_and_path {
-                    skip_dfs(node, dfs);
-                } else {
-                    skip_dfs_with_empty_bitmaps(node, dfs, out);
-                }
+                skip_dfs_with_empty_bitmaps(node, dfs, out);
                 return Ok(RoaringBitmap::new());
             }
         }
@@ -235,7 +212,6 @@ fn prefetch_node(
                     page_prune_metrics,
                     dfs,
                     out,
-                    under_all_and_path,
                     stats_prune_tree.and_then(|spt| spt.children.get(i)),
                     rg_index_to_pos,
                 )?;
@@ -260,21 +236,12 @@ fn prefetch_node(
                     }
                 }
 
-                // Short circuit case
-                // 1. Skip if subtree only consists of AND [ since all bits are not set here, no need to evaluate ]
-                // 2. Collect if subtree is mixed with OR/NOT, which can produce set bits and recover
+                // Short circuit: AND is dead (empty ∩ anything = empty).
+                // Remaining children get empty bitmap entries (no FFM
+                // upcalls) so refinement can look them up without panic.
                 if result_bitmap.as_ref().unwrap().is_empty() {
-                    // Remaining children still need to advance `dfs` so leaf
-                    // IDs remain stable.
                     for &j in indices.iter().skip_while(|&&x| x != i).skip(1) {
-                        if under_all_and_path {
-                            // Empty propagates to root → RG skipped → bitmaps
-                            // unused. Just advance the counter.
-                            skip_dfs(&children[j], dfs);
-                        } else {
-                            // OR/NOT ancestor can recover
-                            collect_collector_leaves(&children[j], ctx, leaves, dfs, out)?;
-                        }
+                        skip_dfs_with_empty_bitmaps(&children[j], dfs, out);
                     }
                     break;
                 }
@@ -300,8 +267,6 @@ fn prefetch_node(
                     page_prune_metrics,
                     dfs,
                     out,
-                    // OR breaks all-AND propagation for its subtree.
-                    false,
                     stats_prune_tree.and_then(|spt| spt.children.get(val)),
                     rg_index_to_pos,
                 )?;
@@ -324,9 +289,6 @@ fn prefetch_node(
         // Mainly needed for collectors, predicate expressions are inversed where possible
         // and wouldn't usually hit this
         ResolvedNode::Not(child) => {
-            // NOT breaks all-AND propagation — inverting empty gives universe,
-            // which is non-empty, so the RG will be read and refinement will
-            // run. Materialise bitmaps below.
             let child_bm = prefetch_node(
                 child,
                 ctx,
@@ -336,7 +298,6 @@ fn prefetch_node(
                 page_prune_metrics,
                 dfs,
                 out,
-                /* under_all_and_path */ false,
                 stats_prune_tree.and_then(|spt| spt.children.first()),
                 rg_index_to_pos,
             )?;
@@ -399,22 +360,40 @@ fn prefetch_node(
     }
 }
 
-/// Walk a subtree without combining into the parent accumulator, but still
-/// populate the per-leaf bitmap side-table that the refinement stage will
-/// read from later.
-///
-/// Called when the parent's candidate-stage accumulator has short-circuited
-/// (AND reached empty, OR reached the universe) and so this subtree's
-/// contribution is no longer needed for the candidate superset. We can't
-/// just skip the subtree entirely though — the refinement stage walks the
-/// whole tree and will look up every Collector leaf's bitmap in the
-/// side-table. Missing entries there would panic at refinement time. So we
-/// still materialise the bitmaps (but skip the expensive AND/OR combine and
-/// skip the page-pruner work for Predicate leaves, since those never enter
-/// the side-table).
-///
-/// Also advances the `dfs` counter in lockstep with the main walker so
-/// downstream leaf_dfs_index assignments stay consistent.
+/// Advance `dfs` and push empty bitmaps for each Collector leaf without
+/// making FFM calls. Used when a subtree is provably dead (AND
+/// short-circuit or stats-prune) — entries ensure refinement doesn't
+/// panic on missing keys.
+fn skip_dfs_with_empty_bitmaps(
+    node: &ResolvedNode,
+    dfs: &mut usize,
+    out: &mut Vec<(usize, RoaringBitmap)>,
+) {
+    match node {
+        ResolvedNode::And(children) | ResolvedNode::Or(children) => {
+            for c in children {
+                skip_dfs_with_empty_bitmaps(c, dfs, out);
+            }
+        }
+        ResolvedNode::Not(child) => skip_dfs_with_empty_bitmaps(child, dfs, out),
+        ResolvedNode::Collector { collector, .. } => {
+            *dfs += 1;
+            let key = Arc::as_ptr(collector) as *const () as usize;
+            out.push((key, RoaringBitmap::new()));
+        }
+        ResolvedNode::Predicate(_) => *dfs += 1,
+        ResolvedNode::DelegationPossible { .. } => {
+            unimplemented!(
+                "invariant violation: DelegationPossible reached skip_dfs_with_empty_bitmaps."
+            )
+        }
+    }
+}
+
+/// Walk a subtree materializing Collector bitmaps without combining into
+/// the parent accumulator. Used at the OR saturation short-circuit: the
+/// candidate superset is already full, but refinement still needs real
+/// Collector bitmaps because Predicate supersets shrink at refinement.
 fn collect_collector_leaves(
     node: &ResolvedNode,
     ctx: &RgEvalContext,
@@ -449,60 +428,6 @@ fn collect_collector_leaves(
         }
     }
     Ok(())
-}
-
-/// Advance the `dfs` counter over a subtree without doing any bitmap work.
-/// Used at an AND short-circuit point when we know the whole candidate
-/// result will be empty and the RG will be skipped — there's no refinement
-/// stage to prepare bitmaps for, so we only need to keep leaf-ID assignment
-/// stable. See the `under_all_and_path` handling in `prefetch_node`.
-fn skip_dfs(node: &ResolvedNode, dfs: &mut usize) {
-    match node {
-        ResolvedNode::And(children) | ResolvedNode::Or(children) => {
-            for c in children {
-                skip_dfs(c, dfs);
-            }
-        }
-        ResolvedNode::Not(child) => skip_dfs(child, dfs),
-        ResolvedNode::Collector { .. } | ResolvedNode::Predicate(_) => *dfs += 1,
-        ResolvedNode::DelegationPossible { .. } => {
-            // Invariant: see prefetch_node arm. Same contract.
-            unimplemented!(
-                "invariant violation: DelegationPossible reached skip_dfs. \
-                 Planner must drop performance peers under OR/NOT before fragment conversion."
-            )
-        }
-    }
-}
-
-/// Advance `dfs` and push empty bitmaps for each Collector leaf without
-/// making FFM calls. Used when a subtree is pruned by RG-level stats but
-/// refinement may still run (OR/NOT ancestor) — ensures the side-table
-/// has entries so refinement doesn't panic on missing keys.
-fn skip_dfs_with_empty_bitmaps(
-    node: &ResolvedNode,
-    dfs: &mut usize,
-    out: &mut Vec<(usize, RoaringBitmap)>,
-) {
-    match node {
-        ResolvedNode::And(children) | ResolvedNode::Or(children) => {
-            for c in children {
-                skip_dfs_with_empty_bitmaps(c, dfs, out);
-            }
-        }
-        ResolvedNode::Not(child) => skip_dfs_with_empty_bitmaps(child, dfs, out),
-        ResolvedNode::Collector { collector, .. } => {
-            *dfs += 1;
-            let key = Arc::as_ptr(collector) as *const () as usize;
-            out.push((key, RoaringBitmap::new()));
-        }
-        ResolvedNode::Predicate(_) => *dfs += 1,
-        ResolvedNode::DelegationPossible { .. } => {
-            unimplemented!(
-                "invariant violation: DelegationPossible reached skip_dfs_with_empty_bitmaps."
-            )
-        }
-    }
 }
 
 fn predicate_page_bitmap(
@@ -1571,17 +1496,17 @@ mod tests {
     }
 
     #[test]
-    fn candidate_and_short_circuit_under_or_still_materialises() {
+    fn candidate_and_short_circuit_under_or_skips_ffm() {
         // Tree: OR(AND(empty_leaf, other_leaf), standalone_leaf).
         // Cost sort at root OR: [standalone_leaf (10), AND (20)].
         // DFS order:
         //   idx 0 = standalone_leaf (evaluated first by cost sort),
         //   idx 1 = empty_leaf (AND's first child),
-        //   idx 2 = other_leaf (AND's second child).
+        //   idx 2 = other_leaf (AND's second child — skipped).
         //
-        // The AND short-circuits on idx 1 (empty). Because the path to
-        // root contains an OR (not all-AND), the walker must still
-        // materialise idx 2's bitmap so refinement can look it up.
+        // The AND short-circuits on idx 1 (empty). skip_dfs advances the
+        // counter for idx 2 without calling leaf_bitmap. Refinement treats
+        // the missing entry as all-false.
         let tree = ResolvedNode::Or(vec![
             ResolvedNode::And(vec![collector_leaf(0), collector_leaf(1)]),
             collector_leaf(2),
@@ -1593,15 +1518,9 @@ mod tests {
             b
         });
         allowed.insert(1, RoaringBitmap::new()); // empty → short-circuit
-        allowed.insert(2, {
-            let mut b = RoaringBitmap::new();
-            b.insert(7);
-            b
-        });
-        let leaves = PoisonLeafBitmaps {
-            allowed,
-            forbidden: HashSet::new(),
-        };
+        let mut forbidden = HashSet::new();
+        forbidden.insert(2); // must NOT be called — AND is dead
+        let leaves = PoisonLeafBitmaps { allowed, forbidden };
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
@@ -1618,8 +1537,9 @@ mod tests {
             .unwrap();
         // OR contributes {5} from standalone_leaf → non-empty candidates.
         assert!(!result.candidates.is_empty());
-        // All 3 collector leaves must have per_leaf entries — AND
-        // short-circuit under OR does NOT skip materialisation.
+        // All 3 collector leaves have per_leaf entries. The key difference:
+        // other_leaf (idx 2) gets an empty bitmap from skip_dfs_with_empty_bitmaps
+        // without calling leaf_bitmap (the forbidden set verifies this).
         assert_eq!(
             result.per_leaf.len(),
             3,
@@ -1629,26 +1549,20 @@ mod tests {
     }
 
     #[test]
-    fn candidate_and_short_circuit_under_not_still_materialises() {
+    fn candidate_and_short_circuit_under_not_skips_ffm() {
         // Tree: NOT(AND(empty_leaf, other_leaf)).
         // Inner AND short-circuits on empty_leaf. NOT inverts empty to
-        // universe → candidates non-empty → RG read → refinement will
-        // look up other_leaf's bitmap.
+        // universe → candidates non-empty → RG read. other_leaf gets an
+        // empty bitmap via skip_dfs_with_empty_bitmaps (no FFM call).
         let tree = ResolvedNode::Not(Box::new(ResolvedNode::And(vec![
             collector_leaf(0),
             collector_leaf(1),
         ])));
         let mut allowed = HashMap::new();
         allowed.insert(0, RoaringBitmap::new()); // triggers short-circuit
-        allowed.insert(1, {
-            let mut b = RoaringBitmap::new();
-            b.insert(9);
-            b
-        });
-        let leaves = PoisonLeafBitmaps {
-            allowed,
-            forbidden: HashSet::new(),
-        };
+        let mut forbidden = HashSet::new();
+        forbidden.insert(1); // must NOT be called — AND is dead
+        let leaves = PoisonLeafBitmaps { allowed, forbidden };
         let pruner = empty_pruner();
 
         let result = BitmapTreeEvaluator
@@ -1665,7 +1579,7 @@ mod tests {
             .unwrap();
         // NOT inverts empty AND → universe.
         assert_eq!(result.candidates.len(), 16);
-        // Both collector leaves materialised.
+        // Both entries present (other_leaf has empty bitmap from skip).
         assert_eq!(result.per_leaf.len(), 2);
     }
 
@@ -2192,13 +2106,12 @@ mod tests {
             .unwrap();
         // AND subtree pruned → empty; coll2 → {5,6,7}; OR = {5,6,7}
         assert_eq!(result.candidates, bm(&[5, 6, 7]));
-        // Critical: both collector leaves from pruned subtree must have
-        // per_leaf entries (empty bitmaps) so refinement doesn't panic.
-        // coll2 (dfs=0) → real bitmap; coll0 (dfs=2), coll1 (dfs=3) → empty.
+        // All 3 collector leaves have per_leaf entries. coll0 and coll1
+        // get empty bitmaps from skip_dfs_with_empty_bitmaps (no FFM calls).
         assert_eq!(
             result.per_leaf.len(),
             3,
-            "stats-pruned collectors under OR must still have per_leaf entries; got {}",
+            "expected 3 per_leaf entries; got {}",
             result.per_leaf.len()
         );
         // coll2 (dfs=0) gets real bitmap
@@ -2289,7 +2202,7 @@ mod tests {
         // coll3={5,6,7,8}; OR: inner AND pruned→empty, coll2={6,7,8}; OR={6,7,8}
         // Final AND = {5,6,7,8} ∩ {6,7,8} = {6,7,8}
         assert_eq!(result.candidates, bm(&[6, 7, 8]));
-        // All 4 collector leaves must have per_leaf entries (coll3, coll2 real;
+        // All 4 collector leaves have per_leaf entries (coll3, coll2 real;
         // coll0, coll1 empty from skip_dfs_with_empty_bitmaps).
         assert_eq!(
             result.per_leaf.len(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -1989,7 +1989,8 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
         .downcast_ref::<crate::indexed_table::eval::TreePrefetch>()
         .expect("context should be TreePrefetch");
 
-    // Critical assertion: per_leaf must have 2 entries (one per collector).
+    // Both collectors have per_leaf entries. Collector0 (inside pruned AND)
+    // gets empty bitmap from skip_dfs_with_empty_bitmaps (no FFM call).
     assert_eq!(
         tree_prefetch.per_leaf.len(),
         2,


### PR DESCRIPTION
Remove the `under_all_and_path` flag from `prefetch_node` and simplify short-circuit handling. When an AND node short-circuits on an empty child, remaining siblings now get empty bitmaps via `skip_dfs_with_empty_bitmaps` instead of firing real FFM `collectDocs` calls. This saves ~10μs per skipped Collector leaf with no correctness impact — AND refinement short-circuits on the first all-false mask it encounters.

OR saturation retains `collect_collector_leaves` because Predicate bitmaps are supersets that shrink at refinement; real Collector bitmaps are still needed for correct OR results.


```

Results — 100M docs | r8g.2xlarge | 3 iter avg

 #  Query                                                                                    Sel%                     Result        Main    Custom    M/C    CvsM  Match
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 1  SC1: inner AND with 2 extra matches                                                    17.98%                   17978401      1955ms    1837ms   1.06x     Cus       ✅
 2  SC2: inner AND with 3 extra matches                                                    17.98%                   17978400      1962ms    1832ms   1.07x     Cus       ✅
 3  SC3: inner AND with 5 extra matches — max savings per short-circuit                    17.98%                   17978400      1964ms    1835ms   1.07x     Cus       ✅
 4  SC4: both OR branches have 3 extra matches each                                         0.00%                          1       705ms     119ms   5.94x     Cus       ✅
 5  SC5: D75 augmented — original + 4 match siblings per inner AND                              —                          0       756ms     257ms   2.94x     Cus       ✅
 6  SC6: triple NOT branches each with 3 match siblings                                     0.00%                       3581       128ms     137ms   0.94x     Mai       ✅
 7  SC7: P20 augmented — add 3 matches at inner AND level                                   0.00%                       2479       363ms     363ms   1.00x              ✅
 8  SC8: depth-8 with NOT at depth-4 + 4 match siblings                                    69.42%                   69419660      2088ms    2111ms   0.99x              ✅
 9  SC9: single deep AND with NOT + 6 match siblings — max density                         98.78%                   98773512      1364ms    1376ms   0.99x              ✅
10  SC10: NOT(OR(3 wide matches, pred)) AND 4 matches — De Morgan narrows + many siblings  17.98%                   17978400      1311ms    1316ms   1.00x              ✅
11  SC11: cascading NOTs + 5 match siblings                                                11.47%                   11468735      1917ms    1919ms   1.00x              ✅
12  SC12: 3 OR branches × (NOT + 4 matches) — wide fan-out of savings                       0.00%                       2939       763ms     184ms   4.15x     Cus       ✅
13  SC13: SC5 + sum/avg agg — correctness with many skipped collectors                      0.00%  90, 216, 33.2222222222...       802ms     322ms   2.49x     Cus       ✅
14  SC14: SC5 + group by — correctness with grouping                                            —                    10 rows       797ms     320ms   2.49x     Cus       ✅
15  SC15: SC9 max density + multi-agg — 6 matches at single AND level                      98.78%  98773512, 161561596, 2...      1513ms    1540ms   0.98x              ✅
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
    TOTAL                                                                                                                        18387ms   15468ms   1.19x  C:8/15       
  Generated: results/report_20260717_164346.html
```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
