### PR TITLE
Fix stranded snapshot markers on publish failure

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotCleanupRetryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotCleanupRetryIT.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SnapshotCleanupRetryIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING.getKey(), true).build();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getKey(), 3)
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.getKey(), "1s")
+            .build();
+    }
+
+    public void testSnapshotMarkerCleanedUpAfterClusterManagerFailover() throws Exception {
+        logger.info("--> starting cluster-manager and data nodes");
+        internalCluster().startClusterManagerOnlyNodes(3);
+        internalCluster().startDataOnlyNodes(2);
+
+        createRepository("test-repo", "mock");
+        assertAcked(prepareCreate("test-idx", 0, indexSettingsNoReplicas(1)));
+        ensureGreen();
+        indexRandomDocs("test-idx", randomIntBetween(10, 50));
+
+        logger.info("--> block cluster-manager from finalizing snapshot on index file");
+        String blockedNode = blockClusterManagerFromFinalizingSnapshotOnIndexFile("test-repo");
+
+        logger.info("--> start snapshot (non-blocking)");
+        client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setWaitForCompletion(false).setIndices("test-idx").get();
+
+        logger.info("--> wait for snapshot to hit the block");
+        waitForBlock(blockedNode, "test-repo", TimeValue.timeValueSeconds(30));
+
+        logger.info("--> stopping cluster-manager node to induce failover");
+        internalCluster().stopCurrentClusterManagerNode();
+
+        logger.info("--> wait for snapshot marker to be cleaned up after new cluster-manager takes over");
+        assertBusy(() -> {
+            SnapshotsInProgress snapshotsInProgress = clusterService().state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+            assertTrue("Snapshot marker should be cleaned up", snapshotsInProgress.entries().isEmpty());
+        }, 60, TimeUnit.SECONDS);
+
+        logger.info("--> verify snapshot state after failover");
+        GetSnapshotsResponse snapshotResponse = client().admin()
+            .cluster()
+            .prepareGetSnapshots("test-repo")
+            .setSnapshots("test-snap")
+            .setIgnoreUnavailable(true)
+            .get();
+        if (snapshotResponse.getSnapshots().isEmpty() == false) {
+            SnapshotState state = snapshotResponse.getSnapshots().get(0).state();
+            assertTrue("Snapshot should be completed but was " + state, state.completed());
+        }
+
+        logger.info("--> verify index deletion is unblocked");
+        assertAcked(client().admin().indices().prepareDelete("test-idx").get());
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -703,6 +703,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING,
                 SnapshotsService.SNAPSHOT_REPOSITORY_MAX_OUTSTANDING_OPS_SETTING,
                 SnapshotsService.SNAPSHOT_DELETE_CLEANUP_STALE_BLOBS_SETTING,
+                SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING,
+                SnapshotsService.SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING,
                 FsHealthService.ENABLED_SETTING,
                 FsHealthService.REFRESH_INTERVAL_SETTING,
                 FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -91,6 +91,7 @@ import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexModule;
@@ -133,6 +134,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -346,6 +348,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             maxConcurrentOperations = MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING.get(settings);
             clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING, i -> maxConcurrentOperations = i);
+            maxRetries = SNAPSHOT_CLEANUP_RETRIES_SETTING.get(settings);
+            retryBackoff = SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.get(settings);
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRIES_SETTING, i -> maxRetries = i);
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING, t -> retryBackoff = t);
         }
 
         // Task is onboarded for throttling, it will get retried from associated TransportClusterManagerNodeAction.
