### PR TITLE
Restore default max nesting depth to 1000 and decouple stream depth limit

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -725,8 +725,12 @@ public abstract class StreamInput extends InputStream {
     /**
      * Maximum depth for recursive deserialization of nested generic values.
      * Protects against StackOverflowError from deeply nested binary payloads.
+     * Deliberately on its own property (not {@code opensearch.xcontent.depth.max}) so that relaxing
+     * the XContent parsing limit does not relax this transport-level security bound.
      */
-    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(
+        System.getProperty("opensearch.stream.depth.max", "1000" /* aligned with StreamReadConstraints.DEFAULT_MAX_DEPTH */)
+    );
 
     /**
      * Reads a value of unspecified type. If a collection is read then the collection will be mutable if it contains any entry but might

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/AbstractXContentParser.java
@@ -385,13 +385,19 @@ public abstract class AbstractXContentParser implements XContentParser {
     }
 
     // Maximum depth for recursive deserialization of nested objects/arrays.
-    private static final int MAX_DESERIALIZATION_DEPTH = Integer.parseInt(System.getProperty("opensearch.xcontent.depth.max", "100"));
+    // Must stay aligned with XContentConstraints.DEFAULT_MAX_DEPTH_PROPERTY / DEFAULT_MAX_DEPTH (same property,
+    // same default) since both guards sit on the same parse path; libs/core cannot reference libs/x-content,
+    // hence the duplicated definitions.
+    private static final String DEFAULT_MAX_DEPTH_PROPERTY = "opensearch.xcontent.depth.max";
+    private static final int MAX_NESTING_DEPTH = Integer.parseInt(
+        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "1000" /* StreamReadConstraints.DEFAULT_MAX_DEPTH */)
+    );
 
     // read a list without bounds checks, assuming the current parser is always on an array start
     private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory, int depth)
         throws IOException {
-        if (depth > MAX_DESERIALIZATION_DEPTH) {
-            throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+        if (depth > MAX_NESTING_DEPTH) {
+            throw new IllegalStateException("Maximum nesting depth [" + MAX_NESTING_DEPTH + "] exceeded");
         }
         assert parser.currentToken() == Token.START_ARRAY;
         ArrayList<Object> list = new ArrayList<>();
@@ -428,8 +434,8 @@ public abstract class AbstractXContentParser implements XContentParser {
             case VALUE_BOOLEAN:
                 return parser.booleanValue();
             case START_OBJECT: {
-                if (depth > MAX_DESERIALIZATION_DEPTH) {
-                    throw new IllegalStateException("Maximum nesting depth [" + MAX_DESERIALIZATION_DEPTH + "] exceeded");
+                if (depth > MAX_NESTING_DEPTH) {
+                    throw new IllegalStateException("Maximum nesting depth [" + MAX_NESTING_DEPTH + "] exceeded");
                 }
                 final Map<String, Object> map = mapFactory.get();
                 return parser.nextToken() != Token.FIELD_NAME ? map : readMapEntries(parser, mapFactory, map, depth + 1);

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentConstraints.java
@@ -31,7 +31,9 @@ public interface XContentConstraints {
         System.getProperty(DEFAULT_MAX_NAME_LEN_PROPERTY, "50000" /* StreamReadConstraints.DEFAULT_MAX_NAME_LEN */)
     );
 
-    final int DEFAULT_MAX_DEPTH = Integer.parseInt(System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "100"));
+    final int DEFAULT_MAX_DEPTH = Integer.parseInt(
+        System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, "1000" /* StreamReadConstraints.DEFAULT_MAX_DEPTH */)
+    );
 
     final int DEFAULT_CODEPOINT_LIMIT = Integer.parseInt(System.getProperty(DEFAULT_CODEPOINT_LIMIT_PROPERTY, "52428800" /* ~50 Mb */));
     final int DEFAULT_BUFFER_SIZE = Integer.parseInt(

--- a/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/StreamInputMaxDepthTests.java
@@ -17,7 +17,7 @@ public class StreamInputMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedArrayListThrows() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
-        for (int i = 0; i < 200; i++) {
+        for (int i = 0; i < 1200; i++) {
             out.writeByte((byte) 7);  // ArrayList type tag
             out.writeVInt(1);         // size = 1
         }
@@ -31,7 +31,7 @@ public class StreamInputMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedHashMapThrows() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
-        for (int i = 0; i < 200; i++) {
+        for (int i = 0; i < 1200; i++) {
             out.writeByte((byte) 10); // HashMap type tag
             out.writeVInt(1);         // size = 1
             out.writeString("k");     // key

--- a/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/XContentParserMaxDepthTests.java
@@ -20,9 +20,9 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedArrayThrows() throws IOException {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 200; i++)
+        for (int i = 0; i < 1200; i++)
             sb.append('[');
-        for (int i = 0; i < 200; i++)
+        for (int i = 0; i < 1200; i++)
             sb.append(']');
 
         try (
@@ -39,10 +39,10 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
 
     public void testDeeplyNestedObjectThrows() throws IOException {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 200; i++)
+        for (int i = 0; i < 1200; i++)
             sb.append("{\"a\":");
         sb.append("1");
-        for (int i = 0; i < 200; i++)
+        for (int i = 0; i < 1200; i++)
             sb.append('}');
 
         try (
@@ -74,6 +74,30 @@ public class XContentParserMaxDepthTests extends OpenSearchTestCase {
         ) {
             parser.nextToken();
             assertNotNull(parser.list());
+        }
+    }
+
+    /**
+     * Regression test: nesting depth just above 100 must be accepted. A previous change lowered the
+     * default XContent depth limit from 1000 to 100, rejecting legitimate customer payloads at depth 101.
+     */
+    public void testNestingDepthAbove100Succeeds() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 101; i++)
+            sb.append("{\"a\":");
+        sb.append("1");
+        for (int i = 0; i < 101; i++)
+            sb.append('}');
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                sb.toString()
+            )
+        ) {
+            parser.nextToken();
+            assertNotNull(parser.map());
         }
     }
 }


### PR DESCRIPTION
PR #22404 fixed unbounded recursion in deserialization by adding depth guards to StreamInput and AbstractXContentParser, but also lowered the Jackson StreamReadConstraints maxNestingDepth default from 1000 to 100 and tied all three limits to the same system property (opensearch.xcontent.depth.max). This broke previously-valid requests with nesting depth between 101 and 1000, which now fail with stream_constraints_exception.

  This change:
  - Restores XContentConstraints.DEFAULT_MAX_DEPTH to 1000, Jackson's own default, which the JSON parsing path ran at safely for years.
  - Aligns the AbstractXContentParser guard default to 1000 so it does not trip before Jackson on the same parse path.
  - Moves the StreamInput binary deserialization guard to its own property (opensearch.stream.depth.max, default 1000) so tuning the XContent parsing limit can never silently change the transport-level bound, and vice versa.
  - Updates depth tests: deeply-nested payloads bumped past the 1000 limit, and adds a regression test asserting depth 101 is accepted.

  The security fix from #22404 is unchanged in kind: both recursion paths remain bounded and fail with a catchable exception instead of a StackOverflowError that halts the JVM. The 1200-deep test payloads also verify that recursion through 1000 levels completes without stack overflow before the guard trips.

  Both limits remain tunable at startup via their respective system properties.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
