### PR TITLE
Fix V1 template merge regression that broke dynamic object inheritance

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -77,6 +77,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.set.Sets;
+import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.unit.ByteSizeValue;
@@ -953,112 +954,27 @@ public class MetadataCreateIndexService {
         List<CompressedXContent> templateMappings,
         NamedXContentRegistry xContentRegistry
     ) throws Exception {
-        // Step 1: Collect all mappings into a list
-        List<Map<String, Object>> allMappings = new ArrayList<>();
-
-        // Add template mappings first (lower priority)
+        Map<String, Object> mappings = MapperService.parseMapping(xContentRegistry, requestMappings);
+        // apply templates, merging the mappings into the request mapping if exists
         for (CompressedXContent mapping : templateMappings) {
             if (mapping != null) {
                 Map<String, Object> templateMapping = MapperService.parseMapping(xContentRegistry, mapping.string());
-                if (!templateMapping.isEmpty()) {
-                    assert templateMapping.size() == 1 : "expected exactly one mapping value, got: " + templateMapping;
-                    // pre-8x templates may have a wrapper type other than _doc, so we re-wrap things here
-                    templateMapping = new HashMap<>(Map.of(MapperService.SINGLE_MAPPING_NAME, templateMapping.values().iterator().next()));
-                    allMappings.add(templateMapping);
+                if (templateMapping.isEmpty()) {
+                    // Someone provided an empty '{}' for mappings, which is okay, but to avoid
+                    // tripping the below assertion, we can safely ignore it
+                    continue;
                 }
-            }
-        }
-
-        // Add request mapping last (highest priority)
-        Map<String, Object> requestMapping = MapperService.parseMapping(xContentRegistry, requestMappings);
-        if (!requestMapping.isEmpty()) {
-            allMappings.add(requestMapping);
-        }
-
-        // Step 2: Apply shared disable_objects override logic (same as V2 templates)
-        applyDisableObjectsOverrides(allMappings);
-
-        // Step 3: Merge all mappings using field-aware replacement logic
-        // Process mappings in forward order, with special handling for request mappings
-        Map<String, Object> result = new HashMap<>();
-        boolean hasRequestMapping = !MapperService.parseMapping(xContentRegistry, requestMappings).isEmpty();
-
-        for (int i = 0; i < allMappings.size(); i++) {
-            Map<String, Object> mapping = allMappings.get(i);
-            boolean isRequestMapping = hasRequestMapping && (i == allMappings.size() - 1);
-
-            if (result.isEmpty()) {
-                result = new HashMap<>(mapping);
-            } else {
-                if (isRequestMapping) {
-                    // For request mappings: request wins over templates
-                    Map<String, Object> newMapping = new HashMap<>(mapping);
-                    mergeTemplateFieldMappings(newMapping, result);
-                    result = newMapping;
+                assert templateMapping.size() == 1 : "expected exactly one mapping value, got: " + templateMapping;
+                // pre-8x templates may have a wrapper type other than _doc, so we re-wrap things here
+                templateMapping = Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, templateMapping.values().iterator().next());
+                if (mappings.isEmpty()) {
+                    mappings = templateMapping;
                 } else {
-                    // For template mappings: accumulated result (higher priority) wins over current (lower priority)
-                    mergeTemplateFieldMappings(result, mapping);
+                    XContentHelper.mergeDefaults(mappings, templateMapping);
                 }
             }
         }
-
-        return result;
-    }
-
-    /**
-     * Merges template mappings with complete field definition replacement.
-     * Higher priority mappings completely override field definitions from lower priority mappings.
-     *
-     * @param target the target mapping to merge into (higher priority)
-     * @param source the source mapping to merge from (lower priority)
-     */
-    private static void mergeTemplateFieldMappings(Map<String, Object> target, Map<String, Object> source) {
-        for (Map.Entry<String, Object> sourceEntry : source.entrySet()) {
-            String key = sourceEntry.getKey();
-            Object sourceValue = sourceEntry.getValue();
-
-            if (!target.containsKey(key)) {
-                // Key doesn't exist in target, add it
-                target.put(key, sourceValue);
-            } else if (key.equals("properties") && sourceValue instanceof Map && target.get(key) instanceof Map) {
-                // Special handling for "properties" section - merge field definitions with replacement
-                @SuppressWarnings("unchecked")
-                Map<String, Object> targetProperties = (Map<String, Object>) target.get(key);
-                @SuppressWarnings("unchecked")
-                Map<String, Object> sourceProperties = (Map<String, Object>) sourceValue;
-                mergeFieldProperties(targetProperties, sourceProperties);
-            } else if (sourceValue instanceof Map && target.get(key) instanceof Map) {
-                // Recursively merge other Map objects (but not field definitions)
-                @SuppressWarnings("unchecked")
-                Map<String, Object> targetMap = (Map<String, Object>) target.get(key);
-                @SuppressWarnings("unchecked")
-                Map<String, Object> sourceMap = (Map<String, Object>) sourceValue;
-                mergeTemplateFieldMappings(targetMap, sourceMap);
-            }
-            // For non-Map values or when target already has the key, target value takes precedence (no override)
-        }
-    }
-
-    /**
-     * Merges field properties with complete field definition replacement.
-     * If a field exists in both maps, the target field definition completely replaces the source.
-     *
-     * @param targetProperties the target properties map (higher priority)
-     * @param sourceProperties the source properties map (lower priority)
-     */
-    private static void mergeFieldProperties(Map<String, Object> targetProperties, Map<String, Object> sourceProperties) {
-        for (Map.Entry<String, Object> sourceField : sourceProperties.entrySet()) {
-            String fieldName = sourceField.getKey();
-            Object sourceFieldDef = sourceField.getValue();
-
-            if (!targetProperties.containsKey(fieldName)) {
-                // Field doesn't exist in target, add it
-                targetProperties.put(fieldName, sourceFieldDef);
-            } else {
-                // If field exists in target, target takes precedence (higher priority template wins)
-                // This ensures complete field definition replacement rather than property merging
-            }
-        }
+        return mappings;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -4580,4 +4580,165 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         MetadataCreateIndexService.validateIngestionSourceSettings(settings, state);
     }
+
+    /**
+     * Template A (lower priority) defines @fields as a dynamic object.
+     * Template B (higher priority) defines a specific sub-field @fields.userstate as keyword.
+     * After merging, @fields should retain both the dynamic:true/type:object settings AND
+     * the specific userstate mapping. The regression in PR#19958 caused the dynamic/object
+     * settings to be dropped, breaking index creation for dynamic fields under @fields.
+     */
+    public void testV1TemplateMergingPreservesDynamicObjectWithSubFieldMapping() throws Exception {
+        // Template A (lower priority / later in list): defines @fields as dynamic object
+        CompressedXContent templateA = new CompressedXContent("""
+            {
+              "_doc": {
+                "properties": {
+                  "@fields": {
+                    "type": "object",
+                    "dynamic": "true",
+                    "properties": {
+                      "status": { "type": "keyword" }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        // Template B (higher priority / earlier in list): defines specific sub-field @fields.userstate
+        CompressedXContent templateB = new CompressedXContent("""
+            {
+              "_doc": {
+                "properties": {
+                  "@fields": {
+                    "properties": {
+                      "userstate": { "type": "keyword" }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        // Template B is higher priority (first in list), Template A is lower priority (second in list)
+        List<CompressedXContent> templates = Arrays.asList(templateB, templateA);
+        Map<String, Object> result = MetadataCreateIndexService.parseV1Mappings("", templates, NamedXContentRegistry.EMPTY);
+
+        // Serialize result to JSON and compare against expected merged output
+        String resultJson = XContentFactory.jsonBuilder().map(result).toString();
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                resultJson
+            )
+        ) {
+            Map<String, Object> actual = parser.map();
+            try (
+                XContentParser expectedParser = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    """
+                        {
+                          "_doc": {
+                            "properties": {
+                              "@fields": {
+                                "type": "object",
+                                "dynamic": "true",
+                                "properties": {
+                                  "userstate": { "type": "keyword" },
+                                  "status": { "type": "keyword" }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        """
+                )
+            ) {
+                Map<String, Object> expected = expectedParser.map();
+                assertEquals("Merged V1 template result should preserve dynamic object with all sub-fields", expected, actual);
+            }
+        }
+    }
+
+    /**
+     * Tests that V1 template merging correctly handles request mapping overriding template
+     * while still inheriting non-conflicting object-level settings from templates.
+     * This ensures that a request mapping defining only sub-fields of an object still
+     * inherits the object's type/dynamic settings from templates.
+     */
+    public void testV1RequestMappingInheritsObjectSettingsFromTemplate() throws Exception {
+        // Template defines @fields as dynamic object
+        CompressedXContent template = new CompressedXContent("""
+            {
+              "_doc": {
+                "properties": {
+                  "@fields": {
+                    "type": "object",
+                    "dynamic": "true"
+                  }
+                }
+              }
+            }
+            """);
+
+        // Request mapping defines a specific sub-field under @fields
+        String requestMapping = """
+            {
+              "_doc": {
+                "properties": {
+                  "@fields": {
+                    "properties": {
+                      "userstate": { "type": "keyword" }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        List<CompressedXContent> templates = Collections.singletonList(template);
+        Map<String, Object> result = MetadataCreateIndexService.parseV1Mappings(requestMapping, templates, NamedXContentRegistry.EMPTY);
+
+        // Serialize result to JSON and compare against expected merged output
+        String resultJson = XContentFactory.jsonBuilder().map(result).toString();
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                resultJson
+            )
+        ) {
+            Map<String, Object> actual = parser.map();
+            try (
+                XContentParser expectedParser = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    """
+                        {
+                          "_doc": {
+                            "properties": {
+                              "@fields": {
+                                "type": "object",
+                                "dynamic": "true",
+                                "properties": {
+                                  "userstate": { "type": "keyword" }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        """
+                )
+            ) {
+                Map<String, Object> expected = expectedParser.map();
+                assertEquals("Request mapping should inherit object settings from template", expected, actual);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The dotted field feature (PR#19958) replaced `XContentHelper.mergeDefaults()` with a custom mergeTemplateFieldMappings/mergeFieldProperties logic in parseV1Mappings. The new logic used complete field definition replacement instead of deep recursive merging, which broke template inheritance for customers relying on multiple templates defining different aspects of the same field path (e.g., one template defines @fields as dynamic:true object, another defines @fields.userstate as keyword).

This restores the original parseV1Mappings behavior using `XContentHelper.mergeDefaults()` which performs deep recursive merging. The disable_objects feature remains fully functional via `collectV2Mappings` and `applyDisableObjectsOverrides` for V2 composable templates, and V1 templates with disable_objects still work correctly since mergeDefaults propagates the setting from any template that defines it.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
