### PR TITLE
Add navneet1v as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,6 +26,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Marc Handalian    | [mch2](https://github.com/mch2)                         | Amazon      |
 | Michael Froh      | [msfroh](https://github.com/msfroh)                     | Apple       |
 | Mohit Godwani     | [mgodwan](https://github.com/mgodwan)                   | Amazon      |
+| Navneet Verma     | [navneet1v](https://github.com/navneet1v)               | Amazon      |
 | Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Pan Guixin        | [bugmakerrrrrr](https://github.com/bugmakerrrrrr)       | ByteDance   |
 | Peter Nied        | [peternied](https://github.com/peternied)               | Amazon      |


### PR DESCRIPTION
Note - this should not be merged until https://github.com/opensearch-project/.github/issues/590 is complete.

Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Navneet Verma (@navneet1v) as a co-maintainer of the OpenSearch repository. He has graciously accepted the invitation.

Navneet has authored 26 issues (including several feature-request RFCs and design proposals), merged 22 PRs in OpenSearch core, and reviewed 33 PRs for others in the core repo. He has been actively contributing to OpenSearch core since June 2022. His core contributions span geospatial aggregations, the search pipeline framework, vector-search enablement in the engine, Lucene/codec integration, and query-path performance optimization — ranging from multi-PR feature deliveries to critical bug fixes and code reviews.

Some of his key highlights:

**Geospatial Aggregations (core engine)**
- Refactored GeoBounds aggregation from server into the geo module: https://github.com/opensearch-project/OpenSearch/pull/3992
- Refactored GeoHashGrid and GeoTileGrid aggregations on GeoPoint into the geo module: https://github.com/opensearch-project/OpenSearch/pull/4180
- GeoBounds aggregation on GeoShape field type: https://github.com/opensearch-project/OpenSearch/pull/4266
- GeoTile and GeoHash grid aggregations on GeoShapes: https://github.com/opensearch-project/OpenSearch/pull/5589
- Enabled doc values for GeoShape fields with backward-compatibility version gating: https://github.com/opensearch-project/OpenSearch/pull/11095

**Search Pipeline Framework**
- Added the SearchPhaseResultsProcessor interface to the Search Pipeline, extending processing to the results phase: https://github.com/opensearch-project/OpenSearch/pull/7283

**Vector Search & Extensibility Enablement**
- Removed the vec file extension from INDEX_STORE_HYBRID_NIO_EXTENSIONS to avoid performance degradation for Lucene-engine vector search: https://github.com/opensearch-project/OpenSearch/pull/9528
- Enabled reloading of KNNVectorsFormat SPIs from plugins: https://github.com/opensearch-project/OpenSearch/pull/13864

**Indexing, Recovery & Codec**
- Added the capability to disable _recovery_source per index/field: https://github.com/opensearch-project/OpenSearch/pull/13590
- Bumped Apache Lucene to the 9.11.0 snapshot: https://github.com/opensearch-project/OpenSearch/pull/13850

**Query-Path Performance**
- Updated MMapDirectory to use ReadAdviseByContext rather than Lucene's default readadvise: https://github.com/opensearch-project/OpenSearch/pull/21031
- Added queryTimeout to IndexSearcher so queries exit when they time out during search: https://github.com/opensearch-project/OpenSearch/pull/21316

**Test Infrastructure**
- Added the capability to override the indices.breaker.total.use_real_memory setting for test clusters: https://github.com/opensearch-project/OpenSearch/pull/15906

**Design Proposals / RFCs (issues)**
- Enabling multiple QueryPhaseSearcher implementations in OpenSearch: https://github.com/opensearch-project/OpenSearch/issues/7020
- Merging query and fetch phases to reduce latency for QUERY_AND_FETCH: https://github.com/opensearch-project/OpenSearch/issues/9418
- Query-clause-level stats in OpenSearch: https://github.com/opensearch-project/OpenSearch/issues/5983
- Enhancing the terms-lookup query to take a query clause rather than a docId: https://github.com/opensearch-project/OpenSearch/issues/17599

**Selected PR reviews**
- https://github.com/opensearch-project/OpenSearch/pull/17146
- https://github.com/opensearch-project/OpenSearch/pull/9405
- https://github.com/opensearch-project/OpenSearch/pull/6587
- https://github.com/opensearch-project/OpenSearch/pull/13306
- https://github.com/opensearch-project/OpenSearch/pull/18050
- https://github.com/opensearch-project/OpenSearch/pull/20129
- https://github.com/opensearch-project/OpenSearch/pull/4597
