### PR TITLE
Fix flaky testBulkScoringWithBoost under concurrent search

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -357,7 +357,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
         refresh();
         indexRandomForConcurrentSearch("bulk-test-explain");
 
-        // The bulk scorer produces score = (docId + 1) * boost, but explain always uses the per-doc
+        // The bulk scorer produces score = 1.0 * boost, but explain always uses the per-doc
         // path (newInstance → execute() returns 2.0). Verify explain returns the per-doc score.
         Script script = new Script(ScriptType.INLINE, BulkScoringScriptEngine.NAME, "bulk_score", Collections.emptyMap());
         SearchResponse resp = client().prepareSearch("bulk-test-explain")
@@ -382,7 +382,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
     /**
      * A minimal script engine that produces a {@link ScoreScript.BulkScoringLeafFactory}.
      * <p>
-     * Source "bulk_score": bulk scorer assigns score = (segment-local docId + 1) * boost.
+     * Source "bulk_score": bulk scorer assigns score = 1.0 * boost (docId-independent).
      * Source "fallback_score": bulkScorer() returns null, falling back to per-doc scoring with score = 2.0.
      */
     public static class BulkScoringScriptEngine implements ScriptEngine {
@@ -455,9 +455,16 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
 
     /**
      * A simple bulk scorer that drives the sub-query's bulk scorer to discover matched docs,
-     * then assigns each document a score of (docId + 1) * boost.
+     * then assigns each document a score of BASE_SCORE * boost.
+     * <p>
+     * The base score is intentionally independent of the (segment-local) docId. With concurrent
+     * segment search, the bogus docs indexed by {@code indexRandomForConcurrentSearch} shift the
+     * segment-local docId of the real doc non-deterministically, so a docId-derived score would
+     * make assertions on absolute score values flaky.
      */
     private static class SimpleBulkScorer extends BulkScorer {
+
+        private static final float BASE_SCORE = 1.0f;
 
         private final BulkScorer subQueryBulkScorer;
         private final float boost;
@@ -484,7 +491,7 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
 
                 @Override
                 public void collect(int doc) throws IOException {
-                    currentScore[0] = (doc + 1) * boost;
+                    currentScore[0] = BASE_SCORE * boost;
                     collector.collect(doc);
                 }
             }, acceptDocs, min, max);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flaky testBulkScoringWithBoost under concurrent search

Why test was failing:
The test's bulk scorer derived each document's score from its segment-local docId ((docId + 1) * boost). With concurrent segment  search enabled, indexRandomForConcurrentSearch indexes and deletes  bogus docs to force multiple segments, which shifts the real doc's  segment-local docId non-deterministically. The base and boosted  queries could observe different docIds, breaking the baseScore * boost assertion (e.g. expected 21.0 but got 165.0).

Make the bulk scorer produce a docId-independent score (BASE_SCORE * boost) so the boost relationship holds regardless of segment layout.

### Related Issues
Ref: https://github.com/opensearch-project/OpenSearch/pull/22441#issuecomment-5019958559
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
