### PR TITLE
Eliminate FFM round-trips via nextDoc piggyback on collectDocs

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FilterDelegationHandle.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FilterDelegationHandle.java
@@ -62,13 +62,17 @@ public interface FilterDelegationHandle extends Closeable {
      * <p>Bit layout: word {@code i} contains matches for docs
      * {@code [minDoc + i*64, minDoc + (i+1)*64)}, LSB-first within each word.
      *
+     * <p>Return value packs two fields: upper 32 bits = next matching docId beyond
+     * maxDoc (or {@code Integer.MAX_VALUE} if exhausted), lower 32 bits = words written.
+     * Callers can use the nextDoc to skip subsequent RGs where {@code nextDoc >= rgMax}.
+     *
      * @param collectorKey key returned by {@link #createCollector(int, long, int, int)}
      * @param minDoc inclusive lower bound
      * @param maxDoc exclusive upper bound
      * @param out destination buffer; implementation writes up to {@code out.byteSize() / 8} words
-     * @return number of words written, or {@code -1} on error
+     * @return packed long: upper 32 = nextDoc, lower 32 = wordsWritten; or {@code -1} on error
      */
-    int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out);
+    long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out);
 
     /**
      * Release resources for a collector.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -1360,9 +1360,9 @@ async unsafe fn execute_indexed_with_context_inner(
                         let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                             tree: resolved,
                             evaluator: Arc::new(BitmapTreeEvaluator),
-                            leaves: Arc::new(CollectorLeafBitmaps {
-                                ffm_collector_calls: stream_metrics.ffm_collector_calls.clone(),
-                            }),
+                            leaves: Arc::new(CollectorLeafBitmaps::new(
+                                stream_metrics.ffm_collector_calls.clone(),
+                            )),
                             page_pruner: pruner,
                             cost_predicate,
                             cost_collector,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bool_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/bool_tree.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use datafusion::physical_expr::PhysicalExpr;
 
 use super::index::RowGroupDocsCollector;
+use crate::indexed_table::index::CollectDocsResult;
 
 /// A node in the boolean query tree (unresolved).
 #[derive(Debug, Clone)]
@@ -463,6 +464,7 @@ pub fn residual_bool_to_physical_expr(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::indexed_table::index::CollectDocsResult;
     use crate::indexed_table::index::RowGroupDocsCollector;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::common::ScalarValue;
@@ -473,8 +475,8 @@ mod tests {
     #[derive(Debug)]
     struct StubCollector(u8);
     impl RowGroupDocsCollector for StubCollector {
-        fn collect_packed_u64_bitset(&self, _: i32, _: i32) -> Result<Vec<u64>, String> {
-            Ok(vec![self.0 as u64])
+        fn collect_packed_u64_bitset(&self, _: i32, _: i32) -> Result<CollectDocsResult, String> {
+            Ok(vec![self.0 as u64].into())
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/bitmap_tree.rs
@@ -984,14 +984,41 @@ pub struct CollectorLeafBitmaps {
     /// round-trip to Java per Collector leaf per RG. `None` for tests
     /// that don't care about metrics.
     pub ffm_collector_calls: Option<datafusion::physical_plan::metrics::Count>,
+    /// Per-leaf iterator position carried across row groups: maps a collector
+    /// leaf (keyed by its `Arc` pointer identity) to the next matching docId
+    /// returned by that leaf's last `collectDocs` call. A later RG whose whole
+    /// range sits below this value has no matches for the leaf and is skipped
+    /// without an FFM call.
+    ///
+    /// Why interior mutability at all: `leaf_bitmap` takes `&self` (the
+    /// `LeafBitmapSource` trait signature) but must update this map on every
+    /// RG, so it can't take `&mut self`.
+    ///
+    /// Why `Mutex` and not `RefCell`: `LeafBitmapSource: Send + Sync` and the
+    /// impl is held as `Arc<dyn LeafBitmapSource>`, so the whole struct must be
+    /// `Sync`. `RefCell` is `!Sync` and won't compile under that bound; `Mutex`
+    /// is the simplest `Sync` keyed cell. (`SingleCollectorEvaluator` uses a
+    /// single `AtomicI32` because it tracks exactly one collector; a tree has
+    /// many leaves, hence a keyed map.)
+    ///
+    /// The lock is uncontended in practice: within a partition, row groups are
+    /// prefetched sequentially, so no two threads call `leaf_bitmap` on the same
+    /// instance at once. The `Mutex` satisfies the `Sync` bound, not real
+    /// concurrent access.
+    leaf_to_next_doc_map: std::sync::Mutex<HashMap<usize, i32>>,
 }
 
 impl CollectorLeafBitmaps {
+    pub fn new(ffm_collector_calls: Option<datafusion::physical_plan::metrics::Count>) -> Self {
+        Self {
+            ffm_collector_calls,
+            leaf_to_next_doc_map: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
     /// Construct a `CollectorLeafBitmaps` with no metrics.
     pub fn without_metrics() -> Self {
-        Self {
-            ffm_collector_calls: None,
-        }
+        Self::new(None)
     }
 }
 
@@ -1008,7 +1035,26 @@ impl LeafBitmapSource for CollectorLeafBitmaps {
                 return Err("CollectorLeafBitmaps: non-Collector node passed to leaf_bitmap".into())
             }
         };
-        // Use the narrowed call ranges if available (set by AND evaluator
+
+        // `Arc` pointer identity is a stable per-query key: the collector Arc
+        // lives inside the resolved tree for the whole query, so its address
+        // never aliases another leaf mid-query.
+        let leaf_key = Arc::as_ptr(collector) as *const () as usize;
+
+        // nextDoc from this leaf's previous collectDocs (i32::MIN = "no info yet").
+        // Ranges are half-open [min, max): a nextDoc at or past a range's exclusive
+        // upper bound means no match in that range, so we compare with `>=`.
+        let last_next_doc = {
+            let map = self.leaf_to_next_doc_map.lock().unwrap();
+            map.get(&leaf_key).copied().unwrap_or(i32::MIN)
+        };
+
+        // Whole RG is past the next match → no FFM call needed.
+        if last_next_doc >= ctx.max_doc {
+            return Ok(RoaringBitmap::new());
+        }
+
+        // Use the narrowed call ranges if available (set by the AND evaluator
         // after earlier children shrink the candidate set). Each range
         // produces one FFM call; results are merged into one bitmap in
         // min_doc-relative coordinates.
@@ -1019,15 +1065,32 @@ impl LeafBitmapSource for CollectorLeafBitmaps {
             .unwrap_or_else(|| vec![(ctx.min_doc, ctx.max_doc)]);
 
         let mut result_bitmap = RoaringBitmap::new();
+        let mut next_doc_out = last_next_doc;
         for (call_min, call_max) in &call_ranges {
-            let bitset = collector.collect_packed_u64_bitset(*call_min, *call_max)?;
+            // Sub-ranges are ascending; carry the freshest next_doc forward so a
+            // later sub-range skips/tightens on the position the iterator has
+            // already advanced to. Skip a sub-range entirely below the next match;
+            // otherwise tighten its lower bound so collectDocs skips the empty prefix.
+            if next_doc_out >= *call_max {
+                continue;
+            }
+            let effective_min = next_doc_out.max(*call_min);
+            let result = collector.collect_packed_u64_bitset(effective_min, *call_max)?;
             if let Some(ref c) = self.ffm_collector_calls {
                 c.add(1);
             }
-            let offset = (*call_min - ctx.min_doc) as u32;
-            let num_docs = (*call_max - *call_min) as u32;
+            // Advance only forward — the iterator position is monotonic; guard
+            // against a stale/sentinel next_doc dragging it backward.
+            next_doc_out = next_doc_out.max(result.next_doc);
+            // Bitset is relative to effective_min; place it at the matching
+            // RG-relative offset so bit k maps to absolute doc effective_min + k.
+            let offset = (effective_min - ctx.min_doc) as u32;
+            let num_docs = (*call_max - effective_min) as u32;
             let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(bitset.as_ptr() as *const u8, bitset.len() * 8)
+                std::slice::from_raw_parts(
+                    result.words.as_ptr() as *const u8,
+                    result.words.len() * 8,
+                )
             };
             let mut chunk = RoaringBitmap::from_lsb0_bytes(offset, bytes);
             let upper = offset + num_docs;
@@ -1036,6 +1099,11 @@ impl LeafBitmapSource for CollectorLeafBitmaps {
             }
             result_bitmap |= chunk;
         }
+
+        // Persist this leaf's advanced position for subsequent row groups.
+        let mut map = self.leaf_to_next_doc_map.lock().unwrap();
+        map.insert(leaf_key, next_doc_out);
+
         Ok(result_bitmap)
     }
 }
@@ -1048,6 +1116,7 @@ impl LeafBitmapSource for CollectorLeafBitmaps {
 mod tests {
     use super::*;
     use crate::indexed_table::bool_tree::ResolvedNode;
+    use crate::indexed_table::index::CollectDocsResult;
     use crate::indexed_table::index::RowGroupDocsCollector;
     use datafusion::arrow::array::Int32Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -1120,8 +1189,12 @@ mod tests {
         #[derive(Debug)]
         struct Dummy;
         impl RowGroupDocsCollector for Dummy {
-            fn collect_packed_u64_bitset(&self, _: i32, _: i32) -> Result<Vec<u64>, String> {
-                Ok(vec![])
+            fn collect_packed_u64_bitset(
+                &self,
+                _: i32,
+                _: i32,
+            ) -> Result<CollectDocsResult, String> {
+                Ok(vec![].into())
             }
         }
         let _ = idx;
@@ -1366,7 +1439,11 @@ mod tests {
         #[derive(Debug)]
         struct Poison;
         impl RowGroupDocsCollector for Poison {
-            fn collect_packed_u64_bitset(&self, _: i32, _: i32) -> Result<Vec<u64>, String> {
+            fn collect_packed_u64_bitset(
+                &self,
+                _: i32,
+                _: i32,
+            ) -> Result<CollectDocsResult, String> {
                 unreachable!("Phase 2 must not call collect")
             }
         }
@@ -2010,6 +2087,302 @@ mod tests {
             .unwrap();
         // Not pruned — both collectors contribute.
         assert_eq!(result.candidates, bm(&[2, 3]));
+    }
+
+    // ── CollectorLeafBitmaps next_doc skip/tighten tests ─────────────
+
+    /// Mock collector that returns configurable docs and next_doc, and records
+    /// the (min_doc, max_doc) arguments it was called with.
+    #[derive(Debug)]
+    struct NextDocMockCollector {
+        /// Absolute doc IDs to include in the returned bitset.
+        docs: Vec<i32>,
+        /// The `next_doc` value to return from `collect_packed_u64_bitset`.
+        next_doc: i32,
+        /// Records each (min_doc, max_doc) invocation.
+        calls: std::sync::Mutex<Vec<(i32, i32)>>,
+    }
+
+    impl NextDocMockCollector {
+        fn new(docs: Vec<i32>, next_doc: i32) -> Self {
+            Self {
+                docs,
+                next_doc,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn call_args(&self) -> Vec<(i32, i32)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl RowGroupDocsCollector for NextDocMockCollector {
+        fn collect_packed_u64_bitset(
+            &self,
+            min_doc: i32,
+            max_doc: i32,
+        ) -> Result<CollectDocsResult, String> {
+            self.calls.lock().unwrap().push((min_doc, max_doc));
+            // Mirror the real FfmSegmentCollector empty-range shortcut: an empty
+            // range yields no words and reports the scorer as exhausted. A skip
+            // check that lets an empty (min == max) call through would poison the
+            // stored next_doc to i32::MAX and drop later matches.
+            if max_doc <= min_doc {
+                return Ok(CollectDocsResult {
+                    words: Vec::new(),
+                    next_doc: i32::MAX,
+                });
+            }
+            let num_docs = (max_doc - min_doc) as usize;
+            let num_words = num_docs.div_ceil(64);
+            let mut words = vec![0u64; num_words];
+            for &d in &self.docs {
+                if d >= min_doc && d < max_doc {
+                    let bit = (d - min_doc) as usize;
+                    words[bit / 64] |= 1u64 << (bit % 64);
+                }
+            }
+            Ok(CollectDocsResult {
+                words,
+                next_doc: self.next_doc,
+            })
+        }
+    }
+
+    /// Helper: build a ResolvedNode::Collector wrapping a given Arc collector.
+    fn collector_node_from_arc(collector: Arc<dyn RowGroupDocsCollector>) -> ResolvedNode {
+        ResolvedNode::Collector {
+            provider_key: 1,
+            collector,
+        }
+    }
+
+    /// Test 1: Per-leaf skip.
+    /// RG0 returns next_doc=500. RG1 covers [100, 200).
+    /// Since 500 > 200 (call_max), the sub-range is skipped entirely,
+    /// resulting in an empty bitmap for RG1.
+    #[test]
+    fn next_doc_skip_when_next_doc_exceeds_call_max() {
+        let mock = Arc::new(NextDocMockCollector::new(vec![110, 120, 130], 500));
+        let node = collector_node_from_arc(mock.clone());
+        let source = CollectorLeafBitmaps::without_metrics();
+
+        // RG0: covers [0, 100). Collector returns next_doc=500.
+        let ctx0 = RgEvalContext {
+            rg_idx: 0,
+            rg_first_row: 0,
+            rg_num_rows: 100,
+            min_doc: 0,
+            max_doc: 100,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let bm0 = source.leaf_bitmap(&node, 0, &ctx0).unwrap();
+        // The mock returns docs in [0,100) that match — none do, so empty.
+        assert!(bm0.is_empty());
+        // Verify the collector was called for RG0.
+        assert_eq!(mock.call_args().len(), 1);
+
+        // RG1: covers [100, 200). Since last_next_doc=500 > 200 (call_max),
+        // the entire range is skipped — collector should NOT be called again.
+        let ctx1 = RgEvalContext {
+            rg_idx: 1,
+            rg_first_row: 100,
+            rg_num_rows: 100,
+            min_doc: 100,
+            max_doc: 200,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let bm1 = source.leaf_bitmap(&node, 0, &ctx1).unwrap();
+        assert!(
+            bm1.is_empty(),
+            "RG1 should be empty because next_doc > max_doc"
+        );
+        // Collector was NOT called for RG1 — still only 1 total call.
+        assert_eq!(
+            mock.call_args().len(),
+            1,
+            "collector should not be called when next_doc > call_max"
+        );
+    }
+
+    /// Test 2: Per-leaf tighten.
+    /// RG0 returns next_doc=150. RG1 covers [100, 200).
+    /// effective_min = max(150, 100) = 150. The collector should be called
+    /// with min_doc=150, not 100.
+    #[test]
+    fn next_doc_tighten_effective_min() {
+        // Docs at 160, 170 — both within the tightened range [150, 200).
+        let mock = Arc::new(NextDocMockCollector::new(vec![160, 170], 150));
+        let node = collector_node_from_arc(mock.clone());
+        let source = CollectorLeafBitmaps::without_metrics();
+
+        // RG0: covers [0, 100). Returns next_doc=150.
+        let ctx0 = RgEvalContext {
+            rg_idx: 0,
+            rg_first_row: 0,
+            rg_num_rows: 100,
+            min_doc: 0,
+            max_doc: 100,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let _ = source.leaf_bitmap(&node, 0, &ctx0).unwrap();
+        assert_eq!(mock.call_args(), vec![(0, 100)]);
+
+        // RG1: covers [100, 200). last_next_doc=150, so effective_min=max(150,100)=150.
+        let ctx1 = RgEvalContext {
+            rg_idx: 1,
+            rg_first_row: 100,
+            rg_num_rows: 100,
+            min_doc: 100,
+            max_doc: 200,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let bm1 = source.leaf_bitmap(&node, 0, &ctx1).unwrap();
+
+        // Verify the collector was called with tightened min_doc=150, not 100.
+        let calls = mock.call_args();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1], (150, 200));
+
+        // Bitmap contains docs 160 and 170 at correct RG-relative positions.
+        // offset = (150 - 100) = 50. doc 160 at bit (160-150)=10 placed at 50+10=60.
+        assert!(bm1.contains(60), "doc 160 should be at position 60");
+        assert!(bm1.contains(70), "doc 170 should be at position 70");
+        assert_eq!(bm1.len(), 2);
+    }
+
+    /// Test 3: Multiple leaves are independent.
+    /// Leaf A returns next_doc=500, leaf B returns next_doc=50.
+    /// For RG1 [100, 200): leaf A skips (500 > 200), leaf B does not (50 < 200).
+    #[test]
+    fn next_doc_multiple_leaves_independent() {
+        let mock_a = Arc::new(NextDocMockCollector::new(vec![], 500));
+        let mock_b = Arc::new(NextDocMockCollector::new(vec![110, 120], 50));
+        let node_a = collector_node_from_arc(mock_a.clone());
+        let node_b = collector_node_from_arc(mock_b.clone());
+        let source = CollectorLeafBitmaps::without_metrics();
+
+        // RG0: covers [0, 100). Both leaves are called.
+        let ctx0 = RgEvalContext {
+            rg_idx: 0,
+            rg_first_row: 0,
+            rg_num_rows: 100,
+            min_doc: 0,
+            max_doc: 100,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let _ = source.leaf_bitmap(&node_a, 0, &ctx0).unwrap();
+        let _ = source.leaf_bitmap(&node_b, 1, &ctx0).unwrap();
+        assert_eq!(mock_a.call_args().len(), 1);
+        assert_eq!(mock_b.call_args().len(), 1);
+
+        // RG1: covers [100, 200).
+        let ctx1 = RgEvalContext {
+            rg_idx: 1,
+            rg_first_row: 100,
+            rg_num_rows: 100,
+            min_doc: 100,
+            max_doc: 200,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+        let bm_a = source.leaf_bitmap(&node_a, 0, &ctx1).unwrap();
+        let bm_b = source.leaf_bitmap(&node_b, 1, &ctx1).unwrap();
+
+        // Leaf A: next_doc=500 > 200 (call_max) → skipped, empty bitmap.
+        assert!(
+            bm_a.is_empty(),
+            "leaf A should skip: next_doc=500 > max_doc=200"
+        );
+        assert_eq!(
+            mock_a.call_args().len(),
+            1,
+            "leaf A collector should not be called for RG1"
+        );
+
+        // Leaf B: next_doc=50 < 200 → not skipped, collector called.
+        assert!(
+            !bm_b.is_empty(),
+            "leaf B should not skip: next_doc=50 < max_doc=200"
+        );
+        assert_eq!(
+            mock_b.call_args().len(),
+            2,
+            "leaf B collector should be called for RG1"
+        );
+        // Docs 110, 120 relative to min_doc=100 → bits 10, 20.
+        assert!(bm_b.contains(10));
+        assert!(bm_b.contains(20));
+    }
+
+    /// Regression for the exclusive-boundary bug (Bharath's scenario):
+    /// 3 RGs of 100 docs each. A match sits at doc 200 — exactly the start of
+    /// RG2, i.e. exactly RG1's exclusive max_doc.
+    ///   RG0 [0,100)   match: doc 5,  next_doc=200
+    ///   RG1 [100,200) no matches — must be skipped WITHOUT an empty collect call
+    ///   RG2 [200,300) match: doc 200 — boundary doc, must be collected
+    /// With a `>` check, RG1 would tighten to an empty collect(200,200) → the
+    /// mock returns next_doc=i32::MAX → RG2 skipped → doc 200 silently dropped.
+    /// With `>=`, RG1 is skipped outright and doc 200 survives.
+    #[test]
+    fn next_doc_boundary_doc_not_dropped() {
+        let mock = Arc::new(NextDocMockCollector::new(vec![5, 200], 200));
+        let node = collector_node_from_arc(mock.clone());
+        let source = CollectorLeafBitmaps::without_metrics();
+
+        let mk_ctx = |rg_idx: usize, first: i64, min: i32, max: i32| RgEvalContext {
+            rg_idx,
+            rg_first_row: first,
+            rg_num_rows: 100,
+            min_doc: min,
+            max_doc: max,
+            cost_predicate: 1,
+            cost_collector: 10,
+            collector_call_ranges: None,
+            collector_strategy: super::super::CollectorCallStrategy::FullRange,
+        };
+
+        // RG0 [0,100): doc 5 matches, next_doc=200.
+        let bm0 = source.leaf_bitmap(&node, 0, &mk_ctx(0, 0, 0, 100)).unwrap();
+        assert!(bm0.contains(5), "doc 5 should be collected in RG0");
+
+        // RG1 [100,200): next_doc=200 >= max_doc=200 → skipped, no collect call.
+        let bm1 = source
+            .leaf_bitmap(&node, 0, &mk_ctx(1, 100, 100, 200))
+            .unwrap();
+        assert!(bm1.is_empty(), "RG1 has no matches");
+        assert_eq!(
+            mock.call_args().len(),
+            1,
+            "RG1 must be skipped without a collect call (no empty-range poison)"
+        );
+
+        // RG2 [200,300): boundary doc 200 must be collected.
+        let bm2 = source
+            .leaf_bitmap(&node, 0, &mk_ctx(2, 200, 200, 300))
+            .unwrap();
+        assert!(
+            bm2.contains(0),
+            "boundary doc 200 (RG-relative pos 0) must not be dropped"
+        );
     }
 
     /// When `rg_idx` IS in the reverse map and maps to a position where

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/mod.rs
@@ -724,6 +724,7 @@ fn precompute_collector_leaves<'a>(
 mod tests {
     use super::*;
     use crate::indexed_table::bool_tree::ResolvedNode;
+    use crate::indexed_table::index::CollectDocsResult;
     use crate::indexed_table::index::RowGroupDocsCollector;
     use crate::indexed_table::page_pruner::PagePruner;
     use datafusion::arrow::array::Int32Array;
@@ -814,8 +815,12 @@ mod tests {
         #[derive(Debug)]
         struct Dummy;
         impl RowGroupDocsCollector for Dummy {
-            fn collect_packed_u64_bitset(&self, _: i32, _: i32) -> Result<Vec<u64>, String> {
-                Ok(vec![])
+            fn collect_packed_u64_bitset(
+                &self,
+                _: i32,
+                _: i32,
+            ) -> Result<CollectDocsResult, String> {
+                Ok(vec![].into())
             }
         }
         let source = TreeBitsetSource {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/eval/single_collector.rs
@@ -32,7 +32,7 @@ use roaring::RoaringBitmap;
 
 use super::{PrefetchedRg, RowGroupBitsetSource};
 use crate::indexed_table::ffm_callbacks::{create_provider, FfmSegmentCollector, ProviderHandle};
-use crate::indexed_table::index::RowGroupDocsCollector;
+use crate::indexed_table::index::{CollectDocsResult, RowGroupDocsCollector};
 use crate::indexed_table::page_pruner::{PagePruneMetrics, PagePruner, StatsPruneTree};
 use crate::indexed_table::row_selection::{
     bitmap_to_packed_bits, packed_bits_to_boolean_array, row_selection_to_bitmap, PositionMap,
@@ -186,6 +186,9 @@ pub struct SingleCollectorEvaluator {
     stats_prune_tree: Option<Arc<StatsPruneTree>>,
     /// Reverse map: absolute RG index → position in `rg_can_match` vectors.
     rg_index_to_pos: HashMap<usize, usize>,
+    /// Next matching docId from the last collectDocs call. When next_doc >= rg.max_doc,
+    /// the RG can be skipped without an FFM call. Initialized to i32::MIN (no skip info).
+    last_next_doc: std::sync::atomic::AtomicI32,
 }
 
 /// Resources needed for per-RG bloom filter pruning.
@@ -231,6 +234,7 @@ impl SingleCollectorEvaluator {
             bloom_config,
             stats_prune_tree,
             rg_index_to_pos,
+            last_next_doc: std::sync::atomic::AtomicI32::new(i32::MIN),
         }
     }
 }
@@ -282,6 +286,21 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                     return Ok(None);
                 }
             }
+        }
+
+        // Skip RG if the previous collectDocs told us the next match is beyond this RG.
+        let last_next = self
+            .last_next_doc
+            .load(std::sync::atomic::Ordering::Acquire);
+        // max_doc is exclusive, so nextDoc == max_doc also means "no match in this RG".
+        if last_next >= max_doc {
+            native_bridge_common::log_debug!(
+                "SingleCollector: skipping RG {} — nextDoc={} >= maxDoc={}",
+                rg.index,
+                last_next,
+                max_doc
+            );
+            return Ok(None);
         }
 
         // Page-prune to discover which row ranges survive.
@@ -357,10 +376,18 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                 };
 
                 // Call collector for each range, merge into one RG-relative bitmap.
+                // Sub-ranges are ascending; carry the freshest next_doc forward so
+                // a later sub-range skips/tightens on the position the iterator has
+                // already advanced to, not the stale pre-loop value.
                 let mut bm = RoaringBitmap::new();
+                let mut next_doc_out = last_next;
                 for (r_min, r_max) in &call_ranges {
-                    let bitset = collector
-                        .collect_packed_u64_bitset(*r_min, *r_max)
+                    if next_doc_out >= *r_max {
+                        continue;
+                    }
+                    let effective_min = next_doc_out.max(*r_min);
+                    let result = collector
+                        .collect_packed_u64_bitset(effective_min, *r_max)
                         .map_err(|e| {
                             format!(
                                 "collector.collect_packed_u64_bitset(rg={}, [{}, {})): {}",
@@ -370,10 +397,16 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                     if let Some(ref c) = self.ffm_collector_calls {
                         c.add(1);
                     }
-                    let offset = (*r_min as i64 - rg.first_row) as u32;
-                    let num_docs = (*r_max - *r_min) as u32;
+                    // Advance only forward — the iterator position is monotonic; guard
+                    // against a stale/sentinel next_doc dragging it backward.
+                    next_doc_out = next_doc_out.max(result.next_doc);
+                    let offset = (effective_min as i64 - rg.first_row) as u32;
+                    let num_docs = (*r_max - effective_min) as u32;
                     let bytes: &[u8] = unsafe {
-                        std::slice::from_raw_parts(bitset.as_ptr() as *const u8, bitset.len() * 8)
+                        std::slice::from_raw_parts(
+                            result.words.as_ptr() as *const u8,
+                            result.words.len() * 8,
+                        )
                     };
                     let mut chunk = RoaringBitmap::from_lsb0_bytes(offset, bytes);
                     let upper = offset.saturating_add(num_docs);
@@ -382,6 +415,8 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                     }
                     bm |= chunk;
                 }
+                self.last_next_doc
+                    .store(next_doc_out, std::sync::atomic::Ordering::Release);
 
                 // For FullRange and TightenOuterBounds, AND with page bitmap
                 // to remove rows in dead pages that the collector scanned.
@@ -477,7 +512,7 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
                         e
                     )
                 })?;
-            let bitset = collector
+            let result = collector
                 .collect_packed_u64_bitset(min_doc, max_doc)
                 .map_err(|e| {
                     format!(
@@ -491,7 +526,10 @@ impl RowGroupBitsetSource for SingleCollectorEvaluator {
             let offset = (min_doc as i64 - rg.first_row) as u32;
             let num_docs = (max_doc - min_doc) as u32;
             let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(bitset.as_ptr() as *const u8, bitset.len() * 8)
+                std::slice::from_raw_parts(
+                    result.words.as_ptr() as *const u8,
+                    result.words.len() * 8,
+                )
             };
             let mut peer_bm = RoaringBitmap::from_lsb0_bytes(offset, bytes);
             let upper = offset.saturating_add(num_docs);
@@ -674,7 +712,7 @@ mod tests {
             &self,
             min_doc: i32,
             max_doc: i32,
-        ) -> Result<Vec<u64>, String> {
+        ) -> Result<CollectDocsResult, String> {
             let span = (max_doc - min_doc) as usize;
             let mut bitset = vec![0u64; (span + 63) / 64];
             for &doc in &self.docs {
@@ -683,7 +721,7 @@ mod tests {
                     bitset[idx / 64] |= 1u64 << (idx % 64);
                 }
             }
-            Ok(bitset)
+            Ok(bitset.into())
         }
     }
 
@@ -986,6 +1024,232 @@ mod tests {
             .expect("should have matches");
         let got: Vec<u32> = prefetched.candidates.iter().collect();
         assert_eq!(got, vec![1u32, 5]);
+    }
+
+    /// Mock collector that returns specific docs AND a configurable next_doc.
+    #[derive(Debug)]
+    struct NextDocCollector {
+        docs: Vec<i32>,
+        next_doc: i32,
+    }
+
+    impl RowGroupDocsCollector for NextDocCollector {
+        fn collect_packed_u64_bitset(
+            &self,
+            min_doc: i32,
+            max_doc: i32,
+        ) -> Result<CollectDocsResult, String> {
+            let span = (max_doc - min_doc) as usize;
+            let mut words = vec![0u64; (span + 63) / 64];
+            for &doc in &self.docs {
+                if doc >= min_doc && doc < max_doc {
+                    let idx = (doc - min_doc) as usize;
+                    words[idx / 64] |= 1u64 << (idx % 64);
+                }
+            }
+            Ok(CollectDocsResult {
+                words,
+                next_doc: self.next_doc,
+            })
+        }
+    }
+
+    #[test]
+    fn next_doc_skips_subsequent_rg() {
+        // RG0 [0,8): collector returns next_doc=20 (beyond RG1's max_doc=16)
+        // RG1 [8,16): should be skipped entirely
+        // RG2 [16,24): next_doc=20 < 24, should NOT be skipped (doc 20 is in range)
+        let collector = Arc::new(NextDocCollector {
+            docs: vec![2, 20],
+            next_doc: 20,
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let eval = SingleCollectorEvaluator::new(
+            Some(collector),
+            pruner,
+            None,
+            None,
+            None,
+            None,
+            CollectorCallStrategy::FullRange,
+            Arc::new(HashMap::new()),
+            0,
+            Arc::new(FfmDelegatedBackendCollectorFactory),
+            0,
+            None,
+            None,
+            HashMap::new(),
+        );
+
+        let rg0 = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        let rg1 = RowGroupInfo {
+            index: 1,
+            first_row: 8,
+            num_rows: 8,
+        };
+        let rg2 = RowGroupInfo {
+            index: 2,
+            first_row: 16,
+            num_rows: 8,
+        };
+
+        // RG0: has doc 2
+        let pf = eval.prefetch_rg(&rg0, 0, 8).unwrap().expect("has match");
+        assert_eq!(pf.candidates.iter().collect::<Vec<_>>(), vec![2u32]);
+
+        // RG1: skipped (next_doc=20 > max_doc=16)
+        assert!(eval.prefetch_rg(&rg1, 8, 16).unwrap().is_none());
+
+        // RG2: NOT skipped (next_doc=20 < max_doc=24)
+        let pf = eval.prefetch_rg(&rg2, 16, 24).unwrap();
+        assert!(pf.is_some());
+    }
+
+    #[test]
+    fn next_doc_tightens_min_doc() {
+        // Collector has doc at position 5. next_doc=5 means the iterator
+        // is at doc 5 after RG0. For RG1 [4,8), effective_min should be
+        // max(5, 4) = 5, not 4.
+        let collector = Arc::new(NextDocCollector {
+            docs: vec![1, 5],
+            next_doc: 5,
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let eval = SingleCollectorEvaluator::new(
+            Some(collector),
+            pruner,
+            None,
+            None,
+            None,
+            None,
+            CollectorCallStrategy::FullRange,
+            Arc::new(HashMap::new()),
+            0,
+            Arc::new(FfmDelegatedBackendCollectorFactory),
+            0,
+            None,
+            None,
+            HashMap::new(),
+        );
+
+        let rg0 = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 4,
+        };
+        let rg1 = RowGroupInfo {
+            index: 1,
+            first_row: 4,
+            num_rows: 4,
+        };
+
+        // RG0 [0,4): doc 1 matches
+        let pf = eval.prefetch_rg(&rg0, 0, 4).unwrap().expect("has match");
+        assert_eq!(pf.candidates.iter().collect::<Vec<_>>(), vec![1u32]);
+
+        // RG1 [4,8): doc 5 matches, effective_min tightened to 5
+        let pf = eval.prefetch_rg(&rg1, 4, 8).unwrap().expect("has match");
+        assert_eq!(pf.candidates.iter().collect::<Vec<_>>(), vec![1u32]); // doc 5 is at RG-relative pos 1
+    }
+
+    #[test]
+    fn next_doc_max_value_skips_all_remaining() {
+        // next_doc = i32::MAX means scorer exhausted — all subsequent RGs skipped
+        let collector = Arc::new(NextDocCollector {
+            docs: vec![0],
+            next_doc: i32::MAX,
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let eval = SingleCollectorEvaluator::new(
+            Some(collector),
+            pruner,
+            None,
+            None,
+            None,
+            None,
+            CollectorCallStrategy::FullRange,
+            Arc::new(HashMap::new()),
+            0,
+            Arc::new(FfmDelegatedBackendCollectorFactory),
+            0,
+            None,
+            None,
+            HashMap::new(),
+        );
+
+        let rg0 = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        let rg1 = RowGroupInfo {
+            index: 1,
+            first_row: 8,
+            num_rows: 8,
+        };
+
+        // RG0: has doc 0
+        assert!(eval.prefetch_rg(&rg0, 0, 8).unwrap().is_some());
+
+        // RG1: skipped (next_doc=MAX > any max_doc)
+        assert!(eval.prefetch_rg(&rg1, 8, 16).unwrap().is_none());
+    }
+
+    #[test]
+    fn next_doc_at_rg_boundary_is_not_dropped() {
+        // Regression for the exclusive-boundary bug: a match sitting exactly at
+        // an RG's start (== previous RG's exclusive max_doc) must NOT be dropped.
+        // docs: 5 (in RG0) and 8 (start of RG1, == RG0's max_doc=8).
+        let collector = Arc::new(NextDocCollector {
+            docs: vec![5, 8],
+            next_doc: 8,
+        }) as Arc<dyn RowGroupDocsCollector>;
+        let pruner = minimal_page_pruner();
+        let eval = SingleCollectorEvaluator::new(
+            Some(collector),
+            pruner,
+            None,
+            None,
+            None,
+            None,
+            CollectorCallStrategy::FullRange,
+            Arc::new(HashMap::new()),
+            0,
+            Arc::new(FfmDelegatedBackendCollectorFactory),
+            0,
+            None,
+            None,
+            HashMap::new(),
+        );
+
+        let rg0 = RowGroupInfo {
+            index: 0,
+            first_row: 0,
+            num_rows: 8,
+        };
+        let rg1 = RowGroupInfo {
+            index: 1,
+            first_row: 8,
+            num_rows: 8,
+        };
+
+        // RG0 [0,8): doc 5 matches, next_doc=8 (boundary).
+        let pf0 = eval
+            .prefetch_rg(&rg0, 0, 8)
+            .unwrap()
+            .expect("RG0 has doc 5");
+        assert_eq!(pf0.candidates.iter().collect::<Vec<_>>(), vec![5u32]);
+
+        // RG1 [8,16): next_doc=8 == min_doc, NOT skipped. Doc 8 must be collected.
+        let pf1 = eval
+            .prefetch_rg(&rg1, 8, 16)
+            .unwrap()
+            .expect("RG1 has boundary doc 8");
+        assert_eq!(pf1.candidates.iter().collect::<Vec<_>>(), vec![0u32]); // doc 8 at RG-relative pos 0
     }
 
     // Keep the `fmt` import used

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/ffm_callbacks.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/ffm_callbacks.rs
@@ -26,7 +26,7 @@
 
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use super::index::RowGroupDocsCollector;
+use super::index::{CollectDocsResult, RowGroupDocsCollector};
 
 // ── Callback signatures ───────────────────────────────────────────────
 
@@ -209,15 +209,22 @@ impl FfmSegmentCollector {
 }
 
 impl RowGroupDocsCollector for FfmSegmentCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         if max_doc <= min_doc {
-            return Ok(Vec::new());
+            return Ok(CollectDocsResult {
+                words: Vec::new(),
+                next_doc: i32::MAX,
+            });
         }
         let span = (max_doc - min_doc) as usize;
         let word_count = span.div_ceil(64);
         let mut buf = vec![0u64; word_count];
         let collect_fn = load_collect_docs()?;
-        let n = unsafe {
+        let packed = unsafe {
             collect_fn(
                 self.context_id,
                 self.key,
@@ -227,27 +234,27 @@ impl RowGroupDocsCollector for FfmSegmentCollector {
                 word_count as i64,
             )
         };
-        if n < 0 {
+        if packed < 0 {
             return Err(format!(
                 "collectDocs(context_id={}, key={}) failed: {}",
-                self.context_id, self.key, n
+                self.context_id, self.key, packed
             ));
         }
-        // Defensive: the Java callback is contracted to return
-        // `wordsWritten <= outWordCap`. If it lied, the buffer already
-        // overflowed, but truncating won't recover the clobbered heap.
-        // Detect the violation and fail loudly so the Java callback bug
-        // is surfaced before downstream code consumes the tainted bitset.
-        let n = n as usize;
-        if n > word_count {
+        let packed_u = packed as u64;
+        let words_written = (packed_u & 0xFFFF_FFFF) as usize;
+        let next_doc = (packed_u >> 32) as i32;
+        if words_written > word_count {
             return Err(format!(
                 "collectDocs(context_id={}, key={}) reported wordsWritten={} > capacity={}; \
                  callback contract violated (possible heap overflow)",
-                self.context_id, self.key, n, word_count,
+                self.context_id, self.key, words_written, word_count,
             ));
         }
-        buf.truncate(n);
-        Ok(buf)
+        buf.truncate(words_written);
+        Ok(CollectDocsResult {
+            words: buf,
+            next_doc,
+        })
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/index.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/index.rs
@@ -45,8 +45,31 @@ use std::sync::Arc;
 /// (zero-length bitset). This is a no-op case and must not error. Callers
 /// rely on this — e.g. `IndexedStream` skips filter-bitset fetch on empty
 /// row groups by calling with `max_doc == min_doc`.
+/// Result of a `collect_packed_u64_bitset` call.
+#[derive(Debug, Clone)]
+pub struct CollectDocsResult {
+    /// The packed u64 bitset of matching docs within the requested range.
+    pub words: Vec<u64>,
+    /// The next matching doc ID beyond `max_doc`, or `i32::MAX` if exhausted.
+    /// Callers can use this to skip subsequent RGs where `next_doc >= rg_max`.
+    pub next_doc: i32,
+}
+
+impl From<Vec<u64>> for CollectDocsResult {
+    fn from(words: Vec<u64>) -> Self {
+        CollectDocsResult {
+            words,
+            next_doc: i32::MIN,
+        }
+    }
+}
+
 pub trait RowGroupDocsCollector: Send + Sync + Debug {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String>;
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String>;
 }
 
 /// A searcher scoped to a single shard (index), created once per query.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/dynamic_filter_pushdown.rs
@@ -32,6 +32,7 @@ use super::super::index::RowGroupDocsCollector;
 use super::super::page_pruner::PagePruner;
 use super::super::stream::{FilterStrategy, RowGroupInfo};
 use super::super::table_provider::{IndexedTableConfig, IndexedTableProvider, SegmentFileInfo};
+use crate::indexed_table::index::CollectDocsResult;
 
 /// 16 rows, `price` = 15..0 **descending** in file order, 4 rows per row group →
 /// RG ranges (by row position) [15..12], [11..8], [7..4], [3..0]. The scan reads
@@ -78,13 +79,17 @@ fn write_fixture() -> (NamedTempFile, SchemaRef) {
 struct MatchAllCollector;
 
 impl RowGroupDocsCollector for MatchAllCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc).max(0) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for rel in 0..span {
             out[rel / 64] |= 1u64 << (rel % 64);
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/delegation.rs
@@ -49,6 +49,7 @@ use crate::indexed_table::eval::single_collector::{
 };
 use crate::indexed_table::eval::RowGroupBitsetSource;
 use crate::indexed_table::ffm_callbacks::ProviderHandle;
+use crate::indexed_table::index::CollectDocsResult;
 use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::PagePruner;
 use crate::indexed_table::table_provider::{
@@ -212,7 +213,11 @@ struct StaticBitsetCollector {
 }
 
 impl RowGroupDocsCollector for StaticBitsetCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching {
@@ -221,7 +226,7 @@ impl RowGroupDocsCollector for StaticBitsetCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/fuzz/harness.rs
@@ -29,6 +29,7 @@ use crate::indexed_table::bool_tree::BoolNode;
 use crate::indexed_table::eval::bitmap_tree::{BitmapTreeEvaluator, CollectorLeafBitmaps};
 use crate::indexed_table::eval::single_collector::SingleCollectorEvaluator;
 use crate::indexed_table::eval::{RowGroupBitsetSource, TreeBitsetSource};
+use crate::indexed_table::index::CollectDocsResult;
 use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::PagePruner;
 use crate::indexed_table::stream::{FilterStrategy, RowGroupInfo};
@@ -46,7 +47,11 @@ struct MockCollector {
 }
 
 impl RowGroupDocsCollector for MockCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching {
@@ -55,7 +60,7 @@ impl RowGroupDocsCollector for MockCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 
@@ -259,9 +264,9 @@ pub(in crate::indexed_table::tests_e2e) async fn execute_tree_with_plan_pushdown
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
-                leaves: Arc::new(CollectorLeafBitmaps {
-                    ffm_collector_calls: stream_metrics.ffm_collector_calls.clone(),
-                }),
+                leaves: Arc::new(CollectorLeafBitmaps::new(
+                    stream_metrics.ffm_collector_calls.clone(),
+                )),
                 page_pruner: pruner,
                 cost_predicate: 1,
                 cost_collector: 10,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/mod.rs
@@ -37,6 +37,7 @@ use super::index::RowGroupDocsCollector;
 use super::page_pruner::PagePruner;
 use super::stream::{FilterStrategy, RowGroupInfo};
 use super::table_provider::{IndexedTableConfig, IndexedTableProvider, SegmentFileInfo};
+use crate::indexed_table::index::CollectDocsResult;
 
 mod boolean_algebra;
 mod constant_predicate;
@@ -152,7 +153,11 @@ struct MockCollector {
 }
 
 impl RowGroupDocsCollector for MockCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching {
@@ -161,7 +166,7 @@ impl RowGroupDocsCollector for MockCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 
@@ -264,9 +269,9 @@ async fn run_tree_and_plan(
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/multi_segment.rs
@@ -74,7 +74,11 @@ struct PerSegmentCollector {
 }
 
 impl RowGroupDocsCollector for PerSegmentCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching {
@@ -83,7 +87,7 @@ impl RowGroupDocsCollector for PerSegmentCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 
@@ -272,7 +276,11 @@ struct ConcurrencyWitnessCollector {
 }
 
 impl RowGroupDocsCollector for ConcurrencyWitnessCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         use std::sync::atomic::Ordering;
         let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
         // Update high-water-mark with a CAS loop.
@@ -1016,13 +1024,13 @@ async fn run_wide_segments(
             &self,
             min_doc: i32,
             max_doc: i32,
-        ) -> Result<Vec<u64>, String> {
+        ) -> Result<CollectDocsResult, String> {
             let span = (max_doc - min_doc) as usize;
             let mut out = vec![0u64; span.div_ceil(64)];
             for i in 0..span {
                 out[i / 64] |= 1u64 << (i % 64);
             }
-            Ok(out)
+            Ok(out.into())
         }
     }
 
@@ -1365,13 +1373,13 @@ async fn run_wide_segments_with_stats_pruning(
             &self,
             min_doc: i32,
             max_doc: i32,
-        ) -> Result<Vec<u64>, String> {
+        ) -> Result<CollectDocsResult, String> {
             let span = (max_doc - min_doc) as usize;
             let mut out = vec![0u64; span.div_ceil(64)];
             for i in 0..span {
                 out[i / 64] |= 1u64 << (i % 64);
             }
-            Ok(out)
+            Ok(out.into())
         }
     }
 
@@ -1760,13 +1768,13 @@ async fn stats_prune_direct_prefetch_asserts_pruning_and_empty_bitsets() {
             &self,
             min_doc: i32,
             max_doc: i32,
-        ) -> Result<Vec<u64>, String> {
+        ) -> Result<CollectDocsResult, String> {
             let span = (max_doc - min_doc) as usize;
             let mut out = vec![0u64; span.div_ceil(64)];
             for i in 0..span {
                 out[i / 64] |= 1u64 << (i % 64);
             }
-            Ok(out)
+            Ok(out.into())
         }
     }
 
@@ -1961,13 +1969,13 @@ async fn stats_prune_asserts_empty_collector_bitset_in_pruned_subtree() {
             &self,
             min_doc: i32,
             max_doc: i32,
-        ) -> Result<Vec<u64>, String> {
+        ) -> Result<CollectDocsResult, String> {
             let span = (max_doc - min_doc) as usize;
             let mut out = vec![0u64; span.div_ceil(64)];
             for i in 0..span {
                 out[i / 64] |= 1u64 << (i % 64);
             }
-            Ok(out)
+            Ok(out.into())
         }
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/null_columns.rs
@@ -106,7 +106,11 @@ struct RgScopedCollector {
 }
 
 impl RowGroupDocsCollector for RgScopedCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching_rows {
@@ -115,7 +119,7 @@ impl RowGroupDocsCollector for RgScopedCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/page_pruning.rs
@@ -63,6 +63,7 @@ use crate::indexed_table::eval::single_collector::SingleCollectorEvaluator;
 use crate::indexed_table::eval::{
     CollectorCallStrategy, RgEvalContext, RowGroupBitsetSource, TreeBitsetSource,
 };
+use crate::indexed_table::index::CollectDocsResult;
 use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::{build_pruning_predicate, PagePruner};
 use crate::indexed_table::stream::{FilterStrategy, RowGroupInfo};
@@ -153,7 +154,11 @@ struct MockCollector {
 }
 
 impl RowGroupDocsCollector for MockCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.docs {
@@ -162,7 +167,7 @@ impl RowGroupDocsCollector for MockCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 
@@ -320,9 +325,7 @@ async fn run_bitmap_tree(tree: BoolNode) -> (Vec<i32>, Arc<dyn ExecutionPlan>) {
             let eval: Arc<dyn RowGroupBitsetSource> = Arc::new(TreeBitsetSource {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
-                leaves: Arc::new(CollectorLeafBitmaps {
-                    ffm_collector_calls: sm.ffm_collector_calls.clone(),
-                }),
+                leaves: Arc::new(CollectorLeafBitmaps::new(sm.ffm_collector_calls.clone())),
                 page_pruner: pruner,
                 cost_predicate: 1,
                 cost_collector: 10,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/qtf_fetch_phase.rs
@@ -90,9 +90,9 @@ async fn query_phase(tree: BoolNode) -> Vec<i64> {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/row_id_emission.rs
@@ -79,9 +79,9 @@ async fn run_tree_row_ids(tree: BoolNode) -> Vec<i64> {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,
@@ -256,9 +256,9 @@ async fn run_tree_row_ids_with_global_base(tree: BoolNode, global_base: u64) -> 
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,
@@ -543,9 +543,9 @@ async fn test_row_id_with_data_columns() {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,
@@ -815,9 +815,9 @@ async fn run_two_segments_row_ids(tree: BoolNode) -> Vec<i64> {
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/tests_e2e/sort_reverse_row_id.rs
@@ -38,6 +38,7 @@ use crate::indexed_executor::reverse_segment_iteration_order;
 use crate::indexed_table::bool_tree::BoolNode;
 use crate::indexed_table::eval::bitmap_tree::BitmapTreeEvaluator;
 use crate::indexed_table::eval::{RowGroupBitsetSource, TreeBitsetSource};
+use crate::indexed_table::index::CollectDocsResult;
 use crate::indexed_table::index::RowGroupDocsCollector;
 use crate::indexed_table::page_pruner::PagePruner;
 use crate::indexed_table::stream::{FilterStrategy, RowGroupInfo};
@@ -102,7 +103,11 @@ struct LocalOffsetCollector {
 }
 
 impl RowGroupDocsCollector for LocalOffsetCollector {
-    fn collect_packed_u64_bitset(&self, min_doc: i32, max_doc: i32) -> Result<Vec<u64>, String> {
+    fn collect_packed_u64_bitset(
+        &self,
+        min_doc: i32,
+        max_doc: i32,
+    ) -> Result<CollectDocsResult, String> {
         let span = (max_doc - min_doc) as usize;
         let mut out = vec![0u64; span.div_ceil(64)];
         for &doc in &self.matching {
@@ -111,7 +116,7 @@ impl RowGroupDocsCollector for LocalOffsetCollector {
                 out[rel / 64] |= 1u64 << (rel % 64);
             }
         }
-        Ok(out)
+        Ok(out.into())
     }
 }
 
@@ -202,9 +207,9 @@ async fn collect_row_ids(
                 tree: Arc::new(resolved),
                 evaluator: Arc::new(BitmapTreeEvaluator),
                 leaves: Arc::new(
-                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps {
-                        ffm_collector_calls: _stream_metrics.ffm_collector_calls.clone(),
-                    },
+                    crate::indexed_table::eval::bitmap_tree::CollectorLeafBitmaps::new(
+                        _stream_metrics.ffm_collector_calls.clone(),
+                    ),
                 ),
                 page_pruner: pruner,
                 cost_predicate: 1,

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
@@ -223,7 +223,7 @@ public final class FilterTreeCallbacks {
     }
 
     /**
-     * {@code collectDocs(contextId, collectorKey, minDoc, maxDoc, outPtr, outWordCap) -> wordsWritten|-1}.
+     * {@code collectDocs(contextId, collectorKey, minDoc, maxDoc, outPtr, outWordCap) -> packed(nextDoc|wordsWritten)|-1}.
      */
     public static long collectDocs(long contextId, int collectorKey, int minDoc, int maxDoc, MemorySegment outPtr, long outWordCap) {
         long tid = trackStart(contextId);
@@ -239,8 +239,8 @@ public final class FilterTreeCallbacks {
             }
             int maxWords = (int) Math.min(outWordCap, (long) Integer.MAX_VALUE);
             MemorySegment view = outPtr.reinterpret((long) maxWords * Long.BYTES);
-            int wordsWritten = handle.collectDocs(collectorKey, minDoc, maxDoc, view);
-            return (wordsWritten < 0) ? -1L : wordsWritten;
+            long result = handle.collectDocs(collectorKey, minDoc, maxDoc, view);
+            return (result < 0) ? -1L : result;
         } catch (AssertionError e) {
             throw e;
         } catch (Throwable throwable) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
