### PR TITLE
Add virtual thread-per-task executor support

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/threadpool/VirtualThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/threadpool/VirtualThreadPoolIT.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.threadpool;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Single-node IT that defines an inline plugin to register a virtual thread-per-task executor ("vt_pool")
+ * and verifies it is available on the node and runs tasks on virtual threads.
+ */
+public class VirtualThreadPoolIT extends OpenSearchSingleNodeTestCase {
+
+    private static final String POOL_NAME = "vt_pool";
+
+    /**
+     * Inline test plugin that registers a virtual thread-per-task executor named "vt_pool".
+     */
+    public static class TestPlugin extends Plugin {
+        @Override
+        public List<ExecutorBuilder<?>> getExecutorBuilders(final Settings settings) {
+            return List.of(new VirtualExecutorBuilder(POOL_NAME));
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        // Load the inline plugin into the single-node cluster for this test
+        return List.of(TestPlugin.class);
+    }
+
+    public void testVirtualThreadPoolExists() throws Exception {
+        ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
+        ExecutorService executor = threadPool.executor(POOL_NAME);
+        assertNotNull(POOL_NAME + " executor should be registered by the test plugin", executor);
+
+        // Tasks must run on virtual threads named with the standard opensearch[node][pool]#N convention
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean isVirtual = new AtomicBoolean();
+        final AtomicReference<String> threadName = new AtomicReference<>();
+        executor.execute(() -> {
+            isVirtual.set(Thread.currentThread().isVirtual());
+            threadName.set(Thread.currentThread().getName());
+            latch.countDown();
+        });
+        assertTrue("task should have run", latch.await(10, TimeUnit.SECONDS));
+        assertTrue("task should run on a virtual thread", isVirtual.get());
+
+        final String expectedPrefix = OpenSearchExecutors.threadName(node().settings(), POOL_NAME) + "#";
+        assertTrue(
+            "thread name [" + threadName.get() + "] should start with [" + expectedPrefix + "]",
+            threadName.get().startsWith(expectedPrefix)
+        );
+
+        // ThreadPool.Info should report VIRTUAL with no size, queue, or keep alive
+        ThreadPool.Info info = threadPool.info(POOL_NAME);
+        assertNotNull("ThreadPool.Info for " + POOL_NAME + " should exist", info);
+        assertEquals(POOL_NAME, info.getName());
+        assertEquals("type must be VIRTUAL", ThreadPool.ThreadPoolType.VIRTUAL, info.getThreadPoolType());
+        assertEquals("an unbounded pool reports no min", -1, info.getMin());
+        assertEquals("an unbounded pool reports no max", -1, info.getMax());
+        assertNull("an unbounded pool has no keep alive", info.getKeepAlive());
+        assertNull("an unbounded pool has no queue", info.getQueueSize());
+    }
+
+    public void testVirtualThreadPoolPreservesThreadContext() throws Exception {
+        ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
+        final ThreadContext threadContext = threadPool.getThreadContext();
+        // stash the context so the header set below does not leak into other tests
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("test-header", "test-value");
+            assertEquals(
+                "test-value",
+                threadPool.executor(POOL_NAME).submit(() -> threadContext.getHeader("test-header")).get(10, TimeUnit.SECONDS)
+            );
+        }
+    }
+
+    public void testVirtualThreadPoolAppearsInNodeStatsAndInfo() {
+        ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
+
+        ThreadPool.Info info = null;
+        for (ThreadPool.Info candidate : threadPool.info()) {
+            if (POOL_NAME.equals(candidate.getName())) {
+                info = candidate;
+                break;
+            }
+        }
+        assertNotNull("virtual pool should be listed in thread pool info", info);
+
+        ThreadPoolStats.Stats stats = null;
+        for (ThreadPoolStats.Stats candidate : threadPool.stats()) {
+            if (POOL_NAME.equals(candidate.getName())) {
+                stats = candidate;
+                break;
+            }
+        }
+        assertNotNull("virtual pool should be listed in thread pool stats", stats);
+        // a virtual thread-per-task pool has neither workers nor a queue, so these have no referent
+        assertEquals(-1, stats.getThreads());
+        assertEquals(-1, stats.getQueue());
+        assertEquals(-1, stats.getLargest());
+        assertEquals(-1L, stats.getRejected());
+        // task flow counters are tracked, so they are never negative
+        assertTrue("active must not be negative", stats.getActive() >= 0);
+        assertTrue("completed must not be negative", stats.getCompleted() >= 0);
+    }
+
+    public void testVirtualThreadPoolReportsTaskFlowStats() throws Exception {
+        ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
+        final long completedBefore = statsFor(threadPool).getCompleted();
+
+        final int taskCount = randomIntBetween(1, 10);
+        final CountDownLatch done = new CountDownLatch(taskCount);
+        for (int i = 0; i < taskCount; i++) {
+            threadPool.executor(POOL_NAME).execute(done::countDown);
+        }
+        assertTrue("all tasks should have run", done.await(10, TimeUnit.SECONDS));
+
+        // the counters are updated in a finally block after the task body, so poll rather than asserting immediately
+        assertBusy(() -> {
+            ThreadPoolStats.Stats stats = statsFor(threadPool);
+            assertEquals("completed should advance by the task count", completedBefore + taskCount, stats.getCompleted());
+            assertEquals("no tasks should remain in flight", 0, stats.getActive());
+        });
+    }
+
+    private static ThreadPoolStats.Stats statsFor(ThreadPool threadPool) {
+        for (ThreadPoolStats.Stats candidate : threadPool.stats()) {
+            if (POOL_NAME.equals(candidate.getName())) {
+                return candidate;
+            }
+        }
+        throw new AssertionError("no stats for thread pool [" + POOL_NAME + "]");
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ContextPreservingExecutorService.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ContextPreservingExecutorService.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util.concurrent;
+
+import org.opensearch.common.SuppressForbidden;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An {@link ExecutorService} wrapper that preserves {@link ThreadContext} across task submissions.
+ *
+ * @opensearch.internal
+ */
+class ContextPreservingExecutorService extends AbstractExecutorService {
+
+    private final ExecutorService delegate;
+    private final ThreadContext threadContext;
+
+    @SuppressForbidden(reason = "properly rethrowing errors, see OpenSearchExecutors.rethrowErrors")
+    ContextPreservingExecutorService(ExecutorService delegate, ThreadContext threadContext) {
+        super();
+        this.delegate = delegate;
+        this.threadContext = threadContext;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        final Runnable contextPreserving = threadContext.preserveContext(command);
+        delegate.execute(() -> {
+            try {
+                contextPreserving.run();
+                // Tasks submitted via submit()/invokeAll()/invokeAny() are RunnableFutures that capture any thrown
+                // Error instead of letting it propagate, so unwrap and rethrow it here the way
+                // OpenSearchThreadPoolExecutor does.
+                OpenSearchExecutors.rethrowErrors(threadContext.unwrap(contextPreserving));
+            } finally {
+                onTaskFinished();
+            }
+        });
+    }
+
+    /**
+     * Invoked on the executing thread once a task has finished, whether it completed normally or threw. Rethrowing a
+     * fatal {@link Error} happens before this, so it is called from a finally block. Does nothing by default.
+     */
+    protected void onTaskFinished() {}
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
@@ -50,6 +50,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -262,6 +263,25 @@ public class OpenSearchExecutors {
             new OpenSearchAbortPolicy(),
             contextHolder
         );
+    }
+
+    /**
+     * Returns a new executor that creates a new virtual thread for each task.
+     *
+     * @param nodeName       the name of the node
+     * @param namePrefix     the name prefix for virtual threads
+     * @param threadContext  the thread context to preserve across task execution
+     * @return a new virtual-thread-per-task executor
+     */
+    public static ExecutorService newVirtualThreadPerTaskExecutor(
+        final String nodeName,
+        final String namePrefix,
+        final ThreadContext threadContext
+    ) {
+        assert nodeName != null && false == nodeName.isEmpty();
+        final ThreadFactory threadFactory = Thread.ofVirtual().name(threadName(nodeName, namePrefix) + "#", 0).factory();
+        final ExecutorService delegate = Executors.newThreadPerTaskExecutor(threadFactory);
+        return new VirtualThreadPerTaskExecutorService(delegate, threadContext);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/util/concurrent/VirtualThreadPerTaskExecutorService.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/VirtualThreadPerTaskExecutorService.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * An {@link ExecutorService} that runs each task on its own virtual thread, preserving the {@link ThreadContext} at
+ * submission time.
+ *
+ * @opensearch.internal
+ */
+public class VirtualThreadPerTaskExecutorService extends ContextPreservingExecutorService {
+
+    /**
+     * Tasks submitted but not yet finished. A thread-per-task executor has no queue, so a submitted task is either
+     * running or about to be, making this both the in-flight task count and the live thread count.
+     */
+    private final LongAdder active = new LongAdder();
+
+    /** Tasks that have finished, whether normally or by throwing. */
+    private final LongAdder completed = new LongAdder();
+
+    VirtualThreadPerTaskExecutorService(ExecutorService delegate, ThreadContext threadContext) {
+        super(delegate, threadContext);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        active.increment();
+        boolean submitted = false;
+        try {
+            super.execute(command);
+            submitted = true;
+        } finally {
+            if (submitted == false) {
+                // the delegate rejected the task (or was already shut down), so it will never run
+                active.decrement();
+            }
+        }
+    }
+
+    @Override
+    protected void onTaskFinished() {
+        active.decrement();
+        completed.increment();
+    }
+
+    /**
+     * Returns the number of tasks that have been submitted but have not yet finished.
+     */
+    public int getActiveCount() {
+        // Clamp to zero because LongAdder::sum isn't atomic when concurrent updates
+        // happen but is good enough for stats.
+        // Do a simple cast to int because if active count exceeds max int we have
+        // bigger problems than this integer overflow.
+        return (int) Math.max(0, active.sum());
+    }
+
+    /**
+     * Returns the number of tasks that have finished executing.
+     */
+    public long getCompletedTaskCount() {
+        return completed.sum();
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
@@ -236,6 +236,9 @@ public class RestThreadPoolAction extends AbstractCatAction {
                     core = poolInfo.getMin();
                     assert poolInfo.getMax() > 0;
                     max = poolInfo.getMax();
+                } else if (poolInfo.getThreadPoolType() == ThreadPool.ThreadPoolType.VIRTUAL) {
+                    // a virtual thread-per-task pool is unbounded, so core, max, and size are all left unset
+                    assert poolInfo.getMin() == -1 && poolInfo.getMax() == -1;
                 } else {
                     assert poolInfo.getMin() == poolInfo.getMax() && poolInfo.getMax() > 0;
                     size = poolInfo.getMax();

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -46,6 +46,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.OpenSearchThreadPoolExecutor;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.util.concurrent.VirtualThreadPerTaskExecutorService;
 import org.opensearch.common.util.concurrent.XRejectedExecutionHandler;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -74,7 +75,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -146,7 +146,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         FIXED("fixed"),
         RESIZABLE("resizable"),
         SCALING("scaling"),
-        FORK_JOIN("fork_join");
+        FORK_JOIN("fork_join"),
+        VIRTUAL("virtual");
 
         private final String type;
 
@@ -474,8 +475,9 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             }
             Settings tpGroup = entry.getValue();
             ExecutorHolder holder = executors.get(tpName);
-            // Skip validation for ForkJoinPool type since it does not support setting updates
-            if (holder.info.type == ThreadPoolType.FORK_JOIN) {
+            // Skip validation for pool types that do not support setting updates. ForkJoinPool is not resizable, and a
+            // virtual thread-per-task pool has no size or queue to configure in the first place.
+            if (holder.info.type == ThreadPoolType.FORK_JOIN || holder.info.type == ThreadPoolType.VIRTUAL) {
                 continue;
             }
             assert holder.executor instanceof OpenSearchThreadPoolExecutor;
@@ -516,7 +518,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             if (holder == null) {
                 throw new IllegalArgumentException("illegal thread_pool name : " + tpName);
             }
-            if (holder.info.type == ThreadPoolType.FORK_JOIN) {
+            // neither a ForkJoinPool nor a virtual thread-per-task pool can be resized
+            if (holder.info.type == ThreadPoolType.FORK_JOIN || holder.info.type == ThreadPoolType.VIRTUAL) {
                 continue;
             }
             assert holder.executor instanceof OpenSearchThreadPoolExecutor;
@@ -582,7 +585,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             long waitTimeNanos = -1;
             int parallelism = -1;
 
-            if (holder.executor() instanceof OpenSearchThreadPoolExecutor threadPoolExecutor) {
+            // Executor types that do not expose pool metrics fall through with the -1 "unavailable" defaults set above.
+            // A virtual thread-per-task pool has neither a bounded set of worker threads nor a queue, so threads,
+            // queue, largest, and rejected have no referent; only the task flow counters are meaningful.
+            if (holder.executor() instanceof VirtualThreadPerTaskExecutorService virtualExecutor) {
+                active = virtualExecutor.getActiveCount();
+                completed = virtualExecutor.getCompletedTaskCount();
+            } else if (holder.executor() instanceof OpenSearchThreadPoolExecutor threadPoolExecutor) {
                 threads = threadPoolExecutor.getPoolSize();
                 queue = threadPoolExecutor.getQueue().size();
                 active = threadPoolExecutor.getActiveCount();
@@ -707,9 +716,9 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         stopCachedTimeThread();
         scheduler.shutdown();
         for (ExecutorHolder executor : executors.values()) {
-            ExecutorService es = executor.executor();
-            if (es instanceof ThreadPoolExecutor || es instanceof ForkJoinPool) {
-                es.shutdown();
+            // the direct executor runs tasks on the calling thread and does not support being shut down
+            if (executor.executor() != DIRECT_EXECUTOR) {
+                executor.executor().shutdown();
             }
         }
     }
@@ -718,9 +727,9 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         stopCachedTimeThread();
         scheduler.shutdownNow();
         for (ExecutorHolder executor : executors.values()) {
-            ExecutorService es = executor.executor();
-            if (es instanceof ThreadPoolExecutor || es instanceof ForkJoinPool) {
-                es.shutdownNow();
+            // the direct executor runs tasks on the calling thread and does not support being shut down
+            if (executor.executor() != DIRECT_EXECUTOR) {
+                executor.executor().shutdownNow();
             }
         }
     }
@@ -728,7 +737,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         boolean result = scheduler.awaitTermination(timeout, unit);
         for (ExecutorHolder executor : executors.values()) {
-            if (executor.executor() instanceof ThreadPoolExecutor || executor.executor() instanceof ForkJoinPool) {
+            // the direct executor has no threads of its own and never terminates
+            if (executor.executor() != DIRECT_EXECUTOR) {
                 result &= executor.executor().awaitTermination(timeout, unit);
             }
         }
@@ -929,7 +939,10 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public final Info info;
 
         ExecutorHolder(ExecutorService executor, Info info) {
-            assert executor instanceof OpenSearchThreadPoolExecutor || executor == DIRECT_EXECUTOR || executor instanceof ForkJoinPool;
+            assert executor instanceof OpenSearchThreadPoolExecutor
+                || executor == DIRECT_EXECUTOR
+                || executor instanceof ForkJoinPool
+                || info.type == ThreadPoolType.VIRTUAL;
             this.executor = executor;
             this.info = info;
         }
@@ -1008,12 +1021,15 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(name);
             if (type == ThreadPoolType.RESIZABLE && out.getVersion().before(Version.V_3_0_0)) {
-                // Opensearch on older version doesn't know about "resizable" thread pool. Convert RESIZABLE to FIXED
+                // OpenSearch on older version doesn't know about "resizable" thread pool. Convert RESIZABLE to FIXED
                 // to avoid serialization/de-serization issue between nodes with different OpenSearch version
                 out.writeString(ThreadPoolType.FIXED.getType());
             } else if (type == ThreadPoolType.FORK_JOIN && out.getVersion().before(Version.V_3_4_0)) {
-                // Opensearch on older version doesn't know about "fork_join" thread pool. Convert FORK_JOIN to FIXED
+                // OpenSearch on older version doesn't know about "fork_join" thread pool. Convert FORK_JOIN to FIXED
                 out.writeString(ThreadPoolType.FIXED.getType());
+            } else if (type == ThreadPoolType.VIRTUAL && out.getVersion().before(Version.V_3_8_0)) {
+                // VIRTUAL introduced in 3.8, convert to SCALING for bwc
+                out.writeString(ThreadPoolType.SCALING.getType());
             } else {
                 out.writeString(type.getType());
             }
@@ -1069,6 +1085,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                 }
             } else if (type == ThreadPoolType.FORK_JOIN) {
                 builder.field("parallelism", max);
+            } else if (type == ThreadPoolType.VIRTUAL) {
+                // an unbounded virtual thread-per-task pool has no size, keep alive, or queue to report
             } else {
                 assert max != -1;
                 builder.field("size", max);

--- a/server/src/main/java/org/opensearch/threadpool/VirtualExecutorBuilder.java
+++ b/server/src/main/java/org/opensearch/threadpool/VirtualExecutorBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.threadpool;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.node.Node;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A builder for executors backed by a virtual thread per task.
+ *
+ * @opensearch.internal
+ */
+public final class VirtualExecutorBuilder extends ExecutorBuilder<VirtualExecutorBuilder.VirtualExecutorSettings> {
+
+    /**
+     * Construct a virtual thread-per-task executor builder.
+     *
+     * @param name the name of the executor
+     */
+    public VirtualExecutorBuilder(final String name) {
+        super(name);
+    }
+
+    @Override
+    public List<Setting<?>> getRegisteredSettings() {
+        return List.of();
+    }
+
+    @Override
+    VirtualExecutorSettings getSettings(Settings settings) {
+        final String nodeName = Node.NODE_NAME_SETTING.get(settings);
+        return new VirtualExecutorSettings(nodeName);
+    }
+
+    @Override
+    ThreadPool.ExecutorHolder build(final VirtualExecutorSettings settings, final ThreadContext threadContext) {
+        final ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor(settings.nodeName, name(), threadContext);
+        final ThreadPool.Info info = new ThreadPool.Info(name(), ThreadPool.ThreadPoolType.VIRTUAL);
+        return new ThreadPool.ExecutorHolder(executor, info);
+    }
+
+    @Override
+    String formatInfo(ThreadPool.Info info) {
+        return String.format(Locale.ROOT, "name [%s], virtual thread per task", info.getName());
+    }
+
+    static class VirtualExecutorSettings extends ExecutorBuilder.ExecutorSettings {
+        VirtualExecutorSettings(final String nodeName) {
+            super(nodeName);
+        }
+    }
+
+}

--- a/server/src/test/java/org/opensearch/common/util/concurrent/OpenSearchExecutorsTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/OpenSearchExecutorsTests.java
@@ -38,12 +38,18 @@ import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matcher;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -507,4 +513,141 @@ public class OpenSearchExecutorsTests extends OpenSearchTestCase {
         assertSettingDeprecationsAndWarnings(deprecatedSettings, expectedWarning);
     }
 
+    public void testVirtualThreadPerTaskExecutor() throws Exception {
+        ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor("node1", "test-virtual", threadContext);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicBoolean isVirtual = new AtomicBoolean();
+            executor.execute(() -> {
+                isVirtual.set(Thread.currentThread().isVirtual());
+                latch.countDown();
+            });
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue("task should run on a virtual thread", isVirtual.get());
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPerTaskExecutorPreservesThreadContext() throws Exception {
+        ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor("node1", "test-virtual-ctx", threadContext);
+        try {
+            threadContext.putHeader("test-header", "test-value");
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicBoolean contextPreserved = new AtomicBoolean();
+            executor.execute(() -> {
+                contextPreserved.set("test-value".equals(threadContext.getHeader("test-header")));
+                latch.countDown();
+            });
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue("thread context should be preserved on virtual thread", contextPreserved.get());
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPerTaskExecutorThreadNaming() throws Exception {
+        ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor("node1", "test-naming", threadContext);
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<String> threadName = new AtomicReference<>();
+            executor.execute(() -> {
+                threadName.set(Thread.currentThread().getName());
+                latch.countDown();
+            });
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            // threads follow the same opensearch[node][pool]#N convention used for platform threads
+            assertEquals("opensearch[node1][test-naming]#0", threadName.get());
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPerTaskExecutorPreservesThreadContextForCallable() throws Exception {
+        ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor("node1", "test-virtual-callable", threadContext);
+        try {
+            threadContext.putHeader("test-header", "test-value");
+            assertEquals("test-value", executor.submit(() -> threadContext.getHeader("test-header")).get(10, TimeUnit.SECONDS));
+
+            List<Future<String>> futures = executor.invokeAll(
+                List.of(() -> threadContext.getHeader("test-header"), () -> threadContext.getHeader("test-header"))
+            );
+            for (Future<String> future : futures) {
+                assertEquals("test-value", future.get(10, TimeUnit.SECONDS));
+            }
+
+            assertEquals(
+                "test-value",
+                executor.invokeAny(List.of(() -> threadContext.getHeader("test-header"), () -> threadContext.getHeader("test-header")))
+            );
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPerTaskExecutorDoesNotLeakActiveCountOnRejection() throws Exception {
+        VirtualThreadPerTaskExecutorService executor = (VirtualThreadPerTaskExecutorService) OpenSearchExecutors
+            .newVirtualThreadPerTaskExecutor("node1", "test-virtual-reject", threadContext);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+        // a thread-per-task executor rejects submissions once shut down; the task never runs, so it must not be
+        // counted as active or completed
+        expectThrows(RejectedExecutionException.class, () -> executor.execute(() -> {}));
+        assertEquals(0, executor.getActiveCount());
+        assertEquals(0L, executor.getCompletedTaskCount());
+    }
+
+    public void testVirtualThreadPerTaskExecutorCountsErrorsAsCompleted() throws Exception {
+        VirtualThreadPerTaskExecutorService executor = (VirtualThreadPerTaskExecutorService) OpenSearchExecutors
+            .newVirtualThreadPerTaskExecutor("node1", "test-virtual-error-count", threadContext);
+        final Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+        try {
+            final CountDownLatch handlerCalled = new CountDownLatch(1);
+            Thread.setDefaultUncaughtExceptionHandler((t, e) -> handlerCalled.countDown());
+            executor.submit((Runnable) () -> { throw new Error("expected"); });
+            assertTrue(handlerCalled.await(10, TimeUnit.SECONDS));
+
+            // rethrowErrors throws past the task body, so only a finally block keeps the counters consistent
+            assertBusy(() -> {
+                assertEquals("a task that dies with an Error must not leak the active count", 0, executor.getActiveCount());
+                assertEquals("a task that dies with an Error still counts as completed", 1L, executor.getCompletedTaskCount());
+            });
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPerTaskExecutorRethrowsErrors() throws Exception {
+        ExecutorService executor = OpenSearchExecutors.newVirtualThreadPerTaskExecutor("node1", "test-virtual-error", threadContext);
+        final Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+        try {
+            final AtomicReference<Throwable> uncaught = new AtomicReference<>();
+            final CountDownLatch handlerCalled = new CountDownLatch(1);
+            Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+                uncaught.set(e);
+                handlerCalled.countDown();
+            });
+
+            final Error error = new Error("expected");
+            // A submitted task captures the Error in its Future, so it is only visible to the uncaught exception
+            // handler if the executor rethrows it on the executing thread.
+            final Future<?> future = executor.submit((Runnable) () -> { throw error; });
+
+            assertTrue("uncaught exception handler should have been called", handlerCalled.await(10, TimeUnit.SECONDS));
+            assertSame(error, uncaught.get());
+            ExecutionException e = expectThrows(ExecutionException.class, () -> future.get(10, TimeUnit.SECONDS));
+            assertSame(error, e.getCause());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/threadpool/ThreadPoolSerializationTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ThreadPoolSerializationTests.java
@@ -42,6 +42,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -101,8 +102,8 @@ public class ThreadPoolSerializationTests extends OpenSearchTestCase {
         Map<String, Object> map = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
         assertThat(map, hasKey("foo"));
         map = (Map<String, Object>) map.get("foo");
-        if (threadPoolType == ThreadPool.ThreadPoolType.FORK_JOIN) {
-            // ForkJoinPool does not write queue_size field at all
+        if (threadPoolType == ThreadPool.ThreadPoolType.FORK_JOIN || threadPoolType == ThreadPool.ThreadPoolType.VIRTUAL) {
+            // neither a ForkJoinPool nor an unbounded virtual thread-per-task pool writes a queue_size field
             assertThat(map.containsKey("queue_size"), is(false));
         } else {
             assertThat(map, hasKey("queue_size"));
@@ -134,8 +135,8 @@ public class ThreadPoolSerializationTests extends OpenSearchTestCase {
         Map<String, Object> map = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
         assertThat(map, hasKey("foo"));
         map = (Map<String, Object>) map.get("foo");
-        if (threadPoolType == ThreadPool.ThreadPoolType.FORK_JOIN) {
-            // ForkJoinPool does not write queue_size field at all
+        if (threadPoolType == ThreadPool.ThreadPoolType.FORK_JOIN || threadPoolType == ThreadPool.ThreadPoolType.VIRTUAL) {
+            // neither a ForkJoinPool nor an unbounded virtual thread-per-task pool writes a queue_size field
             assertThat(map.containsKey("queue_size"), is(false));
         } else {
             assertThat(map, hasKey("queue_size"));
@@ -155,5 +156,17 @@ public class ThreadPoolSerializationTests extends OpenSearchTestCase {
          * the same conversion in test to maintain parity.
          */
         assertThat(newInfo.getThreadPoolType(), is(threadPoolType));
+    }
+
+    public void testThatVirtualThreadPoolTypeIsSerializedAsScalingForOlderVersions() throws IOException {
+        ThreadPool.Info info = new ThreadPool.Info("foo", ThreadPool.ThreadPoolType.VIRTUAL);
+        output.setVersion(VersionUtils.getPreviousVersion(Version.V_3_8_0));
+        info.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        ThreadPool.Info newInfo = new ThreadPool.Info(input);
+
+        // Nodes older than 3.8.0 do not know about the "virtual" type, so it is written as "scaling"
+        assertThat(newInfo.getThreadPoolType(), is(ThreadPool.ThreadPoolType.SCALING));
     }
 }

--- a/server/src/test/java/org/opensearch/threadpool/ThreadPoolVirtualTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ThreadPoolVirtualTests.java
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.threadpool;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.is;
+
+public class ThreadPoolVirtualTests extends OpenSearchTestCase {
+
+    private static final String POOL_NAME = "test_virtual";
+
+    private ThreadPool buildThreadPool() {
+        Settings settings = Settings.builder().put("node.name", "testnode").build();
+        return new ThreadPool(settings, new VirtualExecutorBuilder(POOL_NAME));
+    }
+
+    public void testRegisterVirtualThreadPool() throws Exception {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            ExecutorService executor = threadPool.executor(POOL_NAME);
+            assertNotNull(executor);
+
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AtomicBoolean isVirtual = new AtomicBoolean();
+            final AtomicReference<String> threadName = new AtomicReference<>();
+            executor.execute(() -> {
+                isVirtual.set(Thread.currentThread().isVirtual());
+                threadName.set(Thread.currentThread().getName());
+                latch.countDown();
+            });
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue("task should run on a virtual thread", isVirtual.get());
+            assertEquals("opensearch[testnode][" + POOL_NAME + "]#0", threadName.get());
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPoolPreservesThreadContext() throws Exception {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            threadPool.getThreadContext().putHeader("test-header", "test-value");
+            assertEquals(
+                "test-value",
+                threadPool.executor(POOL_NAME)
+                    .submit(() -> threadPool.getThreadContext().getHeader("test-header"))
+                    .get(10, TimeUnit.SECONDS)
+            );
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPoolInfo() {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            ThreadPool.Info info = null;
+            for (ThreadPool.Info candidate : threadPool.info()) {
+                if (POOL_NAME.equals(candidate.getName())) {
+                    info = candidate;
+                    break;
+                }
+            }
+            assertNotNull("virtual thread pool should be reported in thread pool info", info);
+            assertThat(info.getThreadPoolType(), is(ThreadPool.ThreadPoolType.VIRTUAL));
+            // an unbounded pool reports no size, queue, or keep alive
+            assertEquals(-1, info.getMin());
+            assertEquals(-1, info.getMax());
+            assertNull(info.getKeepAlive());
+            assertNull(info.getQueueSize());
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testVirtualThreadPoolInfoXContent() throws Exception {
+        ThreadPool.Info info = new ThreadPool.Info(POOL_NAME, ThreadPool.ThreadPoolType.VIRTUAL);
+        XContentBuilder builder = JsonXContent.contentBuilder().startObject();
+        info.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        Map<String, Object> map = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        map = (Map<String, Object>) map.get(POOL_NAME);
+        assertEquals("virtual", map.get("type"));
+        // an unbounded pool renders no size, queue, or keep alive fields
+        assertFalse(map.containsKey("size"));
+        assertFalse(map.containsKey("queue_size"));
+        assertFalse(map.containsKey("core"));
+        assertFalse(map.containsKey("max"));
+        assertFalse(map.containsKey("keep_alive"));
+    }
+
+    public void testVirtualThreadPoolStats() {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            ThreadPoolStats.Stats stats = statsFor(threadPool);
+            // a virtual thread-per-task pool has neither workers nor a queue, so these have no referent
+            assertEquals(-1, stats.getThreads());
+            assertEquals(-1, stats.getQueue());
+            assertEquals(-1, stats.getLargest());
+            assertEquals(-1L, stats.getRejected());
+            // task flow counters are tracked, and nothing has run yet
+            assertEquals(0, stats.getActive());
+            assertEquals(0L, stats.getCompleted());
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPoolTracksCompletedTasks() throws Exception {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            final int taskCount = randomIntBetween(1, 20);
+            final CountDownLatch done = new CountDownLatch(taskCount);
+            for (int i = 0; i < taskCount; i++) {
+                threadPool.executor(POOL_NAME).execute(done::countDown);
+            }
+            assertTrue("all tasks should have run", done.await(10, TimeUnit.SECONDS));
+
+            // the last task decrements active and increments completed in a finally block after countDown, so poll
+            assertBusy(() -> {
+                ThreadPoolStats.Stats stats = statsFor(threadPool);
+                assertEquals("all tasks should be counted as completed", taskCount, stats.getCompleted());
+                assertEquals("no tasks should remain in flight", 0, stats.getActive());
+            });
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPoolTracksActiveTasks() throws Exception {
+        ThreadPool threadPool = buildThreadPool();
+        final CountDownLatch block = new CountDownLatch(1);
+        final CountDownLatch started = new CountDownLatch(2);
+        try {
+            for (int i = 0; i < 2; i++) {
+                threadPool.executor(POOL_NAME).execute(() -> {
+                    started.countDown();
+                    try {
+                        block.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+            assertTrue("both tasks should have started", started.await(10, TimeUnit.SECONDS));
+
+            ThreadPoolStats.Stats stats = statsFor(threadPool);
+            assertEquals("both blocked tasks should be active", 2, stats.getActive());
+            assertEquals("neither blocked task should be completed", 0L, stats.getCompleted());
+        } finally {
+            block.countDown();
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testVirtualThreadPoolCountsTasksThatThrow() throws Exception {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            // submit() captures the exception in the Future rather than letting it reach the uncaught exception
+            // handler, which keeps the failure out of the test framework's uncaught exception check
+            Future<?> future = threadPool.executor(POOL_NAME).submit(() -> { throw new RuntimeException("expected"); });
+            ExecutionException e = expectThrows(ExecutionException.class, () -> future.get(10, TimeUnit.SECONDS));
+            assertEquals("expected", e.getCause().getMessage());
+
+            // a task that throws still finishes, so it must not leak the active count
+            assertBusy(() -> {
+                ThreadPoolStats.Stats stats = statsFor(threadPool);
+                assertEquals("a failed task should still count as completed", 1L, stats.getCompleted());
+                assertEquals("a failed task must not leak the active count", 0, stats.getActive());
+            });
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+
+    private static ThreadPoolStats.Stats statsFor(ThreadPool threadPool) {
+        for (ThreadPoolStats.Stats candidate : threadPool.stats()) {
+            if (POOL_NAME.equals(candidate.getName())) {
+                return candidate;
+            }
+        }
+        throw new AssertionError("no stats for thread pool [" + POOL_NAME + "]");
+    }
+
+    public void testVirtualThreadPoolRegistersNoSettings() {
+        assertTrue(new VirtualExecutorBuilder(POOL_NAME).getRegisteredSettings().isEmpty());
+    }
+
+    public void testVirtualThreadPoolIsNotResizable() {
+        ThreadPool threadPool = buildThreadPool();
+        try {
+            // a virtual pool has no size to update; setThreadPool should skip it rather than fail on a cast
+            threadPool.setThreadPool(Settings.builder().put(POOL_NAME + ".size", 5).build());
+        } finally {
+            assertTrue(ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
+        }
+    }
+}


### PR DESCRIPTION
Introduce plumbing for thread pools backed by virtual threads:

- Add ContextPreservingExecutorService, an ExecutorService wrapper that preserves ThreadContext across all task submission paths.
- Add OpenSearchExecutors.newVirtualThreadPerTaskExecutor to create a context-preserving virtual thread-per-task executor with named threads.
- Add the VIRTUAL thread pool type to ThreadPool. It is serialized as SCALING when communicating with nodes older than 3.8.0, which do not know about the "virtual" type.
- Generalize ThreadPool shutdown handling to cover any executor type other than the direct executor.

Nothing in this code base uses virtual threads yet; this is groundwork for future efforts to build on VTs.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
