### PR TITLE
Add RepositoryOperationGuard circuit breaker

### DIFF
--- a/server/src/main/java/org/opensearch/snapshots/RepositoryOperationGuard.java
+++ b/server/src/main/java/org/opensearch/snapshots/RepositoryOperationGuard.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.repositories.RepositoryException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-repository guard bounding the number of outstanding cluster-manager-side repository operations, so a degraded
+ * repository cannot drain the shared snapshot thread pool. Past the limit, {@link #tryAcquire(String)} fails fast
+ * instead of dispatching another operation.
+ * @opensearch.internal
+ */
+public final class RepositoryOperationGuard {
+    private final Map<String, Integer> outstandingOpsByRepository = new ConcurrentHashMap<>();
+    private volatile int maxOutstandingOps;
+
+    public RepositoryOperationGuard(int maxOutstandingOps) {
+        setMaxOutstandingOps(maxOutstandingOps);
+    }
+
+    public void setMaxOutstandingOps(int maxOutstandingOps) {
+        if (maxOutstandingOps <= 0) {
+            throw new IllegalArgumentException("maxOutstandingOps must be positive, got [" + maxOutstandingOps + "]");
+        }
+        this.maxOutstandingOps = maxOutstandingOps;
+    }
+
+    public int getMaxOutstandingOps() {
+        return maxOutstandingOps;
+    }
+
+    /**
+     * Acquires a permit for {@code repository}, or throws {@link RepositoryException} if the limit is reached. On
+     * success the caller must call {@link #release(String)} exactly once for this acquisition.
+     */
+    public void tryAcquire(String repository) {
+        final int limit = maxOutstandingOps;
+        outstandingOpsByRepository.compute(repository, (repo, current) -> {
+            final int count = (current == null) ? 0 : current;
+            if (count >= limit) {
+                throw new RepositoryException(repo, "[" + count + "] outstanding repository operations at the limit of [" + limit + "]");
+            }
+            return count + 1;
+        });
+    }
+
+    /**
+     * Releases a permit for {@code repository}. Must be called exactly once per successful {@link #tryAcquire(String)}.
+     */
+    public void release(String repository) {
+        outstandingOpsByRepository.compute(repository, (repo, current) -> {
+            if (current == null || current <= 0) {
+                assert false : "release() with no outstanding operations tracked for repository [" + repo + "]";
+                return null;
+            }
+            final int updated = current - 1;
+            return updated == 0 ? null : updated;
+        });
+    }
+
+    public int getOutstandingOps(String repository) {
+        return outstandingOpsByRepository.getOrDefault(repository, 0);
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/RepositoryOperationGuardTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RepositoryOperationGuardTests.java
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.OpenSearchTimeoutException;
+import org.opensearch.action.support.ListenerTimeouts;
+import org.opensearch.cluster.coordination.DeterministicTaskQueue;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.repositories.RepositoryException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.node.Node.NODE_NAME_SETTING;
+
+public class RepositoryOperationGuardTests extends OpenSearchTestCase {
+
+    private static final String REPO = "test-repo";
+
+    private DeterministicTaskQueue taskQueue;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        taskQueue = new DeterministicTaskQueue(Settings.builder().put(NODE_NAME_SETTING.getKey(), "node").build(), random());
+    }
+
+    // Acquisitions succeed while under the limit and fail fast with no permit taken once the limit is reached.
+    public void testTryAcquireSucceedsUnderLimitAndFailsFastAtLimit() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(2);
+        guard.tryAcquire(REPO);
+        assertEquals(1, guard.getOutstandingOps(REPO));
+        guard.tryAcquire(REPO);
+        assertEquals(2, guard.getOutstandingOps(REPO));
+
+        final RepositoryException e = expectThrows(RepositoryException.class, () -> guard.tryAcquire(REPO));
+        assertTrue(e.getMessage().contains("at the limit of"));
+        assertEquals(2, guard.getOutstandingOps(REPO)); // rejected attempt must not increment the count
+    }
+
+    // A released permit frees up capacity for a subsequent acquisition.
+    public void testReleaseOnResponseBalancesAcquire() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire(REPO);
+        assertEquals(1, guard.getOutstandingOps(REPO));
+        guard.release(REPO);
+        assertEquals(0, guard.getOutstandingOps(REPO));
+        guard.tryAcquire(REPO);
+        assertEquals(1, guard.getOutstandingOps(REPO));
+    }
+
+    // Releasing without a matching acquire is a caller bug: it trips the assertion under -ea
+    // and never drives the count negative (which in prod would silently grant extra capacity)
+    public void testReleaseWithoutAcquireIsGuarded() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        expectThrows(AssertionError.class, () -> guard.release(REPO));
+        assertEquals(0, guard.getOutstandingOps(REPO));
+    }
+
+    // Release fires exactly once on response, even if the underlying listener is (incorrectly) notified twice.
+    public void testReleaseRunsExactlyOnceOnResponseEvenWithLateDuplicateCompletion() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire(REPO);
+        final AtomicInteger releaseCount = new AtomicInteger(0);
+        final ActionListener<String> business = ActionListener.wrap(r -> {}, e -> {});
+        final ActionListener<String> released = ActionListener.runAfter(business, () -> {
+            releaseCount.incrementAndGet();
+            guard.release(REPO);
+        });
+        final ActionListener<String> timed = ListenerTimeouts.wrapWithTimeout(
+            taskQueue.getThreadPool(),
+            released,
+            TimeValue.timeValueMinutes(1),
+            ThreadPool.Names.GENERIC,
+            "test"
+        );
+
+        timed.onResponse("ok");
+        timed.onResponse("late-duplicate");
+        timed.onFailure(new RuntimeException("late-duplicate"));
+
+        assertEquals(1, releaseCount.get());
+        assertEquals(0, guard.getOutstandingOps(REPO));
+
+        // Pending timeout task must be a no-op now that the listener has already resolved.
+        assertTrue(taskQueue.hasDeferredTasks());
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+        assertEquals(1, releaseCount.get());
+    }
+
+    // Release fires exactly once on failure, even if a later response also reaches the listener.
+    public void testReleaseRunsExactlyOnceOnFailureEvenWithLateDuplicateCompletion() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire(REPO);
+        final AtomicInteger releaseCount = new AtomicInteger(0);
+        final ActionListener<String> business = ActionListener.wrap(r -> {}, e -> {});
+        final ActionListener<String> released = ActionListener.runAfter(business, () -> {
+            releaseCount.incrementAndGet();
+            guard.release(REPO);
+        });
+        final ActionListener<String> timed = ListenerTimeouts.wrapWithTimeout(
+            taskQueue.getThreadPool(),
+            released,
+            TimeValue.timeValueMinutes(1),
+            ThreadPool.Names.GENERIC,
+            "test"
+        );
+
+        timed.onFailure(new RuntimeException("boom"));
+        timed.onResponse("late-duplicate");
+
+        assertEquals(1, releaseCount.get());
+        assertEquals(0, guard.getOutstandingOps(REPO));
+
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+        assertEquals(1, releaseCount.get());
+    }
+
+    // The sharpest correctness case: a timeout releases the permit, and the orphaned worker's late completion
+    // must be dropped by ListenerTimeouts rather than double-releasing.
+    public void testReleaseRunsExactlyOnceOnTimeoutAndOrphanedLateCompletionDoesNotDoubleRelease() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire(REPO);
+        final AtomicInteger releaseCount = new AtomicInteger(0);
+        final AtomicReference<Exception> observedFailure = new AtomicReference<>();
+        final ActionListener<String> business = ActionListener.wrap(r -> {}, observedFailure::set);
+        final ActionListener<String> released = ActionListener.runAfter(business, () -> {
+            releaseCount.incrementAndGet();
+            guard.release(REPO);
+        });
+        final ActionListener<String> timed = ListenerTimeouts.wrapWithTimeout(
+            taskQueue.getThreadPool(),
+            released,
+            TimeValue.timeValueMillis(10),
+            ThreadPool.Names.GENERIC,
+            "test"
+        );
+
+        assertTrue(taskQueue.hasDeferredTasks());
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+
+        assertTrue(observedFailure.get() instanceof OpenSearchTimeoutException);
+        assertEquals(1, releaseCount.get());
+        assertEquals(0, guard.getOutstandingOps(REPO));
+
+        // Simulates the orphaned worker thread finally completing after the timeout already fired.
+        timed.onResponse("late-orphaned-completion");
+        assertEquals(1, releaseCount.get());
+        assertEquals(0, guard.getOutstandingOps(REPO));
+    }
+
+    // Raising or lowering the limit at runtime takes effect on the next acquisition attempt.
+    public void testDynamicLimitUpdateAppliesToSubsequentAcquisitions() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire(REPO);
+        expectThrows(RepositoryException.class, () -> guard.tryAcquire(REPO));
+
+        guard.setMaxOutstandingOps(2);
+        assertEquals(2, guard.getMaxOutstandingOps());
+        guard.tryAcquire(REPO);
+        assertEquals(2, guard.getOutstandingOps(REPO));
+
+        guard.setMaxOutstandingOps(1);
+        expectThrows(RepositoryException.class, () -> guard.tryAcquire(REPO));
+    }
+
+    // Zero or negative limits are rejected both at construction and via a dynamic update.
+    public void testRejectsNonPositiveLimit() {
+        expectThrows(IllegalArgumentException.class, () -> new RepositoryOperationGuard(0));
+        expectThrows(IllegalArgumentException.class, () -> new RepositoryOperationGuard(-1));
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(4);
+        expectThrows(IllegalArgumentException.class, () -> guard.setMaxOutstandingOps(0));
+        expectThrows(IllegalArgumentException.class, () -> guard.setMaxOutstandingOps(-1));
+    }
+
+    // The constructor argument is the initial limit exposed via the getter. 7 is arbitrary — chosen only to be
+    // distinct from the production default (4) and other values used elsewhere in this suite.
+    public void testConstructorSetsInitialLimit() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(7);
+        assertEquals(7, guard.getMaxOutstandingOps());
+    }
+
+    // Each repository has its own independent limit and count; one repo hitting its limit does not affect another.
+    public void testTracksMultipleRepositoriesIndependently() {
+        final RepositoryOperationGuard guard = new RepositoryOperationGuard(1);
+        guard.tryAcquire("repo-a");
+        guard.tryAcquire("repo-b");
+        assertEquals(1, guard.getOutstandingOps("repo-a"));
+        assertEquals(1, guard.getOutstandingOps("repo-b"));
+        expectThrows(RepositoryException.class, () -> guard.tryAcquire("repo-a"));
+
+        guard.release("repo-a");
+        assertEquals(0, guard.getOutstandingOps("repo-a"));
+        assertEquals(1, guard.getOutstandingOps("repo-b"));
+    }
+}


