### PR TITLE
Add FieldDomain Metadata producer API 

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsIT.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddomain.DateRangeFieldDomain;
+import org.opensearch.index.fielddomain.IndexFieldDomainMetadata;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class PutIndexFieldDomainsIT extends OpenSearchIntegTestCase {
+    public void testPutIndexFieldDomainsActionPublishesIndexMetadata() throws Exception {
+        String indexName = "logs-000001";
+        assertAcked(prepareCreate(indexName).setMapping("@timestamp", "type=date", "event.ingested", "type=date"));
+        ensureGreen(indexName);
+
+        Index targetIndex = indexMetadata(indexName).getIndex();
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomains(
+            List.of(
+                new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer"),
+                new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test_producer")
+            )
+        );
+
+        assertAcked(client().execute(PutIndexFieldDomainsAction.INSTANCE, request).actionGet());
+
+        Map<String, String> customData = indexMetadata(indexName).getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY);
+        assertThat(customData, notNullValue());
+        assertThat(customData.get("fields.@timestamp.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.@timestamp.finalized"), equalTo("true"));
+        assertThat(customData.get("fields.@timestamp.source"), equalTo("test_producer"));
+        assertThat(customData.get("fields.event.ingested.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.event.ingested.min"), equalTo("300"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+        assertThat(customData.get("fields.event.ingested.finalized"), equalTo("true"));
+        assertThat(customData.get("fields.event.ingested.source"), equalTo("test_producer"));
+    }
+
+    private IndexMetadata indexMetadata(String indexName) {
+        return client().admin().cluster().prepareState().clear().setMetadata(true).get().getState().metadata().index(indexName);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -161,6 +161,8 @@ import org.opensearch.action.admin.indices.delete.DeleteIndexAction;
 import org.opensearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsAction;
 import org.opensearch.action.admin.indices.exists.indices.TransportIndicesExistsAction;
+import org.opensearch.action.admin.indices.fielddomain.PutIndexFieldDomainsAction;
+import org.opensearch.action.admin.indices.fielddomain.TransportPutIndexFieldDomainsAction;
 import org.opensearch.action.admin.indices.flush.FlushAction;
 import org.opensearch.action.admin.indices.flush.TransportFlushAction;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeAction;
@@ -731,6 +733,7 @@ public class ActionModule extends AbstractModule {
         actions.register(AutoPutMappingAction.INSTANCE, TransportAutoPutMappingAction.class);
         actions.register(IndicesAliasesAction.INSTANCE, TransportIndicesAliasesAction.class);
         actions.register(UpdateSettingsAction.INSTANCE, TransportUpdateSettingsAction.class);
+        actions.register(PutIndexFieldDomainsAction.INSTANCE, TransportPutIndexFieldDomainsAction.class);
         actions.register(ScaleIndexAction.INSTANCE, TransportScaleIndexAction.class);
         actions.register(AnalyzeAction.INSTANCE, TransportAnalyzeAction.class);
         actions.register(PutIndexTemplateAction.INSTANCE, TransportPutIndexTemplateAction.class);

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsAction.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Action type for publishing index-level field-domain metadata.
+ *
+ * This action is intended for trusted metadata producers. The cluster-manager node validates and merges the supplied
+ * field-domain metadata into the target concrete index metadata.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class PutIndexFieldDomainsAction extends ActionType<AcknowledgedResponse> {
+    /**
+     * Singleton action instance.
+     */
+    public static final PutIndexFieldDomainsAction INSTANCE = new PutIndexFieldDomainsAction();
+
+    /**
+     * Transport action name.
+     */
+    public static final String NAME = "indices:admin/field_domains/put";
+
+    private PutIndexFieldDomainsAction() {
+        super(NAME, AcknowledgedResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsClusterStateUpdateRequest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.cluster.ack.ClusterStateUpdateRequest;
+import org.opensearch.core.index.Index;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Cluster state update request for inserting field-domain metadata into one index.
+ *
+ * The transport layer resolves action-specific request details and hands this smaller request to the metadata service,
+ * following the same split used by other index metadata update actions.
+ */
+public class PutIndexFieldDomainsClusterStateUpdateRequest extends ClusterStateUpdateRequest<
+    PutIndexFieldDomainsClusterStateUpdateRequest> {
+    private Index targetIndex;
+    private Map<String, String> fieldDomainCustomData = Map.of();
+
+    /**
+     * Returns the exact target concrete index.
+     */
+    public Index targetIndex() {
+        return targetIndex;
+    }
+
+    /**
+     * Sets the exact target concrete index.
+     */
+    public PutIndexFieldDomainsClusterStateUpdateRequest targetIndex(Index targetIndex) {
+        this.targetIndex = targetIndex;
+        return this;
+    }
+
+    /**
+     * Returns encoded field-domain metadata.
+     */
+    public Map<String, String> fieldDomainCustomData() {
+        return fieldDomainCustomData;
+    }
+
+    /**
+     * Sets encoded field-domain metadata.
+     */
+    public PutIndexFieldDomainsClusterStateUpdateRequest fieldDomainCustomData(Map<String, String> fieldDomainCustomData) {
+        this.fieldDomainCustomData = Map.copyOf(Objects.requireNonNull(fieldDomainCustomData, "fieldDomainCustomData must not be null"));
+        return this;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequest.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.IndicesRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddomain.FieldDomain;
+import org.opensearch.index.fielddomain.IndexFieldDomainMetadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+/**
+ * Request for publishing field-domain metadata to one concrete index.
+ *
+ * Producers should use {@link #fieldDomain(FieldDomain)} or {@link #fieldDomains(Collection)} so typed
+ * {@link FieldDomain} objects are encoded through the central {@link IndexFieldDomainMetadata} codec. The transport
+ * request carries the encoded map because {@link org.opensearch.cluster.metadata.IndexMetadata} stores custom metadata
+ * as a flat {@code Map<String, String>}. This request intentionally targets an exact concrete {@link Index} instead of
+ * implementing {@link IndicesRequest.Replaceable}; callers must not rewrite the target name without also preserving the
+ * UUID identity guard.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class PutIndexFieldDomainsRequest extends AcknowledgedRequest<PutIndexFieldDomainsRequest> implements IndicesRequest {
+    private Index targetIndex;
+    private Map<String, String> fieldDomainCustomData = Map.of();
+
+    /**
+     * Deserializes the request from transport.
+     */
+    public PutIndexFieldDomainsRequest(StreamInput in) throws IOException {
+        super(in);
+        targetIndex = new Index(in);
+        fieldDomainCustomData = Map.copyOf(in.readMap(StreamInput::readString, StreamInput::readString));
+    }
+
+    /**
+     * Creates a request for the exact target concrete index.
+     */
+    public PutIndexFieldDomainsRequest(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    /**
+     * Returns the exact target concrete index.
+     */
+    public Index targetIndex() {
+        return targetIndex;
+    }
+
+    /**
+     * Sets the exact target concrete index.
+     */
+    public PutIndexFieldDomainsRequest targetIndex(Index targetIndex) {
+        this.targetIndex = targetIndex;
+        return this;
+    }
+
+    /**
+     * Encodes and adds one field domain to this request.
+     */
+    public PutIndexFieldDomainsRequest fieldDomain(FieldDomain domain) {
+        Objects.requireNonNull(domain, "domain must not be null");
+
+        List<FieldDomain> domains = new ArrayList<>();
+        if (fieldDomainCustomData.isEmpty() == false) {
+            domains.addAll(IndexFieldDomainMetadata.getInstance().validateAndParseCustomData(fieldDomainCustomData));
+        }
+        domains.add(domain);
+        return fieldDomains(domains);
+    }
+
+    /**
+     * Encodes and sets field domains, replacing any field domains already configured on this request.
+     */
+    public PutIndexFieldDomainsRequest fieldDomains(Collection<? extends FieldDomain> domains) {
+        fieldDomainCustomData = IndexFieldDomainMetadata.getInstance().toCustomData(domains);
+        return this;
+    }
+
+    /**
+     * Returns the encoded field-domain metadata carried by this request.
+     */
+    public Map<String, String> fieldDomainCustomData() {
+        return fieldDomainCustomData;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (targetIndex == null) {
+            validationException = addValidationError("target index is required", validationException);
+        } else {
+            if (targetIndex.getName().isBlank()) {
+                validationException = addValidationError("target index name is required", validationException);
+            }
+            if (targetIndex.getUUID().isBlank() || Strings.UNKNOWN_UUID_VALUE.equals(targetIndex.getUUID())) {
+                validationException = addValidationError("target index UUID is required", validationException);
+            }
+        }
+        if (fieldDomainCustomData == null || fieldDomainCustomData.isEmpty()) {
+            validationException = addValidationError("field domain metadata is required", validationException);
+        } else {
+            for (Map.Entry<String, String> entry : fieldDomainCustomData.entrySet()) {
+                if (entry.getKey() == null || entry.getKey().isBlank()) {
+                    validationException = addValidationError("field domain metadata keys must not be empty", validationException);
+                }
+                if (entry.getValue() == null) {
+                    validationException = addValidationError("field domain metadata values must not be null", validationException);
+                }
+            }
+        }
+        return validationException;
+    }
+
+    @Override
+    public String[] indices() {
+        return targetIndex == null ? Strings.EMPTY_ARRAY : new String[] { targetIndex.getName() };
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        Objects.requireNonNull(targetIndex, "targetIndex must not be null").writeTo(out);
+        out.writeMap(fieldDomainCustomData, StreamOutput::writeString, StreamOutput::writeString);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PutIndexFieldDomainsRequest that = (PutIndexFieldDomainsRequest) o;
+        return Objects.equals(targetIndex, that.targetIndex)
+            && Objects.equals(fieldDomainCustomData, that.fieldDomainCustomData)
+            && Objects.equals(clusterManagerNodeTimeout, that.clusterManagerNodeTimeout)
+            && Objects.equals(timeout, that.timeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetIndex, fieldDomainCustomData, clusterManagerNodeTimeout, timeout);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsAction.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportIndicesResolvingAction;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MetadataIndexFieldDomainService;
+import org.opensearch.cluster.metadata.OptionallyResolvedIndices;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+
+/**
+ * Transport action for publishing field-domain metadata to one concrete index.
+ */
+public class TransportPutIndexFieldDomainsAction extends TransportClusterManagerNodeAction<
+    PutIndexFieldDomainsRequest,
+    AcknowledgedResponse> implements TransportIndicesResolvingAction<PutIndexFieldDomainsRequest> {
+    private static final Logger logger = LogManager.getLogger(TransportPutIndexFieldDomainsAction.class);
+
+    private final MetadataIndexFieldDomainService fieldDomainService;
+
+    @Inject
+    public TransportPutIndexFieldDomainsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        MetadataIndexFieldDomainService fieldDomainService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            PutIndexFieldDomainsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            PutIndexFieldDomainsRequest::new,
+            indexNameExpressionResolver
+        );
+        this.fieldDomainService = fieldDomainService;
+    }
+
+    @Override
+    protected String executor() {
+        // The transport action only submits a cluster state update task.
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(PutIndexFieldDomainsRequest request, ClusterState state) {
+        ClusterBlockException globalBlock = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        if (globalBlock != null) {
+            return globalBlock;
+        }
+        if (request.targetIndex() == null) {
+            return null;
+        }
+        return state.blocks()
+            .indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNameExpressionResolver.concreteIndexNames(state, request));
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        final PutIndexFieldDomainsRequest request,
+        final ClusterState state,
+        final ActionListener<AcknowledgedResponse> listener
+    ) {
+        PutIndexFieldDomainsClusterStateUpdateRequest clusterStateUpdateRequest = new PutIndexFieldDomainsClusterStateUpdateRequest()
+            .targetIndex(request.targetIndex())
+            .fieldDomainCustomData(request.fieldDomainCustomData())
+            .ackTimeout(request.timeout())
+            .clusterManagerNodeTimeout(request.clusterManagerNodeTimeout());
+
+        fieldDomainService.putFieldDomains(clusterStateUpdateRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(ClusterStateUpdateResponse response) {
+                listener.onResponse(new AcknowledgedResponse(response.isAcknowledged()));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.debug(() -> new ParameterizedMessage("failed to publish field domains for index [{}]", request.targetIndex()), e);
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    @Override
+    public OptionallyResolvedIndices resolveIndices(PutIndexFieldDomainsRequest request) {
+        if (request.targetIndex() == null) {
+            return ResolvedIndices.unknown();
+        }
+        return ResolvedIndices.of(request.targetIndex());
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsAction.java
@@ -83,8 +83,7 @@ public class TransportPutIndexFieldDomainsAction extends TransportClusterManager
         if (request.targetIndex() == null) {
             return null;
         }
-        return state.blocks()
-            .indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNameExpressionResolver.concreteIndexNames(state, request));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, new String[] { request.targetIndex().getName() });
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/package-info.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/fielddomain/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Actions for publishing index-level field-domain metadata. */
+package org.opensearch.action.admin.indices.fielddomain;

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -45,6 +45,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver.ExpressionRes
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataDeleteIndexService;
 import org.opensearch.cluster.metadata.MetadataIndexAliasesService;
+import org.opensearch.cluster.metadata.MetadataIndexFieldDomainService;
 import org.opensearch.cluster.metadata.MetadataIndexStateService;
 import org.opensearch.cluster.metadata.MetadataIndexTemplateService;
 import org.opensearch.cluster.metadata.MetadataMappingService;
@@ -473,6 +474,7 @@ public class ClusterModule extends AbstractModule {
         bind(MetadataIndexStateService.class).asEagerSingleton();
         bind(MetadataMappingService.class).asEagerSingleton();
         bind(MetadataIndexAliasesService.class).asEagerSingleton();
+        bind(MetadataIndexFieldDomainService.class).asEagerSingleton();
         bind(MetadataUpdateSettingsService.class).asEagerSingleton();
         bind(MetadataIndexTemplateService.class).asEagerSingleton();
         bind(IndexNameExpressionResolver.class).toInstance(indexNameExpressionResolver);

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.action.admin.indices.fielddomain.PutIndexFieldDomainsClusterStateUpdateRequest;
+import org.opensearch.cluster.AckedClusterStateUpdateTask;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.fielddomain.IndexFieldDomainMetadata;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.action.support.ContextPreservingActionListener.wrapPreservingContext;
+import static org.opensearch.cluster.service.ClusterManagerTask.PUT_INDEX_FIELD_DOMAINS;
+
+/**
+ * Service responsible for publishing index-level field-domain metadata.
+ *
+ * Field-domain metadata describes values that may exist for a field in one concrete index. Trusted producers use this
+ * service to merge validated metadata into {@link IndexMetadata#getCustomData(String)} on the cluster-manager node.
+ */
+public class MetadataIndexFieldDomainService {
+    private final ClusterService clusterService;
+    private final ThreadPool threadPool;
+    private final ClusterManagerTaskThrottler.ThrottlingKey putIndexFieldDomainsTaskKey;
+
+    @Inject
+    public MetadataIndexFieldDomainService(ClusterService clusterService, ThreadPool threadPool) {
+        this.clusterService = Objects.requireNonNull(clusterService, "clusterService must not be null");
+        this.threadPool = Objects.requireNonNull(threadPool, "threadPool must not be null");
+
+        // Task is onboarded for throttling, it will get retried from associated TransportClusterManagerNodeAction.
+        putIndexFieldDomainsTaskKey = clusterService.registerClusterManagerTask(PUT_INDEX_FIELD_DOMAINS, true);
+    }
+
+    /**
+     * Publishes field-domain metadata through a cluster state update.
+     */
+    public void putFieldDomains(
+        final PutIndexFieldDomainsClusterStateUpdateRequest request,
+        final ActionListener<ClusterStateUpdateResponse> listener
+    ) {
+        clusterService.submitStateUpdateTask(
+            "put-index-field-domains [" + request.targetIndex() + "]",
+            new AckedClusterStateUpdateTask<>(Priority.URGENT, request, wrapPreservingContext(listener, threadPool.getThreadContext())) {
+                @Override
+                protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                    return new ClusterStateUpdateResponse(acknowledged);
+                }
+
+                @Override
+                public ClusterManagerTaskThrottler.ThrottlingKey getClusterManagerThrottlingKey() {
+                    return putIndexFieldDomainsTaskKey;
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    return applyFieldDomains(currentState, request);
+                }
+            }
+        );
+    }
+
+    /**
+     * Applies the metadata merge to the supplied cluster state.
+     */
+    static ClusterState applyFieldDomains(ClusterState currentState, PutIndexFieldDomainsClusterStateUpdateRequest request) {
+        Objects.requireNonNull(currentState, "currentState must not be null");
+        Objects.requireNonNull(request, "request must not be null");
+
+        IndexMetadata currentIndexMetadata = currentState.metadata()
+            .getIndexSafe(Objects.requireNonNull(request.targetIndex(), "targetIndex must not be null"));
+
+        Map<String, String> encodedFieldDomains = request.fieldDomainCustomData();
+        if (encodedFieldDomains == null || encodedFieldDomains.isEmpty()) {
+            throw new IllegalArgumentException("field domain metadata is required");
+        }
+
+        IndexMetadata updatedIndexMetadata = IndexFieldDomainMetadata.getInstance()
+            .putFieldDomains(currentIndexMetadata, encodedFieldDomains);
+        if (Objects.equals(
+            currentIndexMetadata.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY),
+            updatedIndexMetadata.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY)
+        )) {
+            return currentState;
+        }
+
+        Metadata.Builder metadata = Metadata.builder(currentState.metadata()).put(updatedIndexMetadata, true);
+        return ClusterState.builder(currentState).metadata(metadata).build();
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
@@ -55,7 +55,7 @@ public class MetadataIndexFieldDomainService {
     ) {
         clusterService.submitStateUpdateTask(
             "put-index-field-domains [" + request.targetIndex() + "]",
-            new AckedClusterStateUpdateTask<>(Priority.URGENT, request, wrapPreservingContext(listener, threadPool.getThreadContext())) {
+            new AckedClusterStateUpdateTask<>(Priority.NORMAL, request, wrapPreservingContext(listener, threadPool.getThreadContext())) {
                 @Override
                 protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
                     return new ClusterStateUpdateResponse(acknowledged);

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainService.java
@@ -95,6 +95,7 @@ public class MetadataIndexFieldDomainService {
             currentIndexMetadata.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY),
             updatedIndexMetadata.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY)
         )) {
+            // Avoid publishing a new cluster state when the stored field-domain metadata is unchanged.
             return currentState;
         }
 

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTask.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTask.java
@@ -19,6 +19,7 @@ public enum ClusterManagerTask {
     // Tasks with default threshold (50)
     CREATE_INDEX("create-index", 50),
     UPDATE_SETTINGS("update-settings", 50),
+    PUT_INDEX_FIELD_DOMAINS("put-index-field-domains", 50),
     CLUSTER_UPDATE_SETTINGS("cluster-update-settings", 50),
     DELETE_INDEX("delete-index", 50),
     DELETE_DANGLING_INDEX("delete-dangling-index", 50),

--- a/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
+++ b/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
@@ -8,10 +8,10 @@
 
 package org.opensearch.index.fielddomain;
 
+import org.apache.lucene.util.UnicodeUtil;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.annotation.ExperimentalApi;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,7 +38,7 @@ public final class IndexFieldDomainMetadata {
      */
     public static final String CUSTOM_KEY = "index_field_domains";
 
-    static final int MAX_CUSTOM_DATA_BYTES = 1 << 20; // 1 MiB
+    static final int MAX_CUSTOM_DATA_BYTES = 16 * 1024; // 16 KiB
 
     private static final IndexFieldDomainMetadata INSTANCE = new IndexFieldDomainMetadata();
 
@@ -253,7 +253,7 @@ public final class IndexFieldDomainMetadata {
     }
 
     private static int utf8Length(String value) {
-        return value == null ? 0 : value.getBytes(StandardCharsets.UTF_8).length;
+        return value == null ? 0 : UnicodeUtil.calcUTF16toUTF8Length(value, 0, value.length());
     }
 
     private static String fieldPrefix(String field) {

--- a/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
+++ b/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
@@ -11,10 +11,17 @@ package org.opensearch.index.fielddomain;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.annotation.ExperimentalApi;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Codec for the {@code index_field_domains} index custom metadata.
@@ -30,6 +37,8 @@ public final class IndexFieldDomainMetadata {
      * Custom metadata key used on {@link IndexMetadata}.
      */
     public static final String CUSTOM_KEY = "index_field_domains";
+
+    static final int MAX_CUSTOM_DATA_BYTES = 1 << 20; // 1 MiB
 
     private static final IndexFieldDomainMetadata INSTANCE = new IndexFieldDomainMetadata();
 
@@ -78,6 +87,62 @@ public final class IndexFieldDomainMetadata {
     }
 
     /**
+     * Validates and parses all field domains declared in an {@code index_field_domains} custom metadata map.
+     *
+     * This method is intentionally strict for producer-side writes: a request that declares an unsupported or malformed
+     * field domain is rejected instead of being silently stored. Search-time consumers should use
+     * {@link #fromCustomData(Map, String)} to read one field conservatively.
+     *
+     * @param customData custom metadata map stored under {@link #CUSTOM_KEY}
+     * @return parsed field domains in an unspecified order
+     * @throws IllegalArgumentException when the metadata declares an unsupported or malformed field domain
+     */
+    public List<FieldDomain> validateAndParseCustomData(Map<String, String> customData) {
+        if (customData == null || customData.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> fields = declaredFields(customData);
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("field domain metadata contains no field declarations");
+        }
+
+        List<FieldDomain> domains = new ArrayList<>(fields.size());
+        for (String field : fields) {
+            String type = customData.get(fieldPrefix(field) + KEY_TYPE);
+            if (parserRegistry.contains(type) == false) {
+                throw new IllegalArgumentException("unsupported field domain type [" + type + "] for field [" + field + "]");
+            }
+
+            Optional<FieldDomain> domain = fromCustomData(customData, field);
+            if (domain.isEmpty()) {
+                throw new IllegalArgumentException("invalid field domain metadata for field [" + field + "]");
+            }
+            domains.add(domain.get());
+        }
+        return List.copyOf(domains);
+    }
+
+    /**
+     * Encodes field-domain objects into a custom metadata map.
+     */
+    public Map<String, String> toCustomData(Collection<? extends FieldDomain> domains) {
+        Objects.requireNonNull(domains, "domains must not be null");
+
+        Map<String, String> customData = new HashMap<>();
+        Set<String> fields = new HashSet<>();
+        for (FieldDomain domain : domains) {
+            Objects.requireNonNull(domain, "domain must not be null");
+            if (fields.add(domain.field()) == false) {
+                throw new IllegalArgumentException("duplicate field domain for field [" + domain.field() + "]");
+            }
+            customData.putAll(toCustomData(domain));
+        }
+        ensureCustomDataWithinLimit(customData);
+        return Map.copyOf(customData);
+    }
+
+    /**
      * Encodes one field-domain object into a custom metadata map containing only that field.
      */
     public Map<String, String> toCustomData(FieldDomain domain) {
@@ -87,6 +152,7 @@ public final class IndexFieldDomainMetadata {
         String prefix = fieldPrefix(domain.field());
         customData.put(prefix + KEY_TYPE, domain.type());
         parserRegistry.writeToCustomData(domain, customData, prefix);
+        ensureCustomDataWithinLimit(customData);
         return Map.copyOf(customData);
     }
 
@@ -106,13 +172,88 @@ public final class IndexFieldDomainMetadata {
         String prefix = fieldPrefix(domain.field());
         removeKnownFieldKeys(updated, prefix);
         updated.putAll(toCustomData(domain));
+        ensureCustomDataWithinLimit(updated);
 
         return IndexMetadata.builder(metadata).putCustom(CUSTOM_KEY, updated).build();
+    }
+
+    /**
+     * Returns updated index metadata with the supplied field domains inserted under {@link #CUSTOM_KEY}.
+     *
+     * Existing metadata for other fields is preserved. Existing metadata for the same fields and known parser keys is
+     * replaced so stale values do not survive type changes.
+     */
+    public IndexMetadata putFieldDomains(IndexMetadata metadata, Collection<? extends FieldDomain> domains) {
+        Objects.requireNonNull(metadata, "metadata must not be null");
+        Objects.requireNonNull(domains, "domains must not be null");
+        if (domains.isEmpty()) {
+            return metadata;
+        }
+
+        Map<String, String> existing = metadata.getCustomData(CUSTOM_KEY);
+        Map<String, String> updated = existing == null ? new HashMap<>() : new HashMap<>(existing);
+
+        for (FieldDomain domain : domains) {
+            Objects.requireNonNull(domain, "domain must not be null");
+            removeKnownFieldKeys(updated, fieldPrefix(domain.field()));
+        }
+        updated.putAll(toCustomData(domains));
+        ensureCustomDataWithinLimit(updated);
+
+        return IndexMetadata.builder(metadata).putCustom(CUSTOM_KEY, updated).build();
+    }
+
+    /**
+     * Validates and inserts encoded field-domain metadata under {@link #CUSTOM_KEY}.
+     */
+    public IndexMetadata putFieldDomains(IndexMetadata metadata, Map<String, String> customData) {
+        Objects.requireNonNull(customData, "customData must not be null");
+        if (customData.isEmpty()) {
+            throw new IllegalArgumentException("field domain metadata is required");
+        }
+        return putFieldDomains(metadata, validateAndParseCustomData(customData));
     }
 
     private void removeKnownFieldKeys(Map<String, String> target, String prefix) {
         target.remove(prefix + KEY_TYPE);
         parserRegistry.removeFieldKeys(target, prefix);
+    }
+
+    private static Set<String> declaredFields(Map<String, String> customData) {
+        Set<String> fields = new LinkedHashSet<>();
+        String typeSuffix = "." + KEY_TYPE;
+        for (String key : customData.keySet()) {
+            if (key == null) {
+                throw new IllegalArgumentException("field domain metadata keys must not be null");
+            }
+            if (key.startsWith(FIELDS_PREFIX) && key.endsWith(typeSuffix)) {
+                int fieldStart = FIELDS_PREFIX.length();
+                int fieldEnd = key.length() - typeSuffix.length();
+                if (fieldEnd <= fieldStart) {
+                    throw new IllegalArgumentException("field domain metadata field name must not be empty");
+                }
+                String field = key.substring(fieldStart, fieldEnd);
+                fields.add(field);
+            }
+        }
+        return fields;
+    }
+
+    private static void ensureCustomDataWithinLimit(Map<String, String> customData) {
+        long sizeInBytes = 0L;
+        for (Map.Entry<String, String> entry : customData.entrySet()) {
+            sizeInBytes += utf8Length(entry.getKey());
+            sizeInBytes += utf8Length(entry.getValue());
+            if (sizeInBytes > MAX_CUSTOM_DATA_BYTES) {
+                throw new IllegalArgumentException(
+                    "index field domain metadata is too large, size must be less than or equal to [" + MAX_CUSTOM_DATA_BYTES + "] bytes"
+                );
+            }
+        }
+    }
+
+    private static int utf8Length(String value) {
+        return value == null ? 0 : value.getBytes(StandardCharsets.UTF_8).length;
     }
 
     private static String fieldPrefix(String field) {

--- a/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
+++ b/server/src/main/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadata.java
@@ -174,6 +174,9 @@ public final class IndexFieldDomainMetadata {
         updated.putAll(toCustomData(domain));
         ensureCustomDataWithinLimit(updated);
 
+        if (Objects.equals(existing, updated)) {
+            return metadata;
+        }
         return IndexMetadata.builder(metadata).putCustom(CUSTOM_KEY, updated).build();
     }
 
@@ -200,6 +203,9 @@ public final class IndexFieldDomainMetadata {
         updated.putAll(toCustomData(domains));
         ensureCustomDataWithinLimit(updated);
 
+        if (Objects.equals(existing, updated)) {
+            return metadata;
+        }
         return IndexMetadata.builder(metadata).putCustom(CUSTOM_KEY, updated).build();
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequestSerializationTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequestSerializationTests.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddomain.DateRangeFieldDomain;
+import org.opensearch.index.fielddomain.FieldDomain;
+import org.opensearch.index.fielddomain.IndexFieldDomainMetadata;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Wire serialization and equality tests for {@link PutIndexFieldDomainsRequest}.
+ */
+public class PutIndexFieldDomainsRequestSerializationTests extends AbstractWireSerializingTestCase<PutIndexFieldDomainsRequest> {
+    @Override
+    protected PutIndexFieldDomainsRequest createTestInstance() {
+        return randomRequest();
+    }
+
+    @Override
+    protected Writeable.Reader<PutIndexFieldDomainsRequest> instanceReader() {
+        return PutIndexFieldDomainsRequest::new;
+    }
+
+    @Override
+    protected PutIndexFieldDomainsRequest mutateInstance(PutIndexFieldDomainsRequest instance) throws IOException {
+        PutIndexFieldDomainsRequest mutation = copyRequest(instance);
+        Supplier<TimeValue> timeoutSupplier = () -> TimeValue.parseTimeValue(randomTimeValue(), "field_domain_test");
+        List<Runnable> mutators = new ArrayList<>();
+        mutators.add(
+            () -> mutation.targetIndex(new Index(instance.targetIndex().getName() + "-mutated", instance.targetIndex().getUUID()))
+        );
+        mutators.add(
+            () -> mutation.targetIndex(new Index(instance.targetIndex().getName(), instance.targetIndex().getUUID() + "-mutated"))
+        );
+        mutators.add(() -> mutation.timeout(randomValueOtherThan(instance.timeout(), timeoutSupplier)));
+        mutators.add(() -> mutation.clusterManagerNodeTimeout(randomValueOtherThan(instance.clusterManagerNodeTimeout(), timeoutSupplier)));
+        mutators.add(
+            () -> mutation.fieldDomain(
+                new DateRangeFieldDomain("mutated." + randomAlphaOfLengthBetween(4, 8), 10_000L, 20_000L, true, "test")
+            )
+        );
+        randomFrom(mutators).run();
+        return mutation;
+    }
+
+    private static PutIndexFieldDomainsRequest randomRequest() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(
+            new Index("logs-" + randomAlphaOfLengthBetween(4, 8), randomAlphaOfLengthBetween(8, 16))
+        );
+        request.fieldDomains(randomDomains());
+        request.timeout(randomPositiveTimeValue());
+        request.clusterManagerNodeTimeout(randomPositiveTimeValue());
+        return request;
+    }
+
+    private static PutIndexFieldDomainsRequest copyRequest(PutIndexFieldDomainsRequest request) {
+        PutIndexFieldDomainsRequest copy = new PutIndexFieldDomainsRequest(request.targetIndex());
+        copy.fieldDomains(IndexFieldDomainMetadata.getInstance().validateAndParseCustomData(request.fieldDomainCustomData()));
+        copy.timeout(request.timeout());
+        copy.clusterManagerNodeTimeout(request.clusterManagerNodeTimeout());
+        return copy;
+    }
+
+    private static List<FieldDomain> randomDomains() {
+        int domainCount = randomIntBetween(1, 3);
+        List<FieldDomain> domains = new ArrayList<>(domainCount);
+        for (int i = 0; i < domainCount; i++) {
+            long min = randomLongBetween(0L, 1_000_000L);
+            long max = randomLongBetween(min, min + 1_000_000L);
+            domains.add(new DateRangeFieldDomain("field." + i, min, max, randomBoolean(), "test"));
+        }
+        return domains;
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/PutIndexFieldDomainsRequestTests.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddomain.DateRangeFieldDomain;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class PutIndexFieldDomainsRequestTests extends OpenSearchTestCase {
+    public void testValidationRequiresIndexAndMetadata() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest((Index) null);
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertNotNull(validationException);
+        assertTrue(validationException.validationErrors().contains("target index is required"));
+        assertTrue(validationException.validationErrors().contains("field domain metadata is required"));
+    }
+
+    public void testValidationRequiresTargetIndexUUID() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", Strings.UNKNOWN_UUID_VALUE))
+            .fieldDomain(new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"));
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertNotNull(validationException);
+        assertTrue(validationException.validationErrors().contains("target index UUID is required"));
+    }
+
+    public void testFieldDomainSetterEncodesMetadata() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test")
+        );
+
+        Map<String, String> customData = request.fieldDomainCustomData();
+        assertThat(customData.get("fields.@timestamp.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.@timestamp.finalized"), equalTo("true"));
+        assertThat(customData.get("fields.@timestamp.resolution"), equalTo("milliseconds"));
+    }
+
+    public void testFieldDomainSetterAddsDomains() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test")
+        ).fieldDomain(new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test"));
+
+        Map<String, String> customData = request.fieldDomainCustomData();
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+    }
+
+    public void testFieldDomainSetterRejectsDuplicateField() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test")
+        );
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> request.fieldDomain(new DateRangeFieldDomain("@timestamp", 300L, 400L, true, "test"))
+        );
+
+        assertThat(exception.getMessage(), equalTo("duplicate field domain for field [@timestamp]"));
+    }
+
+    public void testFieldDomainsSetterEncodesMultipleDomains() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomains(
+            List.of(
+                new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"),
+                new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test")
+            )
+        );
+
+        Map<String, String> customData = request.fieldDomainCustomData();
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+    }
+
+    public void testSerialization() throws IOException {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomains(
+            List.of(
+                new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"),
+                new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test")
+            )
+        );
+        request.timeout(randomPositiveTimeValue());
+        request.clusterManagerNodeTimeout(randomPositiveTimeValue());
+        request.setParentTask(randomAlphaOfLength(5), randomNonNegativeLong());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+
+            PutIndexFieldDomainsRequest deserialized;
+            try (StreamInput in = out.bytes().streamInput()) {
+                deserialized = new PutIndexFieldDomainsRequest(in);
+            }
+            assertThat(deserialized.targetIndex(), equalTo(request.targetIndex()));
+            assertThat(deserialized.fieldDomainCustomData(), equalTo(request.fieldDomainCustomData()));
+            assertThat(deserialized.timeout(), equalTo(request.timeout()));
+            assertThat(deserialized.clusterManagerNodeTimeout(), equalTo(request.clusterManagerNodeTimeout()));
+            assertThat(deserialized.getParentTask(), equalTo(request.getParentTask()));
+        }
+    }
+
+    public void testIndicesRequestProperties() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid"));
+
+        assertArrayEquals(new String[] { "logs-000001" }, request.indices());
+        assertThat(request.indicesOptions(), equalTo(IndicesOptions.strictSingleIndexNoExpandForbidClosed()));
+        assertFalse(request.includeDataStreams());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/fielddomain/TransportPutIndexFieldDomainsActionTests.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.fielddomain;
+
+import org.opensearch.Version;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.block.ClusterBlock;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.MetadataIndexFieldDomainService;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.fielddomain.DateRangeFieldDomain;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.util.EnumSet;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutIndexFieldDomainsActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private MetadataIndexFieldDomainService fieldDomainService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ActionListener<AcknowledgedResponse> listener;
+    @Mock
+    private ClusterState clusterState;
+
+    private TransportPutIndexFieldDomainsAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        action = new TransportPutIndexFieldDomainsAction(
+            transportService,
+            clusterService,
+            threadPool,
+            fieldDomainService,
+            actionFilters,
+            new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY))
+        );
+    }
+
+    public void testClusterManagerOperationDelegatesToMetadataService() {
+        Index targetIndex = new Index("logs-000001", "index-uuid");
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+
+        ArgumentCaptor<PutIndexFieldDomainsClusterStateUpdateRequest> updateRequestCaptor = ArgumentCaptor.forClass(
+            PutIndexFieldDomainsClusterStateUpdateRequest.class
+        );
+        ArgumentCaptor<ActionListener<ClusterStateUpdateResponse>> updateListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(fieldDomainService).putFieldDomains(updateRequestCaptor.capture(), updateListenerCaptor.capture());
+
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        PutIndexFieldDomainsClusterStateUpdateRequest updateRequest = updateRequestCaptor.getValue();
+        assertThat(updateRequest.targetIndex(), sameInstance(targetIndex));
+        assertThat(updateRequest.fieldDomainCustomData(), equalTo(request.fieldDomainCustomData()));
+        assertThat(updateRequest.ackTimeout(), equalTo(request.timeout()));
+        assertThat(updateRequest.clusterManagerNodeTimeout(), equalTo(request.clusterManagerNodeTimeout()));
+
+        updateListenerCaptor.getValue().onResponse(new ClusterStateUpdateResponse(true));
+        ArgumentCaptor<AcknowledgedResponse> responseCaptor = ArgumentCaptor.forClass(AcknowledgedResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().isAcknowledged());
+    }
+
+    public void testClusterManagerOperationForwardsMetadataServiceFailure() {
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(new Index("logs-000001", "index-uuid")).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+        RuntimeException failure = new RuntimeException("boom");
+
+        ArgumentCaptor<ActionListener<ClusterStateUpdateResponse>> updateListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(fieldDomainService).putFieldDomains(any(), updateListenerCaptor.capture());
+
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        updateListenerCaptor.getValue().onFailure(failure);
+        verify(listener).onFailure(failure);
+    }
+
+    public void testCheckBlockAllowsUnblockedState() {
+        Index targetIndex = new Index("logs-000001", "index-uuid");
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+
+        assertNull(action.checkBlock(request, clusterState(targetIndex, ClusterBlocks.EMPTY_CLUSTER_BLOCK)));
+    }
+
+    public void testCheckBlockRejectsGlobalMetadataWriteBlock() {
+        Index targetIndex = new Index("logs-000001", "index-uuid");
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+        ClusterBlock metadataWriteBlock = metadataWriteBlock();
+        ClusterState blockedState = clusterState(targetIndex, ClusterBlocks.builder().addGlobalBlock(metadataWriteBlock).build());
+
+        ClusterBlockException exception = action.checkBlock(request, blockedState);
+
+        assertNotNull(exception);
+        assertTrue(exception.blocks().contains(metadataWriteBlock));
+    }
+
+    public void testCheckBlockRejectsIndexMetadataWriteBlock() {
+        Index targetIndex = new Index("logs-000001", "index-uuid");
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+        ClusterBlock metadataWriteBlock = metadataWriteBlock();
+        ClusterState blockedState = clusterState(
+            targetIndex,
+            ClusterBlocks.builder().addIndexBlock(targetIndex.getName(), metadataWriteBlock).build()
+        );
+
+        ClusterBlockException exception = action.checkBlock(request, blockedState);
+
+        assertNotNull(exception);
+        assertTrue(exception.blocks().contains(metadataWriteBlock));
+    }
+
+    public void testResolveIndicesReturnsExactTargetIndex() {
+        Index targetIndex = new Index("logs-000001", "index-uuid");
+        PutIndexFieldDomainsRequest request = new PutIndexFieldDomainsRequest(targetIndex).fieldDomain(
+            new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test_producer")
+        );
+
+        assertThat(action.resolveIndices(request), equalTo(ResolvedIndices.of(targetIndex)));
+    }
+
+    private static ClusterState clusterState(Index targetIndex, ClusterBlocks blocks) {
+        IndexMetadata indexMetadata = IndexMetadata.builder(targetIndex.getName())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, targetIndex.getUUID())
+                    .build()
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        return ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().put(indexMetadata, true)).blocks(blocks).build();
+    }
+
+    private static ClusterBlock metadataWriteBlock() {
+        return new ClusterBlock(
+            1,
+            "metadata write block",
+            false,
+            false,
+            false,
+            RestStatus.FORBIDDEN,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexFieldDomainServiceTests.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.fielddomain.PutIndexFieldDomainsClusterStateUpdateRequest;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.fielddomain.DateRangeFieldDomain;
+import org.opensearch.index.fielddomain.IndexFieldDomainMetadata;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MetadataIndexFieldDomainServiceTests extends OpenSearchTestCase {
+    private static final IndexFieldDomainMetadata FIELD_DOMAIN_METADATA = IndexFieldDomainMetadata.getInstance();
+
+    public void testApplyFieldDomainsPublishesMetadata() {
+        Map<String, String> existing = new HashMap<>();
+        existing.put("fields.host.name.type", "term_set");
+        existing.put("fields.host.name.value", "server-a");
+        ClusterState state = clusterState(indexMetadata("logs-000001", "index-uuid", existing));
+
+        ClusterState updated = MetadataIndexFieldDomainService.applyFieldDomains(
+            state,
+            request("logs-000001", "index-uuid", new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"))
+        );
+
+        Map<String, String> customData = updated.metadata().index("logs-000001").getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY);
+        assertThat(customData.get("fields.@timestamp.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.host.name.type"), equalTo("term_set"));
+        assertThat(customData.get("fields.host.name.value"), equalTo("server-a"));
+    }
+
+    public void testApplyFieldDomainsReturnsSameStateWhenMetadataIsUnchanged() {
+        DateRangeFieldDomain domain = new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test");
+        ClusterState state = clusterState(indexMetadata("logs-000001", "index-uuid", FIELD_DOMAIN_METADATA.toCustomData(domain)));
+
+        ClusterState updated = MetadataIndexFieldDomainService.applyFieldDomains(state, request("logs-000001", "index-uuid", domain));
+
+        assertSame(state, updated);
+    }
+
+    public void testApplyFieldDomainsFailsWhenIndexIsMissing() {
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
+
+        expectThrows(
+            IndexNotFoundException.class,
+            () -> MetadataIndexFieldDomainService.applyFieldDomains(
+                state,
+                request("logs-000001", "index-uuid", new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"))
+            )
+        );
+    }
+
+    public void testApplyFieldDomainsFailsOnIndexUUIDMismatch() {
+        ClusterState state = clusterState(indexMetadata("logs-000001", "actual-uuid", Map.of()));
+
+        IndexNotFoundException exception = expectThrows(
+            IndexNotFoundException.class,
+            () -> MetadataIndexFieldDomainService.applyFieldDomains(
+                state,
+                request("logs-000001", "expected-uuid", new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"))
+            )
+        );
+
+        assertThat(exception.getMessage(), containsString("no such index [logs-000001]"));
+        assertNotNull(exception.getCause());
+        assertThat(exception.getCause().getMessage(), containsString("expected: [expected-uuid]"));
+        assertThat(exception.getCause().getMessage(), containsString("got: [actual-uuid]"));
+    }
+
+    public void testApplyFieldDomainsFailsOnMissingMetadata() {
+        ClusterState state = clusterState(indexMetadata("logs-000001", "index-uuid", Map.of()));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> MetadataIndexFieldDomainService.applyFieldDomains(
+                state,
+                new PutIndexFieldDomainsClusterStateUpdateRequest().targetIndex(new Index("logs-000001", "index-uuid"))
+            )
+        );
+
+        assertThat(exception.getMessage(), equalTo("field domain metadata is required"));
+    }
+
+    private static PutIndexFieldDomainsClusterStateUpdateRequest request(String index, String indexUUID, DateRangeFieldDomain domain) {
+        return new PutIndexFieldDomainsClusterStateUpdateRequest().targetIndex(new Index(index, indexUUID))
+            .fieldDomainCustomData(FIELD_DOMAIN_METADATA.toCustomData(domain));
+    }
+
+    private static ClusterState clusterState(IndexMetadata indexMetadata) {
+        return ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexMetadata, false)).build();
+    }
+
+    private static IndexMetadata indexMetadata(String index, String indexUUID, Map<String, String> customData) {
+        IndexMetadata.Builder builder = IndexMetadata.builder(index)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
+                    .build()
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        if (customData.isEmpty() == false) {
+            builder.putCustom(IndexFieldDomainMetadata.CUSTOM_KEY, customData);
+        }
+        return builder.build();
+    }
+}

--- a/server/src/test/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadataTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadataTests.java
@@ -14,9 +14,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -227,6 +229,143 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
         assertThat(customData.get("fields.@timestamp.resolution"), equalTo("milliseconds"));
     }
 
+    public void testValidateAndParseCustomDataReadsAllDeclaredDomains() {
+        Map<String, String> customData = new HashMap<>();
+        customData.putAll(METADATA.toCustomData(new DateRangeFieldDomain("event.created", 10L, 20L, true, "test")));
+        customData.putAll(METADATA.toCustomData(new DateRangeFieldDomain("event.ingested", 100L, 200L, true, "test")));
+
+        List<FieldDomain> domains = METADATA.validateAndParseCustomData(customData);
+
+        assertThat(domains.size(), equalTo(2));
+        DateRangeFieldDomain created = dateRangeDomain(domains, "event.created");
+        assertThat(created.min(), equalTo("10"));
+        assertThat(created.max(), equalTo("20"));
+        DateRangeFieldDomain ingested = dateRangeDomain(domains, "event.ingested");
+        assertThat(ingested.min(), equalTo("100"));
+        assertThat(ingested.max(), equalTo("200"));
+    }
+
+    public void testValidateAndParseCustomDataRejectsUnknownDeclaredType() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(Map.of("fields.host.name.type", "keyword_set"))
+        );
+
+        assertThat(exception.getMessage(), equalTo("unsupported field domain type [keyword_set] for field [host.name]"));
+    }
+
+    public void testValidateAndParseCustomDataRejectsMalformedDeclaredDomain() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(Map.of("fields.@timestamp.type", "date_range", "fields.@timestamp.min", "100"))
+        );
+
+        assertThat(exception.getMessage(), equalTo("invalid field domain metadata for field [@timestamp]"));
+    }
+
+    public void testValidateAndParseCustomDataRejectsInvalidDateRangeValues() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(
+                Map.of(
+                    "fields.@timestamp.type",
+                    "date_range",
+                    "fields.@timestamp.min",
+                    "1000000000",
+                    "fields.@timestamp.max",
+                    "2000000000",
+                    "fields.@timestamp.finalized",
+                    "true"
+                )
+            )
+        );
+        assertThat(exception.getMessage(), equalTo("invalid field domain metadata for field [@timestamp]"));
+
+        exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(
+                Map.of(
+                    "fields.@timestamp.type",
+                    "date_range",
+                    "fields.@timestamp.min",
+                    "bad",
+                    "fields.@timestamp.max",
+                    "200",
+                    "fields.@timestamp.finalized",
+                    "true",
+                    "fields.@timestamp.resolution",
+                    "milliseconds"
+                )
+            )
+        );
+        assertThat(exception.getMessage(), equalTo("invalid field domain metadata for field [@timestamp]"));
+    }
+
+    public void testValidateAndParseCustomDataRejectsMetadataWithoutFieldDeclarations() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(Map.of("producer", "test"))
+        );
+
+        assertThat(exception.getMessage(), equalTo("field domain metadata contains no field declarations"));
+    }
+
+    public void testValidateAndParseCustomDataRejectsEmptyFieldDeclaration() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.validateAndParseCustomData(Map.of("fields.type", "date_range"))
+        );
+
+        assertThat(exception.getMessage(), equalTo("field domain metadata field name must not be empty"));
+    }
+
+    public void testToCustomDataWritesMultipleDomains() {
+        Map<String, String> customData = METADATA.toCustomData(
+            List.of(
+                new DateRangeFieldDomain("event.created", 10L, 20L, true, "test"),
+                new DateRangeFieldDomain("event.ingested", 100L, 200L, true, "test")
+            )
+        );
+
+        assertThat(customData.get("fields.event.created.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.event.created.min"), equalTo("10"));
+        assertThat(customData.get("fields.event.ingested.type"), equalTo("date_range"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("200"));
+    }
+
+    public void testToCustomDataRejectsDuplicateFields() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.toCustomData(
+                List.of(
+                    new DateRangeFieldDomain("@timestamp", 1L, 2L, true, "test"),
+                    new DateRangeFieldDomain("@timestamp", 3L, 4L, true, "test")
+                )
+            )
+        );
+
+        assertThat(exception.getMessage(), equalTo("duplicate field domain for field [@timestamp]"));
+    }
+
+    public void testToCustomDataRejectsOversizedMetadata() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.toCustomData(
+                new DateRangeFieldDomain(
+                    "@timestamp",
+                    "100",
+                    "200",
+                    true,
+                    randomAlphaOfLength(IndexFieldDomainMetadata.MAX_CUSTOM_DATA_BYTES),
+                    null,
+                    "milliseconds"
+                )
+            )
+        );
+
+        assertThat(exception.getMessage(), containsString("index field domain metadata is too large"));
+    }
+
     public void testToCustomDataReturnsImmutableMap() {
         Map<String, String> customData = METADATA.toCustomData(new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"));
 
@@ -332,6 +471,61 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
         assertThat(customData.get("fields.@timestamp.custom"), equalTo("preserved"));
     }
 
+    public void testPutFieldDomainsMergesMultipleFields() {
+        Map<String, String> existing = new HashMap<>();
+        existing.put("fields.@timestamp.type", "date_range");
+        existing.put("fields.@timestamp.min", "1");
+        existing.put("fields.@timestamp.max", "2");
+        existing.put("fields.@timestamp.finalized", "true");
+        existing.put("fields.host.name.type", "term_set");
+        existing.put("fields.host.name.value", "server-a");
+
+        IndexMetadata metadata = indexMetadataBuilder("logs-000001").putCustom(IndexFieldDomainMetadata.CUSTOM_KEY, existing).build();
+
+        IndexMetadata updated = METADATA.putFieldDomains(
+            metadata,
+            List.of(
+                new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"),
+                new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test")
+            )
+        );
+
+        Map<String, String> customData = updated.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY);
+        assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
+        assertThat(customData.get("fields.@timestamp.max"), equalTo("200"));
+        assertThat(customData.get("fields.event.ingested.min"), equalTo("300"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+        assertThat(customData.get("fields.host.name.type"), equalTo("term_set"));
+        assertThat(customData.get("fields.host.name.value"), equalTo("server-a"));
+    }
+
+    public void testPutFieldDomainsFromEncodedMetadataValidatesAndMerges() {
+        IndexMetadata metadata = indexMetadataBuilder("logs-000001").build();
+        Map<String, String> encodedMetadata = METADATA.toCustomData(
+            List.of(
+                new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test"),
+                new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test")
+            )
+        );
+
+        IndexMetadata updated = METADATA.putFieldDomains(metadata, encodedMetadata);
+
+        Map<String, String> customData = updated.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY);
+        assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
+        assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+    }
+
+    public void testPutFieldDomainsFromEncodedMetadataRejectsEmptyMetadata() {
+        IndexMetadata metadata = indexMetadataBuilder("logs-000001").build();
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> METADATA.putFieldDomains(metadata, Map.of())
+        );
+
+        assertThat(exception.getMessage(), equalTo("field domain metadata is required"));
+    }
+
     public void testPutFieldDomainRejectsNullInputs() {
         IndexMetadata metadata = indexMetadataBuilder("logs-000001").build();
 
@@ -340,6 +534,7 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
             () -> METADATA.putFieldDomain(null, new DateRangeFieldDomain("@timestamp", 1L, 2L, true, "test"))
         );
         expectThrows(NullPointerException.class, () -> METADATA.putFieldDomain(metadata, null));
