### PR TITLE
fix(plugin-cli): disconnect HTTP connections in InstallPluginCommand to prevent leaks

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/InstallPluginCommand.java
@@ -402,10 +402,14 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         URL url = URI.create(urlString).toURL();
         assert "https".equals(url.getProtocol()) : "Use of https protocol is required";
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-        urlConnection.addRequestProperty("User-Agent", "opensearch-plugin-installer");
-        urlConnection.setRequestMethod("HEAD");
-        urlConnection.connect();
-        return urlConnection.getResponseCode() == 200;
+        try {
+            urlConnection.addRequestProperty("User-Agent", "opensearch-plugin-installer");
+            urlConnection.setRequestMethod("HEAD");
+            urlConnection.connect();
+            return urlConnection.getResponseCode() == 200;
+        } finally {
+            urlConnection.disconnect();
+        }
     }
 
     /** Returns all the official plugin names that look similar to pluginId. **/
@@ -686,10 +690,14 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     URL openUrl(String urlString) throws IOException {
         URL checksumUrl = URI.create(urlString).toURL();
         HttpURLConnection connection = (HttpURLConnection) checksumUrl.openConnection();
-        if (connection.getResponseCode() == 404) {
-            return null;
+        try {
+            if (connection.getResponseCode() == 404) {
+                return null;
+            }
+            return checksumUrl;
+        } finally {
+            connection.disconnect();
         }
-        return checksumUrl;
     }
 
     private Path unzip(Path zip, Path pluginsDir) throws IOException, UserException {


### PR DESCRIPTION
## Summary
- Fix HTTP connection leaks in plugin install command's URL checking methods

## Bug
`openUrl()` and `urlExists()` in `InstallPluginCommand.java` open `HttpURLConnection` but never call `\disconnect()`. Each plugin installation leaks sockets. The methods are called multiple times per install (for SHA-512 and SHA-1 checksum URLs).

## Fix
Wrap connection usage in try/finally blocks that call `disconnect()` on all code paths.