@@ -324,7 +324,7 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
         }
 
         @Override
-        public int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+        public long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
             int n = Math.min(words.length, (int) (out.byteSize() / Long.BYTES));
             for (int i = 0; i < n; i++)
                 out.setAtIndex(ValueLayout.JAVA_LONG, i, words[i]);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
@@ -108,7 +108,7 @@ public class IndexFilterCallbackTests extends OpenSearchTestCase {
             }
 
             @Override
-            public int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+            public long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
                 return -1;
             }
 
@@ -165,7 +165,7 @@ public class IndexFilterCallbackTests extends OpenSearchTestCase {
         }
 
         @Override
-        public int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+        public long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
             this.lastCollectorKey = collectorKey;
             int wordCount = Math.min(cannedWords.length, (int) (out.byteSize() / Long.BYTES));
             for (int i = 0; i < wordCount; i++) {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFilterDelegationHandle.java
@@ -223,7 +223,7 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
     }
 
     @Override
-    public int collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+    public long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
         ScorerHandle handle = scorersByCollectorKey.get(collectorKey);
         if (handle == null) {
             return -1;
@@ -233,6 +233,7 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
         }
         int span = maxDoc - minDoc;
         FixedBitSet bits = new FixedBitSet(span);
+        int nextDoc = Integer.MAX_VALUE;
 
         if (handle.scorer != null) {
             int scanFrom = Math.max(minDoc, handle.partitionMinDoc);
@@ -252,9 +253,16 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
                         }
                         handle.currentDoc = docId;
                     }
