### PR TITLE
fix(analysis-common): use try-with-resources for hyphenation patterns InputStream

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
@@ -71,8 +71,7 @@ public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundW
 
         Path hyphenationPatternsFile = Analysis.resolveAnalyzerPath(env, hyphenationPatternsPath);
 
-        try {
-            InputStream in = Files.newInputStream(hyphenationPatternsFile);
+        try (InputStream in = Files.newInputStream(hyphenationPatternsFile)) {
             hyphenationTree = HyphenationCompoundWordTokenFilter.getHyphenationTree(new InputSource(in));
         } catch (Exception e) {
             LogManager.getLogger(HyphenationCompoundWordTokenFilterFactory.class)


### PR DESCRIPTION
## Summary
- Fix InputStream leak when loading hyphenation patterns

## Bug
In `HyphenationCompoundWordTokenFilterFactory.java`, an `InputStream` opened via `Files.newInputStream()` is never closed. This leaks a file descriptor until GC runs, and on Windows can prevent file deletion during index close/reopen.

## Fix
Use try-with-resources to ensure the InputStream is always closed.
