### PR TITLE
Wire request_timeout into S3 sync client

### DIFF
--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3SyncClientRequestTimeoutIT.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3SyncClientRequestTimeoutIT.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.s3;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.network.InetAddresses;
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.s3.utils.AwsRequestSigner;
+import org.opensearch.secure_sm.AccessController;
+import org.opensearch.snapshots.SnapshotState;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import fixture.s3.DelayedS3HttpHandler;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+@SuppressForbidden(reason = "this test uses a HttpServer to emulate an S3 endpoint")
+@ThreadLeakFilters(filters = EventLoopThreadFilter.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST)
+public class S3SyncClientRequestTimeoutIT extends OpenSearchIntegTestCase {
+
+    private static final int DELAY_MILLIS = 15000;
+    private static final String REQUEST_TIMEOUT = "3s";
+
+    private static HttpServer httpServer;
+    private static DelayedS3HttpHandler delayedHandler;
+    private String previousOpenSearchPathConf;
+
+    @BeforeClass
+    public static void startHttpServer() throws Exception {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.setExecutor(Executors.newFixedThreadPool(4, r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        }));
+        httpServer.start();
+        delayedHandler = new DelayedS3HttpHandler("bucket", DELAY_MILLIS, "PUT", "/snap-");
+        httpServer.createContext("/bucket", delayedHandler);
+    }
+
+    @AfterClass
+    public static void stopHttpServer() {
+        httpServer.stop(0);
+        httpServer = null;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        previousOpenSearchPathConf = AccessController.doPrivileged(() -> System.setProperty("opensearch.path.conf", "config"));
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (previousOpenSearchPathConf != null) {
+            AccessController.doPrivileged(() -> System.setProperty("opensearch.path.conf", previousOpenSearchPathConf));
+        } else {
+            AccessController.doPrivileged(() -> System.clearProperty("opensearch.path.conf"));
+        }
+        super.tearDown();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(TimeoutTestS3RepositoryPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        final MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "access");
+        secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "secret");
+
+        InetSocketAddress address = httpServer.getAddress();
+        String endpoint = "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+
+        return Settings.builder()
+            .put(S3ClientSettings.ENDPOINT_SETTING.getConcreteSettingForNamespace("test").getKey(), endpoint)
+            .put(S3ClientSettings.DISABLE_CHUNKED_ENCODING.getConcreteSettingForNamespace("test").getKey(), true)
+            .put(S3ClientSettings.USE_THROTTLE_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), false)
+            .put(S3ClientSettings.PROXY_TYPE_SETTING.getConcreteSettingForNamespace("test").getKey(), ProxySettings.ProxyType.DIRECT)
+            .put(S3ClientSettings.REGION.getConcreteSettingForNamespace("test").getKey(), "test-region")
+            .put(
+                S3ClientSettings.SIGNER_OVERRIDE.getConcreteSettingForNamespace("test").getKey(),
+                AwsRequestSigner.VERSION_FOUR_SIGNER.getName()
+            )
+            .put(S3ClientSettings.REQUEST_TIMEOUT_SETTING.getConcreteSettingForNamespace("test").getKey(), REQUEST_TIMEOUT)
+            .put(S3ClientSettings.MAX_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), 1)
+            .put(super.nodeSettings(nodeOrdinal))
+            .setSecureSettings(secureSettings)
+            .build();
+    }
+
+    public void testSyncClientTimesOutOnSlowRepository() throws Exception {
+        delayedHandler.resetDelayedRequestCount();
+
+        client().admin()
+            .cluster()
+            .putRepository(
+                new PutRepositoryRequest("test-repo").type("s3")
+                    .settings(
+                        Settings.builder()
+                            .put(S3Repository.BUCKET_SETTING.getKey(), "bucket")
+                            .put(S3Repository.CLIENT_NAME.getKey(), "test")
+                    )
+                    .verify(false)
+            )
+            .get();
+
+        final String index = "test-index";
+        createIndex(
+            index,
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
+        );
+
+        client().prepareIndex(index).setSource("field", "value").get();
+        flushAndRefresh(index);
+
+        try {
+            CreateSnapshotResponse response = client().admin()
+                .cluster()
+                .prepareCreateSnapshot("test-repo", "test-snap")
+                .setWaitForCompletion(true)
+                .setIndices(index)
+                .get();
+
+            SnapshotState state = response.getSnapshotInfo().state();
+            assertTrue("Snapshot should fail due to request timeout, but got state: " + state, state == SnapshotState.FAILED);
+        } catch (Exception e) {
+            Throwable cause = e;
+            boolean foundTimeout = false;
+            while (cause != null) {
+                if (cause.getMessage() != null && cause.getMessage().contains("timeout")) {
+                    foundTimeout = true;
+                    break;
+                }
+                cause = cause.getCause();
+            }
+            assertTrue("Expected timeout-related exception but got: " + e.getMessage(), foundTimeout);
+        }
+
+        assertThat("Expected requests to the delayed S3 handler", delayedHandler.getDelayedRequestCount(), greaterThan(0));
+    }
+
+    /**
+     * Plugin that provides the S3 repository for testing.
+     */
+    public static class TimeoutTestS3RepositoryPlugin extends S3RepositoryPlugin {
+        public TimeoutTestS3RepositoryPlugin(final Settings settings, final Path configPath) {
+            super(
+                settings,
+                configPath,
+                new S3Service(configPath, Executors.newSingleThreadScheduledExecutor()),
+                new S3AsyncService(configPath, Executors.newSingleThreadScheduledExecutor())
+            );
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            final List<Setting<?>> settings = new ArrayList<>(super.getSettings());
+            settings.add(S3ClientSettings.DISABLE_CHUNKED_ENCODING);
+            settings.add(S3ClientSettings.REQUEST_TIMEOUT_SETTING);
+            return settings;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            Stream.of(service.getClientExecutorService(), s3AsyncService.getClientExecutorService())
+                .forEach(e -> assertTrue(ThreadPool.terminate(e, 5, TimeUnit.SECONDS)));
+        }
+    }
+}

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -368,7 +368,9 @@ class S3Service implements Closeable {
         } else {
             retryPolicy.throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy(RetryMode.STANDARD));
         }