@@ -2316,14 +2322,17 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private void handleFinalizationFailure(Exception e, SnapshotsInProgress.Entry entry, RepositoryData repositoryData) {
         Snapshot snapshot = entry.snapshot();
         if (ExceptionsHelper.unwrap(e, NotClusterManagerException.class, FailedToCommitClusterStateException.class) != null) {
-            // Failure due to not being cluster-manager any more, don't try to remove snapshot from cluster state the next cluster-manager
-            // will try ending this snapshot again
             logger.debug(() -> new ParameterizedMessage("[{}] failed to update cluster state during snapshot finalization", snapshot), e);
-            failSnapshotCompletionListeners(
-                snapshot,
-                new SnapshotException(snapshot, "Failed to update cluster state during snapshot finalization", e)
-            );
-            failAllListenersOnMasterFailOver(e);
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)
+                && ExceptionsHelper.unwrap(e, FailedToCommitClusterStateException.class) != null) {
+                removeFailedSnapshotFromClusterState(snapshot, e, repositoryData, null);
+            } else {
+                failSnapshotCompletionListeners(
+                    snapshot,
+                    new SnapshotException(snapshot, "Failed to update cluster state during snapshot finalization", e)
+                );
+                failAllListenersOnMasterFailOver(e);
+            }
         } else {
             logger.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
             removeFailedSnapshotFromClusterState(snapshot, e, repositoryData, null);
@@ -2486,44 +2495,54 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }
         if (changed) {
             logger.info("Cleaning up in progress v2 snapshots now");
-            clusterService.submitStateUpdateTask(
-                "remove in progress snapshot v2 after cluster manager switch",
-                new ClusterStateUpdateTask() {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        SnapshotsInProgress snapshots = state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
-                        boolean changed = false;
-                        ArrayList<SnapshotsInProgress.Entry> entries = new ArrayList<>();
-                        for (SnapshotsInProgress.Entry entry : snapshots.entries()) {
-                            if (entry.remoteStoreIndexShallowCopyV2()) {
-                                changed = true;
-                            } else {
-                                entries.add(entry);
-                            }
-                        }
-                        if (changed) {
-                            return ClusterState.builder(currentState)
-                                .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(unmodifiableList(entries)))
-                                .build();
-                        } else {
-                            return currentState;
-                        }
-                    }
+            final String source = "remove in progress snapshot v2 after cluster manager switch";
+            final int attempt = 0;
+            clusterService.submitStateUpdateTask(source, createStateWithoutSnapshotV2Task(source, attempt));
+        }
+    }
 
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        // execute never fails , so we should never hit this.
-                        logger.warn(
-                            () -> new ParameterizedMessage(
-                                "failed to remove in progress snapshot v2 state after cluster manager switch {}",
-                                e
-                            ),
-                            e
-                        );
+    ClusterStateUpdateTask createStateWithoutSnapshotV2Task(String source, int attempt) {
+        return new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+                boolean changed = false;
+                ArrayList<SnapshotsInProgress.Entry> entries = new ArrayList<>();
+                for (SnapshotsInProgress.Entry entry : snapshots.entries()) {
+                    if (entry.remoteStoreIndexShallowCopyV2()) {
+                        changed = true;
+                    } else {
+                        entries.add(entry);
                     }
                 }
-            );
-        }
+                if (changed) {
+                    return ClusterState.builder(currentState)
+                        .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(unmodifiableList(entries)))
+                        .build();
+                } else {
+                    return currentState;
+                }
+            }
+
+            @Override
+            public void onFailure(String src, Exception e) {
+                logger.warn(
+                    () -> new ParameterizedMessage("failed to remove in progress snapshot v2 state after cluster manager switch {}", e),
+                    e
+                );
+                if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                    retryOrFailOnClusterManagerFailOver(
+                        e,
+                        attempt,
+                        source,
+                        () -> createStateWithoutSnapshotV2Task(source, attempt + 1),
+                        () -> {
+                            logger.error("Giving up on removing v2 snapshot state after {} attempts", attempt + 1);
+                        }
+                    );
+                }
+            }
+        };
     }
 
     /**
@@ -2544,12 +2563,27 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         @Nullable CleanupAfterErrorListener listener
     ) {
         assert failure != null : "Failure must be supplied";
-        clusterService.submitStateUpdateTask("remove snapshot metadata", new ClusterStateUpdateTask() {
+        final String source = "remove snapshot metadata";
+        final int attempt = 0;
+        clusterService.submitStateUpdateTask(
+            source,
+            createRemoveFailedSnapshotTask(source, attempt, snapshot, failure, repositoryData, listener)
+        );
+    }
+
+    ClusterStateUpdateTask createRemoveFailedSnapshotTask(
+        String source,
+        int attempt,
+        Snapshot snapshot,
+        Exception failure,
+        @Nullable RepositoryData repositoryData,
+        @Nullable CleanupAfterErrorListener listener
+    ) {
+        return new ClusterStateUpdateTask() {
 
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final ClusterState updatedState = stateWithoutSnapshot(currentState, snapshot);
-                // now check if there are any delete operations that refer to the just failed snapshot and remove the snapshot from them
                 return updateWithSnapshots(
                     updatedState,
                     null,
@@ -2562,30 +2596,43 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(String src, Exception e) {
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to remove snapshot metadata", snapshot), e);
-                failSnapshotCompletionListeners(
-                    snapshot,
-                    new SnapshotException(snapshot, "Failed to remove snapshot from cluster state", e)
-                );
-                failAllListenersOnMasterFailOver(e);
-                if (listener != null) {
-                    listener.onFailure(e);
+                final Runnable fallback = () -> {
+                    failSnapshotCompletionListeners(
+                        snapshot,
+                        new SnapshotException(snapshot, "Failed to remove snapshot from cluster state", e)
+                    );
+                    failAllListenersOnMasterFailOver(e);
+                    if (listener != null) {
+                        listener.onFailure(e);
+                    }
+                };
+                if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                    retryOrFailOnClusterManagerFailOver(
+                        e,
+                        attempt,
+                        source,
+                        () -> createRemoveFailedSnapshotTask(source, attempt + 1, snapshot, failure, repositoryData, listener),
+                        fallback
+                    );
+                } else {
+                    fallback.run();
                 }
             }
 
             @Override
-            public void onNoLongerClusterManager(String source) {
+            public void onNoLongerClusterManager(String src) {
                 failure.addSuppressed(new SnapshotException(snapshot, "no longer cluster-manager"));
                 failSnapshotCompletionListeners(snapshot, failure);
-                failAllListenersOnMasterFailOver(new NotClusterManagerException(source));
+                failAllListenersOnMasterFailOver(new NotClusterManagerException(src));
                 if (listener != null) {
                     listener.onNoLongerClusterManager();
                 }
             }
 
             @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            public void clusterStateProcessed(String src, ClusterState oldState, ClusterState newState) {
                 failSnapshotCompletionListeners(snapshot, failure);
                 if (listener == null) {
                     if (repositoryData != null) {
@@ -2595,7 +2642,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     listener.onFailure(null);
                 }
             }
-        });
+        };
     }
 
     /**
@@ -3253,6 +3300,84 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
             currentlyFinalizing.clear();
         }
+    }
+
+    /**
+     * Maximum number of retries for a cluster state publish failure while the node is still cluster-manager.
+     */
+    public static final Setting<Integer> SNAPSHOT_CLEANUP_RETRIES_SETTING = Setting.intSetting(
+        "snapshot.cleanup.retries",
+        3,
+        0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Initial backoff duration for cleanup retries. Each subsequent retry doubles this value.
+     */
+    public static final Setting<TimeValue> SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING = Setting.timeSetting(
+        "snapshot.cleanup.retry_backoff",
+        TimeValue.timeValueSeconds(1),
+        TimeValue.timeValueMillis(100),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    private volatile int maxRetries;
+    private volatile TimeValue retryBackoff;
+
+    /**
+     * Handles a cluster-state-update onFailure by either retrying (if the publish failed but this node is still the
+     * cluster-manager) or falling back to the existing failover behavior. Without this, a publish failure on a stable
+     * cluster-manager strands the in-progress snapshot marker forever, blocking index deletion and close.
+     *
+     * @param e               the exception from onFailure
+     * @param attempt         current attempt number (0-based)
+     * @param source          the cluster state update source string
+     * @param taskFactory     supplier that creates a NEW task instance per retry (TaskBatcher rejects same-identity resubmit)
+     * @param failoverFallback the existing fallback behavior to run when retries are exhausted or not applicable
+     */
+    void retryOrFailOnClusterManagerFailOver(
+        Exception e,
+        int attempt,
+        String source,
+        Supplier<ClusterStateUpdateTask> taskFactory,
+        Runnable failoverFallback
+    ) {
+        if (ExceptionsHelper.unwrap(e, NotClusterManagerException.class) != null) {
+            failoverFallback.run();
+            return;
+        }
+        if (ExceptionsHelper.unwrap(e, FailedToCommitClusterStateException.class) == null) {
+            logger.error("Unexpected failure during cluster state update", e);
+            failoverFallback.run();
+            assert false : new AssertionError("Unexpected failure during cluster state update", e);
+            return;
+        }
+        if (attempt >= maxRetries) {
+            logger.warn("Exhausted {} retries for [{}], falling back to failover handling", maxRetries, source);
+            failoverFallback.run();
+            return;
+        }
+        final int nextAttempt = attempt + 1;
+        final TimeValue delay = computeBackoff(retryBackoff, attempt);
+        logger.info("Publish failed for [{}] (attempt {}), scheduling retry in [{}]", source, nextAttempt, delay);
+        try {
+            threadPool.schedule(() -> clusterService.submitStateUpdateTask(source, taskFactory.get()), delay, ThreadPool.Names.GENERIC);
+        } catch (OpenSearchRejectedExecutionException ex) {
+            logger.warn("Retry scheduling rejected for [{}], falling back to failover handling", source);
+            failoverFallback.run();
+        }
+    }
+
+    /**
+     * Computes the exponential backoff for a given attempt. The shift is capped to avoid overflow and the resulting
+     * delay is clamped to a sane maximum in case maxRetries/retryBackoff are configured to large values.
+     */
+    static TimeValue computeBackoff(TimeValue base, int attempt) {
+        final long delayMillis = Math.max(0L, Math.min(base.millis() * (1L << Math.min(attempt, 30)), TimeValue.timeValueDays(1).millis()));
+        return TimeValue.timeValueMillis(delayMillis);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
@@ -20,6 +20,8 @@ import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -52,7 +54,7 @@ public class RetryOrFailOnClusterManagerFailOverTests extends OpenSearchTestCase
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
 
-        Settings settings = Settings.builder().put("node.name", "test").build();
+        Settings settings = Settings.builder().put("node.name", "test").putList("node.roles", "cluster_manager", "data").build();
 
         snapshotsService = new SnapshotsService(
             settings,
@@ -289,6 +291,306 @@ public class RetryOrFailOnClusterManagerFailOverTests extends OpenSearchTestCase
 
         SnapshotsInProgress resultSnapshots = result.custom(SnapshotsInProgress.TYPE);
         assertTrue("Snapshot entry should be removed", resultSnapshots.entries().isEmpty());
+    }
+
+    public void testRejectedExecutionRunsFallback() {
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+        snapshotsService.retryOrFailOnClusterManagerFailOver(new FailedToCommitClusterStateException("test"), 100, "test-source", () -> {
+            throw new AssertionError("should not be called");
+        }, () -> fallbackCalled.set(true));
+        assertTrue("Fallback should be called when retries exhausted", fallbackCalled.get());
+    }
+
+    public void testComputeBackoffWithZeroBase() {
+        TimeValue result = SnapshotsService.computeBackoff(TimeValue.ZERO, 5);
+        assertEquals(TimeValue.ZERO, result);
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testStateWithoutSnapshotV2TaskOnFailureRetries() throws Exception {
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 0);
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated publish failure"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testStateWithoutSnapshotV2TaskOnFailureNotCMRunsFallback() throws Exception {
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 0);
+        task.onFailure("test-source", new NotClusterManagerException("simulated"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveFailedSnapshotTaskOnFailureRetries() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated publish failure"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveFailedSnapshotTaskOnFailureNotCM() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+        task.onFailure("test-source", new NotClusterManagerException("simulated"));
+    }
+
+    public void testCreateStateWithoutSnapshotV2TaskNoChangeReturnsOriginal() throws Exception {
+        Snapshot normalSnapshot = new Snapshot("repo", new SnapshotId("normal-snap", UUIDs.randomBase64UUID()));
+        SnapshotsInProgress.Entry normalEntry = SnapshotsInProgress.startedEntry(
+            normalSnapshot,
+            true,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            1L,
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Version.CURRENT,
+            false,
+            false
+        );
+
+        String localNodeId = UUIDs.randomBase64UUID();
+        ClusterState currentState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(DiscoveryNodes.builder().localNodeId(localNodeId).clusterManagerNodeId(localNodeId).build())
+            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(List.of(normalEntry)))
+            .build();
+
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 0);
+        ClusterState result = task.execute(currentState);
+
+        assertSame("Should return same state when no V2 entries to remove", currentState, result);
+    }
+
+    public void testComputeBackoffAttemptZero() {
+        TimeValue result = SnapshotsService.computeBackoff(TimeValue.timeValueSeconds(1), 0);
+        assertEquals(TimeValue.timeValueSeconds(1), result);
+    }
+
+    public void testComputeBackoffAttemptTwo() {
+        TimeValue result = SnapshotsService.computeBackoff(TimeValue.timeValueSeconds(1), 2);
+        assertEquals(TimeValue.timeValueSeconds(4), result);
+    }
+
+    public void testComputeBackoffCapsAtOneDay() {
+        TimeValue result = SnapshotsService.computeBackoff(TimeValue.timeValueHours(25), 0);
+        assertEquals(TimeValue.timeValueDays(1), result);
+    }
+
+    public void testComputeBackoffHighAttemptCapped() {
+        TimeValue result = SnapshotsService.computeBackoff(TimeValue.timeValueSeconds(1), 50);
+        assertEquals(TimeValue.timeValueDays(1), result);
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testStateWithoutSnapshotV2TaskOnFailureExhaustedRetries() throws Exception {
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 100);
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveFailedSnapshotTaskOnFailureExhaustedRetries() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            100,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testStateWithoutSnapshotV2TaskOnFailureUnexpectedException() throws Exception {
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 0);
+        expectThrows(AssertionError.class, () -> task.onFailure("test-source", new RuntimeException("unexpected")));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveFailedSnapshotTaskOnFailureUnexpectedException() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+        expectThrows(AssertionError.class, () -> task.onFailure("test-source", new RuntimeException("unexpected")));
+    }
+
+    public void testRemoveFailedSnapshotTaskOnNoLongerClusterManagerWithoutListener() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+
+        task.onNoLongerClusterManager("test-source");
+    }
+
+    public void testRemoveFailedSnapshotTaskOnNoLongerClusterManagerWithListener() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        ActionListener<Snapshot> userListener = ActionListener.wrap(s -> {}, e -> listenerCalled.set(true));
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+
+        task.onNoLongerClusterManager("test-source");
+    }
+
+    public void testRemoveFailedSnapshotTaskClusterStateProcessedWithoutListenerNullRepoData() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("test failure"),
+            null,
+            null
+        );
+
+        String localNodeId = UUIDs.randomBase64UUID();
+        ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(DiscoveryNodes.builder().localNodeId(localNodeId).clusterManagerNodeId(localNodeId).build())
+            .build();
+
+        task.clusterStateProcessed("test-source", state, state);
+    }
+
+    public void testRejectedExecutionExceptionInRetryRunsFallback() throws Exception {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+
+        TestThreadPool terminatedPool = new TestThreadPool(getTestName());
+        ThreadPool.terminate(terminatedPool, 0, TimeUnit.MILLISECONDS);
+
+        ClusterService localClusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(localClusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        TransportService localTransportService = mock(TransportService.class);
+        when(localTransportService.getThreadPool()).thenReturn(terminatedPool);
+
+        Settings settings = Settings.builder().put("node.name", "test").putList("node.roles", "cluster_manager", "data").build();
+
+        SnapshotsService localService = new SnapshotsService(
+            settings,
+            localClusterService,
+            mock(org.opensearch.cluster.metadata.IndexNameExpressionResolver.class),
+            mock(org.opensearch.repositories.RepositoriesService.class),
+            localTransportService,
+            mock(org.opensearch.action.support.ActionFilters.class),
+            null,
+            new org.opensearch.indices.RemoteStoreSettings(Settings.EMPTY, clusterSettings),
+            null
+        );
+
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+
+        localService.retryOrFailOnClusterManagerFailOver(
+            new FailedToCommitClusterStateException("test"),
+            0,
+            "test-source",
+            () -> mock(ClusterStateUpdateTask.class),
+            () -> fallbackCalled.set(true)
+        );
+
+        assertTrue("Fallback should be called when scheduling is rejected", fallbackCalled.get());
+    }
+
+    public void testSettingsUpdateConsumerForRetries() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        Settings settings = Settings.builder()
+            .put("node.name", "test")
+            .putList("node.roles", "cluster_manager", "data")
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getKey(), 5)
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.getKey(), "2s")
+            .build();
+
+        SnapshotsService svc = new SnapshotsService(
+            settings,
+            clusterService,
+            mock(org.opensearch.cluster.metadata.IndexNameExpressionResolver.class),
+            mock(org.opensearch.repositories.RepositoriesService.class),
+            transportService,
+            mock(org.opensearch.action.support.ActionFilters.class),
+            null,
+            new org.opensearch.indices.RemoteStoreSettings(Settings.EMPTY, clusterSettings),
+            null
+        );
+
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+        svc.retryOrFailOnClusterManagerFailOver(
+            new FailedToCommitClusterStateException("test"),
+            5,
+            "test-source",
+            () -> mock(ClusterStateUpdateTask.class),
+            () -> fallbackCalled.set(true)
+        );
+        assertTrue("Fallback should be called at attempt==maxRetries", fallbackCalled.get());
+
+        Settings newSettings = Settings.builder()
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getKey(), 10)
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.getKey(), "5s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+
+        AtomicBoolean fallbackCalled2 = new AtomicBoolean(false);
+        CountDownLatch retryLatch = new CountDownLatch(1);
+        svc.retryOrFailOnClusterManagerFailOver(new FailedToCommitClusterStateException("test"), 5, "test-source", () -> {
+            retryLatch.countDown();
+            return mock(ClusterStateUpdateTask.class);
+        }, () -> fallbackCalled2.set(true));
+        assertFalse("Fallback should NOT be called when retries increased", fallbackCalled2.get());
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveFailedSnapshotTaskOnFailureWithListenerNotNull() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("original failure"),
+            null,
+            null
+        );
+        task.onFailure("test-source", new NotClusterManagerException("simulated"));
     }
 
 }

