### PR TITLE
add config skip_watermark_on_node_left_recovery for local restart (#2…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -53,6 +53,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.opensearch.cluster.routing.allocation.FileCacheThresholdSettings;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider.Rebalance;
@@ -61,6 +62,7 @@ import org.opensearch.common.Priority;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.io.PathUtilsForTesting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
@@ -81,6 +83,7 @@ import org.opensearch.snapshots.RestoreInfo;
 import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.snapshots.SnapshotState;
 import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -231,6 +234,122 @@ public class DiskThresholdDeciderIT extends ParameterizedStaticSettingsOpenSearc
         // increase disk size of node 0 to allow just enough room for one shard, and check that it's rebalanced back
         fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 1L);
         assertBusyWithDiskUsageRefresh(dataNode0Id, indexName, hasSize(1));
+    }
+
+    public void testSkipWatermarkOnNodeLeftRecoveryRestoresShard() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        ensureStableCluster(3);
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder().put(DiskThresholdDecider.SKIP_WATERMARK_ON_NODE_LEFT_RECOVERY.getKey(), true).build()
+                )
+                .get()
+        );
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        // 1 primary + 1 replica index
+        assertAcked(
+            prepareCreate(
+                indexName,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
+                    .put(IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED.getKey(), false)
+                    // Drop the node-left allocation delay so a leaving/rejoining node triggers an immediate reroute.
+                    .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "0ms")
+            )
+        );
+        ensureGreen(indexName);
+        createReasonableSizedShards(indexName);
+        assertAcked(
+            client().admin()
+                .indices()
+                .updateSettings(
+                    new UpdateSettingsRequest(indexName).settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+                )
+                .get()
+        );
+        ensureGreen(indexName);
+
+        final String replicaNodeName = getReplicaNodeName(indexName);
+        final Settings replicaNodeSettings = internalCluster().dataPathSettings(replicaNodeName);
+        simulateDiskPressure(getMockInternalClusterInfoService());
+
+        // --- Phase 1: default max_age (10m)
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(replicaNodeName));
+        assertBusy(() -> {
+            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            List<ShardRouting> allUnassigned = new ArrayList<>();
+            StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false).forEach(allUnassigned::add);
+            allUnassigned.addAll(state.getRoutingNodes().unassigned().ignored());
+            assertThat(allUnassigned, hasSize(1));
+            assertFalse("only the replica should be unassigned", allUnassigned.get(0).primary());
+            UnassignedInfo unassignedInfo = allUnassigned.get(0).unassignedInfo();
+            assertNotNull(unassignedInfo);
+            assertThat(unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.NODE_LEFT));
+        });
+
+        // Restart the same node with the same dataPath -> the local replica store matches and NODE_LEFT is fresh.
+        internalCluster().startDataOnlyNode(replicaNodeSettings);
+        ensureStableCluster(3);
+        assertBusy(() -> {
+            refreshDiskUsage();
+            assertAcked(client().admin().cluster().prepareReroute());
+            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            List<ShardRouting> replicas = state.getRoutingTable().index(indexName).shard(0).replicaShards();
+            assertThat(replicas, hasSize(1));
+            assertThat(replicas.get(0).state(), equalTo(ShardRoutingState.STARTED));
+        }, 60L, TimeUnit.SECONDS);
+
+        // --- Phase 2: shrink max_age to 1ms so the next NODE_LEFT event is treated as stale.
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(DiskThresholdDecider.SKIP_WATERMARK_ON_NODE_LEFT_MAX_AGE.getKey(), TimeValue.timeValueMillis(1))
+                        .build()
+                )
+                .get()
+        );
+
+        final String replicaNodeNamePhase2 = getReplicaNodeName(indexName);
+        final Settings replicaNodeSettingsPhase2 = internalCluster().dataPathSettings(replicaNodeNamePhase2);
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(replicaNodeNamePhase2));
+        internalCluster().startDataOnlyNode(replicaNodeSettingsPhase2);
+        ensureStableCluster(3);
+
+        assertBusy(() -> {
+            refreshDiskUsage();
+            // Force an allocation attempt; the decider must refuse it, leaving the replica unassigned.
+            assertAcked(client().admin().cluster().prepareReroute());
+            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            IndexShardRoutingTable shard = state.getRoutingTable().index(indexName).shard(0);
+            assertTrue("primary must remain active", shard.primaryShard().active());
+            assertThat(shard.replicaShards(), hasSize(1));
+            assertThat(shard.replicaShards().get(0).state(), equalTo(ShardRoutingState.UNASSIGNED));
+        }, 30L, TimeUnit.SECONDS);
+
+        releaseDiskPressure(getMockInternalClusterInfoService());
+        assertBusy(() -> {
+            refreshDiskUsage();
+            ensureGreen(indexName);
+        }, 60L, TimeUnit.SECONDS);
+    }
+
+    private String getReplicaNodeName(final String indexName) {
+        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final IndexShardRoutingTable shard = state.getRoutingTable().index(indexName).shard(0);
+        assertThat(shard.replicaShards(), hasSize(1));
+        final ShardRouting replica = shard.replicaShards().get(0);
+        assertTrue("replica must be started before bouncing its node", replica.started());
+        return state.nodes().get(replica.currentNodeId()).getName();
     }
 
     public void testIndexWriteBlockWhenNodeFileCacheActiveUsageExceedsIndexThreshold() throws Exception {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -45,10 +45,13 @@ import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.Index;
@@ -97,13 +100,33 @@ public class DiskThresholdDecider extends AllocationDecider {
 
     public static final String NAME = "disk_threshold";
 
+    public static final Setting<Boolean> SKIP_WATERMARK_ON_NODE_LEFT_RECOVERY = Setting.boolSetting(
+        "cluster.routing.allocation.disk.skip_watermark_on_node_left_recovery",
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> SKIP_WATERMARK_ON_NODE_LEFT_MAX_AGE = Setting.positiveTimeSetting(
+        "cluster.routing.allocation.disk.skip_watermark_on_node_left_max_age",
+        TimeValue.timeValueMinutes(10),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
     private final DiskThresholdSettings diskThresholdSettings;
     private final boolean enableForSingleDataNode;
+    private volatile boolean skipWatermarkOnNodeLeftRecovery;
+    private volatile TimeValue skipWatermarkOnNodeLeftMaxAge;
 
     public DiskThresholdDecider(Settings settings, ClusterSettings clusterSettings) {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
         assert Version.CURRENT.major < 9 : "remove enable_for_single_data_node in 9";
         this.enableForSingleDataNode = ENABLE_FOR_SINGLE_DATA_NODE.get(settings);
+        this.skipWatermarkOnNodeLeftRecovery = SKIP_WATERMARK_ON_NODE_LEFT_RECOVERY.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SKIP_WATERMARK_ON_NODE_LEFT_RECOVERY, v -> this.skipWatermarkOnNodeLeftRecovery = v);
+        this.skipWatermarkOnNodeLeftMaxAge = SKIP_WATERMARK_ON_NODE_LEFT_MAX_AGE.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SKIP_WATERMARK_ON_NODE_LEFT_MAX_AGE, v -> this.skipWatermarkOnNodeLeftMaxAge = v);
     }
 
     /**
@@ -175,6 +198,22 @@ public class DiskThresholdDecider extends AllocationDecider {
         final Decision decision = earlyTerminate(allocation, usages);
         if (decision != null) {
             return decision;
+        }
+
+        if (skipWatermarkOnNodeLeftRecovery
+            && isNodeRestartRecovery(shardRouting, node, allocation)
+            && isAboveFloodStageFreeThreshold(node, usages)) {
+            logger.info(
+                "[disk_threshold] waiver granted for shard [{}] on node [{}] (NODE_LEFT local-restart recovery; flood-stage still safe)",
+                shardRouting.shardId(),
+                node.nodeId()
+            );
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                "skipping low/high watermark check because the shard is recovering to its previous node "
+                    + "after a NODE_LEFT event (skip_watermark_on_node_left_recovery=true); flood-stage threshold is still satisfied"
+            );
         }
 
         final double usedDiskThresholdLow = 100.0 - diskThresholdSettings.getFreeDiskThresholdLow();
@@ -636,6 +675,49 @@ public class DiskThresholdDecider extends AllocationDecider {
             return allocation.decision(Decision.YES, NAME, "disk usages are unavailable");
         }
         return null;
+    }
+
+    boolean isNodeRestartRecovery(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        if (shardRouting.unassigned() == false) {
+            return false;
+        }
+        final UnassignedInfo info = shardRouting.unassignedInfo();
+        if (info == null || info.getReason() != UnassignedInfo.Reason.NODE_LEFT) {
+            return false;
+        }
+        final long unassignedAgeMillis = System.currentTimeMillis() - info.getUnassignedTimeInMillis();
+        final long maxAgeMillis = skipWatermarkOnNodeLeftMaxAge.millis();
+        if (unassignedAgeMillis < 0L || unassignedAgeMillis > maxAgeMillis) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                    "[disk_threshold] waiver denied for shard [{}] on node [{}]: NODE_LEFT age {}ms exceeds max {}ms",
+                    shardRouting.shardId(),
+                    node.nodeId(),
+                    unassignedAgeMillis,
+                    maxAgeMillis
+                );
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Strict floor: even when the waiver is enabled, the node must have MORE free disk than
+     * the flood-stage threshold (both percentage and absolute byte variants). This prevents
+     * the waiver from ever pushing a node into read-only-block territory.
+     */
+    boolean isAboveFloodStageFreeThreshold(RoutingNode node, Map<String, DiskUsage> usages) {
+        if (usages == null) {
+            return false;
+        }
+        final DiskUsage usage = usages.get(node.nodeId());
+        if (usage == null) {
+            return false;
+        }
+        final double freePctFloor = diskThresholdSettings.getFreeDiskThresholdFloodStage();
+        final long freeBytesFloor = diskThresholdSettings.getFreeBytesThresholdFloodStage().getBytes();
+        return usage.getFreeBytes() > freeBytesFloor && usage.getFreeDiskAsPercentage() > freePctFloor;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -74,6 +74,7 @@ import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDeci
 import org.opensearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ConcurrentRebalanceAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ConcurrentRecoveriesAllocationDecider;
+import org.opensearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
@@ -361,6 +362,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING,
                 ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING,
                 DiskThresholdSettings.ENABLE_FOR_SINGLE_DATA_NODE,
+                DiskThresholdDecider.SKIP_WATERMARK_ON_NODE_LEFT_RECOVERY,
+                DiskThresholdDecider.SKIP_WATERMARK_ON_NODE_LEFT_MAX_AGE,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING,


### PR DESCRIPTION
…0354)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

When a node restarts and cluster.routing.allocation.disk.skip_watermark_on_node_left_recovery is set to true:
If the node restart duration is shorter than cluster.routing.allocation.disk.skip_watermark_on_node_left_max_age, shards will bypass disk watermark checks and recover from local storage.
If the restart duration exceeds cluster.routing.allocation.disk.skip_watermark_on_node_left_max_age, shard recovery follows the original standard logic without any skip.
Purpose of this feature
In production clusters with extremely large shards and disk utilization exceeding the high watermark threshold, restarting a node under default behavior leaves shards unassigned, which severely impairs cluster business availability.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

fixed: https://github.com/opensearch-project/OpenSearch/issues/20354

### Check List
- [x] Functionality includes testing.  pass ./gradlew :server:internalClusterTest --tests "org.opensearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT"
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
