### PR TITLE
Add prefix and wildcard query support to DSL query executor

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ScalarFunction.java
@@ -69,6 +69,10 @@ public enum ScalarFunction {
     REGEXP(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     REGEXP_CONTAINS(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     WILDCARD_QUERY(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
+    /** Delegated prefix query — passes the value verbatim to Lucene PrefixQueryBuilder. */
+    PREFIX_QUERY(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
+    /** Delegated wildcard query for DSL-origin patterns — passes the Lucene pattern verbatim, no SQL conversion. */
+    WILDCARD_QUERY_DSL(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     QUERY(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
     MATCHALL(Category.FULL_TEXT, SqlKind.OTHER_FUNCTION),
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPlugin.java
@@ -94,6 +94,8 @@ public class LuceneAnalyticsBackendPlugin implements AnalyticsSearchBackendPlugi
         ScalarFunction.WILDCARD,
         ScalarFunction.REGEXP,
         ScalarFunction.WILDCARD_QUERY,
+        ScalarFunction.PREFIX_QUERY,
+        ScalarFunction.WILDCARD_QUERY_DSL,
         ScalarFunction.QUERY,
         ScalarFunction.MATCHALL
     );

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -21,11 +21,13 @@ import org.opensearch.be.lucene.serializers.MatchPhraseSerializer;
 import org.opensearch.be.lucene.serializers.MatchSerializer;
 import org.opensearch.be.lucene.serializers.MultiMatchSerializer;
 import org.opensearch.be.lucene.serializers.NotEqualsSerializer;
+import org.opensearch.be.lucene.serializers.PrefixQuerySerializer;
 import org.opensearch.be.lucene.serializers.QuerySerializer;
 import org.opensearch.be.lucene.serializers.QueryStringSerializer;
 import org.opensearch.be.lucene.serializers.RegexpSerializer;
 import org.opensearch.be.lucene.serializers.SargSerializer;
 import org.opensearch.be.lucene.serializers.SimpleQueryStringSerializer;
+import org.opensearch.be.lucene.serializers.WildcardQueryDslSerializer;
 import org.opensearch.be.lucene.serializers.WildcardQuerySerializer;
 
 import java.util.Map;
@@ -46,6 +48,8 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.QUERY_STRING, new QueryStringSerializer()),
         Map.entry(ScalarFunction.SIMPLE_QUERY_STRING, new SimpleQueryStringSerializer()),
         Map.entry(ScalarFunction.WILDCARD_QUERY, new WildcardQuerySerializer()),
+        Map.entry(ScalarFunction.PREFIX_QUERY, new PrefixQuerySerializer()),
+        Map.entry(ScalarFunction.WILDCARD_QUERY_DSL, new WildcardQueryDslSerializer()),
         Map.entry(ScalarFunction.QUERY, new QuerySerializer()),
         Map.entry(ScalarFunction.MATCHALL, new MatchAllSerializer()),
         Map.entry(ScalarFunction.EQUALS, new EqualsSerializer()),

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/AbstractRelevanceSerializer.java
@@ -32,6 +32,10 @@ import java.util.Map;
  */
 public abstract class AbstractRelevanceSerializer extends AbstractQuerySerializer {
 
+    // Optional-param keys shared with the translator's MAP operand keys — a mismatch silently drops the param.
+    protected static final String PARAM_CASE_INSENSITIVE = "case_insensitive";
+    protected static final String PARAM_REWRITE = "rewrite";
+
     @Override
     public final QueryBuilder buildQueryBuilder(RexCall call, List<FieldStorageInfo> fieldStorage) {
         ConversionUtils.RelevanceOperands operands = ConversionUtils.extractRelevanceOperands(call, fieldStorage);

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializer.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.Map;
+
+/**
+ * Serializer for the PREFIX_QUERY relevance function — passes the value verbatim to Lucene.
+ */
+public class PrefixQuerySerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "prefix_query";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new PrefixQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        PrefixQueryBuilder prefixQb = (PrefixQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "case_insensitive" -> prefixQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
+                case "rewrite" -> prefixQb.rewrite(entry.getValue());
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializer.java
@@ -34,8 +34,8 @@ public class PrefixQuerySerializer extends AbstractRelevanceSerializer {
         PrefixQueryBuilder prefixQb = (PrefixQueryBuilder) qb;
         for (Map.Entry<String, String> entry : params.entrySet()) {
             switch (entry.getKey()) {
-                case "case_insensitive" -> prefixQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
-                case "rewrite" -> prefixQb.rewrite(entry.getValue());
+                case PARAM_CASE_INSENSITIVE -> prefixQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
+                case PARAM_REWRITE -> prefixQb.rewrite(entry.getValue());
                 default -> {
                     /* ignore unrecognized params for forward compatibility */ }
             }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+
+import java.util.Map;
+
+/**
+ * Serializer for WILDCARD_QUERY_DSL — passes DSL-origin Lucene wildcard patterns verbatim, no SQL conversion.
+ */
+public class WildcardQueryDslSerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "wildcard_query_dsl";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        // A DSL wildcard value is already a Lucene pattern — converting it would be a lossy round trip.
+        return new WildcardQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "case_insensitive" -> wildcardQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
+                case "rewrite" -> wildcardQb.rewrite(entry.getValue());
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializer.java
@@ -35,8 +35,8 @@ public class WildcardQueryDslSerializer extends AbstractRelevanceSerializer {
         WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) qb;
         for (Map.Entry<String, String> entry : params.entrySet()) {
             switch (entry.getKey()) {
-                case "case_insensitive" -> wildcardQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
-                case "rewrite" -> wildcardQb.rewrite(entry.getValue());
+                case PARAM_CASE_INSENSITIVE -> wildcardQb.caseInsensitive(Boolean.parseBoolean(entry.getValue()));
+                case PARAM_REWRITE -> wildcardQb.rewrite(entry.getValue());
                 default -> {
                     /* ignore unrecognized params for forward compatibility */ }
             }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Unit tests for {@link QuerySerializerRegistry} serializers — optional parameter round-trips
@@ -252,6 +253,39 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
                 entry.getValue() instanceof DelegatedPredicateSerializer
             );
         }
+    }
+
+    /**
+     * Asserts that the registry's key set exactly equals the expected complete set of ScalarFunction
+     * keys. A dropped or renamed registration fails this test.
+     */
+    public void testRegistryKeySetMatchesExpectedFunctions() {
+        Set<ScalarFunction> expected = Set.of(
+            ScalarFunction.MATCH,
+            ScalarFunction.MATCH_PHRASE,
+            ScalarFunction.MATCH_BOOL_PREFIX,
+            ScalarFunction.MATCH_PHRASE_PREFIX,
+            ScalarFunction.MULTI_MATCH,
+            ScalarFunction.QUERY_STRING,
+            ScalarFunction.SIMPLE_QUERY_STRING,
+            ScalarFunction.WILDCARD_QUERY,
+            ScalarFunction.PREFIX_QUERY,
+            ScalarFunction.WILDCARD_QUERY_DSL,
+            ScalarFunction.QUERY,
+            ScalarFunction.MATCHALL,
+            ScalarFunction.EQUALS,
+            ScalarFunction.NOT_EQUALS,
+            ScalarFunction.IS_NULL,
+            ScalarFunction.IS_NOT_NULL,
+            ScalarFunction.LIKE,
+            ScalarFunction.GREATER_THAN,
+            ScalarFunction.GREATER_THAN_OR_EQUAL,
+            ScalarFunction.LESS_THAN,
+            ScalarFunction.LESS_THAN_OR_EQUAL,
+            ScalarFunction.REGEXP,
+            ScalarFunction.SARG_PREDICATE
+        );
+        assertEquals("Registry key set must match expected ScalarFunction set", expected, serializers.keySet());
     }
 
     // --- MatchAllSerializer tests ---

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/PrefixQuerySerializerTests.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link PrefixQuerySerializer} — validates verbatim value passthrough and case_insensitive param.
+ */
+public class PrefixQuerySerializerTests extends OpenSearchTestCase {
+
+    private static final NamedWriteableRegistry WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(new NamedWriteableRegistry.Entry(QueryBuilder.class, PrefixQueryBuilder.NAME, PrefixQueryBuilder::new))
+    );
+
+    private static final SqlFunction PREFIX_QUERY_FUNCTION = new SqlFunction(
+        "PREFIX_QUERY",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private PrefixQuerySerializer serializer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        serializer = new PrefixQuerySerializer();
+    }
+
+    /**
+     * Verifies that the serializer passes the prefix value verbatim — including metacharacters that
+     * would be special in SQL LIKE or Lucene wildcard context — proving no escaping occurs.
+     */
+    public void testValuePassedVerbatimIncludingMetacharacters() throws IOException {
+        // Value contains *, ? and backslash — must arrive unchanged at PrefixQueryBuilder
+        String verbatimValue = "check*it?out\\done";
+        RexCall call = buildPrefixCall("title", verbatimValue, Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Must produce PrefixQueryBuilder", deserialized instanceof PrefixQueryBuilder);
+            PrefixQueryBuilder prefixQb = (PrefixQueryBuilder) deserialized;
+            assertEquals("title", prefixQb.fieldName());
+            assertEquals(verbatimValue, prefixQb.value());
+        }
+    }
+
+    /**
+     * Verifies case_insensitive param is threaded through to the PrefixQueryBuilder.
+     */
+    public void testCaseInsensitiveParamIsApplied() throws IOException {
+        RexCall call = buildPrefixCall("name", "lap", Map.of("case_insensitive", "true"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("name", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            PrefixQueryBuilder prefixQb = (PrefixQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("name", prefixQb.fieldName());
+            assertEquals("lap", prefixQb.value());
+            assertTrue("case_insensitive must be true", prefixQb.caseInsensitive());
+        }
+    }
+
+    /**
+     * Verifies that a malformed operand list (missing 'field') raises IllegalArgumentException
+     * with the documented message containing the function name.
+     */
+    public void testThrowsOnMissingFieldOperand() {
+        // Build a call with only a 'query' operand, no 'field'
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("test")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(PREFIX_QUERY_FUNCTION, queryMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue("Message must contain 'prefix_query', got: " + ex.getMessage(), ex.getMessage().contains("prefix_query"));
+    }
+
+    /**
+     * Verifies that the rewrite parameter is applied to PrefixQueryBuilder when passed as a MAP operand.
+     */
+    public void testRewriteParameterAppliedToBuilder() throws IOException {
+        RexCall call = buildPrefixCall("title", "lap", Map.of("rewrite", "constant_score"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            PrefixQueryBuilder prefixQb = (PrefixQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("title", prefixQb.fieldName());
+            assertEquals("lap", prefixQb.value());
+            assertEquals("constant_score", prefixQb.rewrite());
+        }
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────────────────
+
+    private RexCall buildPrefixCall(String fieldName, String queryText, Map<String, String> params) {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral(queryText)
+        );
+
+        List<RexNode> operands = new ArrayList<>();
+        operands.add(fieldMap);
+        operands.add(queryMap);
+
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            RexNode paramMap = rexBuilder.makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                rexBuilder.makeLiteral(entry.getKey()),
+                rexBuilder.makeLiteral(entry.getValue())
+            );
+            operands.add(paramMap);
+        }
+
+        return (RexCall) rexBuilder.makeCall(PREFIX_QUERY_FUNCTION, operands);
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializerTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/serializers/WildcardQueryDslSerializerTests.java
@@ -1,0 +1,208 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.FieldType;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link WildcardQueryDslSerializer} — proves Lucene patterns are passed verbatim with no SQL conversion.
+ */
+public class WildcardQueryDslSerializerTests extends OpenSearchTestCase {
+
+    private static final NamedWriteableRegistry WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(new NamedWriteableRegistry.Entry(QueryBuilder.class, WildcardQueryBuilder.NAME, WildcardQueryBuilder::new))
+    );
+
+    private static final SqlFunction WILDCARD_QUERY_DSL_FUNCTION = new SqlFunction(
+        "WILDCARD_QUERY_DSL",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private WildcardQueryDslSerializer serializer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rexBuilder = new RexBuilder(typeFactory);
+        serializer = new WildcardQueryDslSerializer();
+    }
+
+    /**
+     * Lucene multi-char wildcard: {@code che*k} must arrive unchanged — no conversion to SQL {@code %}.
+     */
+    public void testLuceneStarPatternPassedVerbatim() throws IOException {
+        assertVerbatimPattern("che*k");
+    }
+
+    /**
+     * Lucene single-char wildcard: {@code ch?ck} must arrive unchanged — no conversion to SQL {@code _}.
+     */
+    public void testLuceneQuestionMarkPatternPassedVerbatim() throws IOException {
+        assertVerbatimPattern("ch?ck");
+    }
+
+    /**
+     * Escaped literal star: {@code a\*b} must arrive unchanged — the backslash-star is a Lucene escape
+     * for a literal star, not an SQL percent.
+     */
+    public void testEscapedLiteralStarPassedVerbatim() throws IOException {
+        assertVerbatimPattern("a\\*b");
+    }
+
+    /**
+     * Literal backslash in a Windows path: {@code C:\Users} must arrive unchanged.
+     */
+    public void testLiteralBackslashPassedVerbatim() throws IOException {
+        assertVerbatimPattern("C:\\Users");
+    }
+
+    /**
+     * Pattern containing SQL wildcard characters {@code %} and {@code _} as literals — proves
+     * no SQL-to-Lucene conversion occurs (they must NOT become {@code *} and {@code ?}).
+     */
+    public void testSqlWildcardCharsRemainLiteralNoConversion() throws IOException {
+        assertVerbatimPattern("100%_complete");
+    }
+
+    /**
+     * Verifies case_insensitive param is threaded through to WildcardQueryBuilder.
+     */
+    public void testCaseInsensitiveParamIsApplied() throws IOException {
+        RexCall call = buildWildcardDslCall("title", "che*k", Map.of("case_insensitive", "true"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("che*k", wildcardQb.value());
+            assertTrue("case_insensitive must be true", wildcardQb.caseInsensitive());
+        }
+    }
+
+    /**
+     * Verifies that a malformed operand list (missing 'field') raises IllegalArgumentException
+     * with the documented message containing the function name.
+     */
+    public void testThrowsOnMissingFieldOperand() {
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("test*")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(WILDCARD_QUERY_DSL_FUNCTION, queryMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue("Message must contain 'wildcard_query_dsl', got: " + ex.getMessage(), ex.getMessage().contains("wildcard_query_dsl"));
+    }
+
+    /**
+     * Verifies that the rewrite parameter is applied to WildcardQueryBuilder when passed as a MAP operand.
+     */
+    public void testRewriteParameterAppliedToBuilder() throws IOException {
+        RexCall call = buildWildcardDslCall("title", "che*k", Map.of("rewrite", "constant_score"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("che*k", wildcardQb.value());
+            assertEquals("constant_score", wildcardQb.rewrite());
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private void assertVerbatimPattern(String pattern) throws IOException {
+        RexCall call = buildWildcardDslCall("title", pattern, Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue("Must produce WildcardQueryBuilder", deserialized instanceof WildcardQueryBuilder);
+            WildcardQueryBuilder wildcardQb = (WildcardQueryBuilder) deserialized;
+            assertEquals("title", wildcardQb.fieldName());
+            assertEquals("Pattern must be passed verbatim", pattern, wildcardQb.value());
+        }
+    }
+
+    private RexCall buildWildcardDslCall(String fieldName, String queryText, Map<String, String> params) {
+        RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+
+        RexNode fieldMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("field"),
+            rexBuilder.makeInputRef(varcharType, 0)
+        );
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral(queryText)
+        );
+
+        List<RexNode> operands = new ArrayList<>();
+        operands.add(fieldMap);
+        operands.add(queryMap);
+
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            RexNode paramMap = rexBuilder.makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                rexBuilder.makeLiteral(entry.getKey()),
+                rexBuilder.makeLiteral(entry.getValue())
+            );
+            operands.add(paramMap);
+        }
+
+        return (RexCall) rexBuilder.makeCall(WILDCARD_QUERY_DSL_FUNCTION, operands);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -19,6 +19,77 @@ _search request
       → SearchResponseBuilder (builds SearchResponse)
 ```
 
+## Supported Queries
+
+### Term Query
+Converts to Calcite equality expressions.
+```json
+{"term": {"status": "active"}}
+```
+
+### Match All Query
+Converts to boolean true literal.
+```json
+{"match_all": {}}
+```
+
+### Prefix Query
+Converts to Calcite LIKE expressions with wildcard suffix.
+
+**Supported parameters:**
+- `value` - The prefix string
+- `case_insensitive` - Case-insensitive matching (default: false)
+
+**Unsupported parameters (throw ConversionException):**
+- `boost` - Query boosting not supported
+- `rewrite` - Rewrite method not supported
+
+**Examples:**
+```json
+{"prefix": {"name": "lap"}}
+// Converts to: name LIKE 'lap%'
+
+{"prefix": {"name": {"value": "LAP", "case_insensitive": true}}}
+// Converts to: LOWER(name) LIKE 'lap%'
+```
+
+**Special character escaping:**
+- `%` → `\%` (SQL wildcard for any characters)
+- `_` → `\_` (SQL wildcard for single character)
+- `\` → `\\` (escape character)
+
+### Wildcard Query
+Converts to Calcite LIKE expressions with wildcard pattern translation.
+
+**Wildcard characters:**
+- `*` - Matches any character sequence (converts to SQL `%`)
+- `?` - Matches any single character (converts to SQL `_`)
+
+**Supported parameters:**
+- `value` - The wildcard pattern
+- `case_insensitive` - Case-insensitive matching (default: false)
+
+**Unsupported parameters (throw ConversionException):**
+- `boost` - Query boosting not supported
+- `rewrite` - Rewrite method not supported
+
+**Examples:**
+```json
+{"wildcard": {"name": "lap*"}}
+// Converts to: name LIKE 'lap%'
+
+{"wildcard": {"name": "l?ptop"}}
+// Converts to: name LIKE 'l_ptop'
+
+{"wildcard": {"name": {"value": "*BOOK*", "case_insensitive": true}}}
+// Converts to: LOWER(name) LIKE '%book%'
+```
+
+**Special character escaping:**
+- SQL special chars (`%`, `_`, `\`) are escaped before wildcard conversion
+- `*` → `%` (after escaping)
+- `?` → `_` (after escaping)
+
 ## Dependencies
 
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)

--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -2,12 +2,6 @@
 
 A front-end sandbox plugin to the analytics engine that intercepts `_search` requests, converts DSL queries into Calcite RelNode logical plans, and executes them through the analytics engine's query pipeline.
 
-## Supported Query Types
-
-- **Term** — equality filter
-- **Terms** — multi-value equality filter (uses query Filter with SEARCH and EQUALS)
-- **Match All** — matches all documents
-
 ## Architecture
 
 ```
@@ -78,75 +72,58 @@ unsupported on this path.
 }
 ```
 
+### Calcite Representation
+
+| DSL Query | Calcite Representation |
+|-----------|------------------------|
+| `term` | `=($field, value)` — equality filter |
+| `terms` | `SEARCH($field, Sarg[v1, v2, ...])` — multi-value equality |
+| `match_all` | Skipped (boolean literal `TRUE`) |
+| `exists` | `IS NOT NULL($field)` — field existence check (boost not supported) |
+| `prefix` | Delegated `PREFIX_QUERY` RexCall — Lucene `PrefixQueryBuilder` on data node |
+| `wildcard` | Delegated `WILDCARD_QUERY_DSL` RexCall — Lucene `WildcardQueryBuilder` on data node |
+
 ### Prefix Query
-Converts to Calcite LIKE expressions with wildcard suffix.
 
-**Supported parameters:**
-- `value` - The prefix string
-- `case_insensitive` - Case-insensitive matching (default: false)
+Emits a delegated `PREFIX_QUERY` RexCall (Category.FULL_TEXT). The prefix value is passed
+verbatim to `PrefixQuerySerializer`, which builds a real `PrefixQueryBuilder` on the data node.
+Lucene performs the matching against the term dictionary, inheriting normalizer handling and the
+`index_prefixes` O(1) fast path.
 
-**Unsupported parameters (throw ConversionException):**
-- `boost` - Query boosting not supported
-- `rewrite` - Rewrite method not supported
-
-**Examples:**
 ```json
-{"prefix": {"name": "lap"}}
-// Converts to: name LIKE 'lap%'
-
+{"prefix": {"name": "lap"}}           → PREFIX_QUERY(MAP('field',name), MAP('query','lap'))
 {"prefix": {"name": {"value": "LAP", "case_insensitive": true}}}
-// Converts to: LOWER(name) LIKE 'lap%'
+  → PREFIX_QUERY(MAP('field',name), MAP('query','LAP'), MAP('case_insensitive','true'))
 ```
-
-**Special character escaping:**
-- `%` → `\%` (SQL wildcard for any characters)
-- `_` → `\_` (SQL wildcard for single character)
-- `\` → `\\` (escape character)
 
 ### Wildcard Query
-Converts to Calcite LIKE expressions with wildcard pattern translation.
 
-**Wildcard characters:**
-- `*` - Matches any character sequence (converts to SQL `%`)
-- `?` - Matches any single character (converts to SQL `_`)
+Emits a delegated `WILDCARD_QUERY_DSL` RexCall (Category.FULL_TEXT). The Lucene wildcard
+pattern (`*`, `?`, `\` escapes) is passed verbatim — no SQL conversion occurs. A dedicated
+serializer is used because the existing `WildcardQuerySerializer` expects SQL-form patterns
+and would reinterpret a literal `%` in customer data as a wildcard.
 
-**Supported parameters:**
-- `value` - The wildcard pattern
-- `case_insensitive` - Case-insensitive matching (default: false)
-
-**Unsupported parameters (throw ConversionException):**
-- `boost` - Query boosting not supported
-- `rewrite` - Rewrite method not supported
-
-**Examples:**
 ```json
-{"wildcard": {"name": "lap*"}}
-// Converts to: name LIKE 'lap%'
-
-{"wildcard": {"name": "l?ptop"}}
-// Converts to: name LIKE 'l_ptop'
-
-{"wildcard": {"name": {"value": "*BOOK*", "case_insensitive": true}}}
-// Converts to: LOWER(name) LIKE '%book%'
+{"wildcard": {"name": "lap*"}}        → WILDCARD_QUERY_DSL(MAP('field',name), MAP('query','lap*'))
+{"wildcard": {"name": "l?ptop"}}      → WILDCARD_QUERY_DSL(MAP('field',name), MAP('query','l?ptop'))
 ```
 
-**Special character escaping:**
-- SQL special chars (`%`, `_`, `\`) are escaped before wildcard conversion
-- `*` → `%` (after escaping)
-- `?` → `_` (after escaping)
+Supported parameters: `value` (verbatim), `case_insensitive` (delegated to builder; ASCII-only folding),
+`rewrite` (passed through to builder, validated on data node). Rejected: `boost` (throws ConversionException —
+scores are not surfaced). Rejected: `_name` (throws ConversionException — matched_queries not surfaced).
+
+### Known Divergences (prefix / wildcard)
+
+| # | Divergence | Detail |
+|---|---|---|
+| 1 | `search.allow_expensive_queries=false` not honoured | The Lucene backend hardcodes an always-true supplier (LuceneAnalyticsBackendPlugin:284). Vanilla refuses prefix/wildcard when this setting is false. Pre-existing property of the delegation layer. |
+| 2 | Page pruning lost | A delegated predicate yields an all-true bitmap at the pruning stage (page_pruner.rs:779-782); the previous LIKE form was prunable (page_pruner.rs:24). Correctness preserved by residual re-evaluation (single_collector.rs:604-611). Follow-up: schema enrichment would enable a prunable fast path. |
+| 3 | Field types not storable in this engine mode | `wildcard`, `constant_keyword`, `version` and `flat_object` support prefix/wildcard in vanilla, but indexes using them cannot be created in optimized engine mode at all — the Parquet primary format (`CoreDataFieldPlugin`) and the Lucene secondary format (`LuceneFieldFactoryRegistry`) register no writers for them, so index creation fails with `MapperParsingException` (see `CompositeFieldCapabilityIT`). Storage-layer limitation shared by every query front-end via `OpenSearchSchemaBuilder`, not a prefix/wildcard behaviour difference. |
 
 ## Dependencies
 
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)
 - `analytics-framework` — provides Calcite and shared SPI interfaces
-
-## Supported Queries
-
-| DSL Query | Calcite Representation |
-|-----------|------------------------|
-| `term` | `=($field, value)` — equality filter |
-| `match_all` | Skipped (boolean literal `TRUE`) |
-| `exists` | `IS NOT NULL($field)` — field existence check (boost not supported) |
 
 ## Running locally
 

--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -2,12 +2,6 @@
 
 A front-end sandbox plugin to the analytics engine that intercepts `_search` requests, converts DSL queries into Calcite RelNode logical plans, and executes them through the analytics engine's query pipeline.
 
-## Supported Query Types
-
-- **Term** — equality filter
-- **Terms** — multi-value equality filter (uses query Filter with SEARCH and EQUALS)
-- **Match All** — matches all documents
-
 ## Architecture
 
 ```
@@ -21,87 +15,56 @@ _search request
 
 ## Supported Queries
 
-### Term Query
-Converts to Calcite equality expressions.
-```json
-{"term": {"status": "active"}}
-```
-
-### Match All Query
-Converts to boolean true literal.
-```json
-{"match_all": {}}
-```
+| DSL Query | Calcite Representation |
+|-----------|------------------------|
+| `term` | `=($field, value)` — equality filter |
+| `terms` | `SEARCH($field, Sarg[v1, v2, ...])` — multi-value equality |
+| `match_all` | Skipped (boolean literal `TRUE`) |
+| `exists` | `IS NOT NULL($field)` — field existence check (boost not supported) |
+| `prefix` | Delegated `PREFIX_QUERY` RexCall — Lucene `PrefixQueryBuilder` on data node |
+| `wildcard` | Delegated `WILDCARD_QUERY_DSL` RexCall — Lucene `WildcardQueryBuilder` on data node |
 
 ### Prefix Query
-Converts to Calcite LIKE expressions with wildcard suffix.
 
-**Supported parameters:**
-- `value` - The prefix string
-- `case_insensitive` - Case-insensitive matching (default: false)
+Emits a delegated `PREFIX_QUERY` RexCall (Category.FULL_TEXT). The prefix value is passed
+verbatim to `PrefixQuerySerializer`, which builds a real `PrefixQueryBuilder` on the data node.
+Lucene performs the matching against the term dictionary, inheriting normalizer handling and the
+`index_prefixes` O(1) fast path.
 
-**Unsupported parameters (throw ConversionException):**
-- `boost` - Query boosting not supported
-- `rewrite` - Rewrite method not supported
-
-**Examples:**
 ```json
-{"prefix": {"name": "lap"}}
-// Converts to: name LIKE 'lap%'
-
+{"prefix": {"name": "lap"}}           → PREFIX_QUERY(MAP('field',name), MAP('query','lap'))
 {"prefix": {"name": {"value": "LAP", "case_insensitive": true}}}
-// Converts to: LOWER(name) LIKE 'lap%'
+  → PREFIX_QUERY(MAP('field',name), MAP('query','LAP'), MAP('case_insensitive','true'))
 ```
-
-**Special character escaping:**
-- `%` → `\%` (SQL wildcard for any characters)
-- `_` → `\_` (SQL wildcard for single character)
-- `\` → `\\` (escape character)
 
 ### Wildcard Query
-Converts to Calcite LIKE expressions with wildcard pattern translation.
 
-**Wildcard characters:**
-- `*` - Matches any character sequence (converts to SQL `%`)
-- `?` - Matches any single character (converts to SQL `_`)
+Emits a delegated `WILDCARD_QUERY_DSL` RexCall (Category.FULL_TEXT). The Lucene wildcard
+pattern (`*`, `?`, `\` escapes) is passed verbatim — no SQL conversion occurs. A dedicated
+serializer is used because the existing `WildcardQuerySerializer` expects SQL-form patterns
+and would reinterpret a literal `%` in customer data as a wildcard.
 
-**Supported parameters:**
-- `value` - The wildcard pattern
-- `case_insensitive` - Case-insensitive matching (default: false)
-
-**Unsupported parameters (throw ConversionException):**
-- `boost` - Query boosting not supported
-- `rewrite` - Rewrite method not supported
-
-**Examples:**
 ```json
-{"wildcard": {"name": "lap*"}}
-// Converts to: name LIKE 'lap%'
-
-{"wildcard": {"name": "l?ptop"}}
-// Converts to: name LIKE 'l_ptop'
-
-{"wildcard": {"name": {"value": "*BOOK*", "case_insensitive": true}}}
-// Converts to: LOWER(name) LIKE '%book%'
+{"wildcard": {"name": "lap*"}}        → WILDCARD_QUERY_DSL(MAP('field',name), MAP('query','lap*'))
+{"wildcard": {"name": "l?ptop"}}      → WILDCARD_QUERY_DSL(MAP('field',name), MAP('query','l?ptop'))
 ```
 
-**Special character escaping:**
-- SQL special chars (`%`, `_`, `\`) are escaped before wildcard conversion
-- `*` → `%` (after escaping)
-- `?` → `_` (after escaping)
+Supported parameters: `value` (verbatim), `case_insensitive` (delegated to builder; ASCII-only folding),
+`rewrite` (passed through to builder, validated on data node). Rejected: `boost` (throws ConversionException —
+scores are not surfaced). Rejected: `_name` (throws ConversionException — matched_queries not surfaced).
+
+### Known Divergences (prefix / wildcard)
+
+| # | Divergence | Detail |
+|---|---|---|
+| 1 | `search.allow_expensive_queries=false` not honoured | The Lucene backend hardcodes an always-true supplier (LuceneAnalyticsBackendPlugin:284). Vanilla refuses prefix/wildcard when this setting is false. Pre-existing property of the delegation layer. |
+| 2 | Page pruning lost | A delegated predicate yields an all-true bitmap at the pruning stage (page_pruner.rs:779-782); the previous LIKE form was prunable (page_pruner.rs:24). Correctness preserved by residual re-evaluation (single_collector.rs:604-611). Follow-up: schema enrichment would enable a prunable fast path. |
+| 3 | Field types not storable in this engine mode | `wildcard`, `constant_keyword`, `version` and `flat_object` support prefix/wildcard in vanilla, but indexes using them cannot be created in optimized engine mode at all — the Parquet primary format (`CoreDataFieldPlugin`) and the Lucene secondary format (`LuceneFieldFactoryRegistry`) register no writers for them, so index creation fails with `MapperParsingException` (see `CompositeFieldCapabilityIT`). Storage-layer limitation shared by every query front-end via `OpenSearchSchemaBuilder`, not a prefix/wildcard behaviour difference. |
 
 ## Dependencies
 
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)
 - `analytics-framework` — provides Calcite and shared SPI interfaces
-
-## Supported Queries
-
-| DSL Query | Calcite Representation |
-|-----------|------------------------|
-| `term` | `=($field, value)` — equality filter |
-| `match_all` | Skipped (boolean literal `TRUE`) |
-| `exists` | `IS NOT NULL($field)` — field existence check (boost not supported) |
 
 ## Running locally
 

--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -26,6 +26,8 @@ _search request
 - **Match All Query** - Match all documents
 - **Range Query** - Numeric and date range queries with full date math support
 - **Bool Query** - Compound query with `must`, `should`, `must_not`, `filter` and `minimum_should_match`
+- **Prefix Query** - Prefix matching via Calcite LIKE with wildcard suffix
+- **Wildcard Query** - Wildcard pattern matching via Calcite LIKE
 
 ### Range Query Features
 - **Operators**: `gte`, `gt`, `lte`, `lt`
@@ -75,6 +77,63 @@ unsupported on this path.
   }
 }
 ```
+
+### Prefix Query
+Converts to Calcite LIKE expressions with wildcard suffix.
+
+**Supported parameters:**
+- `value` - The prefix string
+- `case_insensitive` - Case-insensitive matching (default: false)
+
+**Unsupported parameters (throw ConversionException):**
+- `boost` - Query boosting not supported
+- `rewrite` - Rewrite method not supported
+
+**Examples:**
+```json
+{"prefix": {"name": "lap"}}
+// Converts to: name LIKE 'lap%'
+
+{"prefix": {"name": {"value": "LAP", "case_insensitive": true}}}
+// Converts to: LOWER(name) LIKE 'lap%'
+```
+
+**Special character escaping:**
+- `%` → `\%` (SQL wildcard for any characters)
+- `_` → `\_` (SQL wildcard for single character)
+- `\` → `\\` (escape character)
+
+### Wildcard Query
+Converts to Calcite LIKE expressions with wildcard pattern translation.
+
+**Wildcard characters:**
+- `*` - Matches any character sequence (converts to SQL `%`)
+- `?` - Matches any single character (converts to SQL `_`)
+
+**Supported parameters:**
+- `value` - The wildcard pattern
+- `case_insensitive` - Case-insensitive matching (default: false)
+
+**Unsupported parameters (throw ConversionException):**
+- `boost` - Query boosting not supported
+- `rewrite` - Rewrite method not supported
+
+**Examples:**
+```json
+{"wildcard": {"name": "lap*"}}
+// Converts to: name LIKE 'lap%'
+
+{"wildcard": {"name": "l?ptop"}}
+// Converts to: name LIKE 'l_ptop'
+
+{"wildcard": {"name": {"value": "*BOOK*", "case_insensitive": true}}}
+// Converts to: LOWER(name) LIKE '%book%'
+```
+
+**Special character escaping:**
+- SQL special chars (`%`, `_`, `\`) are escaped before wildcard conversion
+- `*` → `%` (after escaping)
+- `?` → `_` (after escaping)
 
 ## Dependencies
 

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslPrefixQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslPrefixQueryIT.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl;
+
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Integration tests for prefix query conversion to Calcite LIKE expressions.
+ */
+public class DslPrefixQueryIT extends DslIntegTestBase {
+
+    @Override
+    protected void createTestIndex() {
+        createIndex(INDEX);
+        ensureGreen();
+        
+        client().prepareIndex(INDEX)
+            .setId("1")
+            .setSource("{\"name\":\"laptop\",\"brand\":\"Apple\",\"model\":\"MacBook Pro\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("2")
+            .setSource("{\"name\":\"phone\",\"brand\":\"Samsung\",\"model\":\"Galaxy S21\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("3")
+            .setSource("{\"name\":\"tablet\",\"brand\":\"apple\",\"model\":\"iPad Air\"}", XContentType.JSON)
+            .get();
+        refresh(INDEX);
+    }
+
+    public void testBasicPrefixQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("name", "lap")
+        )));
+    }
+
+    public void testPrefixQueryCaseSensitive() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("brand", "Apple")
+        )));
+    }
+
+    public void testPrefixQueryCaseInsensitive() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("brand", "apple").caseInsensitive(true)
+        )));
+    }
+
+    public void testPrefixQueryWithEmptyString() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("name", "")
+        )));
+    }
+
+    public void testPrefixQueryWithMultipleWords() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("model", "MacBook")
+        )));
+    }
+
+    public void testPrefixQueryInBoolQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.prefixQuery("name", "lap"))
+                .should(QueryBuilders.prefixQuery("brand", "App"))
+        )));
+    }
+
+    public void testPrefixQueryWithSpecialCharacters() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.prefixQuery("model", "Galaxy S")
+        )));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslPrefixQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslPrefixQueryIT.java
@@ -8,20 +8,22 @@
 
 package org.opensearch.dsl;
 
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 /**
- * Integration tests for prefix query conversion to Calcite LIKE expressions.
+ * Integration tests for prefix query delegation to Lucene via PREFIX_QUERY RexCall.
  */
+@AwaitsFix(bugUrl = "DSL query pipeline not fully wired E2E: fragment conversion, shard execution and Arrow Flight drain pending")
 public class DslPrefixQueryIT extends DslIntegTestBase {
 
     @Override
     protected void createTestIndex() {
         createIndex(INDEX);
         ensureGreen();
-        
+
         client().prepareIndex(INDEX)
             .setId("1")
             .setSource("{\"name\":\"laptop\",\"brand\":\"Apple\",\"model\":\"MacBook Pro\"}", XContentType.JSON)
@@ -39,52 +41,44 @@ public class DslPrefixQueryIT extends DslIntegTestBase {
 
     public void testBasicPrefixQuery() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("name", "lap")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap"))));
     }
 
     public void testPrefixQueryCaseSensitive() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("brand", "Apple")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("brand", "Apple"))));
     }
 
     public void testPrefixQueryCaseInsensitive() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("brand", "apple").caseInsensitive(true)
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("brand", "apple").caseInsensitive(true))));
     }
 
     public void testPrefixQueryWithEmptyString() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("name", "")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", ""))));
     }
 
     public void testPrefixQueryWithMultipleWords() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("model", "MacBook")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("model", "MacBook"))));
     }
 
     public void testPrefixQueryInBoolQuery() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.prefixQuery("name", "lap"))
-                .should(QueryBuilders.prefixQuery("brand", "App"))
-        )));
+        assertOk(
+            search(
+                new SearchSourceBuilder().query(
+                    QueryBuilders.boolQuery()
+                        .must(QueryBuilders.prefixQuery("name", "lap"))
+                        .should(QueryBuilders.prefixQuery("brand", "App"))
+                )
+            )
+        );
     }
 
     public void testPrefixQueryWithSpecialCharacters() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.prefixQuery("model", "Galaxy S")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("model", "Galaxy S"))));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslWildcardQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslWildcardQueryIT.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl;
+
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Integration tests for wildcard query conversion to Calcite LIKE expressions.
+ */
+public class DslWildcardQueryIT extends DslIntegTestBase {
+
+    @Override
+    protected void createTestIndex() {
+        createIndex(INDEX);
+        ensureGreen();
+        
+        client().prepareIndex(INDEX)
+            .setId("1")
+            .setSource("{\"name\":\"laptop\",\"model\":\"MacBook Pro\",\"sku\":\"MB-2021-001\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("2")
+            .setSource("{\"name\":\"phone\",\"model\":\"Galaxy S21\",\"sku\":\"GS-2021-002\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("3")
+            .setSource("{\"name\":\"tablet\",\"model\":\"iPad Air\",\"sku\":\"IP-2020-003\"}", XContentType.JSON)
+            .get();
+        refresh(INDEX);
+    }
+
+    public void testWildcardWithAsterisk() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("name", "lap*")
+        )));
+    }
+
+    public void testWildcardWithQuestionMark() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("name", "p?one")
+        )));
+    }
+
+    public void testWildcardWithBothWildcards() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("model", "?acBook*")
+        )));
+    }
+
+    public void testWildcardCaseInsensitive() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("model", "MACBOOK*").caseInsensitive(true)
+        )));
+    }
+
+    public void testWildcardWithMultipleAsterisks() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("sku", "*-2021-*")
+        )));
+    }
+
+    public void testWildcardMatchAll() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.wildcardQuery("name", "*")
+        )));
+    }
+
+    public void testWildcardInBoolQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.wildcardQuery("name", "lap*"))
+                .should(QueryBuilders.wildcardQuery("model", "*Pro"))
+        )));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslWildcardQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslWildcardQueryIT.java
@@ -8,20 +8,22 @@
 
 package org.opensearch.dsl;
 
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 /**
- * Integration tests for wildcard query conversion to Calcite LIKE expressions.
+ * Integration tests for wildcard query delegation to Lucene via WILDCARD_QUERY_DSL RexCall.
  */
+@AwaitsFix(bugUrl = "DSL query pipeline not fully wired E2E: fragment conversion, shard execution and Arrow Flight drain pending")
 public class DslWildcardQueryIT extends DslIntegTestBase {
 
     @Override
     protected void createTestIndex() {
         createIndex(INDEX);
         ensureGreen();
-        
+
         client().prepareIndex(INDEX)
             .setId("1")
             .setSource("{\"name\":\"laptop\",\"model\":\"MacBook Pro\",\"sku\":\"MB-2021-001\"}", XContentType.JSON)
@@ -39,52 +41,44 @@ public class DslWildcardQueryIT extends DslIntegTestBase {
 
     public void testWildcardWithAsterisk() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("name", "lap*")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*"))));
     }
 
     public void testWildcardWithQuestionMark() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("name", "p?one")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "p?one"))));
     }
 
     public void testWildcardWithBothWildcards() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("model", "?acBook*")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("model", "?acBook*"))));
     }
 
     public void testWildcardCaseInsensitive() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("model", "MACBOOK*").caseInsensitive(true)
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("model", "MACBOOK*").caseInsensitive(true))));
     }
 
     public void testWildcardWithMultipleAsterisks() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("sku", "*-2021-*")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("sku", "*-2021-*"))));
     }
 
     public void testWildcardMatchAll() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.wildcardQuery("name", "*")
-        )));
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "*"))));
     }
 
     public void testWildcardInBoolQuery() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.wildcardQuery("name", "lap*"))
-                .should(QueryBuilders.wildcardQuery("model", "*Pro"))
-        )));
+        assertOk(
+            search(
+                new SearchSourceBuilder().query(
+                    QueryBuilders.boolQuery()
+                        .must(QueryBuilders.wildcardQuery("name", "lap*"))
+                        .should(QueryBuilders.wildcardQuery("model", "*Pro"))
+                )
+            )
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/DelegatedRelevanceCallHelper.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/DelegatedRelevanceCallHelper.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Assembles a delegated-relevance RexCall from pre-validated inputs.
+ */
+final class DelegatedRelevanceCallHelper {
+
+    private DelegatedRelevanceCallHelper() {}
+
+    /**
+     * Builds the RexCall for a delegated relevance query.
+     *
+     * @param field      already-resolved field; caller is responsible for type validation
+     * @param queryValue passed verbatim with no escaping
+     */
+    static RexNode buildDelegatedRelevanceCall(
+        String functionName,
+        RelDataTypeField field,
+        String queryValue,
+        boolean caseInsensitive,
+        String rewrite,
+        ConversionContext ctx
+    ) throws ConversionException {
+        SqlFunction function = new SqlFunction(
+            functionName,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.BOOLEAN,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+
+        RexNode fieldMap = ctx.getRexBuilder()
+            .makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, ctx.getRexBuilder().makeLiteral("field"), fieldRef);
+        RexNode queryMap = ctx.getRexBuilder()
+            .makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                ctx.getRexBuilder().makeLiteral("query"),
+                ctx.getRexBuilder().makeLiteral(queryValue)
+            );
+
+        List<RexNode> operands = new ArrayList<>(List.of(fieldMap, queryMap));
+
+        if (caseInsensitive) {
+            operands.add(
+                ctx.getRexBuilder()
+                    .makeCall(
+                        SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                        ctx.getRexBuilder().makeLiteral("case_insensitive"),
+                        ctx.getRexBuilder().makeLiteral("true")
+                    )
+            );
+        }
+
+        // Pass rewrite through without validation — the data node validates via
+        // QueryParsers.parseRewriteMethod when the query is built on the shard.
+        if (rewrite != null) {
+            operands.add(
+                ctx.getRexBuilder()
+                    .makeCall(
+                        SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                        ctx.getRexBuilder().makeLiteral("rewrite"),
+                        ctx.getRexBuilder().makeLiteral(rewrite)
+                    )
+            );
+        }
+
+        return ctx.getRexBuilder().makeCall(function, operands);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+/**
+ * Converts a {@link PrefixQueryBuilder} to a Calcite LIKE expression.
+ * <p>
+ * Converts prefix queries to SQL LIKE patterns with a trailing wildcard:
+ * <ul>
+ *   <li>{@code {"prefix": {"name": "lap"}}} → {@code name LIKE 'lap%'}</li>
+ *   <li>{@code {"prefix": {"name": {"value": "lap", "case_insensitive": true}}}} → {@code LOWER(name) LIKE 'lap%'}</li>
+ * </ul>
+ * <p>
+ * <b>Supported parameters:</b>
+ * <ul>
+ *   <li>{@code value} - The prefix string to match</li>
+ *   <li>{@code case_insensitive} - When true, applies LOWER() to both field and pattern (default: false)</li>
+ * </ul>
+ * <p>
+ * <b>Unsupported parameters</b> (throw {@link ConversionException}):
+ * <ul>
+ *   <li>{@code boost} - Query boosting not supported in analytics engine</li>
+ *   <li>{@code rewrite} - Lucene-specific rewrite methods not applicable to Calcite</li>
+ * </ul>
+ * <p>
+ * <b>Special character escaping:</b>
+ * SQL LIKE special characters in the prefix value are automatically escaped:
+ * <ul>
+ *   <li>{@code %} → {@code \%} (SQL any-characters wildcard)</li>
+ *   <li>{@code _} → {@code \_} (SQL single-character wildcard)</li>
+ *   <li>{@code \} → {@code \\} (escape character)</li>
+ * </ul>
+ * <p>
+ * Example: {@code {"prefix": {"path": "C:\\test_"}}} → {@code path LIKE 'C:\\\\test\\_%'}
+ */
+public class PrefixQueryTranslator implements QueryTranslator {
+
+    /**
+     * Returns the query type this translator handles.
+     *
+     * @return {@link PrefixQueryBuilder} class
+     */
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return PrefixQueryBuilder.class;
+    }
+
+    /**
+     * Converts a prefix query to a Calcite LIKE expression.
+     * <p>
+     * Validates field existence, checks for unsupported parameters, applies case-insensitive
+     * transformation if needed, escapes SQL special characters, and appends trailing wildcard.
+     *
+     * @param query the prefix query to convert
+     * @param ctx the conversion context with schema and RexBuilder
+     * @return RexNode representing {@code field LIKE 'prefix%'} or {@code LOWER(field) LIKE 'prefix%'}
+     * @throws ConversionException if field not found, or boost/rewrite parameters are set
+     */
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        PrefixQueryBuilder prefixQuery = (PrefixQueryBuilder) query;
+        
+        // Check for unsupported parameters
+        if (prefixQuery.boost() != 1.0f) {
+            throw new ConversionException("Prefix query parameter 'boost' is not supported");
+        }
+        if (prefixQuery.rewrite() != null) {
+            throw new ConversionException("Prefix query parameter 'rewrite' is not supported");
+        }
+
+        String fieldName = prefixQuery.fieldName();
+        String prefix = prefixQuery.value();
+        boolean caseInsensitive = prefixQuery.caseInsensitive();
+
+        // Validate field exists in schema
+        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+
+        // Create field reference
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+
+        // Apply LOWER() if case insensitive
+        if (caseInsensitive) {
+            fieldRef = ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LOWER, fieldRef);
+            prefix = prefix.toLowerCase();
+        }
+
+        // Create LIKE pattern: prefix + '%'
+        String likePattern = escapeLikePattern(prefix) + "%";
+        RexNode patternLiteral = ctx.getRexBuilder().makeLiteral(likePattern);
+
+        // Return LIKE expression
+        return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LIKE, fieldRef, patternLiteral);
+    }
+
+    /**
+     * Escapes SQL LIKE special characters in the prefix value.
+     * <p>
+     * Escapes characters that have special meaning in SQL LIKE patterns:
+     * <ul>
+     *   <li>{@code \} → {@code \\} (must be escaped first to avoid double-escaping)</li>
+     *   <li>{@code %} → {@code \%} (matches any sequence of characters)</li>
+     *   <li>{@code _} → {@code \_} (matches any single character)</li>
+     * </ul>
+     * <p>
+     * Example: {@code "test_50%"} → {@code "test\_50\%"}
+     *
+     * @param value the prefix value to escape
+     * @return escaped value safe for use in LIKE pattern
+     */
+    private String escapeLikePattern(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
@@ -10,121 +10,52 @@ package org.opensearch.dsl.query;
 
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.PrefixQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
-/**
- * Converts a {@link PrefixQueryBuilder} to a Calcite LIKE expression.
- * <p>
- * Converts prefix queries to SQL LIKE patterns with a trailing wildcard:
- * <ul>
- *   <li>{@code {"prefix": {"name": "lap"}}} → {@code name LIKE 'lap%'}</li>
- *   <li>{@code {"prefix": {"name": {"value": "lap", "case_insensitive": true}}}} → {@code LOWER(name) LIKE 'lap%'}</li>
- * </ul>
- * <p>
- * <b>Supported parameters:</b>
- * <ul>
- *   <li>{@code value} - The prefix string to match</li>
- *   <li>{@code case_insensitive} - When true, applies LOWER() to both field and pattern (default: false)</li>
- * </ul>
- * <p>
- * <b>Unsupported parameters</b> (throw {@link ConversionException}):
- * <ul>
- *   <li>{@code boost} - Query boosting not supported in analytics engine</li>
- *   <li>{@code rewrite} - Lucene-specific rewrite methods not applicable to Calcite</li>
- * </ul>
- * <p>
- * <b>Special character escaping:</b>
- * SQL LIKE special characters in the prefix value are automatically escaped:
- * <ul>
- *   <li>{@code %} → {@code \%} (SQL any-characters wildcard)</li>
- *   <li>{@code _} → {@code \_} (SQL single-character wildcard)</li>
- *   <li>{@code \} → {@code \\} (escape character)</li>
- * </ul>
- * <p>
- * Example: {@code {"prefix": {"path": "C:\\test_"}}} → {@code path LIKE 'C:\\\\test\\_%'}
- */
+/** Translates a {@link PrefixQueryBuilder} to a PREFIX_QUERY delegated-relevance RexCall. */
 public class PrefixQueryTranslator implements QueryTranslator {
 
-    /**
-     * Returns the query type this translator handles.
-     *
-     * @return {@link PrefixQueryBuilder} class
-     */
     @Override
     public Class<? extends QueryBuilder> getQueryType() {
         return PrefixQueryBuilder.class;
     }
 
-    /**
-     * Converts a prefix query to a Calcite LIKE expression.
-     * <p>
-     * Validates field existence, checks for unsupported parameters, applies case-insensitive
-     * transformation if needed, escapes SQL special characters, and appends trailing wildcard.
-     *
-     * @param query the prefix query to convert
-     * @param ctx the conversion context with schema and RexBuilder
-     * @return RexNode representing {@code field LIKE 'prefix%'} or {@code LOWER(field) LIKE 'prefix%'}
-     * @throws ConversionException if field not found, or boost/rewrite parameters are set
-     */
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         PrefixQueryBuilder prefixQuery = (PrefixQueryBuilder) query;
-        
-        // Check for unsupported parameters
-        if (prefixQuery.boost() != 1.0f) {
+
+        if (prefixQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
             throw new ConversionException("Prefix query parameter 'boost' is not supported");
         }
-        if (prefixQuery.rewrite() != null) {
-            throw new ConversionException("Prefix query parameter 'rewrite' is not supported");
+        // matched_queries is not surfaced by this path
+        if (prefixQuery.queryName() != null) {
+            throw new ConversionException("Prefix query parameter '_name' is not supported");
         }
 
-        String fieldName = prefixQuery.fieldName();
-        String prefix = prefixQuery.value();
-        boolean caseInsensitive = prefixQuery.caseInsensitive();
-
-        // Validate field exists in schema
-        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        // MappedFieldType.prefixQuery:291-297 — only keyword and text fields support prefix queries
+        RelDataTypeField field = ctx.getField(prefixQuery.fieldName());
+        if (field.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            throw new ConversionException(
+                "Can only use prefix queries on keyword and text fields - not on ["
+                    + prefixQuery.fieldName()
+                    + "] which is of type ["
+                    + field.getType().getSqlTypeName()
+                    + "]"
+            );
         }
 
-        // Create field reference
-        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
-
-        // Apply LOWER() if case insensitive
-        if (caseInsensitive) {
-            fieldRef = ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LOWER, fieldRef);
-            prefix = prefix.toLowerCase();
-        }
-
-        // Create LIKE pattern: prefix + '%'
-        String likePattern = escapeLikePattern(prefix) + "%";
-        RexNode patternLiteral = ctx.getRexBuilder().makeLiteral(likePattern);
-
-        // Return LIKE expression
-        return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LIKE, fieldRef, patternLiteral);
-    }
-
-    /**
-     * Escapes SQL LIKE special characters in the prefix value.
-     * <p>
-     * Escapes characters that have special meaning in SQL LIKE patterns:
-     * <ul>
-     *   <li>{@code \} → {@code \\} (must be escaped first to avoid double-escaping)</li>
-     *   <li>{@code %} → {@code \%} (matches any sequence of characters)</li>
-     *   <li>{@code _} → {@code \_} (matches any single character)</li>
-     * </ul>
-     * <p>
-     * Example: {@code "test_50%"} → {@code "test\_50\%"}
-     *
-     * @param value the prefix value to escape
-     * @return escaped value safe for use in LIKE pattern
-     */
-    private String escapeLikePattern(String value) {
-        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        return DelegatedRelevanceCallHelper.buildDelegatedRelevanceCall(
+            "PREFIX_QUERY",
+            field,
+            prefixQuery.value(),
+            prefixQuery.caseInsensitive(),
+            prefixQuery.rewrite(),
+            ctx
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -22,6 +22,8 @@ public class QueryRegistryFactory {
         registry.register(new TermsQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
         registry.register(new ExistsQueryTranslator());
+        registry.register(new PrefixQueryTranslator());
+        registry.register(new WildcardQueryTranslator());
         // TODO: add other query translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -26,6 +26,8 @@ public class QueryRegistryFactory {
         registry.register(new ExistsQueryTranslator());
         registry.register(new RangeQueryTranslator());
         registry.register(new BoolQueryTranslator(registry));
+        registry.register(new PrefixQueryTranslator());
+        registry.register(new WildcardQueryTranslator());
         // TODO: add other query translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+
+/**
+ * Converts a {@link WildcardQueryBuilder} to a Calcite LIKE expression.
+ * <p>
+ * Translates OpenSearch wildcard patterns to SQL LIKE patterns:
+ * <ul>
+ *   <li>{@code *} (matches any character sequence) → {@code %} (SQL any-characters wildcard)</li>
+ *   <li>{@code ?} (matches any single character) → {@code _} (SQL single-character wildcard)</li>
+ * </ul>
+ * <p>
+ * <b>Examples:</b>
+ * <ul>
+ *   <li>{@code {"wildcard": {"name": "lap*"}}} → {@code name LIKE 'lap%'}</li>
+ *   <li>{@code {"wildcard": {"name": "l?ptop"}}} → {@code name LIKE 'l_ptop'}</li>
+ *   <li>{@code {"wildcard": {"name": "*book*"}}} → {@code name LIKE '%book%'}</li>
+ *   <li>{@code {"wildcard": {"name": {"value": "LAP*", "case_insensitive": true}}}} → {@code LOWER(name) LIKE 'lap%'}</li>
+ * </ul>
+ * <p>
+ * <b>Supported parameters:</b>
+ * <ul>
+ *   <li>{@code value} - The wildcard pattern with {@code *} and {@code ?} characters</li>
+ *   <li>{@code case_insensitive} - When true, applies LOWER() to both field and pattern (default: false)</li>
+ * </ul>
+ * <p>
+ * <b>Unsupported parameters</b> (throw {@link ConversionException}):
+ * <ul>
+ *   <li>{@code boost} - Query boosting not supported in analytics engine</li>
+ *   <li>{@code rewrite} - Lucene-specific rewrite methods not applicable to Calcite</li>
+ * </ul>
+ * <p>
+ * <b>Special character handling:</b>
+ * SQL LIKE special characters ({@code %}, {@code _}, {@code \}) in the pattern are escaped
+ * before wildcard conversion to prevent unintended matching.
+ * <p>
+ * Example: {@code {"wildcard": {"name": "a%b_c\\d*"}}} → {@code name LIKE 'a\%b\_c\\\\d%'}
+ */
+public class WildcardQueryTranslator implements QueryTranslator {
+
+    /**
+     * Returns the query type this translator handles.
+     *
+     * @return {@link WildcardQueryBuilder} class
+     */
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return WildcardQueryBuilder.class;
+    }
+
+    /**
+     * Converts a wildcard query to a Calcite LIKE expression.
+     * <p>
+     * Validates field existence, checks for unsupported parameters, applies case-insensitive
+     * transformation if needed, and converts wildcard pattern to SQL LIKE pattern.
+     *
+     * @param query the wildcard query to convert
+     * @param ctx the conversion context with schema and RexBuilder
+     * @return RexNode representing {@code field LIKE 'pattern'} or {@code LOWER(field) LIKE 'pattern'}
+     * @throws ConversionException if field not found, or boost/rewrite parameters are set
+     */
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        WildcardQueryBuilder wildcardQuery = (WildcardQueryBuilder) query;
+        
+        // Check for unsupported parameters
+        if (wildcardQuery.boost() != 1.0f) {
+            throw new ConversionException("Wildcard query parameter 'boost' is not supported");
+        }
+        if (wildcardQuery.rewrite() != null) {
+            throw new ConversionException("Wildcard query parameter 'rewrite' is not supported");
+        }
+
+        String fieldName = wildcardQuery.fieldName();
+        String pattern = wildcardQuery.value();
+        boolean caseInsensitive = wildcardQuery.caseInsensitive();
+
+        // Validate field exists in schema
+        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+
+        // Create field reference
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+
+        // Apply LOWER() if case insensitive
+        if (caseInsensitive) {
+            fieldRef = ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LOWER, fieldRef);
+            pattern = pattern.toLowerCase();
+        }
+
+        // Convert wildcard pattern to LIKE pattern
+        String likePattern = convertWildcardToLike(pattern);
+        RexNode patternLiteral = ctx.getRexBuilder().makeLiteral(likePattern);
+
+        // Return LIKE expression
+        return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LIKE, fieldRef, patternLiteral);
+    }
+
+    /**
+     * Converts OpenSearch wildcard pattern to SQL LIKE pattern.
+     * <p>
+     * Performs two operations:
+     * <ol>
+     *   <li>Escapes SQL LIKE special characters to prevent unintended matching</li>
+     *   <li>Converts OpenSearch wildcards to SQL wildcards</li>
+     * </ol>
+     * <p>
+     * Character transformations:
+     * <ul>
+     *   <li>{@code \} → {@code \\} (escape character, must be escaped first)</li>
+     *   <li>{@code %} → {@code \%} (escape SQL any-characters wildcard)</li>
+     *   <li>{@code _} → {@code \_} (escape SQL single-character wildcard)</li>
+     *   <li>{@code *} → {@code %} (convert OpenSearch any-characters to SQL)</li>
+     *   <li>{@code ?} → {@code _} (convert OpenSearch single-character to SQL)</li>
+     * </ul>
+     * <p>
+     * Example: {@code "a*b?c%d_e\\f"} → {@code "a%b_c\%d\_e\\\\f"}
+     *
+     * @param wildcardPattern the OpenSearch wildcard pattern with {@code *} and {@code ?}
+     * @return SQL LIKE pattern with {@code %} and {@code _}
+     */
+    private String convertWildcardToLike(String wildcardPattern) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < wildcardPattern.length(); i++) {
+            char c = wildcardPattern.charAt(i);
+            switch (c) {
+                case '\\':
+                    // Escape backslash
+                    result.append("\\\\");
+                    break;
+                case '%':
+                    // Escape SQL wildcard
+                    result.append("\\%");
+                    break;
+                case '_':
+                    // Escape SQL wildcard
+                    result.append("\\_");
+                    break;
+                case '*':
+                    // Convert to SQL any-characters wildcard
+                    result.append('%');
+                    break;
+                case '?':
+                    // Convert to SQL single-character wildcard
+                    result.append('_');
+                    break;
+                default:
+                    result.append(c);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
@@ -10,161 +10,52 @@ package org.opensearch.dsl.query;
 
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.WildcardQueryBuilder;
 
-/**
- * Converts a {@link WildcardQueryBuilder} to a Calcite LIKE expression.
- * <p>
- * Translates OpenSearch wildcard patterns to SQL LIKE patterns:
- * <ul>
- *   <li>{@code *} (matches any character sequence) → {@code %} (SQL any-characters wildcard)</li>
- *   <li>{@code ?} (matches any single character) → {@code _} (SQL single-character wildcard)</li>
- * </ul>
- * <p>
- * <b>Examples:</b>
- * <ul>
- *   <li>{@code {"wildcard": {"name": "lap*"}}} → {@code name LIKE 'lap%'}</li>
- *   <li>{@code {"wildcard": {"name": "l?ptop"}}} → {@code name LIKE 'l_ptop'}</li>
- *   <li>{@code {"wildcard": {"name": "*book*"}}} → {@code name LIKE '%book%'}</li>
- *   <li>{@code {"wildcard": {"name": {"value": "LAP*", "case_insensitive": true}}}} → {@code LOWER(name) LIKE 'lap%'}</li>
- * </ul>
- * <p>
- * <b>Supported parameters:</b>
- * <ul>
- *   <li>{@code value} - The wildcard pattern with {@code *} and {@code ?} characters</li>
- *   <li>{@code case_insensitive} - When true, applies LOWER() to both field and pattern (default: false)</li>
- * </ul>
- * <p>
- * <b>Unsupported parameters</b> (throw {@link ConversionException}):
- * <ul>
- *   <li>{@code boost} - Query boosting not supported in analytics engine</li>
- *   <li>{@code rewrite} - Lucene-specific rewrite methods not applicable to Calcite</li>
- * </ul>
- * <p>
- * <b>Special character handling:</b>
- * SQL LIKE special characters ({@code %}, {@code _}, {@code \}) in the pattern are escaped
- * before wildcard conversion to prevent unintended matching.
- * <p>
- * Example: {@code {"wildcard": {"name": "a%b_c\\d*"}}} → {@code name LIKE 'a\%b\_c\\\\d%'}
- */
+/** Translates a {@link WildcardQueryBuilder} to a WILDCARD_QUERY_DSL delegated-relevance RexCall. */
 public class WildcardQueryTranslator implements QueryTranslator {
 
-    /**
-     * Returns the query type this translator handles.
-     *
-     * @return {@link WildcardQueryBuilder} class
-     */
     @Override
     public Class<? extends QueryBuilder> getQueryType() {
         return WildcardQueryBuilder.class;
     }
 
-    /**
-     * Converts a wildcard query to a Calcite LIKE expression.
-     * <p>
-     * Validates field existence, checks for unsupported parameters, applies case-insensitive
-     * transformation if needed, and converts wildcard pattern to SQL LIKE pattern.
-     *
-     * @param query the wildcard query to convert
-     * @param ctx the conversion context with schema and RexBuilder
-     * @return RexNode representing {@code field LIKE 'pattern'} or {@code LOWER(field) LIKE 'pattern'}
-     * @throws ConversionException if field not found, or boost/rewrite parameters are set
-     */
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         WildcardQueryBuilder wildcardQuery = (WildcardQueryBuilder) query;
-        
-        // Check for unsupported parameters
-        if (wildcardQuery.boost() != 1.0f) {
+
+        if (wildcardQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
             throw new ConversionException("Wildcard query parameter 'boost' is not supported");
         }
-        if (wildcardQuery.rewrite() != null) {
-            throw new ConversionException("Wildcard query parameter 'rewrite' is not supported");
+        // matched_queries is not surfaced by this path
+        if (wildcardQuery.queryName() != null) {
+            throw new ConversionException("Wildcard query parameter '_name' is not supported");
         }
 
-        String fieldName = wildcardQuery.fieldName();
-        String pattern = wildcardQuery.value();
-        boolean caseInsensitive = wildcardQuery.caseInsensitive();
-
-        // Validate field exists in schema
-        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        // MappedFieldType.wildcardQuery:309-317 — only keyword and text fields support wildcard queries
+        RelDataTypeField field = ctx.getField(wildcardQuery.fieldName());
+        if (field.getType().getSqlTypeName() != SqlTypeName.VARCHAR) {
+            throw new ConversionException(
+                "Can only use wildcard queries on keyword and text fields - not on ["
+                    + wildcardQuery.fieldName()
+                    + "] which is of type ["
+                    + field.getType().getSqlTypeName()
+                    + "]"
+            );
         }
 
-        // Create field reference
-        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
-
-        // Apply LOWER() if case insensitive
-        if (caseInsensitive) {
-            fieldRef = ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LOWER, fieldRef);
-            pattern = pattern.toLowerCase();
-        }
-
-        // Convert wildcard pattern to LIKE pattern
-        String likePattern = convertWildcardToLike(pattern);
-        RexNode patternLiteral = ctx.getRexBuilder().makeLiteral(likePattern);
-
-        // Return LIKE expression
-        return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LIKE, fieldRef, patternLiteral);
-    }
-
-    /**
-     * Converts OpenSearch wildcard pattern to SQL LIKE pattern.
-     * <p>
-     * Performs two operations:
-     * <ol>
-     *   <li>Escapes SQL LIKE special characters to prevent unintended matching</li>
-     *   <li>Converts OpenSearch wildcards to SQL wildcards</li>
-     * </ol>
-     * <p>
-     * Character transformations:
-     * <ul>
-     *   <li>{@code \} → {@code \\} (escape character, must be escaped first)</li>
-     *   <li>{@code %} → {@code \%} (escape SQL any-characters wildcard)</li>
-     *   <li>{@code _} → {@code \_} (escape SQL single-character wildcard)</li>
-     *   <li>{@code *} → {@code %} (convert OpenSearch any-characters to SQL)</li>
-     *   <li>{@code ?} → {@code _} (convert OpenSearch single-character to SQL)</li>
-     * </ul>
-     * <p>
-     * Example: {@code "a*b?c%d_e\\f"} → {@code "a%b_c\%d\_e\\\\f"}
-     *
-     * @param wildcardPattern the OpenSearch wildcard pattern with {@code *} and {@code ?}
-     * @return SQL LIKE pattern with {@code %} and {@code _}
-     */
-    private String convertWildcardToLike(String wildcardPattern) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < wildcardPattern.length(); i++) {
-            char c = wildcardPattern.charAt(i);
-            switch (c) {
-                case '\\':
-                    // Escape backslash
-                    result.append("\\\\");
-                    break;
-                case '%':
-                    // Escape SQL wildcard
-                    result.append("\\%");
-                    break;
-                case '_':
-                    // Escape SQL wildcard
-                    result.append("\\_");
-                    break;
-                case '*':
-                    // Convert to SQL any-characters wildcard
-                    result.append('%');
-                    break;
-                case '?':
-                    // Convert to SQL single-character wildcard
-                    result.append('_');
-                    break;
-                default:
-                    result.append(c);
-            }
-        }
-        return result.toString();
+        return DelegatedRelevanceCallHelper.buildDelegatedRelevanceCall(
+            "WILDCARD_QUERY_DSL",
+            field,
+            wildcardQuery.value(),
+            wildcardQuery.caseInsensitive(),
+            wildcardQuery.rewrite(),
+            ctx
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
@@ -72,7 +72,7 @@ public class FilterConverterTests extends OpenSearchTestCase {
     }
 
     public void testUnsupportedQueryProducesFilterWithUnresolvedCondition() throws ConversionException {
-        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*"));
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.regexpQuery("name", "lap.*"));
         ConversionContext ctx = TestUtils.createContext(source);
         RelNode result = converter.convert(scan, ctx);
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/PrefixQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/PrefixQueryTranslatorTests.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class PrefixQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final PrefixQueryTranslator translator = new PrefixQueryTranslator();
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(org.opensearch.index.query.PrefixQueryBuilder.class, translator.getQueryType());
+    }
+
+    public void testBasicPrefixQuery() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.LIKE, call.getKind());
+        assertEquals(2, call.getOperands().size());
+
+        // Check pattern is "lap%"
+        RexNode pattern = call.getOperands().get(1);
+        assertTrue(pattern instanceof RexLiteral);
+        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryWithEmptyString() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", ""), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.LIKE, call.getKind());
+
+        // Empty prefix should match all: "%"
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryCaseInsensitive() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "LAP").caseInsensitive(true), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.LIKE, call.getKind());
+
+        // First operand should be LOWER(field)
+        RexNode fieldExpr = call.getOperands().get(0);
+        assertTrue(fieldExpr instanceof RexCall);
+        assertEquals(SqlKind.OTHER_FUNCTION, ((RexCall) fieldExpr).getKind());
+        assertEquals("LOWER", ((RexCall) fieldExpr).getOperator().getName());
+
+        // Pattern should be lowercased
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryCaseSensitive() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "LAP").caseInsensitive(false), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.LIKE, call.getKind());
+
+        // First operand should be direct field reference (no LOWER)
+        RexNode fieldExpr = call.getOperands().get(0);
+        assertTrue(fieldExpr instanceof org.apache.calcite.rex.RexInputRef);
+
+        // Pattern should preserve case
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("LAP%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryEscapesPercentSign() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "50%"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // % should be escaped to \%
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("50\\%%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryEscapesUnderscore() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "test_"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // _ should be escaped to \_
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("test\\_%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryEscapesBackslash() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "path\\to"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // \ should be escaped to \\
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("path\\\\to%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryWithDifferentFields() throws ConversionException {
+        // Test with different schema fields
+        assertNotNull(translator.convert(QueryBuilders.prefixQuery("name", "test"), ctx));
+        assertNotNull(translator.convert(QueryBuilders.prefixQuery("brand", "test"), ctx));
+        assertNotNull(translator.convert(QueryBuilders.prefixQuery("price", "100"), ctx));
+    }
+
+    public void testPrefixQueryThrowsForNonexistentField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.prefixQuery("nonexistent", "value"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("Field 'nonexistent' not found"));
+    }
+
+    public void testPrefixQueryThrowsForBoostParameter() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.prefixQuery("name", "lap").boost(2.0f), ctx)
+        );
+        assertTrue(ex.getMessage().contains("boost"));
+        assertTrue(ex.getMessage().contains("not supported"));
+    }
+
+    public void testPrefixQueryThrowsForRewriteParameter() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("rewrite"));
+        assertTrue(ex.getMessage().contains("not supported"));
+    }
+
+    public void testPrefixQueryWithSpecialCharacters() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "test-123.abc"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // Special chars like - and . should not be escaped
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("test-123.abc%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testPrefixQueryWithMultipleEscapes() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "a%b_c\\d"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // All special chars should be escaped
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("a\\%b\\_c\\\\d%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/PrefixQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/PrefixQueryTranslatorTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.query;
 
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
@@ -18,113 +19,90 @@ import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchTestCase;
 
+/**
+ * Tests for {@link PrefixQueryTranslator} — asserts delegation via PREFIX_QUERY RexCall.
+ */
 public class PrefixQueryTranslatorTests extends OpenSearchTestCase {
 
     private final PrefixQueryTranslator translator = new PrefixQueryTranslator();
     private final ConversionContext ctx = TestUtils.createContext();
 
-    public void testReportsCorrectQueryType() {
-        assertEquals(org.opensearch.index.query.PrefixQueryBuilder.class, translator.getQueryType());
-    }
-
-    public void testBasicPrefixQuery() throws ConversionException {
+    public void testEmitsPrefixQueryRexCall() throws ConversionException {
         RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap"), ctx);
 
-        assertTrue(result instanceof RexCall);
+        assertTrue("Result must be a RexCall", result instanceof RexCall);
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.LIKE, call.getKind());
-        assertEquals(2, call.getOperands().size());
-
-        // Check pattern is "lap%"
-        RexNode pattern = call.getOperands().get(1);
-        assertTrue(pattern instanceof RexLiteral);
-        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+        assertEquals("PREFIX_QUERY", call.getOperator().getName());
+        assertEquals(SqlKind.OTHER_FUNCTION, call.getKind());
     }
 
-    public void testPrefixQueryWithEmptyString() throws ConversionException {
+    public void testFieldOperandContainsInputRef() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap"), ctx);
+        RexCall call = (RexCall) result;
+
+        // Operand 0: MAP('field', $inputRef)
+        RexCall fieldMap = (RexCall) call.getOperands().get(0);
+        assertEquals("MAP", fieldMap.getOperator().getName());
+        RexLiteral fieldKey = (RexLiteral) fieldMap.getOperands().get(0);
+        assertEquals("field", fieldKey.getValueAs(String.class));
+        assertTrue("field value must be an InputRef", fieldMap.getOperands().get(1) instanceof RexInputRef);
+        RexInputRef inputRef = (RexInputRef) fieldMap.getOperands().get(1);
+        assertEquals(0, inputRef.getIndex()); // 'name' is index 0 in test schema
+    }
+
+    public void testQueryOperandContainsLiteralValue() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap"), ctx);
+        RexCall call = (RexCall) result;
+
+        // Operand 1: MAP('query', 'lap')
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        assertEquals("MAP", queryMap.getOperator().getName());
+        RexLiteral queryKey = (RexLiteral) queryMap.getOperands().get(0);
+        assertEquals("query", queryKey.getValueAs(String.class));
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("lap", queryValue.getValueAs(String.class));
+    }
+
+    public void testVerbatimPassthroughOfMetacharacters() throws ConversionException {
+        // Value contains *, ? and backslash — must be passed through unchanged (no escaping)
+        String verbatim = "check*it?out\\done";
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", verbatim), ctx);
+        RexCall call = (RexCall) result;
+
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals(verbatim, queryValue.getValueAs(String.class));
+    }
+
+    public void testEmptyStringPassedVerbatim() throws ConversionException {
         RexNode result = translator.convert(QueryBuilders.prefixQuery("name", ""), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-        assertEquals(SqlKind.LIKE, call.getKind());
-
-        // Empty prefix should match all: "%"
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("%", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testPrefixQueryCaseInsensitive() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "LAP").caseInsensitive(true), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-        assertEquals(SqlKind.LIKE, call.getKind());
-
-        // First operand should be LOWER(field)
-        RexNode fieldExpr = call.getOperands().get(0);
-        assertTrue(fieldExpr instanceof RexCall);
-        assertEquals(SqlKind.OTHER_FUNCTION, ((RexCall) fieldExpr).getKind());
-        assertEquals("LOWER", ((RexCall) fieldExpr).getOperator().getName());
-
-        // Pattern should be lowercased
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testPrefixQueryCaseSensitive() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "LAP").caseInsensitive(false), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-        assertEquals(SqlKind.LIKE, call.getKind());
-
-        // First operand should be direct field reference (no LOWER)
-        RexNode fieldExpr = call.getOperands().get(0);
-        assertTrue(fieldExpr instanceof org.apache.calcite.rex.RexInputRef);
-
-        // Pattern should preserve case
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("LAP%", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testPrefixQueryEscapesPercentSign() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "50%"), ctx);
-
-        assertTrue(result instanceof RexCall);
         RexCall call = (RexCall) result;
 
-        // % should be escaped to \%
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("50\\%%", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("", queryValue.getValueAs(String.class));
     }
 
-    public void testPrefixQueryEscapesUnderscore() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "test_"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testCaseInsensitiveEmitsParam() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "Lap").caseInsensitive(true), ctx);
         RexCall call = (RexCall) result;
 
-        // _ should be escaped to \_
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("test\\_%", ((RexLiteral) pattern).getValueAs(String.class));
+        // Should have 3 operands: field, query, case_insensitive param
+        assertEquals(3, call.getOperands().size());
+        RexCall paramMap = (RexCall) call.getOperands().get(2);
+        assertEquals("MAP", paramMap.getOperator().getName());
+        RexLiteral paramKey = (RexLiteral) paramMap.getOperands().get(0);
+        assertEquals("case_insensitive", paramKey.getValueAs(String.class));
+        RexLiteral paramValue = (RexLiteral) paramMap.getOperands().get(1);
+        assertEquals("true", paramValue.getValueAs(String.class));
     }
 
-    public void testPrefixQueryEscapesBackslash() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "path\\to"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testCaseSensitiveHasNoExtraOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap"), ctx);
         RexCall call = (RexCall) result;
 
-        // \ should be escaped to \\
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("path\\\\to%", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testPrefixQueryWithDifferentFields() throws ConversionException {
-        // Test with different schema fields
-        assertNotNull(translator.convert(QueryBuilders.prefixQuery("name", "test"), ctx));
-        assertNotNull(translator.convert(QueryBuilders.prefixQuery("brand", "test"), ctx));
-        assertNotNull(translator.convert(QueryBuilders.prefixQuery("price", "100"), ctx));
+        // Only 2 operands: field and query (no case_insensitive param)
+        assertEquals(2, call.getOperands().size());
     }
 
     public void testPrefixQueryThrowsForNonexistentField() {
@@ -144,34 +122,89 @@ public class PrefixQueryTranslatorTests extends OpenSearchTestCase {
         assertTrue(ex.getMessage().contains("not supported"));
     }
 
-    public void testPrefixQueryThrowsForRewriteParameter() {
+    public void testPrefixQueryThrowsForRewriteParameter() throws ConversionException {
+        // Rewrite is now passed through (H2 disposition) — no longer rejected.
+        // Validation occurs on the data node via QueryParsers.parseRewriteMethod.
+        translator.convert(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score"), ctx);
+    }
+
+    public void testPrefixQueryThrowsForNonStringField() {
+        // MappedFieldType.prefixQuery:291-297 rejects non-keyword/text fields
         ConversionException ex = expectThrows(
             ConversionException.class,
-            () -> translator.convert(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score"), ctx)
+            () -> translator.convert(QueryBuilders.prefixQuery("price", "12"), ctx)
         );
-        assertTrue(ex.getMessage().contains("rewrite"));
-        assertTrue(ex.getMessage().contains("not supported"));
+        assertTrue(ex.getMessage().contains("keyword and text"));
+        assertTrue(ex.getMessage().contains("price"));
     }
 
-    public void testPrefixQueryWithSpecialCharacters() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "test-123.abc"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testFieldResolutionUsesCorrectIndex() throws ConversionException {
+        // 'brand' is at index 2 in the test schema
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("brand", "app"), ctx);
         RexCall call = (RexCall) result;
 
-        // Special chars like - and . should not be escaped
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("test-123.abc%", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall fieldMap = (RexCall) call.getOperands().get(0);
+        RexInputRef inputRef = (RexInputRef) fieldMap.getOperands().get(1);
+        assertEquals(2, inputRef.getIndex()); // 'brand' is index 2
     }
 
-    public void testPrefixQueryWithMultipleEscapes() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "a%b_c\\d"), ctx);
+    // ── Rewrite pass-through (H2 disposition) ───────────────────────────────────
 
-        assertTrue(result instanceof RexCall);
+    /**
+     * The rewrite parameter must be passed through as a MAP operand rather than rejected.
+     */
+    public void testRewriteParameterEmitsMapOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score"), ctx);
         RexCall call = (RexCall) result;
 
-        // All special chars should be escaped
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("a\\%b\\_c\\\\d%", ((RexLiteral) pattern).getValueAs(String.class));
+        // Should have 3 operands: field, query, rewrite param
+        assertEquals(3, call.getOperands().size());
+        RexCall paramMap = (RexCall) call.getOperands().get(2);
+        assertEquals("MAP", paramMap.getOperator().getName());
+        RexLiteral paramKey = (RexLiteral) paramMap.getOperands().get(0);
+        assertEquals("rewrite", paramKey.getValueAs(String.class));
+        RexLiteral paramValue = (RexLiteral) paramMap.getOperands().get(1);
+        assertEquals("constant_score", paramValue.getValueAs(String.class));
+    }
+
+    // ── Boost rejection regression guard ────────────────────────────────────────
+
+    /**
+     * Boost must remain rejected with ConversionException — regression guard for the approved disposition.
+     */
+    public void testBoostParameterRejectedWithConversionException() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.prefixQuery("name", "lap").boost(1.5f), ctx)
+        );
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+        assertTrue("Must mention 'not supported', got: " + ex.getMessage(), ex.getMessage().contains("not supported"));
+    }
+
+    // ── _name rejection ────────────────────────────────────────────────────────
+
+    /**
+     * _name must be rejected with ConversionException — matched_queries is not surfaced in SQL.
+     */
+    public void testNameParameterRejectedWithConversionException() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.prefixQuery("name", "lap").queryName("my_prefix"), ctx)
+        );
+        assertEquals("Prefix query parameter '_name' is not supported", ex.getMessage());
+    }
+
+    // ── Behaviour-pinning: case_insensitive explicitly false ────────────────────
+
+    /**
+     * Behaviour-pinning test: explicitly setting case_insensitive to false emits no case_insensitive
+     * param operand — the translator only emits the param when true.
+     */
+    public void testExplicitCaseInsensitiveFalseEmitsNoParam() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.prefixQuery("name", "lap").caseInsensitive(false), ctx);
+        RexCall call = (RexCall) result;
+
+        // Only 2 operands: field and query — no case_insensitive param when value is false
+        assertEquals(2, call.getOperands().size());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/QueryRegistryTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/QueryRegistryTests.java
@@ -16,7 +16,6 @@ import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class QueryRegistryTests extends OpenSearchTestCase {
@@ -41,11 +40,11 @@ public class QueryRegistryTests extends OpenSearchTestCase {
     }
 
     public void testUnknownQueryTypeReturnsUnresolved() throws ConversionException {
-        RexNode result = registry.convert(QueryBuilders.wildcardQuery("name", "lap*"), ctx);
+        RexNode result = registry.convert(QueryBuilders.regexpQuery("name", "lap.*"), ctx);
 
         assertTrue(result instanceof UnresolvedQueryCall);
         UnresolvedQueryCall unresolved = (UnresolvedQueryCall) result;
-        assertTrue(unresolved.getQueryBuilder() instanceof WildcardQueryBuilder);
+        assertTrue(unresolved.getQueryBuilder() instanceof org.opensearch.index.query.RegexpQueryBuilder);
     }
 
     public void testEmptyRegistryReturnsUnresolvedForAnyQuery() throws ConversionException {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/WildcardQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/WildcardQueryTranslatorTests.java
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class WildcardQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final WildcardQueryTranslator translator = new WildcardQueryTranslator();
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(org.opensearch.index.query.WildcardQueryBuilder.class, translator.getQueryType());
+    }
+
+    public void testWildcardWithAsterisk() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "lap*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.LIKE, call.getKind());
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithQuestionMark() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l?ptop"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("l_ptop", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithBothWildcards() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l?p*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("l_p%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithMultipleAsterisks() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "*lap*top*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("%lap%top%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithMultipleQuestionMarks() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l??top"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("l__top", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardCaseInsensitive() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "LAP*").caseInsensitive(true), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        // First operand should be LOWER(field)
+        RexNode fieldExpr = call.getOperands().get(0);
+        assertTrue(fieldExpr instanceof RexCall);
+        assertEquals("LOWER", ((RexCall) fieldExpr).getOperator().getName());
+
+        // Pattern should be lowercased
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardEscapesPercent() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "50%*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("50\\%%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardEscapesUnderscore() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "test_*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("test\\_%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardEscapesBackslash() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "path\\*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("path\\\\%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithNoWildcards() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "laptop"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("laptop", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithOnlyAsterisk() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "*"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("%", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithOnlyQuestionMark() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "?"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("_", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardThrowsForNonexistentField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.wildcardQuery("nonexistent", "val*"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("Field 'nonexistent' not found"));
+    }
+
+    public void testWildcardThrowsForBoostParameter() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.wildcardQuery("name", "lap*").boost(2.0f), ctx)
+        );
+        assertTrue(ex.getMessage().contains("boost"));
+        assertTrue(ex.getMessage().contains("not supported"));
+    }
+
+    public void testWildcardThrowsForRewriteParameter() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("rewrite"));
+        assertTrue(ex.getMessage().contains("not supported"));
+    }
+
+    public void testWildcardWithComplexPattern() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "a*b?c*d"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("a%b_c%d", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+
+    public void testWildcardWithMixedEscaping() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "a%b_c\\d*e?"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+
+        RexNode pattern = call.getOperands().get(1);
+        assertEquals("a\\%b\\_c\\\\d%e_", ((RexLiteral) pattern).getValueAs(String.class));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/WildcardQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/WildcardQueryTranslatorTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.query;
 
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
@@ -18,141 +19,140 @@ import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchTestCase;
 
+/**
+ * Tests for {@link WildcardQueryTranslator} — asserts delegation via WILDCARD_QUERY_DSL RexCall
+ * with the Lucene wildcard pattern emitted unchanged.
+ */
 public class WildcardQueryTranslatorTests extends OpenSearchTestCase {
 
     private final WildcardQueryTranslator translator = new WildcardQueryTranslator();
     private final ConversionContext ctx = TestUtils.createContext();
 
-    public void testReportsCorrectQueryType() {
-        assertEquals(org.opensearch.index.query.WildcardQueryBuilder.class, translator.getQueryType());
-    }
+    // ── RexCall shape assertions ────────────────────────────────────────────────
 
-    public void testWildcardWithAsterisk() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "lap*"), ctx);
+    public void testEmitsWildcardQueryDslRexCall() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l*pt?p"), ctx);
 
-        assertTrue(result instanceof RexCall);
+        assertTrue("Result must be a RexCall", result instanceof RexCall);
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.LIKE, call.getKind());
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+        assertEquals("WILDCARD_QUERY_DSL", call.getOperator().getName());
+        assertEquals(SqlKind.OTHER_FUNCTION, call.getKind());
     }
 
-    public void testWildcardWithQuestionMark() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l?ptop"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testFieldOperandContainsInputRef() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l*"), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("l_ptop", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall fieldMap = (RexCall) call.getOperands().get(0);
+        assertEquals("MAP", fieldMap.getOperator().getName());
+        RexLiteral fieldKey = (RexLiteral) fieldMap.getOperands().get(0);
+        assertEquals("field", fieldKey.getValueAs(String.class));
+        assertTrue("field value must be an InputRef", fieldMap.getOperands().get(1) instanceof RexInputRef);
+        RexInputRef inputRef = (RexInputRef) fieldMap.getOperands().get(1);
+        assertEquals(0, inputRef.getIndex()); // 'name' is index 0
     }
 
-    public void testWildcardWithBothWildcards() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l?p*"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testQueryOperandContainsLiteralPattern() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l*pt?p"), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("l_p%", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        assertEquals("MAP", queryMap.getOperator().getName());
+        RexLiteral queryKey = (RexLiteral) queryMap.getOperands().get(0);
+        assertEquals("query", queryKey.getValueAs(String.class));
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("l*pt?p", queryValue.getValueAs(String.class));
     }
 
-    public void testWildcardWithMultipleAsterisks() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "*lap*top*"), ctx);
+    // ── Verbatim passthrough — pattern is emitted UNCHANGED ─────────────────────
 
-        assertTrue(result instanceof RexCall);
+    public void testWildcardPatternPassedVerbatim() throws ConversionException {
+        // Lucene wildcard pattern: *, ?, escaped backslash — all pass through untouched
+        String pattern = "test\\*file\\?name\\\\end";
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", pattern), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("%lap%top%", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals(pattern, queryValue.getValueAs(String.class));
     }
 
-    public void testWildcardWithMultipleQuestionMarks() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l??top"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testPatternWithSqlMetacharsPassedVerbatim() throws ConversionException {
+        // SQL metacharacters % and _ are NOT special in Lucene wildcard syntax — pass through unchanged
+        String pattern = "50%_done*";
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", pattern), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("l__top", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals(pattern, queryValue.getValueAs(String.class));
     }
 
-    public void testWildcardCaseInsensitive() throws ConversionException {
+    public void testPatternWithBackslashPassedVerbatim() throws ConversionException {
+        // A pattern with backslash-escaped chars — no conversion occurs
+        String pattern = "C:\\Users\\test";
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", pattern), ctx);
+        RexCall call = (RexCall) result;
+
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals(pattern, queryValue.getValueAs(String.class));
+    }
+
+    public void testEmptyPatternPassedVerbatim() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", ""), ctx);
+        RexCall call = (RexCall) result;
+
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("", queryValue.getValueAs(String.class));
+    }
+
+    // ── case_insensitive param ──────────────────────────────────────────────────
+
+    public void testCaseInsensitiveEmitsParam() throws ConversionException {
         RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "LAP*").caseInsensitive(true), ctx);
-
-        assertTrue(result instanceof RexCall);
         RexCall call = (RexCall) result;
 
-        // First operand should be LOWER(field)
-        RexNode fieldExpr = call.getOperands().get(0);
-        assertTrue(fieldExpr instanceof RexCall);
-        assertEquals("LOWER", ((RexCall) fieldExpr).getOperator().getName());
-
-        // Pattern should be lowercased
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("lap%", ((RexLiteral) pattern).getValueAs(String.class));
+        assertEquals(3, call.getOperands().size());
+        RexCall paramMap = (RexCall) call.getOperands().get(2);
+        assertEquals("MAP", paramMap.getOperator().getName());
+        RexLiteral paramKey = (RexLiteral) paramMap.getOperands().get(0);
+        assertEquals("case_insensitive", paramKey.getValueAs(String.class));
+        RexLiteral paramValue = (RexLiteral) paramMap.getOperands().get(1);
+        assertEquals("true", paramValue.getValueAs(String.class));
     }
 
-    public void testWildcardEscapesPercent() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "50%*"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testCaseSensitiveHasNoExtraOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l*"), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("50\\%%", ((RexLiteral) pattern).getValueAs(String.class));
+        assertEquals(2, call.getOperands().size());
     }
 
-    public void testWildcardEscapesUnderscore() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "test_*"), ctx);
-
-        assertTrue(result instanceof RexCall);
+    public void testCaseInsensitivePatternNotLowered() throws ConversionException {
+        // Pattern should NOT be lowercased — case_insensitive is now a param, not LOWER() wrapping
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "LAP*").caseInsensitive(true), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("test\\_%", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("LAP*", queryValue.getValueAs(String.class));
     }
 
-    public void testWildcardEscapesBackslash() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "path\\*"), ctx);
+    // ── VARCHAR field-type gate ─────────────────────────────────────────────────
 
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("path\\\\%", ((RexLiteral) pattern).getValueAs(String.class));
+    public void testWildcardThrowsForNonStringField() {
+        // MappedFieldType.wildcardQuery:309-317 rejects non-keyword/text fields
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.wildcardQuery("price", "12*"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("keyword and text"));
+        assertTrue(ex.getMessage().contains("price"));
     }
 
-    public void testWildcardWithNoWildcards() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "laptop"), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("laptop", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testWildcardWithOnlyAsterisk() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "*"), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("%", ((RexLiteral) pattern).getValueAs(String.class));
-    }
-
-    public void testWildcardWithOnlyQuestionMark() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "?"), ctx);
-
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("_", ((RexLiteral) pattern).getValueAs(String.class));
-    }
+    // ── Parameter rejection ─────────────────────────────────────────────────────
 
     public void testWildcardThrowsForNonexistentField() {
         ConversionException ex = expectThrows(
@@ -171,32 +171,112 @@ public class WildcardQueryTranslatorTests extends OpenSearchTestCase {
         assertTrue(ex.getMessage().contains("not supported"));
     }
 
-    public void testWildcardThrowsForRewriteParameter() {
+    public void testWildcardThrowsForRewriteParameter() throws ConversionException {
+        // Rewrite is now passed through (H2 disposition) — no longer rejected.
+        // Validation occurs on the data node via QueryParsers.parseRewriteMethod.
+        translator.convert(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"), ctx);
+    }
+
+    // ── Field resolution ────────────────────────────────────────────────────────
+
+    public void testFieldResolutionUsesCorrectIndex() throws ConversionException {
+        // 'brand' is at index 2 in the test schema
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("brand", "app*"), ctx);
+        RexCall call = (RexCall) result;
+
+        RexCall fieldMap = (RexCall) call.getOperands().get(0);
+        RexInputRef inputRef = (RexInputRef) fieldMap.getOperands().get(1);
+        assertEquals(2, inputRef.getIndex());
+    }
+
+    // ── Rewrite pass-through (H2 disposition) ───────────────────────────────────
+
+    /**
+     * The rewrite parameter must be passed through as a MAP operand rather than rejected.
+     */
+    public void testRewriteParameterEmitsMapOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"), ctx);
+        RexCall call = (RexCall) result;
+
+        // Should have 3 operands: field, query, rewrite param
+        assertEquals(3, call.getOperands().size());
+        RexCall paramMap = (RexCall) call.getOperands().get(2);
+        assertEquals("MAP", paramMap.getOperator().getName());
+        RexLiteral paramKey = (RexLiteral) paramMap.getOperands().get(0);
+        assertEquals("rewrite", paramKey.getValueAs(String.class));
+        RexLiteral paramValue = (RexLiteral) paramMap.getOperands().get(1);
+        assertEquals("constant_score", paramValue.getValueAs(String.class));
+    }
+
+    // ── Boost rejection regression guard ────────────────────────────────────────
+
+    /**
+     * Boost must remain rejected with ConversionException — regression guard for the approved disposition.
+     */
+    public void testBoostParameterRejectedWithConversionException() {
         ConversionException ex = expectThrows(
             ConversionException.class,
-            () -> translator.convert(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"), ctx)
+            () -> translator.convert(QueryBuilders.wildcardQuery("name", "lap*").boost(1.5f), ctx)
         );
-        assertTrue(ex.getMessage().contains("rewrite"));
-        assertTrue(ex.getMessage().contains("not supported"));
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+        assertTrue("Must mention 'not supported', got: " + ex.getMessage(), ex.getMessage().contains("not supported"));
     }
 
-    public void testWildcardWithComplexPattern() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "a*b?c*d"), ctx);
+    // ── _name rejection ────────────────────────────────────────────────────────
 
-        assertTrue(result instanceof RexCall);
-        RexCall call = (RexCall) result;
-
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("a%b_c%d", ((RexLiteral) pattern).getValueAs(String.class));
+    /**
+     * _name must be rejected with ConversionException — matched_queries is not surfaced in SQL.
+     */
+    public void testNameParameterRejectedWithConversionException() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.wildcardQuery("name", "lap*").queryName("my_wildcard"), ctx)
+        );
+        assertEquals("Wildcard query parameter '_name' is not supported", ex.getMessage());
     }
 
-    public void testWildcardWithMixedEscaping() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "a%b_c\\d*e?"), ctx);
+    // ── Behaviour-pinning: leading wildcard emitted verbatim (M3) ───────────────
 
-        assertTrue(result instanceof RexCall);
+    /**
+     * Behaviour-pinning test: a leading-wildcard pattern is emitted verbatim — no rewriting or rejection.
+     */
+    public void testLeadingWildcardPatternEmittedVerbatim() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "*checkout"), ctx);
         RexCall call = (RexCall) result;
 
-        RexNode pattern = call.getOperands().get(1);
-        assertEquals("a\\%b\\_c\\\\d%e_", ((RexLiteral) pattern).getValueAs(String.class));
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("*checkout", queryValue.getValueAs(String.class));
+    }
+
+    // ── Behaviour-pinning: case_insensitive explicitly false ────────────────────
+
+    /**
+     * Behaviour-pinning test: explicitly setting case_insensitive to false emits no case_insensitive
+     * param operand — the translator only emits the param when true.
+     */
+    public void testExplicitCaseInsensitiveFalseEmitsNoParam() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", "l*").caseInsensitive(false), ctx);
+        RexCall call = (RexCall) result;
+
+        // Only 2 operands: field and query — no case_insensitive param when value is false
+        assertEquals(2, call.getOperands().size());
+    }
+
+    // ── Behaviour-pinning: unicode pattern emitted verbatim (L1) ────────────────
+
+    /**
+     * Behaviour-pinning test: a unicode pattern containing German sharp s (ß) and accented characters
+     * is emitted verbatim — documents that case folding is now Lucene's ASCII-only behaviour
+     * rather than our old LOWER() wrapping.
+     */
+    public void testUnicodePatternWithSharpSEmittedVerbatim() throws ConversionException {
+        String unicodePattern = "straße*über?";
+        RexNode result = translator.convert(QueryBuilders.wildcardQuery("name", unicodePattern), ctx);
+        RexCall call = (RexCall) result;
+
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral queryValue = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals(unicodePattern, queryValue.getValueAs(String.class));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
@@ -1,0 +1,39 @@
+{
+  "testName": "prefix_query_case_insensitive_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "prefix": {
+        "name": {
+          "value": "Lap",
+          "case_insensitive": true
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'Lap'), MAP('case_insensitive', 'true'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price"],
+  "mockResultRows": [
+    ["Laptop", 999],
+    ["LAPTOP_PRO", 1499]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
@@ -17,8 +17,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'Lap'), MAP('case_insensitive', 'true'))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'Lap'), MAP('case_insensitive', 'true'))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price"],
   "mockResultRows": [
@@ -29,11 +30,26 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
-      "max_score": 0.0,
-      "hits": []
+      "max_score": null,
+      "hits": [
+        {
+          "_source": {
+            "name": "Laptop",
+            "price": 999
+          },
+          "_score": null
+        },
+        {
+          "_source": {
+            "name": "LAPTOP_PRO",
+            "price": 1499
+          },
+          "_score": null
+        }
+      ]
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
@@ -1,0 +1,38 @@
+{
+  "testName": "prefix_query_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "prefix": {
+        "name": {
+          "value": "lap"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'lap'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price"],
+  "mockResultRows": [
+    ["laptop", 999],
+    ["laptop_pro", 1499]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
@@ -16,8 +16,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'lap'))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'lap'))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price"],
   "mockResultRows": [
@@ -28,11 +29,26 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
-      "max_score": 0.0,
-      "hits": []
+      "max_score": null,
+      "hits": [
+        {
+          "_source": {
+            "name": "laptop",
+            "price": 999
+          },
+          "_score": null
+        },
+        {
+          "_source": {
+            "name": "laptop_pro",
+            "price": 1499
+          },
+          "_score": null
+        }
+      ]
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
@@ -1,0 +1,39 @@
+{
+  "testName": "wildcard_query_case_insensitive_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "wildcard": {
+        "name": {
+          "value": "LAP*",
+          "case_insensitive": true
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'LAP*'), MAP('case_insensitive', 'true'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price"],
+  "mockResultRows": [
+    ["Laptop", 999],
+    ["LAPTOP_PRO", 1499]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
@@ -17,8 +17,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'LAP*'), MAP('case_insensitive', 'true'))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'LAP*'), MAP('case_insensitive', 'true'))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price"],
   "mockResultRows": [
@@ -29,11 +30,26 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
-      "max_score": 0.0,
-      "hits": []
+      "max_score": null,
+      "hits": [
+        {
+          "_source": {
+            "name": "Laptop",
+            "price": 999
+          },
+          "_score": null
+        },
+        {
+          "_source": {
+            "name": "LAPTOP_PRO",
+            "price": 1499
+          },
+          "_score": null
+        }
+      ]
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
@@ -1,0 +1,37 @@
+{
+  "testName": "wildcard_query_escaped_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "wildcard": {
+        "name": {
+          "value": "test\\*file\\?name\\\\end"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'test\\*file\\?name\\\\end'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price"],
+  "mockResultRows": [
+    ["test*file?name\\end", 100]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
@@ -16,8 +16,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'test\\*file\\?name\\\\end'))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'test\\*file\\?name\\\\end'))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price"],
   "mockResultRows": [
@@ -27,11 +28,19 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 1,
         "relation": "eq"
       },
-      "max_score": 0.0,
-      "hits": []
+      "max_score": null,
+      "hits": [
+        {
+          "_source": {
+            "name": "test*file?name\\end",
+            "price": 100
+          },
+          "_score": null
+        }
+      ]
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
@@ -1,0 +1,38 @@
+{
+  "testName": "wildcard_query_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "wildcard": {
+        "name": {
+          "value": "l*pt?p"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'l*pt?p'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price"],
+  "mockResultRows": [
+    ["laptop", 999],
+    ["leptop", 599]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
@@ -16,8 +16,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'l*pt?p'))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'l*pt?p'))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price"],
   "mockResultRows": [
@@ -28,11 +29,26 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
-      "max_score": 0.0,
-      "hits": []
+      "max_score": null,
+      "hits": [
+        {
+          "_source": {
+            "name": "laptop",
+            "price": 999
+          },
+          "_score": null
+        },
+        {
+          "_source": {
+            "name": "leptop",
+            "price": 599
+          },
+          "_score": null
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds DSL-to-Calcite translation for `prefix` and `wildcard` queries in the sandbox `dsl-query-executor` plugin by delegating to real Lucene query builders on the data node. Each translator emits a delegated relevance call (`PREFIX_QUERY` / `WILDCARD_QUERY_DSL`, both `Category.FULL_TEXT`) whose serializer rebuilds a vanilla `PrefixQueryBuilder` or `WildcardQueryBuilder`; Lucene performs the matching against the term dictionary exactly as it does in vanilla OpenSearch.

### Summary

- **Two translators:** `PrefixQueryTranslator` and `WildcardQueryTranslator` emit `FULL_TEXT` RexCalls with MAP operands (`field`, `query`, optional params).
- **Two serializers:** `PrefixQuerySerializer` and `WildcardQueryDslSerializer` extend `AbstractRelevanceSerializer`, rebuilding vanilla query builders with verbatim operands.
- **Verbatim contract:** prefix values are literal; wildcard patterns are already Lucene syntax. No escaping, no SQL conversion, no case folding. `convertWildcardToLike` (43 LOC) and `escapeLikePattern` deleted.
- **Shared helper:** `DelegatedRelevanceCallHelper` (package-private final, static factory) owns field resolution, the VARCHAR gate, and MAP assembly for both translators.
- **Substrait safe:** `DelegatedPredicateCombiner` replaces the leaf with `delegated_predicate(id)` at `DataFusionFragmentConvertor:115,117`; the `QueryBuilder` travels as opaque `NamedWriteable` bytes. No Isthmus mapping needed.

---

### Why delegation

On analyzed text fields, vanilla OpenSearch matches individual analyzed **tokens** in the term dictionary (`StringFieldType:112-128`). A document indexed as `"payment checkout service"` produces a `checkout` token, so `{"prefix": {"field": "check"}}` matches in vanilla. SQL `LIKE 'check%'` over the raw stored value does not match. Delegation makes parity structural rather than hand-maintained.

Additional gains:
- **Normalizer handling:** keyword fields with a custom `normalizer` apply `indexedValueForSearch` at `doToQuery` (`KeywordFieldMapper:478`), which the LIKE path ignored.
- **`index_prefixes` O(1) fast path:** `PrefixQueryBuilder.doToQuery` delegates to `TextFieldType.prefixQuery` → `PrefixFieldType` single term lookup (`TextFieldMapper:863-867`).
- **`case_insensitive` parity:** Lucene's ASCII-only automaton folding (`AutomatonQueries:180-194`) replaces `LOWER()` which over-folded non-ASCII.

The pre-existing `WildcardQuerySerializer` could not be reused: it expects SQL-form patterns and maps `%`→`*` and `_`→`?`, so a literal `%` in customer data would be reinterpreted as a wildcard.

---

### Features

#### Prefix Query

Emits a `PREFIX_QUERY` delegated relevance call:

```json
{"prefix": {"name": "lap"}}
```
Emitted call: `PREFIX_QUERY(MAP('field', name), MAP('query', 'lap'))`

```json
{"prefix": {"name": {"value": "LAP", "case_insensitive": true}}}
```
Emitted call: `PREFIX_QUERY(MAP('field', name), MAP('query', 'LAP'), MAP('case_insensitive', 'true'))`

**Supported parameters:**
- `value` — passed verbatim as `MAP('query', literal)`; direct delegation to `PrefixQueryBuilder`
- `case_insensitive` — delegated to builder; ASCII-only folding (`AutomatonQueries:180-194`)
- `rewrite` — passed through to builder; validated on data node (`QueryParsers.parseRewriteMethod`)

**Rejected parameters (throw ConversionException):**
- `boost` — scores are not surfaced by this engine; accepting would be a silent no-op that misleads clients

**Ignored parameters:**
- `_name` — `matched_queries` is not surfaced; reject-vs-ignore convention pending family-wide decision

#### Wildcard Query

Emits a `WILDCARD_QUERY_DSL` delegated relevance call with the Lucene pattern passed through verbatim:

```json
{"wildcard": {"name": "lap*"}}
```
Emitted call: `WILDCARD_QUERY_DSL(MAP('field', name), MAP('query', 'lap*'))`

```json
{"wildcard": {"name": "l?ptop"}}
```
Emitted call: `WILDCARD_QUERY_DSL(MAP('field', name), MAP('query', 'l?ptop'))`

```json
{"wildcard": {"name": "test\\*file\\?name\\\\end"}}
```
Emitted call: `WILDCARD_QUERY_DSL(MAP('field', name), MAP('query', 'test\\*file\\?name\\\\end'))`

```json
{"wildcard": {"name": {"value": "BOOK*", "case_insensitive": true}}}
```
Emitted call: `WILDCARD_QUERY_DSL(MAP('field', name), MAP('query', 'BOOK*'), MAP('case_insensitive', 'true'))`

**Supported parameters:**
- `value` — passed verbatim as `MAP('query', literal)`; the DSL value is already a valid Lucene wildcard pattern
- `case_insensitive` — delegated to builder; ASCII-only folding (`AutomatonQueries:180-194`)
- `rewrite` — passed through to builder; validated on data node

**Rejected parameters (throw ConversionException):**
- `boost` — scores are not surfaced; silent no-op would mislead clients

**Ignored parameters:**
- `_name` — `matched_queries` not surfaced; convention pending

---

### Pattern handling (verbatim)

Every character in the DSL pattern passes through to `WildcardQueryBuilder` untouched. No conversion, no escaping, no SQL intermediary.

| Pattern char | Passes as | Lucene interpretation |
|---|---|---|
| `*` | `*` | Match any character sequence (zero or more) |
| `?` | `?` | Match any single character |
| `\*` | `\*` | Literal asterisk (escaped metachar) |
| `\?` | `\?` | Literal question mark (escaped metachar) |
| `\\` | `\\` | Literal backslash (escaped escape char) |
| `%` | `%` | Literal percent — no special meaning in Lucene patterns |
| `_` | `_` | Literal underscore — no special meaning in Lucene patterns |

`%` and `_` carry no special meaning in Lucene wildcard syntax, which is exactly why no conversion is performed. The previous architecture converted Lucene patterns to SQL `LIKE` form and back — a lossy round trip requiring complex multi-level backslash arithmetic. That entire conversion layer is deleted.

---

### Case-Insensitive Support

When `case_insensitive: true` is specified, the flag travels as a MAP param and is applied by the builder via `builder.caseInsensitive(true)`. Folding is Lucene's ASCII-only behaviour (`AutomatonQueries:180-194`): A-Z fold to a-z; non-ASCII characters match literally. No `LOWER()` wrapping remains.

---

### Data type support

| Mapping type | Vanilla supports prefix/wildcard | Analytics schema type | Supported here |
|---|---|---|---|
| `keyword` | ✅ | VARCHAR | ✅ |
| `text` | ✅ | VARCHAR | ✅ |
| `match_only_text` | ✅ | VARCHAR | ✅ |
| `wildcard` (field type) | ✅ | not storable | ❌ index creation fails |
| `constant_keyword` | ✅ | not storable | ❌ index creation fails |
| `version` | ✅ | not storable | ❌ index creation fails |
| `flat_object` | ✅ | not storable | ❌ index creation fails |
| numeric / date / ip / boolean | ❌ (throws) | BIGINT / TIMESTAMP / etc. | ❌ rejected by VARCHAR gate |

The VARCHAR-only gate mirrors vanilla's rejection of non-string types (`MappedFieldType.prefixQuery:291-297`, `wildcardQuery:309-317`).

The four "not storable" rows are not a translator gap and not a silent behaviour difference: optimized engine mode has no Parquet writer (`CoreDataFieldPlugin`) and no Lucene secondary field factory (`LuceneFieldFactoryRegistry`) for those types, so creating an index that uses them fails with `MapperParsingException` (`CompositeFieldCapabilityIT`). The schema omission in `OpenSearchSchemaBuilder:222-248` is a consequence of that, and it applies to every query front-end sharing the builder, not just this path.

---

### Examples

**Prefix in Bool Query:**
```json
{
  "bool": {
    "must": [{"prefix": {"category": "electron"}}],
    "should": [
      {"prefix": {"brand": "sam"}},
      {"prefix": {"brand": "app"}}
    ]
  }
}
```
Emitted plan: `(PREFIX_QUERY(MAP('field', category), MAP('query', 'electron'))) AND ((PREFIX_QUERY(MAP('field', brand), MAP('query', 'sam'))) OR (PREFIX_QUERY(MAP('field', brand), MAP('query', 'app'))))`

**Complex Wildcard Pattern:**
```json
{"wildcard": {"sku": "*-2021-*"}}
```
Emitted call: `WILDCARD_QUERY_DSL(MAP('field', sku), MAP('query', '*-2021-*'))`

---

### Testing

**Unit Tests:**
- `PrefixQueryTranslatorTests` — RexCall shape, MAP operands, field resolution, case sensitivity, param rejection/ignore
- `WildcardQueryTranslatorTests` — verbatim pattern passthrough, metachar handling, escaped literals, mixed patterns
- `PrefixQuerySerializerTests` — field extraction, query passthrough, `case_insensitive` / `rewrite` params
- `WildcardQueryDslSerializerTests` — verbatim pattern passthrough, params, builder construction
- 5 golden files: stored plans assert `PREFIX_QUERY` / `WILDCARD_QUERY_DSL` delegated calls; escaped-pattern golden (`test\*file\?name\\end`) pins verbatim passthrough
- Registry key-set completeness assertion in `QuerySerializerRegistryTests`
- **175 dsl-query-executor + 326 analytics-backend-lucene = 501 tests, 0 failures**, spotless clean

**Integration Tests:**
- `DslPrefixQueryIT` — end-to-end validation with real index data
- `DslWildcardQueryIT` — end-to-end validation with real index data
- Parked with `@AwaitsFix` pending analytics engine E2E pipeline wiring (fragment conversion + shard execution + Arrow Flight drain), consistent with all sibling ITs in the module

**Manual verification (captured against the earlier LIKE-based implementation):**

> The following curl examples and log output were captured against the prior LIKE-based architecture. The delegated path has not been manually re-run end to end because the E2E pipeline is not yet wired. Retained for reference only.

Prefix:
```bash
curl -X GET "localhost:9200/parquet_test/_search" -H "Content-Type: application/json" -d '
{
  "query": {
    "prefix": {
      "name": {
        "value": "ali"
      }
    }
  }
}'
```
```
[2026-04-28T18:37:55,451][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[0]=[30, seattle, alice, 95.5]
```

```bash
curl -X GET "localhost:9200/parquet_test/_search" -H "Content-Type: application/json" -d '
{
  "query": {
    "prefix": {
      "city": {
        "value": "po"
      }
    }
  }
}'
```
```
[2026-04-28T18:43:34,574][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] Query result rowCount=2
[2026-04-28T18:43:34,574][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[0]=[25, portland, bob, 88.0]
[2026-04-28T18:43:34,574][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[1]=[28, portland, dave, 76.8]
```

Wildcard:
```bash
curl -X GET "localhost:9200/parquet_test/_search" -H "Content-Type: application/json" -d '
{
  "query": {
    "wildcard": {
      "name": {
        "value": "*a*"
      }
    }
  }
}'
```
```
[2026-04-28T18:45:30,598][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] Query result rowCount=3
[2026-04-28T18:45:30,598][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[0]=[30, seattle, alice, 95.5]
[2026-04-28T18:45:30,598][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[1]=[35, seattle, carol, 92.3]
[2026-04-28T18:45:30,598][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[2]=[28, portland, dave, 76.8]
```

```bash
curl -X GET "localhost:9200/parquet_test/_search" -H "Content-Type: application/json" -d '
{
  "query": {
    "wildcard": {
      "name": {
        "value": "A*",
        "case_insensitive": true
      }
    }
  }
}'
```
```
[2026-04-28T18:46:31,555][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] Query result rowCount=1
[2026-04-28T18:46:31,555][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[0]=[30, seattle, alice, 95.5]
```

```bash
curl -X GET "localhost:9200/parquet_test/_search" -H "Content-Type: application/json" -d '
{
  "query": {
    "wildcard": {
      "name": {
        "value": "d?ve"
      }
    }
  }
}'
```
```
[2026-04-28T18:47:28,792][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] Query result rowCount=1
[2026-04-28T18:47:28,792][INFO ][o.o.d.e.DslQueryPlanExecutor] [runTask-0] row[0]=[28, portland, dave, 76.8]
```

---

### Known divergences

| # | Divergence | Impact | Citation |
|---|---|---|---|
| 1 | `search.allow_expensive_queries=false` not honoured | Queries execute when vanilla would refuse | Lucene backend hardcodes always-true supplier (`LuceneAnalyticsBackendPlugin:284`); pre-existing, not introduced by this change |
| 2 | Page pruning lost | Full segment scan instead of prunable predicate | Delegated predicate yields all-true bitmap (`page_pruner.rs:779-782`); residual re-evaluates (`single_collector.rs:604-611`); correctness preserved. Follow-up: schema enrichment |
| 3 | `_name` ignored | `matched_queries` absent in response | Convention pending family-wide; `matched_queries` not surfaced by this engine |
| 4 | `boost` rejected (not accepted-and-ignored) | `ConversionException` reaches client as error | `SearchActionFilter:55-57` reroutes every `_search` without calling `chain.proceed`; `TransportDslExecuteAction:86` calls `listener.onFailure` |
| 5 | Field types `wildcard`, `constant_keyword`, `version`, `flat_object` not storable | Indexes using them cannot be created in optimized engine mode, so no query on them is reachable | No Parquet writer (`CoreDataFieldPlugin`) and no Lucene secondary factory (`LuceneFieldFactoryRegistry`); index creation fails with `MapperParsingException` (`CompositeFieldCapabilityIT`). Storage-layer limitation shared by all front-ends through `OpenSearchSchemaBuilder:222-248`, not a prefix/wildcard behaviour difference |
| 6 | Integration tests `@AwaitsFix` | No end-to-end proof | E2E pipeline not wired; parity evidence is unit-level plus vanilla source reading |

### Related Issues

- Meta issue: #20914

### Check List

- [x] Functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