### PR DESCRIPTION
 ### Description
  
Adds `RepositoryOperationGuard`, a per-repository circuit breaker that bounds the number of outstanding cluster-manager-side repository operations. This guards against a degraded repository parking enough worker threads (via the upcoming operation-level timeout) to drain the small, shared snapshot thread pool and starve other repositories.
  
  This class is registered nowhere and consumed by no one yet. A follow-up PR wires it into the finalize/delete dispatch paths.
  
  | Method | Purpose |
  |---|---|
  | `tryAcquire(repo)` | Fails fast with `RepositoryException` once a repository is at its limit, without dispatching |
  | `release(repo)` | Releases a permit; must be called exactly once per successful acquire |
  | `setMaxOutstandingOps(int)` | Updates the limit dynamically |
  
  ### Testing
  * `RepositoryOperationGuardTests`: fail-fast at limit, no permit taken on rejection.
  * Release balances acquire; dynamic limit updates apply to subsequent acquisitions.
  * Non-positive limits rejected at construction and via dynamic update.
  * Exactly-once release across response/failure/timeout, verified against the real `ActionListener.runAfter` + `ListenerTimeouts` stack, including a timeout followed by a late orphaned
  completion.
  * Independent per-repository tracking.
  * Deterministic timing via `DeterministicTaskQueue`; no `Thread.sleep`.
  * No IT: this class has no reachable call site, so there is no observable behavior to exercise end-to-end yet. That coverage lands in the follow-up PR that wires this guard in.
  
  ### Related Issues
  <!-- List any other related issues here -->
  
  ### Check List
  - [x] Functionality includes testing.
  - [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
  - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).