+        expectThrows(NullPointerException.class, () -> METADATA.putFieldDomains(metadata, (Map<String, String>) null));
     }
 
     private static IndexMetadata.Builder indexMetadataBuilder(String index) {
@@ -352,6 +547,14 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
             )
             .numberOfShards(1)
             .numberOfReplicas(0);
+    }
+
+    private static DateRangeFieldDomain dateRangeDomain(List<FieldDomain> domains, String field) {
+        return domains.stream()
+            .filter(domain -> field.equals(domain.field()))
+            .map(DateRangeFieldDomain.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("missing field domain [" + field + "]"));
     }
 
     private static final class UnsupportedFieldDomain implements FieldDomain {

--- a/server/src/test/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadataTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddomain/IndexFieldDomainMetadataTests.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
     private static final IndexFieldDomainMetadata METADATA = IndexFieldDomainMetadata.getInstance();
@@ -419,6 +420,16 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
         assertThat(customData.get("producer"), equalTo("existing"));
     }
 
+    public void testPutFieldDomainReturnsOriginalMetadataWhenMergedCustomDataIsUnchanged() {
+        DateRangeFieldDomain timestampDomain = new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test");
+        Map<String, String> existing = new HashMap<>(METADATA.toCustomData(timestampDomain));
+        existing.putAll(METADATA.toCustomData(new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test")));
+
+        IndexMetadata metadata = indexMetadataBuilder("logs-000001").putCustom(IndexFieldDomainMetadata.CUSTOM_KEY, existing).build();
+
+        assertThat(METADATA.putFieldDomain(metadata, timestampDomain), sameInstance(metadata));
+    }
+
     public void testPutFieldDomainPreservesFieldsWithSharedPrefixes() {
         Map<String, String> existing = new HashMap<>();
         existing.put("fields.event.type", "keyword_set");
@@ -513,6 +524,17 @@ public class IndexFieldDomainMetadataTests extends OpenSearchTestCase {
         Map<String, String> customData = updated.getCustomData(IndexFieldDomainMetadata.CUSTOM_KEY);
         assertThat(customData.get("fields.@timestamp.min"), equalTo("100"));
         assertThat(customData.get("fields.event.ingested.max"), equalTo("400"));
+    }
+
+    public void testPutFieldDomainsFromEncodedMetadataReturnsOriginalMetadataWhenMergedCustomDataIsUnchanged() {
+        DateRangeFieldDomain timestampDomain = new DateRangeFieldDomain("@timestamp", 100L, 200L, true, "test");
+        DateRangeFieldDomain ingestedDomain = new DateRangeFieldDomain("event.ingested", 300L, 400L, true, "test");
+        Map<String, String> existing = METADATA.toCustomData(List.of(timestampDomain, ingestedDomain));
+        Map<String, String> encodedPartialUpdate = METADATA.toCustomData(timestampDomain);
+
+        IndexMetadata metadata = indexMetadataBuilder("logs-000001").putCustom(IndexFieldDomainMetadata.CUSTOM_KEY, existing).build();
+
+        assertThat(METADATA.putFieldDomains(metadata, encodedPartialUpdate), sameInstance(metadata));
     }
 
     public void testPutFieldDomainsFromEncodedMetadataRejectsEmptyMetadata() {


### PR DESCRIPTION
Resolves [#22454](https://github.com/opensearch-project/OpenSearch/issues/22454)

Part of a broader contribution to enhance can_match based  shards pruning
This part adds the metadata producer API

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
