### PR TITLE
Fix HTTP/1.1 SSL handler lookup in reactor-netty4

### DIFF
--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
@@ -35,10 +35,9 @@ final class ReactorNetty4BaseHttpChannel {
             final ChannelHandler[] channels = new ChannelHandler[1];
             request.withConnection(connection -> {
                 final Channel channel = connection.channel();
-                if (channel.parent() != null) {
+                channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
+                if (channels[0] == null && channel.parent() != null) {
                     channels[0] = channel.parent().pipeline().get(NettyPipeline.SslHandler);
-                } else {
-                    channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
                 }
             });
             if (channels[0] != null) {

--- a/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannelTests.java
+++ b/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannelTests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.reactor.netty4;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import javax.net.ssl.SSLEngine;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslHandler;
+import reactor.netty.Connection;
+import reactor.netty.NettyPipeline;
+import reactor.netty.http.server.HttpServerRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReactorNetty4BaseHttpChannelTests extends OpenSearchTestCase {
+
+    public void testSslHandlerUsesCurrentChannelBeforeParent() {
+        final SslHandler currentHandler = mock(SslHandler.class);
+        final SslHandler parentHandler = mock(SslHandler.class);
+        final HttpServerRequest request = requestWithChannels(currentHandler, parentHandler);
+
+        final Optional<SslHandler> result = ReactorNetty4BaseHttpChannel.get(request, "ssl_http", SslHandler.class);
+
+        assertSame(currentHandler, result.orElseThrow());
+    }
+
+    public void testSslHandlerFallsBackToParentChannel() {
+        final SslHandler parentHandler = mock(SslHandler.class);
+        final HttpServerRequest request = requestWithChannels(null, parentHandler);
+
+        final Optional<SslHandler> result = ReactorNetty4BaseHttpChannel.get(request, "ssl_http", SslHandler.class);
+
+        assertSame(parentHandler, result.orElseThrow());
+    }
+
+    public void testSslEngineUsesHandlerFromCurrentChannel() {
+        final SSLEngine engine = mock(SSLEngine.class);
+        final SslHandler currentHandler = mock(SslHandler.class);
+        when(currentHandler.engine()).thenReturn(engine);
+        final HttpServerRequest request = requestWithChannels(currentHandler, null);
+
+        final Optional<SSLEngine> result = ReactorNetty4BaseHttpChannel.get(request, "ssl_engine", SSLEngine.class);
+
+        assertSame(engine, result.orElseThrow());
+    }
+
+    private static HttpServerRequest requestWithChannels(SslHandler currentHandler, SslHandler parentHandler) {
+        final ChannelPipeline currentPipeline = mock(ChannelPipeline.class);
+        final ChannelPipeline parentPipeline = mock(ChannelPipeline.class);
+        when(currentPipeline.get(NettyPipeline.SslHandler)).thenReturn(currentHandler);
+        when(parentPipeline.get(NettyPipeline.SslHandler)).thenReturn(parentHandler);
+
+        final Channel parent = mock(Channel.class);
+        when(parent.pipeline()).thenReturn(parentPipeline);
+
+        final Channel current = mock(Channel.class);
+        when(current.pipeline()).thenReturn(currentPipeline);
+        when(current.parent()).thenReturn(parent);
+
+        final Connection connection = mock(Connection.class);
+        when(connection.channel()).thenReturn(current);
+
+        final HttpServerRequest request = mock(HttpServerRequest.class);
+        doAnswer(invocation -> {
+            final Consumer<? super Connection> consumer = invocation.getArgument(0);
+            consumer.accept(connection);
+            return request;
+        }).when(request).withConnection(any());
+        return request;
+    }
+}


### PR DESCRIPTION
## Summary

- check the request channel for the Reactor Netty TLS handler before checking its parent
- preserve the parent-channel fallback used by HTTP/2 stream channels
- add focused coverage for current-channel precedence, parent fallback, and SSL engine retrieval

## Why

HTTP/1.1 connection channels have a parent server channel, but keep `SslHandler` on the current channel. Looking only at the parent prevents downstream plugins such as OpenSearch Security from retrieving the peer certificate. HTTP/2 stream channels still require the parent fallback.

Fixes #22504.

## Test plan

- `./gradlew :plugins:transport-reactor-netty4:test --tests org.opensearch.http.reactor.netty4.ReactorNetty4BaseHttpChannelTests`
- external integration matrix verified valid client-certificate auth over HTTP/1.1 and HTTP/2, unauthenticated rejection over both protocols, and Basic auth over both protocols