### PR TITLE
fix: SslHandler retrieval for HTTP/1.1 client certificate auth

### DIFF
--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
@@ -35,10 +35,9 @@ final class ReactorNetty4BaseHttpChannel {
             final ChannelHandler[] channels = new ChannelHandler[1];
             request.withConnection(connection -> {
                 final Channel channel = connection.channel();
-                if (channel.parent() != null) {
+                channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
+                if (channels[0] == null && channel.parent() != null) {
                     channels[0] = channel.parent().pipeline().get(NettyPipeline.SslHandler);
-                } else {
-                    channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
                 }
             });
             if (channels[0] != null) {


### PR DESCRIPTION
## Summary

Fixes #22504 — SslHandler retrieval in `ReactorNetty4BaseHttpChannel.get()` prioritizes the parent channel over the current channel, breaking client certificate authentication on HTTP/1.1.

## Root cause

For HTTP/1.1 connections, the connection channel has a parent server channel, but its `SslHandler` is on the *current* channel. The original code checked `parent()` first, which returned null — so the Security plugin could not retrieve the `SSLEngine` or peer certificate.

HTTP/2 stream channels correctly inherit the TLS handler from the parent, so HTTP/2 was not affected.

## Fix

Check the current channel first, and fall back to the parent only when no `SslHandler` is found:

```java
channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
if (channels[0] == null && channel.parent() != null) {
    channels[0] = channel.parent().pipeline().get(NettyPipeline.SslHandler);
}
```

## Verified matrix (by reporter)

| Protocol | Auth | Result |
|----------|------|--------|
| HTTP/1.1 | valid cert | 200 ✓ |
| HTTP/2   | valid cert | 200 ✓ |
| HTTP/1.1 | no auth    | 401 ✓ |
| HTTP/2   | no auth    | 401 ✓ |
| HTTP/1.1 | basic auth | 200 ✓ |
| HTTP/2   | basic auth | 200 ✓ |

### Issues resolved

Closes #22504

Signed-off-by: jasstionzyf <jasstionzyf@gmail.com>