### PR TITLE
[BUG] Fix ambiguous Node type reference in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.api.Project;
 import org.gradle.process.ExecResult;
 import groovy.xml.XmlParser;
+import groovy.util.Node;
 
 import static org.opensearch.gradle.util.GradleUtils.maybeConfigure
 


### PR DESCRIPTION
### Description
Fixes the ambiguous Node type reference in the root build.gradle.

Some Gradle environments may resolve Node to org.gradle.execution.plan.Node, causing a ClassCastException during Gradle execution. This change explicitly imports groovy.util.Node so the intended type is always used.

### Related Issues
Resolves #19247

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