+                    nextDoc = handle.currentDoc;
                 } catch (IOException exception) {
                     LOGGER.warn("IOException during collectDocs, returning partial bitset", exception);
+                    // Iteration is only partial — don't signal exhaustion (MAX_VALUE),
+                    // which would make callers skip all subsequent RGs for this leaf.
+                    // Report maxDoc conservatively so later RGs are still probed.
+                    nextDoc = maxDoc;
                 }
+            } else {
+                nextDoc = handle.currentDoc;
             }
         }
 
@@ -263,15 +271,16 @@ final class LuceneFilterDelegationHandle implements FilterDelegationHandle {
         MemorySegment.copy(words, 0, out, ValueLayout.JAVA_LONG, 0, wordCount);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(
-                "[scf] collectDocs collectorKey={} range=[{},{}) → cardinality={} words={}",
+                "[scf] collectDocs collectorKey={} range=[{},{}) → cardinality={} words={} nextDoc={}",
                 collectorKey,
                 minDoc,
                 maxDoc,
                 bits.cardinality(),
-                wordCount
+                wordCount,
+                nextDoc
             );
         }
-        return wordCount;
+        return ((long) nextDoc << 32) | (wordCount & 0xFFFFFFFFL);
     }
 
     @Override


### PR DESCRIPTION
collectDocs now returns packed i64: upper 32 bits = next matching docId beyond maxDoc, lower 32 bits = wordsWritten. No new FFM calls needed.