-        return clientOverrideConfiguration.retryPolicy(retryPolicy.build()).build();
+        return clientOverrideConfiguration.retryPolicy(retryPolicy.build())
+            .apiCallAttemptTimeout(Duration.ofMillis(clientSettings.requestTimeoutMillis))
+            .build();
     }
 
     private static SSLConnectionSocketFactory createSocksSslConnectionSocketFactory(final InetSocketAddress address) {

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ClientSettingsTests.java
@@ -411,4 +411,26 @@ public class S3ClientSettingsTests extends AbstractS3RepositoryTestCase {
             .build();
         expectThrows(SettingsException.class, () -> S3ClientSettings.load(settings, configPath()));
     }
+
+    public void testRequestTimeoutAppliedToSyncClientOverrideConfiguration() {
+        S3Service.setDefaultAwsProfilePath();
+        // Default timeout (5 minutes)
+        final Map<String, S3ClientSettings> defaultSettings = S3ClientSettings.load(Settings.EMPTY, configPath());
+        ClientOverrideConfiguration defaultConfig = AccessController.doPrivileged(
+            () -> S3Service.buildOverrideConfiguration(defaultSettings.get("default"), null)
+        );
+        assertTrue(defaultConfig.apiCallAttemptTimeout().isPresent());
+        assertThat(defaultConfig.apiCallAttemptTimeout().get().toMillis(), is((long) defaultSettings.get("default").requestTimeoutMillis));
+
+        // Custom timeout
+        final Map<String, S3ClientSettings> customSettings = S3ClientSettings.load(
+            Settings.builder().put("s3.client.default.request_timeout", "2m").build(),
+            configPath()
+        );
+        ClientOverrideConfiguration customConfig = AccessController.doPrivileged(
+            () -> S3Service.buildOverrideConfiguration(customSettings.get("default"), null)
+        );
+        assertTrue(customConfig.apiCallAttemptTimeout().isPresent());
+        assertThat(customConfig.apiCallAttemptTimeout().get().toMillis(), is(120_000L));
+    }
 }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/DelayedS3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/DelayedS3HttpHandler.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package fixture.s3;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DelayedS3HttpHandler extends S3HttpHandler {
+
+    private final long delayMillis;
+    private final String pathPattern;
+    private final String methodFilter;
+    private final AtomicInteger delayedRequestCount = new AtomicInteger(0);
+
+    public DelayedS3HttpHandler(String bucket, long delayMillis, String methodFilter, String pathPattern) {
+        super(bucket);
+        this.delayMillis = delayMillis;
+        this.methodFilter = methodFilter;
+        this.pathPattern = pathPattern;
+    }
+
+    @Override
+    public void handle(final HttpExchange exchange) throws IOException {
+        final String method = exchange.getRequestMethod();
+        final String path = exchange.getRequestURI().getPath();
+        if (method.equals(methodFilter) && path.contains(pathPattern)) {
+            delayedRequestCount.incrementAndGet();
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        super.handle(exchange);
+    }
+
+    public int getDelayedRequestCount() {
+        return delayedRequestCount.get();
+    }
+
+    public void resetDelayedRequestCount() {
+        delayedRequestCount.set(0);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The S3 repository plugin's `request_timeout` setting (default 5m) was only applied to the async S3 client. The sync client—used by all snapshot finalize and delete paths—had no call-level timeout, allowing requests to hang indefinitely on a degraded store.

This adds `apiCallAttemptTimeout` to the sync client's `ClientOverrideConfiguration`, mirroring what the async client already does.

### Testing
  - `S3ClientSettingsTests.testRequestTimeoutAppliedToSyncClientOverrideConfiguration`: verifies default (5m) and custom timeout values.
  - Existing repository-s3 test suites pass unchanged.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
