### PR TITLE
Introduce codecExcludes in FieldsVisitor

### DIFF
--- a/server/src/main/java/org/opensearch/common/regex/Regex.java
+++ b/server/src/main/java/org/opensearch/common/regex/Regex.java
@@ -95,6 +95,25 @@ public class Regex {
     }
 
     /**
+     * Determine whether two simple-match patterns overlap, i.e. whether there
+     * exists at least one string that both patterns would match. Each argument
+     * may be a simple-match pattern ("xxx*", "*xxx", "*xxx*", "xxx*yyy") or a
+     * plain literal, which is treated as an exact-match pattern. Matching is
+     * case sensitive.
+     *
+     * @param pattern1 the first pattern (or literal) to compare
+     * @param pattern2 the second pattern (or literal) to compare
+     * @return whether some string is matched by both patterns
+     */
+    public static boolean simpleMatchOverlap(String pattern1, String pattern2) {
+        if (pattern1 == null || pattern2 == null) {
+            return false;
+        }
+        Automaton intersection = Operations.intersection(simpleMatchToAutomaton(pattern1), simpleMatchToAutomaton(pattern2));
+        return Operations.isEmpty(intersection) == false;
+    }
+
+    /**
      * Match a String against the given pattern, supporting the following simple
      * pattern styles: "xxx*", "*xxx", "*xxx*" and "xxx*yyy" matches (with an
      * arbitrary number of pattern parts), as well as direct equality.

--- a/server/src/main/java/org/opensearch/common/regex/Regex.java
+++ b/server/src/main/java/org/opensearch/common/regex/Regex.java
@@ -109,6 +109,22 @@ public class Regex {
         if (pattern1 == null || pattern2 == null) {
             return false;
         }
+        boolean pattern1IsWildcard = isSimpleMatchPattern(pattern1);
+        boolean pattern2IsWildcard = isSimpleMatchPattern(pattern2);
+        // Fast path: two literals overlap only when they are equal.
+        if (pattern1IsWildcard == false && pattern2IsWildcard == false) {
+            return pattern1.equals(pattern2);
+        }
+        // Fast path: literal vs wildcard overlaps iff the wildcard matches the literal (cheap glob scan).
+        if (pattern1IsWildcard == false) {
+            return simpleMatch(pattern2, pattern1);
+        }
+        if (pattern2IsWildcard == false) {
+            return simpleMatch(pattern1, pattern2);
+        }
+        // Both patterns contain wildcards. Simple-match only supports '*', so each pattern maps to a
+        // linear-sized automaton (literals + makeAnyString); the intersection stays small enough that
+        // determinization never hits Lucene's complexity limit.
         Automaton intersection = Operations.intersection(simpleMatchToAutomaton(pattern1), simpleMatchToAutomaton(pattern2));
         return Operations.isEmpty(intersection) == false;
     }

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/CustomFieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/CustomFieldsVisitor.java
@@ -53,7 +53,11 @@ public class CustomFieldsVisitor extends FieldsVisitor {
     }
 
     public CustomFieldsVisitor(Set<String> fields, boolean loadSource, String[] includes, String[] excludes) {
-        super(loadSource, includes, excludes);
+        this(fields, loadSource, includes, excludes, null);
+    }
+
+    public CustomFieldsVisitor(Set<String> fields, boolean loadSource, String[] includes, String[] excludes, String[] codecExcludes) {
+        super(loadSource, includes, excludes, codecExcludes);
         this.fields = fields;
     }
 

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
@@ -69,6 +69,7 @@ public class FieldsVisitor extends StoredFieldVisitor {
     private final Set<String> requiredFields;
     private final String[] sourceIncludes;
     private final String[] sourceExcludes;
+    private final String[] codecExcludes;
     protected BytesReference source;
     protected String id;
     protected Map<String, List<Object>> fieldsValues;
@@ -77,8 +78,8 @@ public class FieldsVisitor extends StoredFieldVisitor {
         this(loadSource, SourceFieldMapper.NAME, null, null);
     }
 
-    public FieldsVisitor(boolean loadSource, String[] includes, String[] excludes) {
-        this(loadSource, SourceFieldMapper.NAME, includes, excludes);
+    public FieldsVisitor(boolean loadSource, String[] includes, String[] excludes, String[] codecExcludes) {
+        this(loadSource, SourceFieldMapper.NAME, includes, excludes, codecExcludes);
     }
 
     public FieldsVisitor(boolean loadSource, String sourceFieldName) {
@@ -86,10 +87,15 @@ public class FieldsVisitor extends StoredFieldVisitor {
     }
 
     public FieldsVisitor(boolean loadSource, String sourceFieldName, String[] includes, String[] excludes) {
+        this(loadSource, sourceFieldName, includes, excludes, null);
+    }
+
+    public FieldsVisitor(boolean loadSource, String sourceFieldName, String[] includes, String[] excludes, String[] codecExcludes) {
         this.loadSource = loadSource;
         this.sourceFieldName = sourceFieldName;
         this.sourceIncludes = includes != null ? includes : Strings.EMPTY_ARRAY;
         this.sourceExcludes = excludes != null ? excludes : Strings.EMPTY_ARRAY;
+        this.codecExcludes = codecExcludes != null ? codecExcludes : Strings.EMPTY_ARRAY;
         requiredFields = new HashSet<>();
         reset();
     }
@@ -189,6 +195,10 @@ public class FieldsVisitor extends StoredFieldVisitor {
      */
     public String[] excludes() {
         return sourceExcludes;
+    }
+
+    public String[] codecExcludes() {
+        return codecExcludes;
     }
 
     public String id() {

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
@@ -69,7 +69,14 @@ public class FieldsVisitor extends StoredFieldVisitor {
     private final Set<String> requiredFields;
     private final String[] sourceIncludes;
     private final String[] sourceExcludes;
-    private final String[] codecExcludes;
+    /**
+     * Decouples the request-level {@link #sourceExcludes} (what the client wants filtered from the returned
+     * {@code _source}) from what a source-aware codec may actually prune while reading. A field can be
+     * excluded from the response yet still be needed by inner hits, which read the same root {@code _source};
+     * such fields are dropped from {@link #sourceExcludes} here so the codec keeps them available. Only the
+     * remaining fields are safe to prune at read time; see {@code FetchPhase#codecSourceExcludes}.
+     */
+    private final String[] codecSourceExcludes;
     protected BytesReference source;
     protected String id;
     protected Map<String, List<Object>> fieldsValues;
@@ -78,8 +85,8 @@ public class FieldsVisitor extends StoredFieldVisitor {
         this(loadSource, SourceFieldMapper.NAME, null, null);
     }
 
-    public FieldsVisitor(boolean loadSource, String[] includes, String[] excludes, String[] codecExcludes) {
-        this(loadSource, SourceFieldMapper.NAME, includes, excludes, codecExcludes);
+    public FieldsVisitor(boolean loadSource, String[] includes, String[] excludes, String[] codecSourceExcludes) {
+        this(loadSource, SourceFieldMapper.NAME, includes, excludes, codecSourceExcludes);
     }
 
     public FieldsVisitor(boolean loadSource, String sourceFieldName) {
@@ -90,12 +97,12 @@ public class FieldsVisitor extends StoredFieldVisitor {
         this(loadSource, sourceFieldName, includes, excludes, null);
     }
 
-    public FieldsVisitor(boolean loadSource, String sourceFieldName, String[] includes, String[] excludes, String[] codecExcludes) {
+    public FieldsVisitor(boolean loadSource, String sourceFieldName, String[] includes, String[] excludes, String[] codecSourceExcludes) {
         this.loadSource = loadSource;
         this.sourceFieldName = sourceFieldName;
         this.sourceIncludes = includes != null ? includes : Strings.EMPTY_ARRAY;
         this.sourceExcludes = excludes != null ? excludes : Strings.EMPTY_ARRAY;
-        this.codecExcludes = codecExcludes != null ? codecExcludes : Strings.EMPTY_ARRAY;
+        this.codecSourceExcludes = codecSourceExcludes != null ? codecSourceExcludes : Strings.EMPTY_ARRAY;
         requiredFields = new HashSet<>();
         reset();
     }
@@ -197,8 +204,13 @@ public class FieldsVisitor extends StoredFieldVisitor {
         return sourceExcludes;
     }
 
+    /**
+     * Returns the source excludes a source-aware codec may prune while reading, as opposed to
+     * {@link #excludes()}, which is filtered from the response after {@code _source} is loaded.
+     * @return String[] codecSourceExcludes
+     */
     public String[] codecExcludes() {
-        return codecExcludes;
+        return codecSourceExcludes;
     }
 
     public String id() {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -87,6 +87,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -377,10 +378,33 @@ public class FetchPhase {
 
         final Set<String> codecExcludes = new HashSet<>(Arrays.asList(requestExcludes));
         for (String reqInclude : requestIncludes) {
-            codecExcludes.removeIf(userExclude -> Regex.simpleMatchOverlap(userExclude, reqInclude));
+            codecExcludes.removeIf(userExclude -> sourcePathOverlap(userExclude, reqInclude));
         }
 
         return codecExcludes.toArray(new String[0]);
+    }
+
+    /**
+     * Determine whether a source exclude pattern and an inner-hit include pattern can affect a common
+     * field. Source include/exclude semantics are hierarchical: excluding {@code obj} also removes
+     * {@code obj.field}, and including {@code obj} pulls in the whole {@code obj} subtree. Both patterns
+     * are therefore compared segment by segment (splitting on {@code .}); they overlap when every segment
+     * up to the shorter path overlaps, i.e. when one path is an ancestor of (or equal to) the other. When
+     * they overlap the exclude must not be applied at the codec level, otherwise the inner hit would read
+     * empty values for the field it requested. Comparing per segment also keeps {@code *} from spanning a
+     * {@code .} boundary, matching how {@link org.opensearch.common.xcontent.support.XContentMapValues}
+     * applies these patterns.
+     */
+    private static boolean sourcePathOverlap(String exclude, String include) {
+        final String[] excludeSegments = exclude.split("\\.");
+        final String[] includeSegments = include.split("\\.");
+        final int common = Math.min(excludeSegments.length, includeSegments.length);
+        for (int i = 0; i < common; i++) {
+            if (Regex.simpleMatchOverlap(excludeSegments[i], includeSegments[i]) == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -403,7 +427,11 @@ public class FetchPhase {
             FetchFieldsContext innerFetchContext = innerHit.fetchFieldsContext();
             if (innerFetchContext != null && innerFetchContext.fields() != null) {
                 requestIncludes.addAll(
-                    innerFetchContext.fields().stream().map(fieldAndFormat -> fieldAndFormat.field).collect(Collectors.toSet())
+                    innerFetchContext.fields()
+                        .stream()
+                        .map(fieldAndFormat -> fieldAndFormat.field)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet())
                 );
             }
             // Nested inner hits read from the same root _source, so descend into their children too.

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -52,6 +52,7 @@ import org.opensearch.common.regex.Regex;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
@@ -358,7 +359,7 @@ public class FetchPhase {
     }
 
     private String[] codecSourceExcludes(SearchContext context, String[] requestExcludes) {
-        if (requestExcludes == null || requestExcludes.length == 0) {
+        if (CollectionUtils.isEmpty(requestExcludes)) {
             return null;
         }
 

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -297,7 +297,6 @@ public class FetchPhase {
         boolean hasFetchContext = context.hasFetchSourceContext();
         String[] requestSourceIncludes = hasFetchContext ? context.fetchSourceContext().includes() : null;
         String[] requestSourceExcludes = hasFetchContext ? context.fetchSourceContext().excludes() : null;
-        String[] codecSourceExcludes = codecSourceExcludes(context, requestSourceExcludes);
 
         if (storedFieldsContext == null) {
             // no fields specified, default to return source if no explicit indication
@@ -305,7 +304,12 @@ public class FetchPhase {
                 context.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             }
             boolean loadSource = sourceRequired(context);
-            return new FieldsVisitor(loadSource, requestSourceIncludes, requestSourceExcludes, codecSourceExcludes);
+            return new FieldsVisitor(
+                loadSource,
+                requestSourceIncludes,
+                requestSourceExcludes,
+                codecSourceExcludes(context, requestSourceExcludes)
+            );
         } else if (storedFieldsContext.fetchFields() == false) {
             // disable stored fields entirely
             return null;
@@ -336,6 +340,7 @@ public class FetchPhase {
             }
             boolean loadSource = sourceRequired(context);
 
+            String[] codecSourceExcludes = codecSourceExcludes(context, requestSourceExcludes);
             if (storedToRequestedFields.isEmpty()) {
                 // empty list specified, default to disable _source if no explicit indication
                 return new FieldsVisitor(loadSource, requestSourceIncludes, requestSourceExcludes, codecSourceExcludes);

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -48,6 +48,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.common.regex.Regex;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.support.XContentMapValues;
@@ -65,6 +66,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.fetch.FetchSubPhase.HitContext;
+import org.opensearch.search.fetch.subphase.FetchFieldsContext;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.fetch.subphase.InnerHitsContext;
 import org.opensearch.search.fetch.subphase.InnerHitsPhase;
@@ -87,6 +89,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 
@@ -291,18 +294,18 @@ public class FetchPhase {
 
     protected FieldsVisitor createStoredFieldsVisitor(SearchContext context, Map<String, Set<String>> storedToRequestedFields) {
         StoredFieldsContext storedFieldsContext = context.storedFieldsContext();
+        boolean hasFetchContext = context.hasFetchSourceContext();
+        String[] requestSourceIncludes = hasFetchContext ? context.fetchSourceContext().includes() : null;
+        String[] requestSourceExcludes = hasFetchContext ? context.fetchSourceContext().excludes() : null;
+        String[] codecSourceExcludes = codecSourceExcludes(context, requestSourceExcludes);
 
         if (storedFieldsContext == null) {
             // no fields specified, default to return source if no explicit indication
-            if (!context.hasScriptFields() && !context.hasFetchSourceContext()) {
+            if (!context.hasScriptFields() && !hasFetchContext) {
                 context.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             }
             boolean loadSource = sourceRequired(context);
-            return new FieldsVisitor(
-                loadSource,
-                context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
-                context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
-            );
+            return new FieldsVisitor(loadSource, requestSourceIncludes, requestSourceExcludes, codecSourceExcludes);
         } else if (storedFieldsContext.fetchFields() == false) {
             // disable stored fields entirely
             return null;
@@ -332,22 +335,54 @@ public class FetchPhase {
                 }
             }
             boolean loadSource = sourceRequired(context);
+
             if (storedToRequestedFields.isEmpty()) {
                 // empty list specified, default to disable _source if no explicit indication
-                return new FieldsVisitor(
-                    loadSource,
-                    context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
-                    context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
-                );
+                return new FieldsVisitor(loadSource, requestSourceIncludes, requestSourceExcludes, codecSourceExcludes);
             } else {
                 return new CustomFieldsVisitor(
                     storedToRequestedFields.keySet(),
                     loadSource,
-                    context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
-                    context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
+                    requestSourceIncludes,
+                    requestSourceExcludes,
+                    codecSourceExcludes
                 );
             }
         }
+    }
+
+    private String[] codecSourceExcludes(SearchContext context, String[] requestExcludes) {
+        if (requestExcludes == null || requestExcludes.length == 0) {
+            return null;
+        }
+
+        // context.innerHits won't throw NPE as it creates an empty innerhitscontext if its null
+        final Map<String, InnerHitsContext.InnerHitSubContext> innerHits = context.innerHits().getInnerHits();
+        if (innerHits.isEmpty()) {
+            return requestExcludes;
+        }
+
+        final Set<String> codecExcludes = new HashSet<>(Arrays.asList(requestExcludes));
+
+        final Set<String> requestIncludes = new HashSet<>();
+        for (InnerHitsContext.InnerHitSubContext innerHit : innerHits.values()) {
+            final FetchSourceContext innerSource = innerHit.fetchSourceContext();
+            if (innerSource != null && innerSource.fetchSource()) {
+                requestIncludes.addAll(Arrays.asList(innerSource.includes()));
+            }
+            FetchFieldsContext innerFetchContext = innerHit.fetchFieldsContext();
+            if (innerFetchContext != null && innerFetchContext.fields() != null) {
+                requestIncludes.addAll(
+                    innerFetchContext.fields().stream().map(fieldAndFormat -> fieldAndFormat.field).collect(Collectors.toSet())
+                );
+            }
+        }
+
+        for (String reqInclude : requestIncludes) {
+            codecExcludes.removeIf(userExclude -> Regex.simpleMatchOverlap(userExclude, reqInclude));
+        }
+
+        return codecExcludes.toArray(new String[0]);
     }
 
     private boolean sourceRequired(SearchContext context) {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -341,8 +341,8 @@ public class FetchPhase {
                 }
             }
             boolean loadSource = sourceRequired(context);
-
             String[] codecSourceExcludes = codecSourceExcludes(context, requestSourceExcludes);
+
             if (storedToRequestedFields.isEmpty()) {
                 // empty list specified, default to disable _source if no explicit indication
                 return new FieldsVisitor(loadSource, requestSourceIncludes, requestSourceExcludes, codecSourceExcludes);

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -362,12 +362,37 @@ public class FetchPhase {
             return requestExcludes;
         }
 
-        final Set<String> codecExcludes = new HashSet<>(Arrays.asList(requestExcludes));
-
         final Set<String> requestIncludes = new HashSet<>();
+        // Inner hits (including nested ones) read from the root document's _source, so any field they
+        // request must stay available at the codec level. If any inner hit fetches the whole source,
+        // every field must remain, so no codec excludes apply.
+        if (collectInnerHitIncludes(innerHits, requestIncludes)) {
+            return null;
+        }
+
+        final Set<String> codecExcludes = new HashSet<>(Arrays.asList(requestExcludes));
+        for (String reqInclude : requestIncludes) {
+            codecExcludes.removeIf(userExclude -> Regex.simpleMatchOverlap(userExclude, reqInclude));
+        }
+
+        return codecExcludes.toArray(new String[0]);
+    }
+
+    /**
+     * Recursively collects the source fields requested by the given inner hits and their nested
+     * children into {@code requestIncludes}.
+     *
+     * @return true if any inner hit fetches the whole source (empty includes), meaning no codec
+     *         excludes should be applied
+     */
+    private boolean collectInnerHitIncludes(Map<String, InnerHitsContext.InnerHitSubContext> innerHits, Set<String> requestIncludes) {
         for (InnerHitsContext.InnerHitSubContext innerHit : innerHits.values()) {
             final FetchSourceContext innerSource = innerHit.fetchSourceContext();
             if (innerSource != null && innerSource.fetchSource()) {
+                // Empty includes means "fetch the whole source", so every field must remain available.
+                if (innerSource.includes().length == 0) {
+                    return true;
+                }
                 requestIncludes.addAll(Arrays.asList(innerSource.includes()));
             }
             FetchFieldsContext innerFetchContext = innerHit.fetchFieldsContext();
@@ -376,13 +401,12 @@ public class FetchPhase {
                     innerFetchContext.fields().stream().map(fieldAndFormat -> fieldAndFormat.field).collect(Collectors.toSet())
                 );
             }
+            // Nested inner hits read from the same root _source, so descend into their children too.
+            if (innerHit.innerHits() != null && collectInnerHitIncludes(innerHit.innerHits().getInnerHits(), requestIncludes)) {
+                return true;
+            }
         }
-
-        for (String reqInclude : requestIncludes) {
-            codecExcludes.removeIf(userExclude -> Regex.simpleMatchOverlap(userExclude, reqInclude));
-        }
-
-        return codecExcludes.toArray(new String[0]);
+        return false;
     }
 
     private boolean sourceRequired(SearchContext context) {

--- a/server/src/test/java/org/opensearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/opensearch/common/regex/RegexTests.java
@@ -114,6 +114,34 @@ public class RegexTests extends OpenSearchTestCase {
         );
     }
 
+    public void testSimpleMatchOverlap() {
+        // two literals: overlap only when equal
+        assertTrue(Regex.simpleMatchOverlap("foo", "foo"));
+        assertFalse(Regex.simpleMatchOverlap("foo", "bar"));
+
+        // literal vs pattern: literal treated as exact-match pattern
+        assertTrue(Regex.simpleMatchOverlap("foo*", "foobar"));
+        assertTrue(Regex.simpleMatchOverlap("foobar", "foo*"));
+        assertFalse(Regex.simpleMatchOverlap("foo*", "bar"));
+
+        // two patterns sharing at least one string
+        assertTrue(Regex.simpleMatchOverlap("a*", "ab*")); // both match "ab"
+        assertTrue(Regex.simpleMatchOverlap("foo*", "*bar")); // both match "foobar"
+        assertTrue(Regex.simpleMatchOverlap("*", "anything")); // "*" matches everything
+
+        // two patterns with no common string
+        assertFalse(Regex.simpleMatchOverlap("a*", "b*"));
+        assertFalse(Regex.simpleMatchOverlap("foo*", "bar*"));
+
+        // overlap is symmetric
+        assertEquals(Regex.simpleMatchOverlap("a*", "ab*"), Regex.simpleMatchOverlap("ab*", "a*"));
+
+        // null inputs never overlap
+        assertFalse(Regex.simpleMatchOverlap(null, "foo"));
+        assertFalse(Regex.simpleMatchOverlap("foo", null));
+        assertFalse(Regex.simpleMatchOverlap(null, null));
+    }
+
     public void testSimpleMatch() {
         for (int i = 0; i < 1000; i++) {
             final String matchingString = randomAlphaOfLength(between(0, 50));

--- a/server/src/test/java/org/opensearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/opensearch/common/regex/RegexTests.java
@@ -136,10 +136,19 @@ public class RegexTests extends OpenSearchTestCase {
         // overlap is symmetric
         assertEquals(Regex.simpleMatchOverlap("a*", "ab*"), Regex.simpleMatchOverlap("ab*", "a*"));
 
+        // literal vs multi-part pattern (fast path via glob, no automaton)
+        assertTrue(Regex.simpleMatchOverlap("foo*bar", "fooXbar"));
+        assertFalse(Regex.simpleMatchOverlap("foo*bar", "fooXbaz"));
+
         // null inputs never overlap
         assertFalse(Regex.simpleMatchOverlap(null, "foo"));
         assertFalse(Regex.simpleMatchOverlap("foo", null));
         assertFalse(Regex.simpleMatchOverlap(null, null));
+
+        // many-wildcard patterns stay cheap: simple-match only supports '*', so the automata are
+        // linear and determinization does not blow up
+        String manyWildcards = "*" + "a*".repeat(200);
+        assertTrue(Regex.simpleMatchOverlap(manyWildcards, manyWildcards));
     }
 
     public void testSimpleMatch() {

--- a/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
@@ -225,7 +225,7 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
         assertArrayEquals(fieldsVisitor.includes(), includes);
         assertArrayEquals(fieldsVisitor.excludes(), excludes);
 
-        FieldsVisitor fieldsVisitor1 = new FieldsVisitor(false, includes, excludes);
+        FieldsVisitor fieldsVisitor1 = new FieldsVisitor(false, includes, excludes, null);
         assertArrayEquals(fieldsVisitor1.includes(), includes);
         assertArrayEquals(fieldsVisitor1.excludes(), excludes);
 

--- a/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
@@ -34,6 +34,7 @@ package org.opensearch.search.fetch;
 
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
@@ -41,7 +42,10 @@ import org.opensearch.index.fieldvisitor.FieldsVisitor;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.fetch.subphase.FetchFieldsContext;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
+import org.opensearch.search.fetch.subphase.FieldAndFormat;
+import org.opensearch.search.fetch.subphase.InnerHitsContext;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.test.OpenSearchTestCase;
@@ -89,12 +93,14 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         FetchSourceContext mockFetchSourceContext = new FetchSourceContext(true, includes, excludes);
         when(mockSearchContext.hasFetchSourceContext()).thenReturn(true);
         when(mockSearchContext.fetchSourceContext()).thenReturn(mockFetchSourceContext);
+        when(mockSearchContext.innerHits()).thenReturn(new InnerHitsContext());
 
         // Case 1
         // if storedFieldsContext is null
         FieldsVisitor fieldsVisitor = fetchPhase.createStoredFieldsVisitor(mockSearchContext, null);
         assertArrayEquals(fieldsVisitor.excludes(), excludes);
         assertArrayEquals(fieldsVisitor.includes(), includes);
+        assertArrayEquals(fieldsVisitor.codecExcludes(), excludes);
 
         // Case 2
         // if storedFieldsContext is not null
@@ -111,6 +117,7 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         fieldsVisitor = fetchPhase.createStoredFieldsVisitor(mockSearchContext, Collections.emptyMap());
         assertArrayEquals(fieldsVisitor.excludes(), excludes);
         assertArrayEquals(fieldsVisitor.includes(), includes);
+        assertArrayEquals(fieldsVisitor.codecExcludes(), excludes);
 
         // Case 4
         // if storedToRequested Fields is not empty
@@ -123,7 +130,75 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         assertTrue(fieldsVisitor instanceof CustomFieldsVisitor);
         assertArrayEquals(fieldsVisitor.excludes(), excludes);
         assertArrayEquals(fieldsVisitor.includes(), includes);
+        assertArrayEquals(fieldsVisitor.codecExcludes(), excludes);
+    }
 
+    public void testCodecSourceExcludes() {
+        // A user source exclude is dropped from the codec excludes when an inner hit requests an
+        // overlapping field (so it stays available at the codec level), while the returned _source
+        // includes/excludes are never mutated. Inner-hit fields may be requested via _source
+        // includes (viaSource=true) or via fetch fields with source disabled (viaSource=false), and
+        // both excludes and includes support simple-match wildcards.
+        //
+        // rootIncludes | excludes | innerField | viaSource | -> codecExcludes
+        // ["field3"] | field1,field2 | field1 | source | -> [field2] literal, source include
+        // null | field1,field2 | field2 | fetch | -> [field1] literal, fetch field
+        // null | obj.*,secret* | obj.field | source | -> [secret*] wildcard exclude vs literal
+        // null | foo*,bar* | bar* | fetch | -> [foo*] identical wildcard patterns
+        // null | foo*,x.y | *bar | source | -> [x.y] "foo*" overlaps "*bar" via "foobar"
+        // null | secret* | public.field | source | -> [secret*] no overlap, exclude kept
+        assertCodecExcludes(new String[] { "field3" }, new String[] { "field1", "field2" }, "field1", true, new String[] { "field2" });
+        assertCodecExcludes(null, new String[] { "field1", "field2" }, "field2", false, new String[] { "field1" });
+        assertCodecExcludes(null, new String[] { "obj.*", "secret*" }, "obj.field", true, new String[] { "secret*" });
+        assertCodecExcludes(null, new String[] { "foo*", "bar*" }, "bar*", false, new String[] { "foo*" });
+        assertCodecExcludes(null, new String[] { "foo*", "x.y" }, "*bar", true, new String[] { "x.y" });
+        assertCodecExcludes(null, new String[] { "secret*" }, "public.field", true, new String[] { "secret*" });
+    }
+
+    /**
+     * Builds a search context whose root source has {@code rootIncludes}/{@code excludes} and a single
+     * inner hit requesting {@code innerHitField}, then asserts the resulting codec excludes. When
+     * {@code viaSource} is true the field is an inner-hit source include; otherwise it is requested via
+     * fetch fields with source fetching disabled. The returned _source includes/excludes are asserted
+     * to be the unmodified root request values.
+     */
+    private void assertCodecExcludes(
+        String[] rootIncludes,
+        String[] excludes,
+        String innerHitField,
+        boolean viaSource,
+        String[] expectedCodecExcludes
+    ) {
+        FetchPhase fetchPhase = new FetchPhase(new ArrayList<>());
+        SearchContext context = mock(SearchContext.class);
+        when(context.hasScriptFields()).thenReturn(false);
+        when(context.storedFieldsContext()).thenReturn(null);
+
+        FetchSourceContext rootSource = new FetchSourceContext(true, rootIncludes, excludes);
+        when(context.hasFetchSourceContext()).thenReturn(true);
+        when(context.fetchSourceContext()).thenReturn(rootSource);
+        when(context.sourceRequested()).thenReturn(true);
+        when(context.fetchFieldsContext()).thenReturn(null);
+
+        InnerHitsContext.InnerHitSubContext innerHit = mock(InnerHitsContext.InnerHitSubContext.class);
+        if (viaSource) {
+            when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(true, new String[] { innerHitField }, null));
+            when(innerHit.fetchFieldsContext()).thenReturn(null);
+        } else {
+            when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(false));
+            when(innerHit.fetchFieldsContext()).thenReturn(new FetchFieldsContext(List.of(new FieldAndFormat(innerHitField, null))));
+        }
+
+        InnerHitsContext innerHitsContext = new InnerHitsContext();
+        innerHitsContext.getInnerHits().put("inner", innerHit);
+        when(context.innerHits()).thenReturn(innerHitsContext);
+
+        FieldsVisitor fieldsVisitor = fetchPhase.createStoredFieldsVisitor(context, null);
+
+        // Requested includes/excludes must not be mutated.
+        assertArrayEquals(excludes, fieldsVisitor.excludes());
+        assertArrayEquals(rootIncludes != null ? rootIncludes : Strings.EMPTY_ARRAY, fieldsVisitor.includes());
+        assertArrayEquals(expectedCodecExcludes, fieldsVisitor.codecExcludes());
     }
 
     public void testTaskCancellationDuringFetch() {
@@ -169,5 +244,4 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         TaskCancelledException ex = expectThrows(TaskCancelledException.class, () -> fetchPhase.execute(context));
         assertEquals("cancelled task with reason: test reason", ex.getMessage());
     }
-
 }

--- a/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
@@ -155,6 +155,20 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         assertCodecExcludes(null, new String[] { "foo*", "x.y" }, "*bar", true, new String[] { "x.y" });
         assertCodecExcludes(null, new String[] { "secret*" }, "public.field", true, new String[] { "secret*" });
         assertCodecExcludes(null, new String[] { "field1", "field2" }, null, true, Strings.EMPTY_ARRAY);
+
+        // Hierarchical (path-prefix) overlap: source excludes/includes apply to whole subtrees.
+        // null | obj,secret | obj.field | source | -> [secret] exclude "obj" is an ancestor of "obj.field"
+        // null | obj.sub,secret | obj | source | -> [secret] include "obj" is an ancestor of exclude "obj.sub"
+        // null | obj.a,obj.b | obj.b | source | -> [obj.a] sibling leaves stay disjoint
+        // null | x.y,secret | x.y.z.w | source | -> [secret] deep descendant of exclude "x.y"
+        // null | x.y.z.w,secret | x.y | source | -> [secret] deep descendant of include "x.y"
+        // null | x.y.a.z | x.y.b.z | source | -> [x.y.a.z] diverges at a deeper segment, exclude kept
+        assertCodecExcludes(null, new String[] { "obj", "secret" }, "obj.field", true, new String[] { "secret" });
+        assertCodecExcludes(null, new String[] { "obj.sub", "secret" }, "obj", true, new String[] { "secret" });
+        assertCodecExcludes(null, new String[] { "obj.a", "obj.b" }, "obj.b", true, new String[] { "obj.a" });
+        assertCodecExcludes(null, new String[] { "x.y", "secret" }, "x.y.z.w", true, new String[] { "secret" });
+        assertCodecExcludes(null, new String[] { "x.y.z.w", "secret" }, "x.y", true, new String[] { "secret" });
+        assertCodecExcludes(null, new String[] { "x.y.a.z" }, "x.y.b.z", true, new String[] { "x.y.a.z" });
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
@@ -169,6 +169,10 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         assertCodecExcludes(null, new String[] { "x.y", "secret" }, "x.y.z.w", true, new String[] { "secret" });
         assertCodecExcludes(null, new String[] { "x.y.z.w", "secret" }, "x.y", true, new String[] { "secret" });
         assertCodecExcludes(null, new String[] { "x.y.a.z" }, "x.y.b.z", true, new String[] { "x.y.a.z" });
+        assertCodecExcludes(null, new String[] { "x.*" }, "x.y", true, Strings.EMPTY_ARRAY);
+        assertCodecExcludes(null, new String[] { "x.y" }, "x.*", true, Strings.EMPTY_ARRAY);
+        assertCodecExcludes(null, new String[] { "x.*" }, "x.y.z", true, Strings.EMPTY_ARRAY);
+        assertCodecExcludes(null, new String[] { "x.*" }, "*", false, Strings.EMPTY_ARRAY);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
@@ -147,20 +147,23 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         // null | foo*,bar* | bar* | fetch | -> [foo*] identical wildcard patterns
         // null | foo*,x.y | *bar | source | -> [x.y] "foo*" overlaps "*bar" via "foobar"
         // null | secret* | public.field | source | -> [secret*] no overlap, exclude kept
+        // null | field1,field2 | null | source | -> [] full-source fetch drops all codec excludes
         assertCodecExcludes(new String[] { "field3" }, new String[] { "field1", "field2" }, "field1", true, new String[] { "field2" });
         assertCodecExcludes(null, new String[] { "field1", "field2" }, "field2", false, new String[] { "field1" });
         assertCodecExcludes(null, new String[] { "obj.*", "secret*" }, "obj.field", true, new String[] { "secret*" });
         assertCodecExcludes(null, new String[] { "foo*", "bar*" }, "bar*", false, new String[] { "foo*" });
         assertCodecExcludes(null, new String[] { "foo*", "x.y" }, "*bar", true, new String[] { "x.y" });
         assertCodecExcludes(null, new String[] { "secret*" }, "public.field", true, new String[] { "secret*" });
+        assertCodecExcludes(null, new String[] { "field1", "field2" }, null, true, Strings.EMPTY_ARRAY);
     }
 
     /**
      * Builds a search context whose root source has {@code rootIncludes}/{@code excludes} and a single
      * inner hit requesting {@code innerHitField}, then asserts the resulting codec excludes. When
      * {@code viaSource} is true the field is an inner-hit source include; otherwise it is requested via
-     * fetch fields with source fetching disabled. The returned _source includes/excludes are asserted
-     * to be the unmodified root request values.
+     * fetch fields with source fetching disabled. A null {@code innerHitField} with {@code viaSource}
+     * true models a default full-source fetch (fetchSource=true, no explicit includes). The returned
+     * _source includes/excludes are asserted to be the unmodified root request values.
      */
     private void assertCodecExcludes(
         String[] rootIncludes,
@@ -182,7 +185,8 @@ public class FetchPhaseTests extends OpenSearchTestCase {
 
         InnerHitsContext.InnerHitSubContext innerHit = mock(InnerHitsContext.InnerHitSubContext.class);
         if (viaSource) {
-            when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(true, new String[] { innerHitField }, null));
+            String[] innerIncludes = innerHitField != null ? new String[] { innerHitField } : null;
+            when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(true, innerIncludes, null));
             when(innerHit.fetchFieldsContext()).thenReturn(null);
         } else {
             when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(false));
@@ -199,6 +203,48 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         assertArrayEquals(excludes, fieldsVisitor.excludes());
         assertArrayEquals(rootIncludes != null ? rootIncludes : Strings.EMPTY_ARRAY, fieldsVisitor.includes());
         assertArrayEquals(expectedCodecExcludes, fieldsVisitor.codecExcludes());
+    }
+
+    public void testCodecSourceExcludesRemovesNestedInnerHitFields() {
+        // A nested (grandchild) inner hit reads from the same root _source, so a field it requests
+        // must also be dropped from the codec excludes.
+        FetchPhase fetchPhase = new FetchPhase(new ArrayList<>());
+        SearchContext context = mock(SearchContext.class);
+        when(context.hasScriptFields()).thenReturn(false);
+        when(context.storedFieldsContext()).thenReturn(null);
+
+        String[] excludes = new String[] { "field1", "field2" };
+        FetchSourceContext rootSource = new FetchSourceContext(true, null, excludes);
+        when(context.hasFetchSourceContext()).thenReturn(true);
+        when(context.fetchSourceContext()).thenReturn(rootSource);
+        when(context.sourceRequested()).thenReturn(true);
+        when(context.fetchFieldsContext()).thenReturn(null);
+
+        // Child inner hit requests nothing overlapping, but its own nested inner hit requests "field1".
+        InnerHitsContext.InnerHitSubContext nestedInnerHit = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(nestedInnerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(true, new String[] { "field1" }, null));
+        when(nestedInnerHit.fetchFieldsContext()).thenReturn(null);
+        when(nestedInnerHit.innerHits()).thenReturn(null);
+
+        InnerHitsContext nestedInnerHitsContext = new InnerHitsContext();
+        nestedInnerHitsContext.getInnerHits().put("nested", nestedInnerHit);
+
+        InnerHitsContext.InnerHitSubContext innerHit = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(innerHit.fetchSourceContext()).thenReturn(new FetchSourceContext(true, new String[] { "field3" }, null));
+        when(innerHit.fetchFieldsContext()).thenReturn(null);
+        when(innerHit.innerHits()).thenReturn(nestedInnerHitsContext);
+
+        InnerHitsContext innerHitsContext = new InnerHitsContext();
+        innerHitsContext.getInnerHits().put("inner", innerHit);
+        when(context.innerHits()).thenReturn(innerHitsContext);
+
+        FieldsVisitor fieldsVisitor = fetchPhase.createStoredFieldsVisitor(context, null);
+
+        // Requested includes/excludes must not be mutated.
+        assertArrayEquals(excludes, fieldsVisitor.excludes());
+        assertArrayEquals(Strings.EMPTY_ARRAY, fieldsVisitor.includes());
+        // "field1" is requested by the nested inner hit so it is dropped; "field2" is not requested anywhere.
+        assertArrayEquals(new String[] { "field2" }, fieldsVisitor.codecExcludes());
     }
 
     public void testTaskCancellationDuringFetch() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Separate user-requested source excludes from engine-level (codec)
excludes. Previously the parent search's source excludes were
applied during source loading, so inner hits requesting those same
fields could get empty values. This surfaced with k-NN but was not
always hit by core.

codecExcludes is computed as the user excludes minus any field an
inner hit requests, so user excludes still control the returned
_source while inner-hit fields stay available at the codec level.

### Related Issues
Resolves [#[22399](https://github.com/opensearch-project/OpenSearch/issues/22399)]

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