Rust consumers use nextDoc for three levels of optimization:
1. Full RG skip: nextDoc >= rgMax → no collectDocs call
2. Tightened range: nextDoc > rgMin → start from nextDoc, smaller bitset
3. No benefit: nextDoc <= rgMin → call as before

Implemented in both SingleCollectorEvaluator (AtomicI32 across RGs) and CollectorLeafBitmaps/BitmapTree (per-leaf HashMap keyed by Arc identity).

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────┬───────────┬─────────┐
│                                                PPL Query (source=textbench | … | stats …)                                                │ Baseline │ Optimized │ Speedup │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'retry') AND ServiceName='cart' AND SeverityNumber >= 0 | stats count()                                                 │   3818ms │     563ms │   6.78× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'timeout') AND ServiceName='cart' AND SeverityNumber >= 0 | stats count()                                               │   3818ms │     626ms │   6.10× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'timeout') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count(), min(SeverityNumber), max(SeverityNumber) │   3141ms │     554ms │   5.67× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'timeout') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count()                                           │   2732ms │     539ms │   5.07× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'timeout') AND ServiceName='frontend' AND SeverityNumber >= 0 AND TraceFlags >= 0 | stats count()                       │   2771ms │     549ms │   5.04× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'retry') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count()                                             │   2779ms │     578ms │   4.81× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'memory') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count() by SeverityNumber                          │   3169ms │     961ms │   3.30× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'memory') AND ServiceName='frontend' AND SeverityNumber >= 0 AND TraceFlags >= 0 | stats count()                        │   2737ms │     848ms │   3.23× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'memory') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count()                                            │   2737ms │     910ms │   3.01× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'exception') AND ServiceName='cart' AND SeverityNumber >= 0 | stats count()                                             │   3885ms │    2832ms │   1.37× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where NOT match(Body,'timeout') AND SeverityNumber >= 0 | stats count()                                                                  │  10748ms │    8811ms │   1.22× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'retry') AND SeverityNumber >= 0 | stats count()                                                                        │    536ms │     451ms │   1.19× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'retry') AND SeverityNumber >= 0 | stats count() by ServiceName                                                         │    525ms │     443ms │   1.18× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'payment') AND SeverityNumber >= 0 | stats count()                                                                      │    663ms │     574ms │   1.16× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'timeout') AND SeverityNumber >= 0 | stats count()                                                                      │    513ms │     446ms │   1.15× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where NOT match(Body,'error') AND SeverityNumber >= 0 | stats count()                                                                    │  12082ms │   10509ms │   1.15× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'memory') AND SeverityNumber >= 0 | stats count()                                                                       │    636ms │     570ms │   1.12× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where match(Body,'exception') AND SeverityNumber >= 0 | stats count()                                                                    │    604ms │     555ms │   1.09× │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ where NOT match(Body,'timeout') AND ServiceName='frontend' AND SeverityNumber >= 0 | stats count()                                       │   6286ms │    5844ms │   1.08× │
  └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────┴───────────┴─────────┘
```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
