### PR TITLE
[BUG] Fix broken Gradle Shadow Plugin links

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -446,7 +446,7 @@ A fat-JAR (or an uber-JAR) is the JAR, which contains classes from all the libra
 
 There might be cases where a developer would like to add some custom logic to the code of a module (or multiple modules) and generate a fat-JAR that can be directly used by the dependency management tool. For example, in [#3665](https://github.com/opensearch-project/OpenSearch/pull/3665) a developer wanted to provide a tentative patch as a fat-JAR to a consumer for changes made in the high level REST client.
 
-Use [Gradle Shadow plugin](https://imperceptiblethoughts.com/shadow/).
+Use [Gradle Shadow plugin](https://gradleup.com/shadow/).
 Add the following to the `build.gradle` file of the module for which you want to create the fat-JAR, e.g. `client/rest-high-level/build.gradle`:
 
 ```
@@ -460,7 +460,7 @@ Run the `shadowJar` command using:
 
 This will generate a fat-JAR in the `build/distributions` folder of the module, e.g. .`/client/rest-high-level/build/distributions/opensearch-rest-high-level-client-1.4.0-SNAPSHOT.jar`.
 
-You can further customize your fat-JAR by customising the plugin, More information about shadow plugin can be found [here](https://imperceptiblethoughts.com/shadow/).
+You can further customize your fat-JAR by customising the plugin, More information about shadow plugin can be found [here](https://gradleup.com/shadow/).
 
 To use the generated JAR, install the JAR locally, e.g.
 ```


### PR DESCRIPTION
### Description
Updates the broken Gradle Shadow Plugin links in `DEVELOPER_GUIDE.md` to point to the current official documentation.

### Related Issues
Resolves #19169

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