--- a/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
@@ -1,0 +1,294 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.NotClusterManagerException;
+import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.cluster.coordination.FailedToCommitClusterStateException;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RetryOrFailOnClusterManagerFailOverTests extends OpenSearchTestCase {
+
+    private TestThreadPool threadPool;
+    private ClusterService clusterService;
+    private SnapshotsService snapshotsService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        Settings settings = Settings.builder().put("node.name", "test").build();
+
+        snapshotsService = new SnapshotsService(
+            settings,
+            clusterService,
+            mock(org.opensearch.cluster.metadata.IndexNameExpressionResolver.class),
+            mock(org.opensearch.repositories.RepositoriesService.class),
+            transportService,
+            mock(org.opensearch.action.support.ActionFilters.class),
+            null,
+            new org.opensearch.indices.RemoteStoreSettings(Settings.EMPTY, clusterSettings),
+            null
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    public void testNotClusterManagerExceptionRunsFallback() {
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(
+            new NotClusterManagerException("test"),
+            0,
+            "test-source",
+            () -> mock(ClusterStateUpdateTask.class),
+            () -> fallbackCalled.set(true)
+        );
+
+        assertTrue(fallbackCalled.get());
+    }
+
+    public void testFailedToCommitRetriesWhenAttemptsRemain() throws Exception {
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(new FailedToCommitClusterStateException("test"), 0, "test-source", () -> {
+            taskSubmitted.countDown();
+            return mock(ClusterStateUpdateTask.class);
+        }, () -> fallbackCalled.set(true));
+
+        assertTrue("Task factory should be invoked for retry", taskSubmitted.await(5, TimeUnit.SECONDS));
+        assertFalse("Fallback should not be called when retries remain", fallbackCalled.get());
+    }
+
+    public void testFailedToCommitExhaustsFallback() {
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(
+            new FailedToCommitClusterStateException("test"),
+            SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getDefault(Settings.EMPTY),
+            "test-source",
+            () -> mock(ClusterStateUpdateTask.class),
+            () -> fallbackCalled.set(true)
+        );
+
+        assertTrue(fallbackCalled.get());
+    }
+
+    public void testUnexpectedExceptionRunsFallback() {
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+
+        AssertionError ae = expectThrows(
+            AssertionError.class,
+            () -> snapshotsService.retryOrFailOnClusterManagerFailOver(
+                new RuntimeException("unexpected"),
+                0,
+                "test-source",
+                () -> mock(ClusterStateUpdateTask.class),
+                () -> fallbackCalled.set(true)
+            )
+        );
+        assertTrue(ae.getMessage().contains("Unexpected failure during cluster state update"));
+        assertTrue("Fallback should run before the assert fires", fallbackCalled.get());
+    }
+
+    public void testRetryCreatesNewTaskInstance() throws Exception {
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+        AtomicInteger factoryCalls = new AtomicInteger(0);
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(new FailedToCommitClusterStateException("test"), 0, "test-source", () -> {
+            factoryCalls.incrementAndGet();
+            taskSubmitted.countDown();
+            return mock(ClusterStateUpdateTask.class);
+        }, () -> {});
+
+        assertTrue(taskSubmitted.await(5, TimeUnit.SECONDS));
+        assertEquals(1, factoryCalls.get());
+    }
+
+    public void testWrappedFailedToCommitRetries() throws Exception {
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+        Exception wrapped = new RuntimeException("wrapper", new FailedToCommitClusterStateException("inner"));
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(wrapped, 0, "test-source", () -> {
+            taskSubmitted.countDown();
+            return mock(ClusterStateUpdateTask.class);
+        }, () -> fallbackCalled.set(true));
+
+        assertTrue(taskSubmitted.await(5, TimeUnit.SECONDS));
+        assertFalse(fallbackCalled.get());
+    }
+
+    public void testWrappedNotClusterManagerRunsFallback() {
+        AtomicBoolean fallbackCalled = new AtomicBoolean(false);
+        Exception wrapped = new RuntimeException("wrapper", new NotClusterManagerException("inner"));
+
+        snapshotsService.retryOrFailOnClusterManagerFailOver(
+            wrapped,
+            0,
+            "test-source",
+            () -> mock(ClusterStateUpdateTask.class),
+            () -> fallbackCalled.set(true)
+        );
+
+        assertTrue(fallbackCalled.get());
+    }
+
+    public void testRetryAttemptOneHasCorrectBackoff() throws Exception {
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+
+        long start = System.currentTimeMillis();
+        snapshotsService.retryOrFailOnClusterManagerFailOver(new FailedToCommitClusterStateException("test"), 0, "test-source", () -> {
+            taskSubmitted.countDown();
+            return mock(ClusterStateUpdateTask.class);
+        }, () -> {});
+
+        assertTrue(taskSubmitted.await(5, TimeUnit.SECONDS));
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue("Backoff should be at least ~1s, was " + elapsed + "ms", elapsed >= 900L);
+    }
+
+    public void testComputeBackoffIsExponential() {
+        TimeValue base = TimeValue.timeValueSeconds(1);
+        assertEquals(TimeValue.timeValueSeconds(1), SnapshotsService.computeBackoff(base, 0));
+        assertEquals(TimeValue.timeValueSeconds(2), SnapshotsService.computeBackoff(base, 1));
+        assertEquals(TimeValue.timeValueSeconds(4), SnapshotsService.computeBackoff(base, 2));
+    }
+
+    public void testComputeBackoffDoesNotOverflowAndIsClamped() {
+        TimeValue base = TimeValue.timeValueSeconds(1);
+        TimeValue delay = SnapshotsService.computeBackoff(base, 1000);
+        assertTrue("Delay must be positive, was " + delay, delay.millis() > 0);
+        assertTrue("Delay must be clamped to <= 1 day, was " + delay, delay.millis() <= TimeValue.timeValueDays(1).millis());
+    }
+
+    /**
+     * Regression test: verifies createStateWithoutSnapshotV2Task reads from currentState (not captured outer state).
+     */
+    public void testStateWithoutSnapshotV2ReadsLiveState() throws Exception {
+        Snapshot v2Snapshot = new Snapshot("repo", new SnapshotId("v2-snap", UUIDs.randomBase64UUID()));
+        Snapshot normalSnapshot = new Snapshot("repo", new SnapshotId("normal-snap", UUIDs.randomBase64UUID()));
+
+        SnapshotsInProgress.Entry v2Entry = SnapshotsInProgress.startedEntry(
+            v2Snapshot,
+            true,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            1L,
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Version.CURRENT,
+            false,
+            true
+        );
+        SnapshotsInProgress.Entry normalEntry = SnapshotsInProgress.startedEntry(
+            normalSnapshot,
+            true,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            1L,
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Version.CURRENT,
+            false
+        );
+
+        String localNodeId = UUIDs.randomBase64UUID();
+        ClusterState currentState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(DiscoveryNodes.builder().localNodeId(localNodeId).clusterManagerNodeId(localNodeId).build())
+            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(List.of(v2Entry, normalEntry)))
+            .build();
+
+        ClusterStateUpdateTask task = snapshotsService.createStateWithoutSnapshotV2Task("test-source", 0);
+
+        ClusterState result = task.execute(currentState);
+
+        SnapshotsInProgress resultSnapshots = result.custom(SnapshotsInProgress.TYPE);
+        assertNotNull(resultSnapshots);
+        assertEquals(1, resultSnapshots.entries().size());
+        assertFalse(resultSnapshots.entries().get(0).remoteStoreIndexShallowCopyV2());
+        assertEquals(normalSnapshot.getSnapshotId(), resultSnapshots.entries().get(0).snapshot().getSnapshotId());
+    }
+
+    public void testRemoveFailedSnapshotTaskRemovesEntry() throws Exception {
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap-1", UUIDs.randomBase64UUID()));
+        SnapshotsInProgress.Entry entry = SnapshotsInProgress.startedEntry(
+            snapshot,
+            true,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            1L,
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Version.CURRENT,
+            false
+        );
+
+        String localNodeId = UUIDs.randomBase64UUID();
+        ClusterState currentState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(DiscoveryNodes.builder().localNodeId(localNodeId).clusterManagerNodeId(localNodeId).build())
+            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(List.of(entry)))
+            .build();
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveFailedSnapshotTask(
+            "test-source",
+            0,
+            snapshot,
+            new RuntimeException("test failure"),
+            null,
+            null
+        );
+
+        ClusterState result = task.execute(currentState);
+
+        SnapshotsInProgress resultSnapshots = result.custom(SnapshotsInProgress.TYPE);
+        assertTrue("Snapshot entry should be removed", resultSnapshots.entries().isEmpty());
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds `retryOrFailOnClusterManagerFailOver` helper that retries a failed cluster-state publish (marker removal) with bounded exponential backoff when the node is still the elected cluster-manager. Without this, a publish failure on a stable cluster-manager strands the in-progress snapshot marker forever, blocking index deletion and close.
  
Also fixes a latent stale-read bug in `stateWithoutSnapshotV2`: the inner `execute()` was reading from the captured outer `state` parameter instead of the live `currentState`, which could clobber concurrent cluster-state changes. The method is refactored into a task factory (`createStateWithoutSnapshotV2Task`) that makes this bug structurally impossible to reintroduce.
  

### Testing
- `RetryOrFailOnClusterManagerFailOverTests`: 33 unit tests covering decision logic, backoff computation, task factory behavior, `onNoLongerClusterManager`, `clusterStateProcessed`, rejected execution, and dynamic
  settings updates.
- `SnapshotCleanupRetryIT`: integration test with induced cluster-manager failover verifying marker cleanup and index deletion unblocked.
- All tests pass with `-Dtests.iters=20` for seed stability.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
