### PR TITLE
Build aggregation responses from execution results

### DIFF
--- a/sandbox/plugins/dsl-query-executor/build.gradle
+++ b/sandbox/plugins/dsl-query-executor/build.gradle
@@ -26,6 +26,9 @@ configurations {
 }
 sourceSets.main.compileClasspath += configurations.calciteCompile
 sourceSets.test.compileClasspath += configurations.calciteCompile
+tasks.named('missingJavadoc').configure {
+  classpath += configurations.calciteCompile
+}
 
 dependencies {
   compileOnly project(':server')

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/action/RequestScopedMapperServiceIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/action/RequestScopedMapperServiceIT.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+/**
+ * Verifies response-typing mapping resolution on a coordinating-only node (hosting no shard)
+ * while dynamic mapping updates arrive from documents indexed on a separate data node. Drives
+ * {@link RequestScopedMapperService} against the coordinator's real {@link IndicesService} and
+ * cluster state, as {@code TransportDslExecuteAction} wires it; the DSL plugins are not
+ * installed because the machinery under test does not depend on the engine.
+ */
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
+public class RequestScopedMapperServiceIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "dynamic-probe";
+
+    public void testCoordinatorResolvesPinnedMappingSnapshotUnderDynamicUpdates() throws Exception {
+        internalCluster().startNode();
+        String coordNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        createSingleShardIndex();
+
+        client().prepareIndex(INDEX).setSource("{\"brand\":\"brandX\"}", XContentType.JSON).get();
+
+        ClusterService coordClusterService = internalCluster().getInstance(ClusterService.class, coordNode);
+        assertBusy(() -> {
+            IndexMetadata metadata = coordClusterService.state().metadata().index(INDEX);
+            assertNotNull(metadata);
+            assertNotNull(metadata.mapping());
+            assertTrue("dynamic mapping for [brand] must reach the coordinator", metadata.mapping().source().string().contains("brand"));
+        });
+
+        IndicesService coordIndicesService = internalCluster().getInstance(IndicesService.class, coordNode);
+        Index index = coordClusterService.state().metadata().index(INDEX).getIndex();
+        assertNull("coordinating-only node must not host the index", coordIndicesService.indexService(index));
+
+        IndexMetadata pinned = coordClusterService.state().metadata().index(INDEX);
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(pinned, coordIndicesService::createIndexMapperService)) {
+            MapperService mapperService = holder.get();
+            assertNotNull(mapperService);
+            assertEquals("keyword", mapperService.fieldType("brand.keyword").typeName());
+            assertNull("a field the snapshot does not carry must not resolve", mapperService.fieldType("price"));
+        }
+
+        client().prepareIndex(INDEX).setSource("{\"brand\":\"brandY\",\"price\":42}", XContentType.JSON).get();
+        final long pinnedMappingVersion = pinned.getMappingVersion();
+        assertBusy(() -> {
+            IndexMetadata current = coordClusterService.state().metadata().index(INDEX);
+            assertNotNull(current);
+            assertTrue("the [price] mapping update must reach the coordinator", current.getMappingVersion() > pinnedMappingVersion);
+        });
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(pinned, coordIndicesService::createIndexMapperService)) {
+            MapperService mapperService = holder.get();
+            assertNotNull(mapperService);
+            assertEquals("keyword", mapperService.fieldType("brand.keyword").typeName());
+            assertNull("the pinned snapshot must be immune to later dynamic updates", mapperService.fieldType("price"));
+        }
+
+        IndexMetadata current = coordClusterService.state().metadata().index(INDEX);
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(current, coordIndicesService::createIndexMapperService)) {
+            MapperService mapperService = holder.get();
+            assertNotNull(mapperService);
+            assertEquals("keyword", mapperService.fieldType("brand.keyword").typeName());
+            assertEquals("long", mapperService.fieldType("price").typeName());
+        }
+    }
+
+    public void testPinnedSnapshotSurvivesIndexDeletion() throws Exception {
+        internalCluster().startNode();
+        String coordNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        createSingleShardIndex();
+
+        client().prepareIndex(INDEX).setSource("{\"brand\":\"brandX\"}", XContentType.JSON).get();
+
+        ClusterService coordClusterService = internalCluster().getInstance(ClusterService.class, coordNode);
+        assertBusy(() -> {
+            IndexMetadata metadata = coordClusterService.state().metadata().index(INDEX);
+            assertNotNull(metadata);
+            assertNotNull(metadata.mapping());
+            assertTrue(metadata.mapping().source().string().contains("brand"));
+        });
+
+        IndicesService coordIndicesService = internalCluster().getInstance(IndicesService.class, coordNode);
+        IndexMetadata pinned = coordClusterService.state().metadata().index(INDEX);
+
+        assertAcked(client().admin().indices().prepareDelete(INDEX));
+        assertBusy(() -> assertNull(coordClusterService.state().metadata().index(INDEX)));
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(pinned, coordIndicesService::createIndexMapperService)) {
+            MapperService mapperService = holder.get();
+            assertNotNull("the pinned snapshot must keep resolving after index deletion", mapperService);
+            assertEquals("keyword", mapperService.fieldType("brand.keyword").typeName());
+        }
+    }
+
+    private void createSingleShardIndex() {
+        createIndex(
+            INDEX,
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
+        );
+        ensureGreen(INDEX);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/RequestScopedMapperService.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/RequestScopedMapperService.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.index.mapper.MapperService;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Request-scoped, lazily created {@link MapperService} for the target index.
+ *
+ * <p>{@code IndicesService#createIndexMapperService} returns an <em>empty</em> MapperService:
+ * the index mapping must be merged in before {@code fieldType()} lookups resolve anything.
+ * This holder performs that merge ({@link MapperService.MergeReason#MAPPING_RECOVERY}, the
+ * same reason the server's {@code MetadataMappingService} uses for this create-and-populate
+ * pattern), caches the result so response building resolves at most one MapperService per
+ * request, and releases the service's analyzer resources on {@link #close()} once the request
+ * completes.
+ *
+ * <p>{@link #get()} returns null — degrading response typing to the translators' key-sampling
+ * fallback instead of failing a query whose results already returned — when the index has been
+ * deleted from cluster state mid-request, or when creating/merging the MapperService fails.
+ */
+final class RequestScopedMapperService implements Supplier<MapperService>, Closeable {
+
+    private static final Logger logger = LogManager.getLogger(RequestScopedMapperService.class);
+
+    private final String indexName;
+    private final Supplier<ClusterState> clusterStateSupplier;
+    private final CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory;
+
+    private MapperService mapperService;
+    private boolean resolved;
+    private boolean closed;
+
+    /**
+     * @param indexName the concrete index whose mapping backs response typing
+     * @param clusterStateSupplier source of the current cluster state
+     * @param mapperServiceFactory creates the standalone MapperService, typically
+     *        {@code indicesService::createIndexMapperService}
+     */
+    RequestScopedMapperService(
+        String indexName,
+        Supplier<ClusterState> clusterStateSupplier,
+        CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory
+    ) {
+        this.indexName = indexName;
+        this.clusterStateSupplier = clusterStateSupplier;
+        this.mapperServiceFactory = mapperServiceFactory;
+    }
+
+    /**
+     * Returns the merged MapperService for the target index, creating it on first call, or
+     * null when the index or its mapping cannot be resolved (see class javadoc).
+     */
+    @Override
+    public synchronized MapperService get() {
+        if (closed) {
+            return null;
+        }
+        if (resolved == false) {
+            resolved = true;
+            mapperService = resolve();
+        }
+        return mapperService;
+    }
+
+    private MapperService resolve() {
+        try {
+            IndexMetadata indexMetadata = clusterStateSupplier.get().metadata().index(indexName);
+            if (indexMetadata == null) {
+                logger.warn("index [{}] not found in cluster state; response typing degrades to key sampling", indexName);
+                return null;
+            }
+            MapperService created = mapperServiceFactory.apply(indexMetadata);
+            try {
+                // The freshly created MapperService is empty — merge the index mapping so
+                // fieldType() resolves. Without this, every lookup returns null and terms
+                // responses silently fall back to sampled typing (RAW-formatted keys).
+                created.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+                return created;
+            } catch (Exception e) {
+                IOUtils.closeWhileHandlingException(created);
+                throw e;
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to resolve MapperService for index [{}]; response typing degrades to key sampling", indexName, e);
+            return null;
+        }
+    }
+
+    /** Releases the MapperService's analyzer resources. Safe to call more than once. */
+    @Override
+    public synchronized void close() {
+        closed = true;
+        if (mapperService != null) {
+            IOUtils.closeWhileHandlingException(mapperService);
+            mapperService = null;
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/RequestScopedMapperService.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/RequestScopedMapperService.java
@@ -10,7 +10,6 @@ package org.opensearch.dsl.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.util.io.IOUtils;
@@ -18,55 +17,36 @@ import org.opensearch.index.mapper.MapperService;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * Request-scoped, lazily created {@link MapperService} for the target index.
- *
- * <p>{@code IndicesService#createIndexMapperService} returns an <em>empty</em> MapperService:
- * the index mapping must be merged in before {@code fieldType()} lookups resolve anything.
- * This holder performs that merge ({@link MapperService.MergeReason#MAPPING_RECOVERY}, the
- * same reason the server's {@code MetadataMappingService} uses for this create-and-populate
- * pattern), caches the result so response building resolves at most one MapperService per
- * request, and releases the service's analyzer resources on {@link #close()} once the request
- * completes.
- *
- * <p>{@link #get()} returns null — degrading response typing to the translators' key-sampling
- * fallback instead of failing a query whose results already returned — when the index has been
- * deleted from cluster state mid-request, or when creating/merging the MapperService fails.
+ * Request-scoped, lazily created {@link MapperService} for response key typing, pinned to the
+ * index mapping captured when the request started. {@code IndicesService#createIndexMapperService}
+ * returns an <em>empty</em> MapperService, so the holder merges the pinned mapping in before
+ * handing it out ({@link MapperService.MergeReason#MAPPING_RECOVERY}, the same create-and-merge
+ * pattern the server's {@code MetadataMappingService} uses), memoizes the result, and releases
+ * it on {@link #close()}. {@link #get()} returns null only when creating or merging fails.
  */
 final class RequestScopedMapperService implements Supplier<MapperService>, Closeable {
 
     private static final Logger logger = LogManager.getLogger(RequestScopedMapperService.class);
 
-    private final String indexName;
-    private final Supplier<ClusterState> clusterStateSupplier;
+    private final IndexMetadata indexMetadata;
     private final CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory;
 
     private MapperService mapperService;
     private boolean resolved;
     private boolean closed;
 
-    /**
-     * @param indexName the concrete index whose mapping backs response typing
-     * @param clusterStateSupplier source of the current cluster state
-     * @param mapperServiceFactory creates the standalone MapperService, typically
-     *        {@code indicesService::createIndexMapperService}
-     */
     RequestScopedMapperService(
-        String indexName,
-        Supplier<ClusterState> clusterStateSupplier,
+        IndexMetadata indexMetadata,
         CheckedFunction<IndexMetadata, MapperService, IOException> mapperServiceFactory
     ) {
-        this.indexName = indexName;
-        this.clusterStateSupplier = clusterStateSupplier;
+        this.indexMetadata = Objects.requireNonNull(indexMetadata, "indexMetadata must not be null");
         this.mapperServiceFactory = mapperServiceFactory;
     }
 
-    /**
-     * Returns the merged MapperService for the target index, creating it on first call, or
-     * null when the index or its mapping cannot be resolved (see class javadoc).
-     */
     @Override
     public synchronized MapperService get() {
         if (closed) {
@@ -81,16 +61,8 @@ final class RequestScopedMapperService implements Supplier<MapperService>, Close
 
     private MapperService resolve() {
         try {
-            IndexMetadata indexMetadata = clusterStateSupplier.get().metadata().index(indexName);
-            if (indexMetadata == null) {
-                logger.warn("index [{}] not found in cluster state; response typing degrades to key sampling", indexName);
-                return null;
-            }
             MapperService created = mapperServiceFactory.apply(indexMetadata);
             try {
-                // The freshly created MapperService is empty — merge the index mapping so
-                // fieldType() resolves. Without this, every lookup returns null and terms
-                // responses silently fall back to sampled typing (RAW-formatted keys).
                 created.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
                 return created;
             } catch (Exception e) {
@@ -98,7 +70,7 @@ final class RequestScopedMapperService implements Supplier<MapperService>, Close
                 throw e;
             }
         } catch (Exception e) {
-            logger.warn("Failed to resolve MapperService for index [{}]; response typing degrades to key sampling", indexName, e);
+            logger.warn("Failed to resolve MapperService for index [{}]", indexMetadata.getIndex().getName(), e);
             return null;
         }
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -78,14 +78,13 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
+            final long startTime = System.currentTimeMillis();
             final QueryPlans plans;
-            final long convertTime;
+            final SearchSourceConverter converter;
             try {
                 String indexName = resolveToSingleIndex(request);
-                long convertStart = System.nanoTime();
-                SearchSourceConverter converter = new SearchSourceConverter(contextProvider.getContext().schema());
+                converter = new SearchSourceConverter(contextProvider.getContext().schema());
                 plans = converter.convert(request.source(), indexName);
-                convertTime = System.nanoTime() - convertStart;
             } catch (Exception e) {
                 logger.error("DSL conversion failed", e);
                 listener.onFailure(e);
@@ -94,7 +93,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             planExecutor.execute(plans, ActionListener.wrap(results -> {
                 final SearchResponse response;
                 try {
-                    response = SearchResponseBuilder.build(results, convertTime);
+                    long tookInMillis = System.currentTimeMillis() - startTime;
+                    response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
                 } catch (Exception buildEx) {
                     logger.error("DSL response building failed", buildEx);
                     listener.onFailure(buildEx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -18,6 +18,8 @@ import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -29,6 +31,8 @@ import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.dsl.result.SearchResponseBuilder;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -36,6 +40,7 @@ import org.opensearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
@@ -51,6 +56,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     private final EngineContextProvider contextProvider;
     private final DslQueryPlanExecutor planExecutor;
     private final ClusterService clusterService;
+    private final IndicesService indicesService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ThreadPool threadPool;
 
@@ -71,6 +77,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         EngineContextProvider contextProvider,
         QueryPlanExecutor<RelNode, Iterable<Object[]>> executor,
         ClusterService clusterService,
+        IndicesService indicesService,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ThreadPool threadPool
     ) {
@@ -78,6 +85,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         this.contextProvider = contextProvider;
         this.planExecutor = new DslQueryPlanExecutor(executor);
         this.clusterService = clusterService;
+        this.indicesService = indicesService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.threadPool = threadPool;
     }
@@ -91,7 +99,21 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             try {
                 String indexName = resolveToSingleIndex(request);
 
-                converter = new SearchSourceConverter(contextProvider.getContext().schema());
+                // Lazily resolves the target index's MapperService for response key typing and
+                // formats; a failed resolution degrades to the translator's sampling fallback.
+                // TODO: cache per (indexUUID, mappingVersion) to avoid rebuilding analyzers.
+                Supplier<MapperService> mapperServiceSupplier = () -> {
+                    try {
+                        ClusterState state = clusterService.state();
+                        IndexMetadata indexMetadata = state.metadata().index(indexName);
+                        return indicesService.createIndexMapperService(indexMetadata);
+                    } catch (Exception e) {
+                        logger.warn("Failed to resolve MapperService for index [{}]", indexName, e);
+                        return null;
+                    }
+                };
+
+                converter = new SearchSourceConverter(contextProvider.getContext().schema(), mapperServiceSupplier);
 
                 plans = converter.convert(request.source(), indexName);
             } catch (ConversionException e) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -18,8 +18,6 @@ import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
-import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -31,7 +29,6 @@ import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.dsl.result.SearchResponseBuilder;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -40,7 +37,6 @@ import org.opensearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
@@ -94,39 +90,42 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             final long startNanos = System.nanoTime();
+            final String indexName;
+            try {
+                indexName = resolveToSingleIndex(request);
+            } catch (Exception e) {
+                listener.onFailure(e);
+                return;
+            }
+
+            // One MapperService per request for response key typing and formats: created on
+            // first use with the index mapping merged in (a freshly created MapperService is
+            // empty and resolves no fields), closed when the request completes either way.
+            // A failed resolution degrades to the translator's sampling fallback.
+            // TODO: cache per (indexUUID, mappingVersion) to avoid rebuilding analyzers.
+            final RequestScopedMapperService mapperServiceHolder = new RequestScopedMapperService(
+                indexName,
+                clusterService::state,
+                indicesService::createIndexMapperService
+            );
+            final ActionListener<SearchResponse> requestListener = ActionListener.runAfter(listener, mapperServiceHolder::close);
+
             final QueryPlans plans;
             final SearchSourceConverter converter;
             try {
-                String indexName = resolveToSingleIndex(request);
-
-                // Lazily resolves the target index's MapperService for response key typing and
-                // formats; a failed resolution degrades to the translator's sampling fallback.
-                // TODO: cache per (indexUUID, mappingVersion) to avoid rebuilding analyzers.
-                Supplier<MapperService> mapperServiceSupplier = () -> {
-                    try {
-                        ClusterState state = clusterService.state();
-                        IndexMetadata indexMetadata = state.metadata().index(indexName);
-                        return indicesService.createIndexMapperService(indexMetadata);
-                    } catch (Exception e) {
-                        logger.warn("Failed to resolve MapperService for index [{}]", indexName, e);
-                        return null;
-                    }
-                };
-
-                converter = new SearchSourceConverter(contextProvider.getContext().schema(), mapperServiceSupplier);
-
+                converter = new SearchSourceConverter(contextProvider.getContext().schema(), mapperServiceHolder);
                 plans = converter.convert(request.source(), indexName);
             } catch (ConversionException e) {
                 // The request carries a shape or parameter this path cannot honor — a client
                 // error (400), matching classic search's rejection of unsupported parameters.
                 logger.debug("DSL conversion rejected the request", e);
-                listener.onFailure(new IllegalArgumentException(e.getMessage(), e));
+                requestListener.onFailure(new IllegalArgumentException(e.getMessage(), e));
                 return;
             } catch (Exception e) {
-                listener.onFailure(e);
+                requestListener.onFailure(e);
                 return;
             }
-            executePlans(plans, request, converter, startNanos, listener);
+            executePlans(plans, request, converter, startNanos, requestListener);
         });
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -30,6 +30,8 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
  * executes them via the analytics engine, and builds a SearchResponse.
@@ -78,7 +80,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
-            final long startTime = System.currentTimeMillis();
+            final long startNanos = System.nanoTime();
             final QueryPlans plans;
             final SearchSourceConverter converter;
             try {
@@ -93,7 +95,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             planExecutor.execute(plans, ActionListener.wrap(results -> {
                 final SearchResponse response;
                 try {
-                    long tookInMillis = System.currentTimeMillis() - startTime;
+                    long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
                     response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
                 } catch (Exception buildEx) {
                     logger.error("DSL response building failed", buildEx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -92,9 +92,12 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             final long startNanos = System.nanoTime();
+            // One snapshot per request: index resolution, the engine schema, and response
+            // typing all derive from the same immutable cluster state.
+            final ClusterState state = clusterService.state();
             final IndexMetadata indexMetadata;
             try {
-                indexMetadata = resolveToSingleIndex(request);
+                indexMetadata = resolveToSingleIndex(state, request);
             } catch (Exception e) {
                 listener.onFailure(e);
                 return;
@@ -114,7 +117,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             final QueryPlans plans;
             final SearchSourceConverter converter;
             try {
-                converter = new SearchSourceConverter(contextProvider.getContext().schema(), mapperServiceHolder);
+                converter = new SearchSourceConverter(contextProvider.getContext(state).schema(), mapperServiceHolder);
                 plans = converter.convert(request.source(), indexName);
             } catch (ConversionException e) {
                 // The request carries a shape or parameter this path cannot honor — a client
@@ -214,8 +217,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
      * index, returning its metadata from the same cluster state snapshot. Throws if the
      * resolution yields zero or more than one concrete index.
      */
-    private IndexMetadata resolveToSingleIndex(SearchRequest request) {
-        ClusterState state = clusterService.state();
+    private IndexMetadata resolveToSingleIndex(ClusterState state, SearchRequest request) {
         Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         if (concreteIndices.length != 1) {
             throw new IllegalArgumentException(

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -18,6 +18,8 @@ import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -90,22 +92,21 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             final long startNanos = System.nanoTime();
-            final String indexName;
+            final IndexMetadata indexMetadata;
             try {
-                indexName = resolveToSingleIndex(request);
+                indexMetadata = resolveToSingleIndex(request);
             } catch (Exception e) {
                 listener.onFailure(e);
                 return;
             }
+            final String indexName = indexMetadata.getIndex().getName();
 
-            // One MapperService per request for response key typing and formats: created on
-            // first use with the index mapping merged in (a freshly created MapperService is
-            // empty and resolves no fields), closed when the request completes either way.
-            // A failed resolution degrades to the translator's sampling fallback.
+            // Response typing works off the mapping pinned at request start: one immutable
+            // snapshot for conversion and response building, created lazily, and closed when
+            // the request completes whether it succeeded or failed.
             // TODO: cache per (indexUUID, mappingVersion) to avoid rebuilding analyzers.
             final RequestScopedMapperService mapperServiceHolder = new RequestScopedMapperService(
-                indexName,
-                clusterService::state,
+                indexMetadata,
                 indicesService::createIndexMapperService
             );
             final ActionListener<SearchResponse> requestListener = ActionListener.runAfter(listener, mapperServiceHolder::close);
@@ -209,16 +210,18 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
     // so this plugin doesn't need its own resolution logic.
     /**
-     * Resolves the request's indices (which may be aliases or wildcards) to a single concrete index.
-     * Throws if the resolution yields zero or more than one concrete index.
+     * Resolves the request's indices (which may be aliases or wildcards) to a single concrete
+     * index, returning its metadata from the same cluster state snapshot. Throws if the
+     * resolution yields zero or more than one concrete index.
      */
-    private String resolveToSingleIndex(SearchRequest request) {
-        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterService.state(), request);
+    private IndexMetadata resolveToSingleIndex(SearchRequest request) {
+        ClusterState state = clusterService.state();
+        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         if (concreteIndices.length != 1) {
             throw new IllegalArgumentException(
                 "DSL execution currently supports exactly one concrete index, but resolved to " + concreteIndices.length + " indices"
             );
         }
-        return concreteIndices[0].getName();
+        return state.metadata().getIndexSafe(concreteIndices[0]);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -123,7 +123,6 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 listener.onFailure(new IllegalArgumentException(e.getMessage(), e));
                 return;
             } catch (Exception e) {
-                logger.error("DSL conversion failed", e);
                 listener.onFailure(e);
                 return;
             }
@@ -154,33 +153,38 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         final QueryPlans mainPlans = mainBuilder.build();
 
         if (countPlans.isEmpty()) {
-            planExecutor.execute(
-                mainPlans,
-                ActionListener.wrap(results -> { buildAndRespond(results, request, converter, startNanos, listener); }, e -> {
-                    logger.error("DSL execution failed", e);
-                    listener.onFailure(e);
-                })
-            );
+            try {
+                planExecutor.execute(
+                    mainPlans,
+                    ActionListener.wrap(results -> buildAndRespond(results, request, converter, startNanos, listener), listener::onFailure)
+                );
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
             return;
         }
 
         // COUNT plans run concurrently with the main plans - all are engine calls.
         final GroupedActionListener<List<ExecutionResult>> joined = new GroupedActionListener<>(ActionListener.wrap(collections -> {
-            final long executedNanos = System.nanoTime();
             List<ExecutionResult> allResults = new ArrayList<>();
             for (List<ExecutionResult> branch : collections) {
                 allResults.addAll(branch);
             }
             buildAndRespond(allResults, request, converter, startNanos, listener);
-        }, e -> {
-            logger.error("DSL execution failed", e);
-            listener.onFailure(e);
-        }), 1 + countPlans.size());
+        }, listener::onFailure), 1 + countPlans.size());
 
-        planExecutor.execute(mainPlans, ActionListener.wrap(results -> { joined.onResponse(results); }, joined::onFailure));
+        try {
+            planExecutor.execute(mainPlans, joined);
+        } catch (Exception e) {
+            joined.onFailure(e);
+        }
 
         for (QueryPlans.QueryPlan countPlan : countPlans) {
-            planExecutor.executeOne(countPlan, ActionListener.wrap(result -> { joined.onResponse(List.of(result)); }, joined::onFailure));
+            try {
+                planExecutor.execute(new QueryPlans.Builder().add(countPlan).build(), joined);
+            } catch (Exception e) {
+                joined.onFailure(e);
+            }
         }
     }
 
@@ -196,7 +200,6 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
             response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
         } catch (Exception buildEx) {
-            logger.error("DSL response building failed", buildEx);
             listener.onFailure(buildEx);
             return;
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
@@ -22,14 +23,18 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.dsl.result.SearchResponseBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -85,29 +90,95 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             final SearchSourceConverter converter;
             try {
                 String indexName = resolveToSingleIndex(request);
+
                 converter = new SearchSourceConverter(contextProvider.getContext().schema());
+
                 plans = converter.convert(request.source(), indexName);
+            } catch (ConversionException e) {
+                // The request carries a shape or parameter this path cannot honor — a client
+                // error (400), matching classic search's rejection of unsupported parameters.
+                logger.debug("DSL conversion rejected the request", e);
+                listener.onFailure(new IllegalArgumentException(e.getMessage(), e));
+                return;
             } catch (Exception e) {
                 logger.error("DSL conversion failed", e);
                 listener.onFailure(e);
                 return;
             }
-            planExecutor.execute(plans, ActionListener.wrap(results -> {
-                final SearchResponse response;
-                try {
-                    long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-                    response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
-                } catch (Exception buildEx) {
-                    logger.error("DSL response building failed", buildEx);
-                    listener.onFailure(buildEx);
-                    return;
-                }
-                listener.onResponse(response);
-            }, e -> {
-                logger.error("DSL execution failed", e);
-                listener.onFailure(e);
-            }));
+            executePlans(plans, request, converter, startNanos, listener);
         });
+    }
+
+    /**
+     * Submits the main plans as one batch and each COUNT plan as its own concurrent engine
+     * call, joins all results, and responds through
+     * {@link #buildAndRespond(List, SearchRequest, SearchSourceConverter, long, ActionListener)}.
+     * Any branch failing fails the request.
+     */
+    private void executePlans(
+        QueryPlans plans,
+        SearchRequest request,
+        SearchSourceConverter converter,
+        long startNanos,
+        ActionListener<SearchResponse> listener
+    ) {
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        QueryPlans.Builder mainBuilder = new QueryPlans.Builder();
+        for (QueryPlans.QueryPlan plan : plans.getAll()) {
+            if (plan.type() != QueryPlans.Type.COUNT) {
+                mainBuilder.add(plan);
+            }
+        }
+        final QueryPlans mainPlans = mainBuilder.build();
+
+        if (countPlans.isEmpty()) {
+            planExecutor.execute(
+                mainPlans,
+                ActionListener.wrap(results -> { buildAndRespond(results, request, converter, startNanos, listener); }, e -> {
+                    logger.error("DSL execution failed", e);
+                    listener.onFailure(e);
+                })
+            );
+            return;
+        }
+
+        // COUNT plans run concurrently with the main plans - all are engine calls.
+        final GroupedActionListener<List<ExecutionResult>> joined = new GroupedActionListener<>(ActionListener.wrap(collections -> {
+            final long executedNanos = System.nanoTime();
+            List<ExecutionResult> allResults = new ArrayList<>();
+            for (List<ExecutionResult> branch : collections) {
+                allResults.addAll(branch);
+            }
+            buildAndRespond(allResults, request, converter, startNanos, listener);
+        }, e -> {
+            logger.error("DSL execution failed", e);
+            listener.onFailure(e);
+        }), 1 + countPlans.size());
+
+        planExecutor.execute(mainPlans, ActionListener.wrap(results -> { joined.onResponse(results); }, joined::onFailure));
+
+        for (QueryPlans.QueryPlan countPlan : countPlans) {
+            planExecutor.executeOne(countPlan, ActionListener.wrap(result -> { joined.onResponse(List.of(result)); }, joined::onFailure));
+        }
+    }
+
+    private void buildAndRespond(
+        List<ExecutionResult> results,
+        SearchRequest request,
+        SearchSourceConverter converter,
+        long startNanos,
+        ActionListener<SearchResponse> listener
+    ) {
+        final SearchResponse response;
+        try {
+            long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
+        } catch (Exception buildEx) {
+            logger.error("DSL response building failed", buildEx);
+            listener.onFailure(buildEx);
+            return;
+        }
+        listener.onResponse(response);
     }
 
     // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
@@ -13,46 +13,101 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.search.aggregations.BucketOrder;
 
 import java.util.List;
+import java.util.Map;
 
 /**
- * Pre-computed metadata for one aggregation granularity level.
- * Contains everything needed to build a single {@code LogicalAggregate}.
+ * Pre-computed metadata for one aggregation plan.
  *
- * <p>A multi-level aggregation tree (e.g., terms → terms → avg) produces
- * multiple metadata instances — one per distinct GROUP BY key set.
+ * <p>A plan is defined by its bucket aggregation, not merely its GROUP BY columns: the
+ * aggregation's {@code size}, {@code min_doc_count}, and order are baked into the plan as
+ * LIMIT, HAVING, and SORT. Two sibling aggregations over the same field therefore produce two
+ * plans — one per aggregation — each bounded and ordered for its own request parameters.
+ * Metrics ride in their enclosing bucket aggregation's plan; root-level metrics form one
+ * global no-GROUP-BY plan.
  *
- * <p>TODO: Add tree structure (parent-child links between granularity levels) and pipeline
- * aggregation support.
+ * <p>Identity is the {@link #getAggNamePath() aggregation-name path} (names are unique among
+ * siblings by DSL contract), which is also the key the response builder uses to match results
+ * back to the request tree.
  */
 public class AggregationMetadata {
 
+    /** NUL cannot appear in aggregation names, so joined path keys cannot collide. */
+    private static final String PATH_SEPARATOR = "\u0000";
+
+    private final List<String> aggNamePath;
     private final ImmutableBitSet groupByBitSet;
     private final List<String> groupByFieldNames;
     private final List<AggregateCall> aggregateCalls;
     private final List<String> aggregateFieldNames;
     private final List<BucketOrder> bucketOrders;
+    private final Integer fetch;
+    private final Integer perParentFetch;
+    private final Long havingMinDocCount;
+    private final Map<String, Object> missingValues;
 
     /**
      * Creates aggregation metadata.
      *
+     * @param aggNamePath the defining aggregation-name path (outer bucket first); empty for
+     *        the global no-GROUP-BY metrics plan
      * @param groupByBitSet column indices for GROUP BY
      * @param groupByFieldNames field names for GROUP BY columns
      * @param aggregateCalls Calcite aggregate calls (AVG, SUM, etc.)
      * @param aggregateFieldNames output names for aggregate results
      * @param bucketOrders bucket orders for post-aggregation sorting
+     * @param fetch plan-level row limit, or null for no limit
+     * @param perParentFetch per-parent row limit for nested levels (ROW_NUMBER window over the
+     *        parent partition), or null
+     * @param havingMinDocCount minimum bucket doc count for a plan-level HAVING filter, or null
+     *        for none
+     * @param missingValues null-substitution value per group field ({@code missing} parameter);
+     *        fields absent from the map get an {@code IS NOT NULL} filter instead
      */
     public AggregationMetadata(
+        List<String> aggNamePath,
         ImmutableBitSet groupByBitSet,
         List<String> groupByFieldNames,
         List<AggregateCall> aggregateCalls,
         List<String> aggregateFieldNames,
-        List<BucketOrder> bucketOrders
+        List<BucketOrder> bucketOrders,
+        Integer fetch,
+        Integer perParentFetch,
+        Long havingMinDocCount,
+        Map<String, Object> missingValues
     ) {
+        this.aggNamePath = List.copyOf(aggNamePath);
         this.groupByBitSet = groupByBitSet;
         this.groupByFieldNames = List.copyOf(groupByFieldNames);
         this.aggregateCalls = List.copyOf(aggregateCalls);
         this.aggregateFieldNames = List.copyOf(aggregateFieldNames);
         this.bucketOrders = List.copyOf(bucketOrders);
+        this.fetch = fetch;
+        this.perParentFetch = perParentFetch;
+        this.havingMinDocCount = havingMinDocCount;
+        this.missingValues = Map.copyOf(missingValues);
+    }
+
+    /**
+     * Returns the defining aggregation-name path, outer bucket first (e.g.
+     * {@code [by_brand, by_category]} for a nested terms tree). Empty for the global
+     * no-GROUP-BY metrics plan. This is the plan's identity: sibling aggregations over the
+     * same fields have distinct paths and distinct plans.
+     */
+    public List<String> getAggNamePath() {
+        return aggNamePath;
+    }
+
+    /**
+     * Canonical string form of an aggregation-name path (see {@link #getAggNamePath()}): names
+     * in nesting order, NUL-joined. This is the one key protocol shared by plan construction,
+     * result registration, and response-side lookup — a plan's results are found only if all
+     * sides build the identical key.
+     *
+     * @param aggNamePath aggregation names, outer bucket first
+     * @return the joined key
+     */
+    public static String pathKey(List<String> aggNamePath) {
+        return String.join(PATH_SEPARATOR, aggNamePath);
     }
 
     /** Returns the GROUP BY column indices. */
@@ -83,5 +138,54 @@ public class AggregationMetadata {
     /** Returns true if bucket orders are present. */
     public boolean hasBucketOrders() {
         return !bucketOrders.isEmpty();
+    }
+
+    /**
+     * Returns the plan-level row limit, or null when the plan's bound is per-parent
+     * ({@link #getPerParentFetch()}) or absent. Root-level sized bucket plans carry this limit.
+     */
+    public Integer getFetch() {
+        return fetch;
+    }
+
+    /**
+     * Returns the per-parent row limit for a nested level's plan — enforced by
+     * {@code ROW_NUMBER() OVER (PARTITION BY parentFields ORDER BY bucketOrder) <= K} with the
+     * plan semi-joined to the parent plan's top-N — or null for non-nested plans. Each
+     * surviving row also carries the parent's eligible-document total for
+     * {@code sum_other_doc_count}.
+     */
+    public Integer getPerParentFetch() {
+        return perParentFetch;
+    }
+
+    /**
+     * Returns the minimum bucket doc count to apply as a plan-level HAVING filter between the
+     * aggregate and the sort, or null when no filtering is needed ({@code min_doc_count} ≤ 1).
+     */
+    public Long getHavingMinDocCount() {
+        return havingMinDocCount;
+    }
+
+    /**
+     * Returns the null-substitution value per group field (the {@code missing} parameter).
+     * Group fields absent from this map exclude null keys via a pre-aggregate
+     * {@code IS NOT NULL} filter instead.
+     */
+    public Map<String, Object> getMissingValues() {
+        return missingValues;
+    }
+
+    /**
+     * Returns true when this bounded plan's eligible-doc count is the plain
+     * matching-document total ({@code COUNT(*)}): a {@code missing} value on the group field
+     * makes every query-matching document eligible. False when the plan carries a
+     * {@code min_doc_count} HAVING — the threshold drops whole groups from eligibility even with
+     * {@code missing} — or when no {@code missing} value is configured; those plans use a
+     * per-aggregation eligible count instead. Meaningful only for plans with {@link #getFetch()}
+     * set (root-level, single-field by eligibility).
+     */
+    public boolean eligibleDocCountIsTotal() {
+        return havingMinDocCount == null && !groupByFieldNames.isEmpty() && missingValues.containsKey(groupByFieldNames.get(0));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -21,45 +21,57 @@ import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalOrder;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mutable builder for {@link AggregationMetadata}. Used by {@link AggregationTreeWalker}
- * to accumulate groupings and aggregate calls during tree traversal.
- * Grouping indices are resolved at build time from the input row type.
+ * to accumulate the defining bucket aggregation's plan parameters, parent groupings, and
+ * metric calls during tree traversal. Grouping indices are resolved at build time from the
+ * input row type.
+ *
+ * <p>One builder exists per aggregation-name path — plans are per aggregation, so exactly one
+ * bucket aggregation defines each builder (none for the global metrics builder).
  */
 public class AggregationMetadataBuilder {
 
     /** Name used for the implicit COUNT(*) aggregate added by bucket aggregations. */
     public static final String IMPLICIT_COUNT_NAME = "_count";
 
+    private final List<String> aggNamePath;
     private final List<GroupingInfo> groupings = new ArrayList<>();
+    private final Map<String, Object> missingValues = new LinkedHashMap<>();
     private final List<AggregateCall> aggregateCalls = new ArrayList<>();
     private final List<String> aggregateFieldNames = new ArrayList<>();
     private final List<BucketOrder> bucketOrders = new ArrayList<>();
+    private Integer definingSize;
+    private Long definingMinDocCount;
     private boolean implicitCountRequested = false;
 
-    /** Creates a new empty builder. */
-    public AggregationMetadataBuilder() {}
+    /** Creates a builder for the global (no defining aggregation) metrics plan. */
+    public AggregationMetadataBuilder() {
+        this(List.of());
+    }
 
     /**
-     * Adds a grouping contribution from a bucket translator.
+     * Creates a builder for the plan defined by the given aggregation-name path.
+     *
+     * @param aggNamePath the defining aggregation-name path, outer bucket first
+     */
+    public AggregationMetadataBuilder(List<String> aggNamePath) {
+        this.aggNamePath = List.copyOf(aggNamePath);
+    }
+
+    /**
+     * Adds a grouping contribution from a bucket translator. The grouping's per-field
+     * {@code missing} values are accumulated for the plan's null handling.
      *
      * @param grouping the grouping info
      */
     public void addGrouping(GroupingInfo grouping) {
         groupings.add(grouping);
-    }
-
-    /**
-     * Adds an aggregate call with its output field name.
-     *
-     * @param call the Calcite aggregate call
-     * @param fieldName the output field name
-     */
-    public void addAggregateCall(AggregateCall call, String fieldName) {
-        aggregateCalls.add(call);
-        aggregateFieldNames.add(fieldName);
+        missingValues.putAll(grouping.getMissingByField());
     }
 
     /**
@@ -68,13 +80,28 @@ public class AggregationMetadataBuilder {
      *
      * @param order the bucket order
      */
-    public void addBucketOrder(BucketOrder order) {
+    private void addBucketOrder(BucketOrder order) {
         if (order == null) return;
         if (order instanceof InternalOrder.CompoundOrder compound) {
             bucketOrders.addAll(compound.orderElements());
         } else {
             bucketOrders.add(order);
         }
+    }
+
+    /**
+     * Records the plan parameters of the bucket aggregation that defines this plan: its sort
+     * order plus the {@code size} and {@code min_doc_count} to bake in as LIMIT and HAVING.
+     * Called exactly once per builder — each bucket aggregation owns its own plan.
+     *
+     * @param order the bucket order (flattened like {@link #addBucketOrder})
+     * @param size the requested bucket count, or null for base-contract bucket types
+     * @param minDocCount the minimum bucket doc count, or null for base-contract bucket types
+     */
+    public void setBucketDefinition(BucketOrder order, Integer size, Long minDocCount) {
+        addBucketOrder(order);
+        this.definingSize = size;
+        this.definingMinDocCount = minDocCount;
     }
 
     /**
@@ -91,8 +118,28 @@ public class AggregationMetadataBuilder {
     }
 
     /**
+     * Adds an aggregate call with its output field name.
+     *
+     * @param call the Calcite aggregate call
+     * @param fieldName the output field name
+     */
+    public void addAggregateCall(AggregateCall call, String fieldName) {
+        aggregateCalls.add(call);
+        aggregateFieldNames.add(fieldName);
+    }
+
+    /**
      * Builds the immutable metadata. Resolves grouping indices from the input row type.
      * For no-GROUP-BY metrics, makes return types nullable (AVG of empty set is null).
+     *
+     * <p>Plan bounds, decided here: {@code min_doc_count} above 1 always becomes a HAVING
+     * filter. Root-level sized plans (a single grouping) get a flat LIMIT
+     * ({@code fetch = size}); nested sized plans (parent groupings present) get a per-parent
+     * bound instead ({@code perParentFetch = size}), enforced by the ROW_NUMBER window plan
+     * shape — a flat LIMIT there would keep globally-top groups, not each parent's top K.
+     * Multi-field groupings get no bound: the eligible-count machinery (count plans,
+     * {@code COUNT(field)}) is single-field today, and an unbounded plan fails loudly at
+     * render rather than accounting with a wrong total.
      *
      * @param inputRowType the schema before aggregation
      * @param typeFactory the type factory for creating types
@@ -151,7 +198,33 @@ public class AggregationMetadataBuilder {
             allFieldNames.add(IMPLICIT_COUNT_NAME);
         }
 
-        return new AggregationMetadata(ImmutableBitSet.of(allGroupIndices), allGroupFieldNames, allCalls, allFieldNames, bucketOrders);
+        // min_doc_count ≤ 1 needs no HAVING: a GROUP BY group has ≥ 1 row by construction.
+        Long havingMinDocCount = definingMinDocCount != null && definingMinDocCount > 1 ? definingMinDocCount : null;
+        Integer fetch = null;
+        Integer perParentFetch = null;
+        boolean singleFieldGroupings = groupings.stream().allMatch(g -> g.getFieldNames().size() == 1);
+        if (definingSize != null && singleFieldGroupings) {
+            if (groupings.size() == 1) {
+                fetch = definingSize;
+            } else {
+                // Nested level: the bound is per parent, not global — a flat LIMIT would keep
+                // globally-top groups, not each parent's top K.
+                perParentFetch = definingSize;
+            }
+        }
+
+        return new AggregationMetadata(
+            aggNamePath,
+            ImmutableBitSet.of(allGroupIndices),
+            allGroupFieldNames,
+            allCalls,
+            allFieldNames,
+            bucketOrders,
+            fetch,
+            perParentFetch,
+            havingMinDocCount,
+            missingValues
+        );
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -29,7 +29,7 @@ public class AggregationRegistryFactory {
      *
      * @param mapperServiceSupplier supplies the MapperService for the current request's target
      *        index — evaluated lazily when the terms translator resolves key types and formats.
-     *        May supply null, in which case key typing falls back to value sampling.
+     *        Supplying null skips mapping-dependent validation and fails terms rendering.
      */
     public static AggregationRegistry create(Supplier<MapperService> mapperServiceSupplier) {
         AggregationRegistry registry = new AggregationRegistry();
@@ -42,7 +42,7 @@ public class AggregationRegistryFactory {
         return registry;
     }
 
-    /** Creates a registry without mapping resolution — key typing falls back to value sampling. */
+    /** Creates a registry without mapping resolution — conversion-only use; terms rendering fails without a MapperService. */
     public static AggregationRegistry create() {
         return create(() -> null);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -13,6 +13,9 @@ import org.opensearch.dsl.aggregation.metric.AvgMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MaxMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MinMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.SumMetricTranslator;
+import org.opensearch.index.mapper.MapperService;
+
+import java.util.function.Supplier;
 
 /**
  * Creates an {@link AggregationRegistry} populated with all supported translators.
@@ -21,15 +24,26 @@ public class AggregationRegistryFactory {
 
     private AggregationRegistryFactory() {}
 
-    /** Creates a registry with all supported metric and bucket translators. */
-    public static AggregationRegistry create() {
+    /**
+     * Creates a registry with all supported metric and bucket translators.
+     *
+     * @param mapperServiceSupplier supplies the MapperService for the current request's target
+     *        index — evaluated lazily when the terms translator resolves key types and formats.
+     *        May supply null, in which case key typing falls back to value sampling.
+     */
+    public static AggregationRegistry create(Supplier<MapperService> mapperServiceSupplier) {
         AggregationRegistry registry = new AggregationRegistry();
         registry.register(new AvgMetricTranslator());
         registry.register(new SumMetricTranslator());
         registry.register(new MinMetricTranslator());
         registry.register(new MaxMetricTranslator());
-        registry.register(new TermsBucketTranslator());
+        registry.register(new TermsBucketTranslator(mapperServiceSupplier));
         // TODO: add other aggregation translators
         return registry;
+    }
+
+    /** Creates a registry without mapping resolution — key typing falls back to value sampling. */
+    public static AggregationRegistry create() {
+        return create(() -> null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
@@ -10,6 +10,8 @@ package org.opensearch.dsl.aggregation;
 
 import org.opensearch.search.aggregations.AggregationBuilder;
 
+import java.util.Map;
+
 /**
  * Base type interface for aggregation translators.
  * Provides type identification for the {@link AggregationRegistry}.
@@ -19,4 +21,15 @@ public interface AggregationTranslator<T extends AggregationBuilder> {
 
     /** Returns the concrete AggregationBuilder class this type handles. */
     Class<T> getAggregationType();
+
+    /**
+     * Returns the user-supplied {@code meta} map from the request, or null when absent so the
+     * response omits the {@code meta} section entirely (classic search renders {@code meta}
+     * only when supplied). {@link AggregationBuilder#getMetadata()} masks "absent" as an empty
+     * map, so an explicitly supplied empty {@code "meta": {}} is also treated as absent here.
+     */
+    static Map<String, Object> userMetadata(AggregationBuilder agg) {
+        Map<String, Object> metadata = agg.getMetadata();
+        return metadata == null || metadata.isEmpty() ? null : metadata;
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
 
 import java.util.Map;
@@ -21,6 +22,19 @@ public interface AggregationTranslator<T extends AggregationBuilder> {
 
     /** Returns the concrete AggregationBuilder class this type handles. */
     Class<T> getAggregationType();
+
+    /**
+     * Rejects requests carrying parameters this translator does not implement. Called once per
+     * aggregation, before any plan is built.
+     *
+     * <p>An unimplemented parameter must be rejected rather than ignored: ignoring it returns
+     * a well-formed response whose numbers differ from classic search. A translator that
+     * honors every parameter of its aggregation type provides an empty implementation.
+     *
+     * @param agg the aggregation builder to validate
+     * @throws ConversionException if the aggregation carries an unsupported parameter
+     */
+    void validate(T agg) throws ConversionException;
 
     /**
      * Returns the user-supplied {@code meta} map from the request, or null when absent so the

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -11,6 +11,7 @@ package org.opensearch.dsl.aggregation;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.bucket.SizedBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.MetricTranslator;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -20,16 +21,16 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Recursively walks the DSL aggregation tree and produces one {@link AggregationMetadata}
- * per distinct granularity level.
+ * per plan.
  *
- * <p>A "granularity" is a unique GROUP BY key set determined by the accumulated bucket
- * nesting path. Metrics at different nesting depths produce separate metadata instances,
- * each yielding its own {@code LogicalAggregate} and {@code QueryPlan}.
+ * <p>Plans are per bucket aggregation, keyed by the aggregation-name path (unique among
+ * siblings by DSL contract): each bucket aggregation's plan bakes in its own {@code size},
+ * {@code min_doc_count}, and order, so sibling aggregations over the same field produce
+ * separate plans rather than sharing one that cannot satisfy both. Metrics ride in their
+ * enclosing bucket aggregation's plan; root-level metrics share one global no-GROUP-BY plan.
  */
 public class AggregationTreeWalker {
 
@@ -44,22 +45,28 @@ public class AggregationTreeWalker {
         this.registry = registry;
     }
 
+    /** One step of the accumulated nesting path: the aggregation name and its grouping. */
+    private record PathStep(String aggName, GroupingInfo grouping) {
+    }
+
     /**
-     * Walks the aggregation tree and returns one AggregationMetadata per granularity level.
+     * Walks the aggregation tree and returns one AggregationMetadata per plan.
      *
      * @param aggs the top-level aggregation builders
      * @param rowType the input row type for field resolution
      * @param typeFactory the type factory for creating aggregate return types
-     * @return metadata list, one per granularity (only levels with metrics or implicit count)
+     * @return metadata list, one per plan (only plans with metrics or implicit count). A parent
+     *         plan always precedes its children — nested plan construction consumes the parent's
+     *         built plan and depends on this order.
      * @throws ConversionException if any aggregation fails to convert
      */
     public List<AggregationMetadata> walk(Collection<AggregationBuilder> aggs, RelDataType rowType, RelDataTypeFactory typeFactory)
         throws ConversionException {
-        Map<String, AggregationMetadataBuilder> granularities = new LinkedHashMap<>();
-        walkRecursive(aggs, new ArrayList<>(), granularities, rowType);
+        Map<String, AggregationMetadataBuilder> plans = new LinkedHashMap<>();
+        walkRecursive(aggs, new ArrayList<>(), plans, rowType);
 
         List<AggregationMetadata> result = new ArrayList<>();
-        for (AggregationMetadataBuilder builder : granularities.values()) {
+        for (AggregationMetadataBuilder builder : plans.values()) {
             if (builder.hasAggregateCalls()) {
                 result.add(builder.build(rowType, typeFactory));
             }
@@ -70,8 +77,8 @@ public class AggregationTreeWalker {
     @SuppressWarnings("unchecked")
     private void walkRecursive(
         Collection<AggregationBuilder> aggs,
-        List<GroupingInfo> currentGroupings,
-        Map<String, AggregationMetadataBuilder> granularities,
+        List<PathStep> currentPath,
+        Map<String, AggregationMetadataBuilder> plans,
         RelDataType rowType
     ) throws ConversionException {
         for (AggregationBuilder aggBuilder : aggs) {
@@ -79,10 +86,13 @@ public class AggregationTreeWalker {
 
             if (type == null) {
                 throw new ConversionException("No translator registered for aggregation type: " + aggBuilder.getClass().getSimpleName());
-            } else if (type instanceof BucketTranslator) {
-                handleBucket((BucketTranslator<AggregationBuilder>) type, aggBuilder, currentGroupings, granularities, rowType);
+            }
+            // Reject unsupported parameters before any plan state accumulates.
+            ((AggregationTranslator<AggregationBuilder>) type).validate(aggBuilder);
+            if (type instanceof BucketTranslator) {
+                handleBucket((BucketTranslator<AggregationBuilder>) type, aggBuilder, currentPath, plans, rowType);
             } else if (type instanceof MetricTranslator) {
-                handleMetric((MetricTranslator<AggregationBuilder>) type, aggBuilder, currentGroupings, granularities, rowType);
+                handleMetric((MetricTranslator<AggregationBuilder>) type, aggBuilder, currentPath, plans, rowType);
             } else {
                 throw new ConversionException("Unsupported aggregation translator kind: " + type.getClass().getSimpleName());
             }
@@ -92,64 +102,63 @@ public class AggregationTreeWalker {
     private void handleBucket(
         BucketTranslator<AggregationBuilder> translator,
         AggregationBuilder aggBuilder,
-        List<GroupingInfo> currentGroupings,
-        Map<String, AggregationMetadataBuilder> granularities,
+        List<PathStep> currentPath,
+        Map<String, AggregationMetadataBuilder> plans,
         RelDataType rowType
     ) throws ConversionException {
         GroupingInfo grouping = translator.getGrouping(aggBuilder);
 
-        List<GroupingInfo> accumulatedGroupings = new ArrayList<>(currentGroupings);
-        accumulatedGroupings.add(grouping);
+        List<PathStep> accumulatedPath = new ArrayList<>(currentPath);
+        accumulatedPath.add(new PathStep(aggBuilder.getName(), grouping));
 
-        // Ensure builder exists for this granularity
-        AggregationMetadataBuilder builder = getOrCreateBuilder(accumulatedGroupings, granularities);
-        builder.addBucketOrder(translator.getBucketOrder(aggBuilder));
+        // Every bucket aggregation defines its own plan; sibling names are unique by DSL
+        // contract, so the path key cannot collide with another plan's.
+        AggregationMetadataBuilder builder = getOrCreateBuilder(accumulatedPath, plans);
+        if (translator instanceof SizedBucketTranslator<AggregationBuilder> sized) {
+            builder.setBucketDefinition(translator.getBucketOrder(aggBuilder), sized.size(aggBuilder), sized.minDocCount(aggBuilder));
+        } else {
+            // Base-contract bucket types return their full bucket set; the plan stays unbounded.
+            builder.setBucketDefinition(translator.getBucketOrder(aggBuilder), null, null);
+        }
 
         // Recurse into sub-aggregations
         Collection<AggregationBuilder> subAggs = translator.getSubAggregations(aggBuilder);
         if (subAggs != null && !subAggs.isEmpty()) {
-            walkRecursive(subAggs, accumulatedGroupings, granularities, rowType);
+            walkRecursive(subAggs, accumulatedPath, plans, rowType);
         }
     }
 
     private void handleMetric(
         MetricTranslator<AggregationBuilder> translator,
         AggregationBuilder aggBuilder,
-        List<GroupingInfo> currentGroupings,
-        Map<String, AggregationMetadataBuilder> granularities,
+        List<PathStep> currentPath,
+        Map<String, AggregationMetadataBuilder> plans,
         RelDataType rowType
     ) throws ConversionException {
-        AggregationMetadataBuilder builder = getOrCreateBuilder(currentGroupings, granularities);
+        AggregationMetadataBuilder builder = getOrCreateBuilder(currentPath, plans);
         builder.addAggregateCall(translator.toAggregateCall(aggBuilder, rowType), translator.getAggregateFieldName(aggBuilder));
     }
 
-    private AggregationMetadataBuilder getOrCreateBuilder(
-        List<GroupingInfo> groupings,
-        Map<String, AggregationMetadataBuilder> granularities
-    ) {
-        String key = granularityKey(groupings);
-        AggregationMetadataBuilder existing = granularities.get(key);
+    private AggregationMetadataBuilder getOrCreateBuilder(List<PathStep> path, Map<String, AggregationMetadataBuilder> plans) {
+        String key = pathKey(path);
+        AggregationMetadataBuilder existing = plans.get(key);
         if (existing != null) {
             return existing;
         }
 
-        AggregationMetadataBuilder builder = new AggregationMetadataBuilder();
-        for (GroupingInfo g : groupings) {
-            builder.addGrouping(g);
+        List<String> aggNamePath = path.stream().map(PathStep::aggName).toList();
+        AggregationMetadataBuilder builder = new AggregationMetadataBuilder(aggNamePath);
+        for (PathStep step : path) {
+            builder.addGrouping(step.grouping());
         }
-        if (!groupings.isEmpty()) {
+        if (!path.isEmpty()) {
             builder.requestImplicitCount();
         }
-        granularities.put(key, builder);
+        plans.put(key, builder);
         return builder;
     }
 
-    private static String granularityKey(List<GroupingInfo> groupings) {
-        if (groupings.isEmpty()) {
-            return "";
-        }
-        return IntStream.range(0, groupings.size())
-            .mapToObj(i -> i + ":" + String.join(",", groupings.get(i).getFieldNames()))
-            .collect(Collectors.joining("|"));
+    private static String pathKey(List<PathStep> path) {
+        return AggregationMetadata.pathKey(path.stream().map(PathStep::aggName).toList());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/FieldGrouping.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/FieldGrouping.java
@@ -9,26 +9,44 @@
 package org.opensearch.dsl.aggregation;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Field-based grouping: GROUP BY field1, field2, ...
- * Used by terms and multi_terms bucket aggregations.
  */
 public class FieldGrouping implements GroupingInfo {
 
     private final List<String> fieldNames;
+    private final Map<String, Object> missingByField;
+
+    /**
+     * Creates a field grouping with no {@code missing} substitutions.
+     *
+     * @param fieldNames the field names to group by
+     */
+    public FieldGrouping(List<String> fieldNames) {
+        this(fieldNames, Map.of());
+    }
 
     /**
      * Creates a field grouping.
      *
      * @param fieldNames the field names to group by
+     * @param missingByField the {@code missing} null-substitution value per field; fields
+     *        absent from the map exclude null-valued documents from grouping
      */
-    public FieldGrouping(List<String> fieldNames) {
+    public FieldGrouping(List<String> fieldNames, Map<String, Object> missingByField) {
         this.fieldNames = List.copyOf(fieldNames);
+        this.missingByField = Map.copyOf(missingByField);
     }
 
     @Override
     public List<String> getFieldNames() {
         return fieldNames;
+    }
+
+    @Override
+    public Map<String, Object> getMissingByField() {
+        return missingByField;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/GroupingInfo.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/GroupingInfo.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a grouping contribution from a bucket aggregation.
@@ -19,4 +20,13 @@ public interface GroupingInfo {
 
     /** Returns the logical field names this grouping contributes. */
     List<String> getFieldNames();
+
+    /**
+     * Returns the null-substitution value per field (the {@code missing} request parameter).
+     * Documents with a null value for a listed field join the substitute value's group; fields
+     * absent from the map keep the default semantics — their null-valued documents are excluded
+     * from grouping entirely, matching classic search. Empty when no field has a
+     * {@code missing} value.
+     */
+    Map<String, Object> getMissingByField();
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BucketTranslator.java
@@ -49,6 +49,8 @@ public interface BucketTranslator<T extends AggregationBuilder> extends Aggregat
 
     /**
      * Converts grouped bucket entries into an OpenSearch InternalAggregation for response building.
+     * Each entry carries one key per field declared in {@link #getGrouping}, in declaration order:
+     * {@code keys().get(i)} is the value of the i-th group field.
      *
      * @param agg the original aggregation builder
      * @param buckets the bucket entries with keys, doc counts, and sub-aggs

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/DoubleTermsStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/DoubleTermsStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a {@link DoubleTerms} response for floating-point key types (float, double,
+ * half_float, scaled_float). Constructor argument semantics match {@link LongTermsStrategy}.
+ */
+public final class DoubleTermsStrategy implements TermsResponseStrategy {
+
+    /** Singleton instance. */
+    public static final DoubleTermsStrategy INSTANCE = new DoubleTermsStrategy();
+
+    private DoubleTermsStrategy() {}
+
+    @Override
+    public InternalAggregation build(TermsAggregationBuilder agg, List<BucketEntry> entries, long otherDocCount, DocValueFormat format) {
+        List<DoubleTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            double term = ((Number) entry.keys().get(0)).doubleValue();
+            termBuckets.add(new DoubleTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
+        }
+        BucketOrder order = agg.order();
+        return new DoubleTerms(
+            agg.getName(),
+            order,
+            order,
+            AggregationTranslator.userMetadata(agg),
+            format,
+            agg.shardSize(),
+            false,
+            otherDocCount,
+            termBuckets,
+            0,
+            TermsBucketTranslator.thresholds(agg)
+        );
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/LongTermsStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/LongTermsStrategy.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.LongTerms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a {@link LongTerms} response. Handles all integral numeric types (long, integer,
+ * short, byte, date, date_nanos, unsigned_long) and booleans (as 0/1).
+ *
+ * <p>The {@link DocValueFormat} controls key rendering: dates produce formatted strings via
+ * {@code DocValueFormat.DateTime}, booleans produce "true"/"false" via
+ * {@code DocValueFormat.BOOLEAN}, plain numerics use RAW (just the number).
+ */
+public final class LongTermsStrategy implements TermsResponseStrategy {
+
+    /** Standard instance for numeric/date fields. */
+    public static final LongTermsStrategy INSTANCE = new LongTermsStrategy(false);
+
+    /** Instance for boolean fields — converts true/false to 1/0. */
+    public static final LongTermsStrategy BOOLEAN_INSTANCE = new LongTermsStrategy(true);
+
+    private final boolean isBoolean;
+
+    private LongTermsStrategy(boolean isBoolean) {
+        this.isBoolean = isBoolean;
+    }
+
+    @Override
+    public InternalAggregation build(TermsAggregationBuilder agg, List<BucketEntry> entries, long otherDocCount, DocValueFormat format) {
+        // Boolean fields use DocValueFormat.BOOLEAN regardless of what was resolved
+        DocValueFormat effectiveFormat = isBoolean ? DocValueFormat.BOOLEAN : format;
+
+        List<LongTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            long term = toLong(entry.keys().get(0));
+            termBuckets.add(new LongTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, effectiveFormat));
+        }
+        BucketOrder order = agg.order();
+        return new LongTerms(
+            agg.getName(),
+            order, // reduceOrder: the plan sorted the bucket list by it
+            order, // the user-requested display order
+            AggregationTranslator.userMetadata(agg),
+            effectiveFormat,
+            agg.shardSize(), // request echo — no shard fan-out on this path
+            false, // no per-bucket doc count error rendering
+            otherDocCount,
+            termBuckets,
+            0, // exact single-plan path: doc_count_error_upper_bound is truly 0
+            TermsBucketTranslator.thresholds(agg)
+        );
+    }
+
+    private long toLong(Object key) {
+        if (key instanceof Boolean bool) {
+            return bool ? 1L : 0L;
+        }
+        return ((Number) key).longValue();
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/SizedBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/SizedBucketTranslator.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+
+/**
+ * A {@link BucketTranslator} for bucket types with top-K semantics: the response carries the
+ * top {@code size} buckets by the requested order, and the remaining documents are reported as
+ * {@code sum_other_doc_count}. Terms and its relatives fit this contract; types that return
+ * their full bucket set (histogram, range, filters) do not implement it.
+ *
+ * <p>Plans for these aggregations enforce {@code size}, {@code min_doc_count}, and order
+ * engine-side (LIMIT, HAVING, SORT), so the engine returns exactly the response's bucket set.
+ * Rendering goes through
+ * {@link #toBucketAggregation(AggregationBuilder, Iterable, long)}, which receives that set
+ * already filtered, ordered, and truncated, plus the eligible-document total that
+ * {@code sum_other_doc_count} is derived from.
+ */
+public interface SizedBucketTranslator<T extends AggregationBuilder> extends BucketTranslator<T> {
+
+    /**
+     * Returns the requested bucket count (the {@code size} parameter).
+     *
+     * @param agg the bucket aggregation builder
+     * @return the requested size
+     */
+    int size(T agg);
+
+    /**
+     * Returns the minimum per-bucket doc count (the {@code min_doc_count} parameter).
+     * Values above 1 become a plan-level HAVING filter.
+     *
+     * @param agg the bucket aggregation builder
+     * @return the minimum doc count
+     */
+    long minDocCount(T agg);
+
+    /**
+     * Renders a level whose plan enforced {@code size}. The entries are the final bucket set —
+     * already filtered (nulls, {@code min_doc_count}), ordered, and truncated by the plan —
+     * and are rendered as received.
+     *
+     * @param agg the original aggregation builder
+     * @param buckets the top bucket entries
+     * @param eligibleDocCount total documents eligible for this level's buckets;
+     *        {@code sum_other_doc_count} is this value minus the received buckets' doc counts
+     * @return the InternalAggregation
+     */
+    InternalAggregation toBucketAggregation(T agg, Iterable<BucketEntry> buckets, long eligibleDocCount);
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Builds a {@link StringTerms} response. Handles keyword, ip, text, and any field type whose
+ * bucket keys are naturally string-representable; also the fallback for unmapped types.
+ *
+ * <p>Keys render through the resolved {@link DocValueFormat}: for ip fields the mapping's
+ * format produces the address string; for keywords it is the identity. Binary keys arriving
+ * without a mapping-resolved format fall back to address-string rendering.
+ */
+public final class StringTermsStrategy implements TermsResponseStrategy {
+
+    /** Singleton instance. */
+    public static final StringTermsStrategy INSTANCE = new StringTermsStrategy();
+
+    private StringTermsStrategy() {}
+
+    @Override
+    public InternalAggregation build(TermsAggregationBuilder agg, List<BucketEntry> entries, long otherDocCount, DocValueFormat format) {
+        List<StringTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            BytesRef term = new BytesRef(formatKey(entry.keys().get(0), format));
+            termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
+        }
+        BucketOrder order = agg.order();
+        return new StringTerms(
+            agg.getName(),
+            order,
+            order,
+            AggregationTranslator.userMetadata(agg),
+            format,
+            agg.shardSize(),
+            false,
+            otherDocCount,
+            termBuckets,
+            0,
+            TermsBucketTranslator.thresholds(agg)
+        );
+    }
+
+    /**
+     * Renders a key through the resolved {@link DocValueFormat}. Binary keys (ip columns)
+     * format through the mapping when one was resolved; with the RAW fallback they render as
+     * the address string directly, or Base64 when not a 4/16-byte address.
+     */
+    private static String formatKey(Object key, DocValueFormat format) {
+        if (key instanceof BytesRef ref) {
+            return format == DocValueFormat.RAW ? binaryKeyString(ref.bytes) : format.format(ref).toString();
+        }
+        if (key instanceof byte[] bytes) {
+            return format == DocValueFormat.RAW ? binaryKeyString(bytes) : format.format(new BytesRef(bytes)).toString();
+        }
+        return key.toString();
+    }
+
+    /** Binary keys are ip columns: render the address string like classic ip terms. */
+    private static String binaryKeyString(byte[] bytes) {
+        try {
+            return NetworkAddress.format(InetAddress.getByAddress(bytes));
+        } catch (UnknownHostException e) {
+            // Not a 4/16-byte address; fall back to a printable, deterministic form.
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
@@ -26,11 +26,12 @@ import java.util.List;
 
 /**
  * Builds a {@link StringTerms} response. Handles keyword, ip, text, and any field type whose
- * bucket keys are naturally string-representable; also the fallback for unmapped types.
+ * bucket keys are naturally string-representable; also the default for unregistered type names.
  *
- * <p>Keys render through the resolved {@link DocValueFormat}: for ip fields the mapping's
- * format produces the address string; for keywords it is the identity. Binary keys arriving
- * without a mapping-resolved format fall back to address-string rendering.
+ * <p>Bucket terms follow the classic StringTerms contract: binary keys (ip columns) are stored
+ * as their encoded bytes and the mapping's {@link DocValueFormat} renders them at serialization;
+ * string keys are stored as their UTF-8 bytes. A binary key without a mapping-resolved format
+ * (RAW) renders as a deterministic Base64 string.
  */
 public final class StringTermsStrategy implements TermsResponseStrategy {
 
@@ -43,7 +44,7 @@ public final class StringTermsStrategy implements TermsResponseStrategy {
     public InternalAggregation build(TermsAggregationBuilder agg, List<BucketEntry> entries, long otherDocCount, DocValueFormat format) {
         List<StringTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
         for (BucketEntry entry : entries) {
-            BytesRef term = new BytesRef(formatKey(entry.keys().get(0), format));
+            BytesRef term = termBytes(entry.keys().get(0), format);
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
         }
         BucketOrder order = agg.order();
@@ -63,18 +64,19 @@ public final class StringTermsStrategy implements TermsResponseStrategy {
     }
 
     /**
-     * Renders a key through the resolved {@link DocValueFormat}. Binary keys (ip columns)
-     * format through the mapping when one was resolved; with the RAW fallback they render as
-     * the address string directly, or Base64 when not a 4/16-byte address.
+     * Converts a key into the bucket's term bytes. Binary keys (ip columns) keep their encoded
+     * bytes so the mapping-resolved {@link DocValueFormat} renders them at serialization — the
+     * classic StringTerms contract; under RAW they are pre-rendered (address string or Base64)
+     * since RAW would otherwise print raw bytes. String keys become their UTF-8 bytes.
      */
-    private static String formatKey(Object key, DocValueFormat format) {
+    private static BytesRef termBytes(Object key, DocValueFormat format) {
         if (key instanceof BytesRef ref) {
-            return format == DocValueFormat.RAW ? binaryKeyString(ref.bytes) : format.format(ref).toString();
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(ref.bytes)) : ref;
         }
         if (key instanceof byte[] bytes) {
-            return format == DocValueFormat.RAW ? binaryKeyString(bytes) : format.format(new BytesRef(bytes)).toString();
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(bytes)) : new BytesRef(bytes);
         }
-        return key.toString();
+        return new BytesRef(key.toString());
     }
 
     /** Binary keys are ip columns: render the address string like classic ip terms. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -8,14 +8,19 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -48,9 +53,39 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
         return agg.order();
     }
 
-    // TODO: implement response conversion
+    /**
+     * Builds a {@link StringTerms} (keys rendered via {@code toString}; per-key-type
+     * Long/Double variants are follow-up work). Shard accounting fields are zero — the
+     * analytics path computes exact groups with no per-shard truncation. Bucket order is
+     * already established by the plan's post-aggregate sort.
+     */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
-        throw new UnsupportedOperationException("toBucketAggregation not yet implemented");
+        List<StringTerms.Bucket> termBuckets = new ArrayList<>();
+        for (BucketEntry entry : buckets) {
+            Object key = entry.keys().get(0);
+            BytesRef term = new BytesRef(key == null ? "" : key.toString());
+            termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
+        }
+        BucketOrder order = agg.order();
+        TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(
+            agg.minDocCount(),
+            agg.shardMinDocCount(),
+            agg.size(),
+            agg.shardSize()
+        );
+        return new StringTerms(
+            agg.getName(),
+            order,
+            order,
+            null,
+            DocValueFormat.RAW,
+            agg.shardSize(),
+            false,
+            0,
+            termBuckets,
+            0,
+            thresholds
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -64,7 +64,12 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
         List<StringTerms.Bucket> termBuckets = new ArrayList<>();
         for (BucketEntry entry : buckets) {
             Object key = entry.keys().get(0);
-            BytesRef term = new BytesRef(key == null ? "" : key.toString());
+            if (key == null) {
+                // SQL GROUP BY emits a NULL group; legacy terms excludes docs with a
+                // missing field entirely (no bucket) unless "missing" is configured.
+                continue;
+            }
+            BytesRef term = new BytesRef(key.toString());
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
         BucketOrder order = agg.order();

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -85,6 +85,7 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             for (int i = agg.size(); i < termBuckets.size(); i++) {
                 otherDocCount += termBuckets.get(i).getDocCount();
             }
+            // Copy rather than clear the tail in place: releases the full-size backing array.
             termBuckets = new ArrayList<>(termBuckets.subList(0, agg.size()));
         }
 
@@ -97,15 +98,15 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
         );
         return new StringTerms(
             agg.getName(),
-            order,
-            order,
+            order, // reduceOrder: the bucket list is already sorted by it (see sort above)
+            order, // the user-requested display order
             AggregationTranslator.userMetadata(agg),
-            DocValueFormat.RAW,
-            agg.shardSize(),
-            false,
+            DocValueFormat.RAW, // keyword parity: the mapping-resolved format for string keys is RAW
+            agg.shardSize(), // request echo — no shard fan-out on this path
+            false, // no per-bucket doc count error rendering
             otherDocCount,
             termBuckets,
-            0,
+            0, // exact single-plan path: doc_count_error_upper_bound is truly 0
             thresholds
         );
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
@@ -17,11 +18,17 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 
@@ -55,16 +62,17 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
     }
 
     /**
-     * Builds a {@link StringTerms}. Buckets are sorted by the requested order, filtered by
-     * {@code min_doc_count}, and truncated to {@code size}; truncated bucket counts are
-     * reported as {@code sum_other_doc_count}.
+     * Builds the terms response with classic-path key typing, sampled from the first bucket key:
+     * integral keys → {@link LongTerms}, floating → {@link DoubleTerms}, booleans → {@link LongTerms}
+     * with the BOOLEAN format, binary (ip) keys render as address strings, else {@link StringTerms}.
+     * Buckets are filtered by {@code min_doc_count}, sorted by the requested order, and truncated to
+     * {@code size}; truncated bucket counts are reported as {@code sum_other_doc_count}.
      */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
-        List<StringTerms.Bucket> termBuckets = new ArrayList<>();
+        List<BucketEntry> kept = new ArrayList<>();
         for (BucketEntry entry : buckets) {
-            Object key = entry.keys().get(0);
-            if (key == null) {
+            if (entry.keys().get(0) == null) {
                 // SQL GROUP BY emits a NULL group; legacy terms excludes docs with a
                 // missing field entirely (no bucket) unless "missing" is configured.
                 continue;
@@ -72,42 +80,142 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             if (entry.docCount() < agg.minDocCount()) {
                 continue;
             }
-            BytesRef term = new BytesRef(key.toString());
+            kept.add(entry);
+        }
+
+        Object sample = kept.isEmpty() ? null : kept.get(0).keys().get(0);
+        if (sample instanceof Boolean) {
+            return longTerms(agg, kept, DocValueFormat.BOOLEAN);
+        }
+        if (sample instanceof Double || sample instanceof Float) {
+            return doubleTerms(agg, kept);
+        }
+        if (sample instanceof Number) {
+            return longTerms(agg, kept, DocValueFormat.RAW);
+        }
+        return stringTerms(agg, kept);
+    }
+
+    /** Builds a {@link StringTerms}; string and binary (ip) keys land here. */
+    private static InternalAggregation stringTerms(TermsAggregationBuilder agg, List<BucketEntry> entries) {
+        List<StringTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            BytesRef term = new BytesRef(keyString(entry.keys().get(0)));
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
-
-        // Sort per this aggregation's own order: sibling aggregations sharing a granularity
-        // share one plan-level sort, which cannot satisfy two different requested orders.
-        termBuckets.sort(getBucketOrder(agg).comparator());
-
-        long otherDocCount = 0;
-        if (termBuckets.size() > agg.size()) {
-            for (int i = agg.size(); i < termBuckets.size(); i++) {
-                otherDocCount += termBuckets.get(i).getDocCount();
-            }
-            // Copy rather than clear the tail in place: releases the full-size backing array.
-            termBuckets = new ArrayList<>(termBuckets.subList(0, agg.size()));
-        }
-
+        Truncated<StringTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
         BucketOrder order = agg.order();
-        TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(
-            agg.minDocCount(),
-            agg.shardMinDocCount(),
-            agg.size(),
-            agg.shardSize()
-        );
         return new StringTerms(
             agg.getName(),
-            order, // reduceOrder: the bucket list is already sorted by it (see sort above)
+            order, // reduceOrder: the bucket list is already sorted by it (see sortAndTruncate)
             order, // the user-requested display order
             AggregationTranslator.userMetadata(agg),
             DocValueFormat.RAW, // keyword parity: the mapping-resolved format for string keys is RAW
             agg.shardSize(), // request echo — no shard fan-out on this path
             false, // no per-bucket doc count error rendering
-            otherDocCount,
-            termBuckets,
+            visible.otherDocCount(),
+            visible.buckets(),
             0, // exact single-plan path: doc_count_error_upper_bound is truly 0
-            thresholds
+            thresholds(agg)
         );
+    }
+
+    /**
+     * Builds a {@link LongTerms} for integral keys; booleans ride along as 0/1 with the BOOLEAN
+     * format. Constructor argument semantics match {@link #stringTerms}.
+     */
+    private static InternalAggregation longTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, DocValueFormat format) {
+        List<LongTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            Object key = entry.keys().get(0);
+            long term = key instanceof Boolean bool ? (bool ? 1L : 0L) : ((Number) key).longValue();
+            termBuckets.add(new LongTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
+        }
+        Truncated<LongTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
+        BucketOrder order = agg.order();
+        return new LongTerms(
+            agg.getName(),
+            order,
+            order,
+            AggregationTranslator.userMetadata(agg),
+            format,
+            agg.shardSize(),
+            false,
+            visible.otherDocCount(),
+            visible.buckets(),
+            0,
+            thresholds(agg)
+        );
+    }
+
+    /**
+     * Builds a {@link DoubleTerms} for floating-point keys. Constructor argument semantics match
+     * {@link #stringTerms}.
+     */
+    private static InternalAggregation doubleTerms(TermsAggregationBuilder agg, List<BucketEntry> entries) {
+        List<DoubleTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
+        for (BucketEntry entry : entries) {
+            double term = ((Number) entry.keys().get(0)).doubleValue();
+            termBuckets.add(new DoubleTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
+        }
+        Truncated<DoubleTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
+        BucketOrder order = agg.order();
+        return new DoubleTerms(
+            agg.getName(),
+            order,
+            order,
+            AggregationTranslator.userMetadata(agg),
+            DocValueFormat.RAW,
+            agg.shardSize(),
+            false,
+            visible.otherDocCount(),
+            visible.buckets(),
+            0,
+            thresholds(agg)
+        );
+    }
+
+    /** Result of {@link #sortAndTruncate}: the visible buckets and the truncated tail's doc count. */
+    private record Truncated<B extends MultiBucketsAggregation.Bucket>(List<B> buckets, long otherDocCount) {
+    }
+
+    /**
+     * Sorts buckets per this aggregation's own order and truncates to {@code size}. The re-sort is
+     * required because sibling aggregations sharing a granularity share one plan-level sort, which
+     * cannot satisfy two different requested orders.
+     */
+    private static <B extends MultiBucketsAggregation.Bucket> Truncated<B> sortAndTruncate(
+        List<B> termBuckets,
+        TermsAggregationBuilder agg
+    ) {
+        termBuckets.sort(agg.order().comparator());
+        long otherDocCount = 0;
+        List<B> visible = termBuckets;
+        if (termBuckets.size() > agg.size()) {
+            for (int i = agg.size(); i < termBuckets.size(); i++) {
+                otherDocCount += termBuckets.get(i).getDocCount();
+            }
+            // Copy rather than clear the tail in place: releases the full-size backing array.
+            visible = new ArrayList<>(termBuckets.subList(0, agg.size()));
+        }
+        return new Truncated<>(visible, otherDocCount);
+    }
+
+    /** Binary keys are ip columns: render the address string like classic ip terms. */
+    private static String keyString(Object key) {
+        if (key instanceof byte[] bytes) {
+            try {
+                return NetworkAddress.format(InetAddress.getByAddress(bytes));
+            } catch (UnknownHostException e) {
+                // Not a 4/16-byte address; fall back to a printable, deterministic form.
+                return Base64.getEncoder().encodeToString(bytes);
+            }
+        }
+        return key.toString();
+    }
+
+    /** Bundles the request's bucket-count knobs for the result constructors. */
+    private static TermsAggregator.BucketCountThresholds thresholds(TermsAggregationBuilder agg) {
+        return new TermsAggregator.BucketCountThresholds(agg.minDocCount(), agg.shardMinDocCount(), agg.size(), agg.shardSize());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -8,40 +8,47 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
-import org.apache.lucene.util.BytesRef;
-import org.opensearch.common.network.NetworkAddress;
-import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
-import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
-import org.opensearch.search.aggregations.bucket.terms.LongTerms;
-import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Translates a {@link TermsAggregationBuilder} — single-field GROUP BY.
  * {@code {"aggs": {"by_brand": {"terms": {"field": "brand"}}}}} becomes {@code GROUP BY brand}.
+ *
+ * <p>Response typing is handled by the {@link TermsResponseStrategy} registry: the field's
+ * mapping-resolved type name selects the strategy that builds the correct {@code InternalTerms}
+ * subclass, with the mapping's {@link DocValueFormat} rendering the keys. When no mapping is
+ * resolvable, typing falls back to sampling the first bucket key's Java type with RAW formats.
  */
 public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggregationBuilder> {
 
-    /** Creates a terms bucket translator. */
-    public TermsBucketTranslator() {}
+    private final Supplier<MapperService> mapperServiceSupplier;
+
+    /**
+     * Creates a terms bucket translator.
+     *
+     * @param mapperServiceSupplier supplies the target index's MapperService for key type and
+     *        format resolution; may supply null, which selects the sampling fallback
+     */
+    public TermsBucketTranslator(Supplier<MapperService> mapperServiceSupplier) {
+        this.mapperServiceSupplier = mapperServiceSupplier;
+    }
 
     @Override
     public Class<TermsAggregationBuilder> getAggregationType() {
@@ -139,105 +146,44 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
     }
 
     /**
-     * Builds the terms response with classic-path key typing, sampled from the first bucket key:
-     * integral keys → {@link LongTerms}, floating → {@link DoubleTerms}, booleans → {@link LongTerms}
-     * with the BOOLEAN format, binary (ip) keys render as address strings, else {@link StringTerms}.
-     * {@code eligibleDocCount} supplies the total {@code sum_other_doc_count} is subtracted from (see
-     * {@link #sumOtherDocCount}).
+     * Builds the terms response: the field's mapping selects the {@link TermsResponseStrategy}
+     * and the {@link DocValueFormat} for key rendering; without a resolvable mapping, both are
+     * inferred from the first bucket key's Java type. {@code eligibleDocCount} supplies the
+     * total {@code sum_other_doc_count} is subtracted from (see {@link #sumOtherDocCount}).
      */
-    private static InternalAggregation render(TermsAggregationBuilder agg, List<BucketEntry> kept, long eligibleDocCount) {
+    private InternalAggregation render(TermsAggregationBuilder agg, List<BucketEntry> kept, long eligibleDocCount) {
+        long otherDocCount = sumOtherDocCount(kept, eligibleDocCount);
+        MappedFieldType fieldType = resolveFieldType(agg.field());
+        if (fieldType != null) {
+            TermsResponseStrategy strategy = TermsResponseStrategy.forType(fieldType.typeName());
+            return strategy.build(agg, kept, otherDocCount, fieldType.docValueFormat(null, null));
+        }
+        return sampledStrategy(kept).build(agg, kept, otherDocCount, DocValueFormat.RAW);
+    }
+
+    /** Resolves the group field's mapping, or null when no MapperService is available. */
+    private MappedFieldType resolveFieldType(String field) {
+        MapperService mapperService = mapperServiceSupplier.get();
+        return mapperService == null ? null : mapperService.fieldType(field);
+    }
+
+    /**
+     * Mapping-less fallback: infers the strategy from the first bucket key's Java type —
+     * booleans and integral numbers → LongTerms, floating point → DoubleTerms, anything
+     * else (including binary ip keys) → StringTerms.
+     */
+    private static TermsResponseStrategy sampledStrategy(List<BucketEntry> kept) {
         Object sample = kept.isEmpty() ? null : kept.get(0).keys().get(0);
         if (sample instanceof Boolean) {
-            return longTerms(agg, kept, DocValueFormat.BOOLEAN, eligibleDocCount);
+            return TermsResponseStrategy.forType("boolean");
         }
         if (sample instanceof Double || sample instanceof Float) {
-            return doubleTerms(agg, kept, eligibleDocCount);
+            return TermsResponseStrategy.forType("double");
         }
         if (sample instanceof Number) {
-            return longTerms(agg, kept, DocValueFormat.RAW, eligibleDocCount);
+            return TermsResponseStrategy.forType("long");
         }
-        return stringTerms(agg, kept, eligibleDocCount);
-    }
-
-    /** Builds a {@link StringTerms}; string and binary (ip) keys land here. */
-    private static InternalAggregation stringTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, long eligibleDocCount) {
-        List<StringTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
-        for (BucketEntry entry : entries) {
-            BytesRef term = new BytesRef(keyString(entry.keys().get(0)));
-            termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
-        }
-        BucketOrder order = agg.order();
-        return new StringTerms(
-            agg.getName(),
-            order, // reduceOrder: the plan sorted the bucket list by it
-            order, // the user-requested display order
-            AggregationTranslator.userMetadata(agg),
-            DocValueFormat.RAW, // keyword parity: the mapping-resolved format for string keys is RAW
-            agg.shardSize(), // request echo — no shard fan-out on this path
-            false, // no per-bucket doc count error rendering
-            sumOtherDocCount(termBuckets, eligibleDocCount),
-            termBuckets,
-            0, // exact single-plan path: doc_count_error_upper_bound is truly 0
-            thresholds(agg)
-        );
-    }
-
-    /**
-     * Builds a {@link LongTerms} for integral keys; booleans ride along as 0/1 with the BOOLEAN
-     * format. Constructor argument semantics match {@link #stringTerms}.
-     */
-    private static InternalAggregation longTerms(
-        TermsAggregationBuilder agg,
-        List<BucketEntry> entries,
-        DocValueFormat format,
-        long eligibleDocCount
-    ) {
-        List<LongTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
-        for (BucketEntry entry : entries) {
-            Object key = entry.keys().get(0);
-            long term = key instanceof Boolean bool ? (bool ? 1L : 0L) : ((Number) key).longValue();
-            termBuckets.add(new LongTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
-        }
-        BucketOrder order = agg.order();
-        return new LongTerms(
-            agg.getName(),
-            order,
-            order,
-            AggregationTranslator.userMetadata(agg),
-            format,
-            agg.shardSize(),
-            false,
-            sumOtherDocCount(termBuckets, eligibleDocCount),
-            termBuckets,
-            0,
-            thresholds(agg)
-        );
-    }
-
-    /**
-     * Builds a {@link DoubleTerms} for floating-point keys. Constructor argument semantics match
-     * {@link #stringTerms}.
-     */
-    private static InternalAggregation doubleTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, long eligibleDocCount) {
-        List<DoubleTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
-        for (BucketEntry entry : entries) {
-            double term = ((Number) entry.keys().get(0)).doubleValue();
-            termBuckets.add(new DoubleTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
-        }
-        BucketOrder order = agg.order();
-        return new DoubleTerms(
-            agg.getName(),
-            order,
-            order,
-            AggregationTranslator.userMetadata(agg),
-            DocValueFormat.RAW,
-            agg.shardSize(),
-            false,
-            sumOtherDocCount(termBuckets, eligibleDocCount),
-            termBuckets,
-            0,
-            thresholds(agg)
-        );
+        return TermsResponseStrategy.DEFAULT;
     }
 
     /**
@@ -247,29 +193,16 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
      * the two queries can leave the eligible count smaller than the received sum. (Nested
      * eligible counts ride the plan's own rows and cannot skew.)
      */
-    private static long sumOtherDocCount(List<? extends MultiBucketsAggregation.Bucket> termBuckets, long eligibleDocCount) {
+    private static long sumOtherDocCount(List<BucketEntry> entries, long eligibleDocCount) {
         long receivedDocCount = 0;
-        for (MultiBucketsAggregation.Bucket bucket : termBuckets) {
-            receivedDocCount += bucket.getDocCount();
+        for (BucketEntry entry : entries) {
+            receivedDocCount += entry.docCount();
         }
         return Math.max(0, eligibleDocCount - receivedDocCount);
     }
 
-    /** Binary keys are ip columns: render the address string like classic ip terms. */
-    private static String keyString(Object key) {
-        if (key instanceof byte[] bytes) {
-            try {
-                return NetworkAddress.format(InetAddress.getByAddress(bytes));
-            } catch (UnknownHostException e) {
-                // Not a 4/16-byte address; fall back to a printable, deterministic form.
-                return Base64.getEncoder().encodeToString(bytes);
-            }
-        }
-        return key.toString();
-    }
-
     /** Bundles the request's bucket-count knobs for the result constructors. */
-    private static TermsAggregator.BucketCountThresholds thresholds(TermsAggregationBuilder agg) {
+    static TermsAggregator.BucketCountThresholds thresholds(TermsAggregationBuilder agg) {
         return new TermsAggregator.BucketCountThresholds(agg.minDocCount(), agg.shardMinDocCount(), agg.size(), agg.shardSize());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -12,6 +12,7 @@ import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.DocValueFormat;
@@ -31,10 +32,10 @@ import java.util.function.Supplier;
  * Translates a {@link TermsAggregationBuilder} — single-field GROUP BY.
  * {@code {"aggs": {"by_brand": {"terms": {"field": "brand"}}}}} becomes {@code GROUP BY brand}.
  *
- * <p>Response typing is handled by the {@link TermsResponseStrategy} registry: the field's
- * mapping-resolved type name selects the strategy that builds the correct {@code InternalTerms}
- * subclass, with the mapping's {@link DocValueFormat} rendering the keys. When no mapping is
- * resolvable, typing falls back to sampling the first bucket key's Java type with RAW formats.
+ * <p>Response typing is mapping-resolved: the field's {@code MappedFieldType.typeName()} selects
+ * the {@link TermsResponseStrategy} that builds the correct {@code InternalTerms} subclass, and
+ * the mapping's {@link DocValueFormat} renders the keys. A field whose mapping cannot be
+ * resolved at render time fails the request.
  */
 public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggregationBuilder> {
 
@@ -44,7 +45,8 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
      * Creates a terms bucket translator.
      *
      * @param mapperServiceSupplier supplies the target index's MapperService for key type and
-     *        format resolution; may supply null, which selects the sampling fallback
+     *        format resolution; supplying null skips {@link #validate} mapping checks and fails
+     *        rendering
      */
     public TermsBucketTranslator(Supplier<MapperService> mapperServiceSupplier) {
         this.mapperServiceSupplier = mapperServiceSupplier;
@@ -73,9 +75,9 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
     }
 
     /**
-     * Rejects {@code include}/{@code exclude}, {@code script}, and {@code min_doc_count: 0}:
-     * the translation implements none of them, and each would change the bucket set relative
-     * to classic search if ignored.
+     * Rejects {@code include}/{@code exclude}, {@code script}, {@code min_doc_count: 0}, and
+     * date-mapped fields: the translation implements none of them, and each would change the
+     * bucket set or key rendering relative to classic search if ignored.
      */
     @Override
     public void validate(TermsAggregationBuilder agg) throws ConversionException {
@@ -95,6 +97,18 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
                     + agg.getName()
                     + "] is not supported by the DSL execution path — zero-count buckets require enumerating the index term "
                     + "dictionary, which a GROUP BY over matching documents cannot produce"
+            );
+        }
+        MappedFieldType fieldType = resolveFieldType(agg.field());
+        if (fieldType != null
+            && (DateFieldMapper.CONTENT_TYPE.equals(fieldType.typeName())
+                || DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(fieldType.typeName()))) {
+            throw new ConversionException(
+                "terms aggregation ["
+                    + agg.getName()
+                    + "] on date field ["
+                    + agg.field()
+                    + "] is not supported by the DSL execution path — date bucket keys cannot yet be rendered with mapping formats"
             );
         }
     }
@@ -147,43 +161,41 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
 
     /**
      * Builds the terms response: the field's mapping selects the {@link TermsResponseStrategy}
-     * and the {@link DocValueFormat} for key rendering; without a resolvable mapping, both are
-     * inferred from the first bucket key's Java type. {@code eligibleDocCount} supplies the
+     * and the {@link DocValueFormat} for key rendering. {@code eligibleDocCount} supplies the
      * total {@code sum_other_doc_count} is subtracted from (see {@link #sumOtherDocCount}).
      */
     private InternalAggregation render(TermsAggregationBuilder agg, List<BucketEntry> kept, long eligibleDocCount) {
         long otherDocCount = sumOtherDocCount(kept, eligibleDocCount);
-        MappedFieldType fieldType = resolveFieldType(agg.field());
-        if (fieldType != null) {
-            TermsResponseStrategy strategy = TermsResponseStrategy.forType(fieldType.typeName());
-            return strategy.build(agg, kept, otherDocCount, fieldType.docValueFormat(null, null));
-        }
-        return sampledStrategy(kept).build(agg, kept, otherDocCount, DocValueFormat.RAW);
+        MappedFieldType fieldType = requireFieldType(agg);
+        TermsResponseStrategy strategy = TermsResponseStrategy.forType(fieldType.typeName());
+        return strategy.build(agg, kept, otherDocCount, fieldType.docValueFormat(null, null));
     }
 
-    /** Resolves the group field's mapping, or null when no MapperService is available. */
+    /** Resolves the group field's mapping, or null when the MapperService or field mapping is unavailable. */
     private MappedFieldType resolveFieldType(String field) {
         MapperService mapperService = mapperServiceSupplier.get();
         return mapperService == null ? null : mapperService.fieldType(field);
     }
 
-    /**
-     * Mapping-less fallback: infers the strategy from the first bucket key's Java type —
-     * booleans and integral numbers → LongTerms, floating point → DoubleTerms, anything
-     * else (including binary ip keys) → StringTerms.
-     */
-    private static TermsResponseStrategy sampledStrategy(List<BucketEntry> kept) {
-        Object sample = kept.isEmpty() ? null : kept.get(0).keys().get(0);
-        if (sample instanceof Boolean) {
-            return TermsResponseStrategy.forType("boolean");
+    /** Resolves the group field's mapping for rendering, failing loudly when it cannot be resolved. */
+    private MappedFieldType requireFieldType(TermsAggregationBuilder agg) {
+        MapperService mapperService = mapperServiceSupplier.get();
+        if (mapperService == null) {
+            throw new IllegalStateException(
+                "index mapping unavailable for terms aggregation ["
+                    + agg.getName()
+                    + "] — cannot resolve the key type for field ["
+                    + agg.field()
+                    + "]"
+            );
         }
-        if (sample instanceof Double || sample instanceof Float) {
-            return TermsResponseStrategy.forType("double");
+        MappedFieldType fieldType = mapperService.fieldType(agg.field());
+        if (fieldType == null) {
+            throw new IllegalStateException(
+                "field [" + agg.field() + "] of terms aggregation [" + agg.getName() + "] is not present in the index mapping"
+            );
         }
-        if (sample instanceof Number) {
-            return TermsResponseStrategy.forType("long");
-        }
-        return TermsResponseStrategy.DEFAULT;
+        return fieldType;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -55,10 +55,9 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
     }
 
     /**
-     * Builds a {@link StringTerms} (keys rendered via {@code toString}; per-key-type
-     * Long/Double variants are follow-up work). Shard accounting fields are zero — the
-     * analytics path computes exact groups with no per-shard truncation. Bucket order is
-     * already established by the plan's post-aggregate sort.
+     * Builds a {@link StringTerms}. Buckets are sorted by the requested order, filtered by
+     * {@code min_doc_count}, and truncated to {@code size}; truncated bucket counts are
+     * reported as {@code sum_other_doc_count}.
      */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
@@ -70,9 +69,25 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
                 // missing field entirely (no bucket) unless "missing" is configured.
                 continue;
             }
+            if (entry.docCount() < agg.minDocCount()) {
+                continue;
+            }
             BytesRef term = new BytesRef(key.toString());
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
+
+        // Sort per this aggregation's own order: sibling aggregations sharing a granularity
+        // share one plan-level sort, which cannot satisfy two different requested orders.
+        termBuckets.sort(getBucketOrder(agg).comparator());
+
+        long otherDocCount = 0;
+        if (termBuckets.size() > agg.size()) {
+            for (int i = agg.size(); i < termBuckets.size(); i++) {
+                otherDocCount += termBuckets.get(i).getDocCount();
+            }
+            termBuckets = new ArrayList<>(termBuckets.subList(0, agg.size()));
+        }
+
         BucketOrder order = agg.order();
         TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(
             agg.minDocCount(),
@@ -88,7 +103,7 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             DocValueFormat.RAW,
             agg.shardSize(),
             false,
-            0,
+            otherDocCount,
             termBuckets,
             0,
             thresholds

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -13,6 +13,7 @@ import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -31,12 +32,13 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Translates a {@link TermsAggregationBuilder} — single-field GROUP BY.
  * {@code {"aggs": {"by_brand": {"terms": {"field": "brand"}}}}} becomes {@code GROUP BY brand}.
  */
-public class TermsBucketTranslator implements BucketTranslator<TermsAggregationBuilder> {
+public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggregationBuilder> {
 
     /** Creates a terms bucket translator. */
     public TermsBucketTranslator() {}
@@ -48,7 +50,9 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
 
     @Override
     public GroupingInfo getGrouping(TermsAggregationBuilder agg) {
-        return new FieldGrouping(List.of(agg.field()));
+        return agg.missing() == null
+            ? new FieldGrouping(List.of(agg.field()))
+            : new FieldGrouping(List.of(agg.field()), Map.of(agg.field(), agg.missing()));
     }
 
     @Override
@@ -62,59 +66,117 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
     }
 
     /**
-     * Builds the terms response with classic-path key typing, sampled from the first bucket key:
-     * integral keys → {@link LongTerms}, floating → {@link DoubleTerms}, booleans → {@link LongTerms}
-     * with the BOOLEAN format, binary (ip) keys render as address strings, else {@link StringTerms}.
-     * Buckets are filtered by {@code min_doc_count}, sorted by the requested order, and truncated to
-     * {@code size}; truncated bucket counts are reported as {@code sum_other_doc_count}.
+     * Rejects {@code include}/{@code exclude}, {@code script}, and {@code min_doc_count: 0}:
+     * the translation implements none of them, and each would change the bucket set relative
+     * to classic search if ignored.
+     */
+    @Override
+    public void validate(TermsAggregationBuilder agg) throws ConversionException {
+        if (agg.includeExclude() != null) {
+            throw new ConversionException(
+                "[include]/[exclude] on terms aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
+        }
+        if (agg.script() != null) {
+            throw new ConversionException(
+                "[script] on terms aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
+        }
+        if (agg.minDocCount() == 0) {
+            throw new ConversionException(
+                "[min_doc_count: 0] on terms aggregation ["
+                    + agg.getName()
+                    + "] is not supported by the DSL execution path — zero-count buckets require enumerating the index term "
+                    + "dictionary, which a GROUP BY over matching documents cannot produce"
+            );
+        }
+    }
+
+    @Override
+    public int size(TermsAggregationBuilder agg) {
+        return agg.size();
+    }
+
+    @Override
+    public long minDocCount(TermsAggregationBuilder agg) {
+        return agg.minDocCount();
+    }
+
+    /**
+     * Renders the empty aggregation for levels with no result rows — the only case that
+     * reaches this method: every terms plan is bounded (root levels by a flat LIMIT, nested
+     * levels by the per-parent ROW_NUMBER window), so non-empty levels render through
+     * {@link #toBucketAggregation(TermsAggregationBuilder, Iterable, long)}. A non-empty
+     * bucket set here means the sized dispatch was bypassed, and the method throws.
      */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
-        List<BucketEntry> kept = new ArrayList<>();
-        for (BucketEntry entry : buckets) {
-            if (entry.keys().get(0) == null) {
-                // SQL GROUP BY emits a NULL group; legacy terms excludes docs with a
-                // missing field entirely (no bucket) unless "missing" is configured.
-                continue;
-            }
-            if (entry.docCount() < agg.minDocCount()) {
-                continue;
-            }
-            kept.add(entry);
+        List<BucketEntry> entries = toList(buckets);
+        if (entries.isEmpty() == false) {
+            throw new IllegalStateException(
+                "terms aggregation ["
+                    + agg.getName()
+                    + "] received buckets on the unsized render path: every terms plan is bounded, so rendering must go through the sized path"
+            );
         }
+        return render(agg, entries, 0L);
+    }
 
+    /**
+     * Renders the plan's bucket set as received: the plan already excluded null keys, applied
+     * {@code min_doc_count}, ordered, and truncated to the top {@code size}.
+     * {@code sum_other_doc_count} is {@code eligibleDocCount − Σ(received doc counts)}.
+     */
+    @Override
+    public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets, long eligibleDocCount) {
+        return render(agg, toList(buckets), eligibleDocCount);
+    }
+
+    private static List<BucketEntry> toList(Iterable<BucketEntry> buckets) {
+        List<BucketEntry> entries = new ArrayList<>();
+        buckets.forEach(entries::add);
+        return entries;
+    }
+
+    /**
+     * Builds the terms response with classic-path key typing, sampled from the first bucket key:
+     * integral keys → {@link LongTerms}, floating → {@link DoubleTerms}, booleans → {@link LongTerms}
+     * with the BOOLEAN format, binary (ip) keys render as address strings, else {@link StringTerms}.
+     * {@code eligibleDocCount} supplies the total {@code sum_other_doc_count} is subtracted from (see
+     * {@link #sumOtherDocCount}).
+     */
+    private static InternalAggregation render(TermsAggregationBuilder agg, List<BucketEntry> kept, long eligibleDocCount) {
         Object sample = kept.isEmpty() ? null : kept.get(0).keys().get(0);
         if (sample instanceof Boolean) {
-            return longTerms(agg, kept, DocValueFormat.BOOLEAN);
+            return longTerms(agg, kept, DocValueFormat.BOOLEAN, eligibleDocCount);
         }
         if (sample instanceof Double || sample instanceof Float) {
-            return doubleTerms(agg, kept);
+            return doubleTerms(agg, kept, eligibleDocCount);
         }
         if (sample instanceof Number) {
-            return longTerms(agg, kept, DocValueFormat.RAW);
+            return longTerms(agg, kept, DocValueFormat.RAW, eligibleDocCount);
         }
-        return stringTerms(agg, kept);
+        return stringTerms(agg, kept, eligibleDocCount);
     }
 
     /** Builds a {@link StringTerms}; string and binary (ip) keys land here. */
-    private static InternalAggregation stringTerms(TermsAggregationBuilder agg, List<BucketEntry> entries) {
+    private static InternalAggregation stringTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, long eligibleDocCount) {
         List<StringTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
         for (BucketEntry entry : entries) {
             BytesRef term = new BytesRef(keyString(entry.keys().get(0)));
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
-        Truncated<StringTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
         BucketOrder order = agg.order();
         return new StringTerms(
             agg.getName(),
-            order, // reduceOrder: the bucket list is already sorted by it (see sortAndTruncate)
+            order, // reduceOrder: the plan sorted the bucket list by it
             order, // the user-requested display order
             AggregationTranslator.userMetadata(agg),
             DocValueFormat.RAW, // keyword parity: the mapping-resolved format for string keys is RAW
             agg.shardSize(), // request echo — no shard fan-out on this path
             false, // no per-bucket doc count error rendering
-            visible.otherDocCount(),
-            visible.buckets(),
+            sumOtherDocCount(termBuckets, eligibleDocCount),
+            termBuckets,
             0, // exact single-plan path: doc_count_error_upper_bound is truly 0
             thresholds(agg)
         );
@@ -124,14 +186,18 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
      * Builds a {@link LongTerms} for integral keys; booleans ride along as 0/1 with the BOOLEAN
      * format. Constructor argument semantics match {@link #stringTerms}.
      */
-    private static InternalAggregation longTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, DocValueFormat format) {
+    private static InternalAggregation longTerms(
+        TermsAggregationBuilder agg,
+        List<BucketEntry> entries,
+        DocValueFormat format,
+        long eligibleDocCount
+    ) {
         List<LongTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
         for (BucketEntry entry : entries) {
             Object key = entry.keys().get(0);
             long term = key instanceof Boolean bool ? (bool ? 1L : 0L) : ((Number) key).longValue();
             termBuckets.add(new LongTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, format));
         }
-        Truncated<LongTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
         BucketOrder order = agg.order();
         return new LongTerms(
             agg.getName(),
@@ -141,8 +207,8 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             format,
             agg.shardSize(),
             false,
-            visible.otherDocCount(),
-            visible.buckets(),
+            sumOtherDocCount(termBuckets, eligibleDocCount),
+            termBuckets,
             0,
             thresholds(agg)
         );
@@ -152,13 +218,12 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
      * Builds a {@link DoubleTerms} for floating-point keys. Constructor argument semantics match
      * {@link #stringTerms}.
      */
-    private static InternalAggregation doubleTerms(TermsAggregationBuilder agg, List<BucketEntry> entries) {
+    private static InternalAggregation doubleTerms(TermsAggregationBuilder agg, List<BucketEntry> entries, long eligibleDocCount) {
         List<DoubleTerms.Bucket> termBuckets = new ArrayList<>(entries.size());
         for (BucketEntry entry : entries) {
             double term = ((Number) entry.keys().get(0)).doubleValue();
             termBuckets.add(new DoubleTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
-        Truncated<DoubleTerms.Bucket> visible = sortAndTruncate(termBuckets, agg);
         BucketOrder order = agg.order();
         return new DoubleTerms(
             agg.getName(),
@@ -168,37 +233,26 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             DocValueFormat.RAW,
             agg.shardSize(),
             false,
-            visible.otherDocCount(),
-            visible.buckets(),
+            sumOtherDocCount(termBuckets, eligibleDocCount),
+            termBuckets,
             0,
             thresholds(agg)
         );
     }
 
-    /** Result of {@link #sortAndTruncate}: the visible buckets and the truncated tail's doc count. */
-    private record Truncated<B extends MultiBucketsAggregation.Bucket>(List<B> buckets, long otherDocCount) {
-    }
-
     /**
-     * Sorts buckets per this aggregation's own order and truncates to {@code size}. The re-sort is
-     * required because sibling aggregations sharing a granularity share one plan-level sort, which
-     * cannot satisfy two different requested orders.
+     * Computes {@code sum_other_doc_count} — docs belonging to groups not in the bucket
+     * list — as {@code eligibleDocCount − Σ(received doc counts)}, clamped at zero: root
+     * eligible counts come from a separately executed COUNT plan, and a refresh landing between
+     * the two queries can leave the eligible count smaller than the received sum. (Nested
+     * eligible counts ride the plan's own rows and cannot skew.)
      */
-    private static <B extends MultiBucketsAggregation.Bucket> Truncated<B> sortAndTruncate(
-        List<B> termBuckets,
-        TermsAggregationBuilder agg
-    ) {
-        termBuckets.sort(agg.order().comparator());
-        long otherDocCount = 0;
-        List<B> visible = termBuckets;
-        if (termBuckets.size() > agg.size()) {
-            for (int i = agg.size(); i < termBuckets.size(); i++) {
-                otherDocCount += termBuckets.get(i).getDocCount();
-            }
-            // Copy rather than clear the tail in place: releases the full-size backing array.
-            visible = new ArrayList<>(termBuckets.subList(0, agg.size()));
+    private static long sumOtherDocCount(List<? extends MultiBucketsAggregation.Bucket> termBuckets, long eligibleDocCount) {
+        long receivedDocCount = 0;
+        for (MultiBucketsAggregation.Bucket bucket : termBuckets) {
+            receivedDocCount += bucket.getDocCount();
         }
-        return new Truncated<>(visible, otherDocCount);
+        return Math.max(0, eligibleDocCount - receivedDocCount);
     }
 
     /** Binary keys are ip columns: render the address string like classic ip terms. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.result.BucketEntry;
@@ -83,7 +84,7 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             agg.getName(),
             order,
             order,
-            null,
+            AggregationTranslator.userMetadata(agg),
             DocValueFormat.RAW,
             agg.shardSize(),
             false,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsResponseStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsResponseStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategy for building a terms aggregation response from bucket entries. Each implementation
+ * handles one family of field types (string, long, double), mirroring the
+ * {@code ValuesSourceRegistry} pattern from classic search: adding support for a new field type
+ * is a registry entry, not a new branch in a switch.
+ */
+public interface TermsResponseStrategy {
+
+    /**
+     * Builds the typed {@code InternalTerms} response from the given bucket entries.
+     *
+     * @param agg           the original terms aggregation builder (name, order, request echo)
+     * @param entries       the visible bucket set, exactly as the plan produced it — null keys
+     *                      excluded, {@code min_doc_count} applied, ordered, truncated
+     * @param otherDocCount the {@code sum_other_doc_count} to report, computed by the caller
+     *                      from the plan's eligible-doc count
+     * @param format        the resolved {@link DocValueFormat} for key rendering
+     * @return a fully constructed aggregation ready for serialization
+     */
+    InternalAggregation build(TermsAggregationBuilder agg, List<BucketEntry> entries, long otherDocCount, DocValueFormat format);
+
+    /**
+     * Registry mapping field type names to their response strategy.
+     *
+     * <p>Key: {@code MappedFieldType.typeName()} (e.g. "keyword", "long", "date", "ip").
+     * Value: the strategy that builds the correct {@code InternalTerms} subclass.
+     */
+    Map<String, TermsResponseStrategy> REGISTRY = Map.ofEntries(
+        // Numeric integral types → LongTerms
+        Map.entry("long", LongTermsStrategy.INSTANCE),
+        Map.entry("integer", LongTermsStrategy.INSTANCE),
+        Map.entry("short", LongTermsStrategy.INSTANCE),
+        Map.entry("byte", LongTermsStrategy.INSTANCE),
+        Map.entry("date", LongTermsStrategy.INSTANCE),
+        Map.entry("date_nanos", LongTermsStrategy.INSTANCE),
+        Map.entry("unsigned_long", LongTermsStrategy.INSTANCE),
+        Map.entry("boolean", LongTermsStrategy.BOOLEAN_INSTANCE),
+
+        // Floating point types → DoubleTerms
+        Map.entry("float", DoubleTermsStrategy.INSTANCE),
+        Map.entry("double", DoubleTermsStrategy.INSTANCE),
+        Map.entry("half_float", DoubleTermsStrategy.INSTANCE),
+        Map.entry("scaled_float", DoubleTermsStrategy.INSTANCE),
+
+        // String/binary types → StringTerms
+        Map.entry("keyword", StringTermsStrategy.INSTANCE),
+        Map.entry("ip", StringTermsStrategy.INSTANCE),
+        Map.entry("text", StringTermsStrategy.INSTANCE),
+        Map.entry("wildcard", StringTermsStrategy.INSTANCE),
+        Map.entry("constant_keyword", StringTermsStrategy.INSTANCE),
+        Map.entry("match_only_text", StringTermsStrategy.INSTANCE)
+    );
+
+    /** Default strategy when the field type is unknown — falls back to StringTerms. */
+    TermsResponseStrategy DEFAULT = StringTermsStrategy.INSTANCE;
+
+    /**
+     * Resolves the strategy for the given field type name.
+     *
+     * @param typeName the field's {@code MappedFieldType.typeName()}, or null if unknown
+     * @return the matching strategy, or {@link #DEFAULT} if not registered
+     */
+    static TermsResponseStrategy forType(String typeName) {
+        if (typeName == null) {
+            return DEFAULT;
+        }
+        return REGISTRY.getOrDefault(typeName, DEFAULT);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -76,6 +76,8 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
         if (value instanceof Number number) {
             return number.doubleValue();
         }
-        throw new IllegalStateException("Expected numeric aggregation result but got " + value.getClass().getSimpleName());
+        throw new IllegalStateException(
+            "Expected numeric aggregation result but got " + (value == null ? "null" : value.getClass().getSimpleName())
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -15,7 +15,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
-import org.opensearch.search.aggregations.InternalAggregation;
 
 import java.util.Collections;
 
@@ -67,9 +66,16 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
         return agg.getName();
     }
 
-    // TODO: implement response conversion per metric type (InternalAvg, InternalSum, etc.)
-    @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
-        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for " + getClass().getSimpleName());
+    /**
+     * Coerces an engine result cell to double. Calcite keeps the input column type (AVG over
+     * an INTEGER column returns an integral value), so the int→double widening happens here.
+     *
+     * @param value the raw cell value (must be a {@link Number})
+     */
+    protected static double toDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        throw new IllegalStateException("Expected numeric aggregation result but got " + value.getClass().getSimpleName());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -14,7 +14,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 
 import java.util.Collections;
@@ -24,7 +23,7 @@ import java.util.Collections;
  * logic — subclasses supply the SQL aggregate function, field name, and optionally
  * override the return type.
  */
-public abstract class AbstractMetricTranslator<T extends AggregationBuilder> implements MetricTranslator<T> {
+public abstract class AbstractMetricTranslator<T extends ValuesSourceAggregationBuilder<T>> implements MetricTranslator<T> {
 
     /** Creates a metric translator. */
     protected AbstractMetricTranslator() {}
@@ -37,17 +36,15 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
      */
     @Override
     public void validate(T agg) throws ConversionException {
-        if (agg instanceof ValuesSourceAggregationBuilder<?> vs) {
-            if (vs.missing() != null) {
-                throw new ConversionException(
-                    "[missing] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
-                );
-            }
-            if (vs.script() != null) {
-                throw new ConversionException(
-                    "[script] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
-                );
-            }
+        if (agg.missing() != null) {
+            throw new ConversionException(
+                "[missing] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
+        }
+        if (agg.script() != null) {
+            throw new ConversionException(
+                "[script] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
         }
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -15,6 +15,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 
 import java.util.Collections;
 
@@ -27,6 +28,28 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
 
     /** Creates a metric translator. */
     protected AbstractMetricTranslator() {}
+
+    /**
+     * Rejects {@code missing} (substitutes a value for docs lacking the field) and
+     * {@code script} (computes the metric input from a script): the translation implements
+     * neither — it emits plain {@code fn(field)}, whose result differs from classic search
+     * when either parameter is present.
+     */
+    @Override
+    public void validate(T agg) throws ConversionException {
+        if (agg instanceof ValuesSourceAggregationBuilder<?> vs) {
+            if (vs.missing() != null) {
+                throw new ConversionException(
+                    "[missing] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+                );
+            }
+            if (vs.script() != null) {
+                throw new ConversionException(
+                    "[script] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+                );
+            }
+        }
+    }
 
     /** Returns the SQL aggregate function (e.g., AVG, SUM, MIN, MAX). */
     protected abstract SqlAggFunction getAggFunction();

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
@@ -10,7 +10,10 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 
 /** Translates AVG metric aggregation to Calcite. */
 public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregationBuilder> {
@@ -31,5 +34,18 @@ public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregation
     @Override
     protected String getFieldName(AvgAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /**
+     * The engine returns the final average; encoded as (sum=value, count=1) so
+     * {@code InternalAvg.getValue()} reproduces it. Null (no matching docs) uses
+     * count=0, which renders as {@code "value": null} like legacy.
+     */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        if (value == null) {
+            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, null);
+        }
+        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
 
+import java.util.Map;
+
 /** Translates AVG metric aggregation to Calcite. */
 public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregationBuilder> {
 
@@ -42,10 +44,10 @@ public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregation
      * count=0, which renders as {@code "value": null} like legacy.
      */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         if (value == null) {
-            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, null);
+            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, metadata);
         }
-        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, null);
+        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalMax;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 
 /** Translates MAX metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregation
     @Override
     protected String getFieldName(MaxAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes -Infinity — legacy sentinel, rendered as {@code "value": null}. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double max = value == null ? Double.NEGATIVE_INFINITY : toDouble(value);
+        return new InternalMax(name, max, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalMax;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates MAX metric aggregation to Calcite. */
 public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregation
 
     /** Null (no matching docs) becomes -Infinity — legacy sentinel, rendered as {@code "value": null}. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double max = value == null ? Double.NEGATIVE_INFINITY : toDouble(value);
-        return new InternalMax(name, max, DocValueFormat.RAW, null);
+        return new InternalMax(name, max, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
 
+import java.util.Map;
+
 /**
  * Translates a metric aggregation (AVG, SUM, MIN, MAX, etc.) to a Calcite AggregateCall,
  * and converts raw result values back to OpenSearch InternalAggregation for response building.
@@ -47,7 +49,9 @@ public interface MetricTranslator<T extends AggregationBuilder> extends Aggregat
      *
      * @param name the aggregation name
      * @param value the raw value (may be null)
+     * @param metadata the user-supplied {@code meta} map from the aggregation request, echoed
+     *        back verbatim in the response like classic search (may be null)
      * @return the corresponding InternalAggregation
      */
-    InternalAggregation toInternalAggregation(String name, Object value);
+    InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata);
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 
 /** Translates MIN metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregation
     @Override
     protected String getFieldName(MinAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes +Infinity — legacy sentinel, rendered as {@code "value": null}. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double min = value == null ? Double.POSITIVE_INFINITY : toDouble(value);
+        return new InternalMin(name, min, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates MIN metric aggregation to Calcite. */
 public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregation
 
     /** Null (no matching docs) becomes +Infinity — legacy sentinel, rendered as {@code "value": null}. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double min = value == null ? Double.POSITIVE_INFINITY : toDouble(value);
-        return new InternalMin(name, min, DocValueFormat.RAW, null);
+        return new InternalMin(name, min, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 
 /** Translates SUM metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregation
     @Override
     protected String getFieldName(SumAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes 0.0 — legacy sum-of-nothing semantics. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double sum = value == null ? 0.0 : toDouble(value);
+        return new InternalSum(name, sum, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates SUM metric aggregation to Calcite. */
 public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregation
 
     /** Null (no matching docs) becomes 0.0 — legacy sum-of-nothing semantics. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double sum = value == null ? 0.0 : toDouble(value);
-        return new InternalSum(name, sum, DocValueFormat.RAW, null);
+        return new InternalSum(name, sum, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ConversionContext.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ConversionContext.java
@@ -10,6 +10,7 @@ package org.opensearch.dsl.converter;
 
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
@@ -29,6 +30,7 @@ public class ConversionContext {
     private final RelOptCluster cluster;
     private final RelOptTable table;
     private final AggregationMetadata aggregationMetadata;
+    private final RelNode parentPlan;
 
     /**
      * Creates a conversion context.
@@ -38,19 +40,21 @@ public class ConversionContext {
      * @param table the resolved Calcite table for the target index
      */
     public ConversionContext(SearchSourceBuilder searchSource, RelOptCluster cluster, RelOptTable table) {
-        this(searchSource, cluster, table, null);
+        this(searchSource, cluster, table, null, null);
     }
 
     private ConversionContext(
         SearchSourceBuilder searchSource,
         RelOptCluster cluster,
         RelOptTable table,
-        AggregationMetadata aggregationMetadata
+        AggregationMetadata aggregationMetadata,
+        RelNode parentPlan
     ) {
         this.searchSource = Objects.requireNonNull(searchSource, "searchSource must not be null");
         this.cluster = Objects.requireNonNull(cluster, "cluster must not be null");
         this.table = Objects.requireNonNull(table, "table must not be null");
         this.aggregationMetadata = aggregationMetadata;
+        this.parentPlan = parentPlan;
     }
 
     /** Returns the original DSL query. */
@@ -89,7 +93,24 @@ public class ConversionContext {
      * @param metadata the aggregation metadata to attach
      */
     public ConversionContext withAggregationMetadata(AggregationMetadata metadata) {
-        return new ConversionContext(searchSource, cluster, table, metadata);
+        return new ConversionContext(searchSource, cluster, table, metadata, parentPlan);
+    }
+
+    /**
+     * Returns the parent level's built plan for a nested aggregation level — the semi-join
+     * input restricting a child plan to the parent's top-N groups — or null at root levels.
+     */
+    public RelNode getParentPlan() {
+        return parentPlan;
+    }
+
+    /**
+     * Returns a new context with the given parent plan attached.
+     *
+     * @param parent the parent level's built plan
+     */
+    public ConversionContext withParentPlan(RelNode parent) {
+        return new ConversionContext(searchSource, cluster, table, aggregationMetadata, parent);
     }
 
     /**
@@ -100,10 +121,7 @@ public class ConversionContext {
      * @throws ConversionException if the field is not found in the schema
      */
     public RexNode makeFieldRef(String fieldName) throws ConversionException {
-        RelDataTypeField field = getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Field '" + fieldName + "' not found in schema");
-        }
+        RelDataTypeField field = getField(fieldName);
         return getRexBuilder().makeInputRef(field.getType(), field.getIndex());
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/PostAggregateConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/PostAggregateConverter.java
@@ -8,37 +8,257 @@
 
 package org.opensearch.dsl.converter;
 
-import org.apache.calcite.rel.RelCollation;
+import com.google.common.collect.ImmutableList;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexFieldCollation;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexWindowBounds;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
- * Applies post-aggregation sorting from BucketOrder collations.
+ * Applies post-aggregation shaping: an optional HAVING filter ({@code min_doc_count}), then the
+ * plan's bound and order.
  *
- * Uses {@link CollationResolver} to resolve bucket orders against the actual
- * post-aggregation schema from the LogicalAggregate node.
+ * <p>Root-level sized plans get a sort with a fetch: the engine's sort becomes a bounded top-K
+ * (O(size) memory, {@code size} rows transferred). The HAVING filter sits between the aggregate
+ * and the sort, so filtering happens before truncation — truncate-then-filter would return
+ * fewer than {@code size} buckets where classic search back-fills.
+ *
+ * <p>Nested levels get the per-parent equivalent ({@link #applyPerParentTopK}): the plan is
+ * semi-joined to the parent level's top-N plan (only winning parents' groups survive), then a
+ * window computes each row's rank within its parent partition —
+ * {@code ROW_NUMBER() OVER (PARTITION BY parentFields ORDER BY bucketOrder)} — and a filter
+ * keeps rank ≤ {@code size}. The same window project also attaches
+ * {@code SUM(_count) OVER (PARTITION BY parentFields)} as the parent's eligible-document total,
+ * computed before the rank filter so it covers the truncated remainder: every surviving row
+ * carries its parent's eligible-doc total for {@code sum_other_doc_count}. The window-inside-a-project
+ * plus plain-filter shape is the one unified-query PPL {@code top} emits, so the engine bridge
+ * is known to execute it.
+ *
+ * <p>The collation always ends with the group key ascending (classic search's tie-breaker,
+ * carried inside every {@code BucketOrder}), so cuts at either bound are deterministic and
+ * match classic ordering. Uses {@link CollationResolver} to resolve bucket orders against the
+ * actual post-aggregation schema.
  */
 public class PostAggregateConverter extends AbstractDslConverter {
+
+    /** Name of the transient window-rank column; dropped before the plan's output. */
+    static final String ROW_NUMBER_NAME = "_row_number_top_";
+
+    /**
+     * Column name of a nested plan's per-parent eligible-document total: a window
+     * {@code SUM(_count) OVER (PARTITION BY parentFields)} emitted here after HAVING and before
+     * the per-parent truncation, so every surviving row carries its parent's
+     * eligible-doc total for {@code sum_other_doc_count}. Constant within a parent's rows; public because
+     * the response builder reads it back off the result columns.
+     */
+    public static final String PARENT_ELIGIBLE_NAME = "_parent_eligible";
 
     /** Creates a post-aggregate converter. */
     public PostAggregateConverter() {}
 
     @Override
     protected boolean isApplicable(ConversionContext ctx) {
-        return ctx.getAggregationMetadata() != null && ctx.getAggregationMetadata().hasBucketOrders();
+        AggregationMetadata metadata = ctx.getAggregationMetadata();
+        return metadata != null
+            && (metadata.hasBucketOrders()
+                || metadata.getFetch() != null
+                || metadata.getPerParentFetch() != null
+                || metadata.getHavingMinDocCount() != null);
     }
 
     @Override
     protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
-        List<RelFieldCollation> collations = CollationResolver.resolve(ctx.getAggregationMetadata(), input.getRowType());
-        if (collations.isEmpty()) {
-            return input;
+        AggregationMetadata metadata = ctx.getAggregationMetadata();
+        RelNode result = input;
+
+        if (metadata.getHavingMinDocCount() != null) {
+            result = applyHaving(result, ctx, metadata.getHavingMinDocCount());
         }
-        RelCollation relCollation = RelCollations.of(collations);
-        return LogicalSort.create(input, relCollation, null, null);
+
+        if (metadata.getPerParentFetch() != null) {
+            return applyPerParentTopK(result, ctx, metadata);
+        }
+
+        List<RelFieldCollation> collations = metadata.hasBucketOrders()
+            ? CollationResolver.resolve(metadata, result.getRowType())
+            : List.of();
+
+        RexNode fetch = metadata.getFetch() == null
+            ? null
+            : ctx.getRexBuilder()
+                .makeLiteral(metadata.getFetch(), ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.INTEGER), false);
+
+        if (collations.isEmpty() && fetch == null) {
+            return result;
+        }
+        return LogicalSort.create(result, RelCollations.of(collations), null, fetch);
+    }
+
+    /** HAVING: {@code _count >= min_doc_count}, between the aggregate and the plan's bound. */
+    private static RelNode applyHaving(RelNode input, ConversionContext ctx, long minDocCount) throws ConversionException {
+        RelDataTypeField countField = input.getRowType().getField(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME, false, false);
+        if (countField == null) {
+            throw new ConversionException(
+                "min_doc_count requires the implicit " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in the aggregate output"
+            );
+        }
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RexNode condition = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(countField.getType(), countField.getIndex()),
+            rexBuilder.makeLiteral(minDocCount, ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT), false)
+        );
+        return LogicalFilter.create(input, condition);
+    }
+
+    /**
+     * Per-parent top-K for a nested level: semi-join to the parent plan's top-N, window-rank
+     * within the parent partition, keep rank ≤ K, attach the per-parent eligible total.
+     */
+    private RelNode applyPerParentTopK(RelNode input, ConversionContext ctx, AggregationMetadata metadata) throws ConversionException {
+        RelNode parentPlan = ctx.getParentPlan();
+        if (parentPlan == null) {
+            throw new ConversionException(
+                "Nested aggregation plan ["
+                    + String.join(",", metadata.getAggNamePath())
+                    + "] requires the parent level's plan for its per-parent bound"
+            );
+        }
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RelDataType rowType = input.getRowType();
+        // All group fields except the last are the parent's keys (eligibility guarantees
+        // single-field groupings).
+        List<String> parentFields = metadata.getGroupByFieldNames().subList(0, metadata.getGroupByFieldNames().size() - 1);
+
+        // 1. Semi-join: only groups belonging to the parent plan's top-N survive. The semi
+        // output keeps the left schema, so downstream indices are unchanged.
+        List<RexNode> equalities = new ArrayList<>(parentFields.size());
+        int leftFieldCount = rowType.getFieldCount();
+        for (String parentField : parentFields) {
+            RelDataTypeField left = rowType.getField(parentField, false, false);
+            RelDataTypeField right = parentPlan.getRowType().getField(parentField, false, false);
+            if (left == null || right == null) {
+                throw new ConversionException("Parent group field '" + parentField + "' not found for nested plan join");
+            }
+            equalities.add(
+                rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    rexBuilder.makeInputRef(left.getType(), left.getIndex()),
+                    rexBuilder.makeInputRef(right.getType(), leftFieldCount + right.getIndex())
+                )
+            );
+        }
+        RexNode joinCondition = equalities.size() == 1 ? equalities.get(0) : rexBuilder.makeCall(SqlStdOperatorTable.AND, equalities);
+        RelNode joined = LogicalJoin.create(input, parentPlan, List.of(), joinCondition, Set.of(), JoinRelType.SEMI);
+
+        // 2. Window project: every column, plus the per-parent eligible total, plus the rank.
+        List<RexNode> partitionKeys = new ArrayList<>(parentFields.size());
+        for (String parentField : parentFields) {
+            RelDataTypeField field = rowType.getField(parentField, false, false);
+            partitionKeys.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+        }
+
+        ImmutableList.Builder<RexFieldCollation> orderKeys = ImmutableList.builder();
+        for (RelFieldCollation collation : CollationResolver.resolve(metadata, rowType)) {
+            Set<SqlKind> flags = new HashSet<>();
+            if (collation.getDirection() == RelFieldCollation.Direction.DESCENDING) {
+                flags.add(SqlKind.DESCENDING);
+            }
+            if (collation.nullDirection == RelFieldCollation.NullDirection.FIRST) {
+                flags.add(SqlKind.NULLS_FIRST);
+            } else if (collation.nullDirection == RelFieldCollation.NullDirection.LAST) {
+                flags.add(SqlKind.NULLS_LAST);
+            }
+            RelDataTypeField field = rowType.getFieldList().get(collation.getFieldIndex());
+            orderKeys.add(new RexFieldCollation(rexBuilder.makeInputRef(field.getType(), field.getIndex()), flags));
+        }
+
+        RelDataType bigint = ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+        RexNode rowNumber = rexBuilder.makeOver(
+            bigint,
+            SqlStdOperatorTable.ROW_NUMBER,
+            List.of(),
+            partitionKeys,
+            orderKeys.build(),
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.CURRENT_ROW,
+            true, // rows frame
+            true, // allow partial
+            false,
+            false,
+            false
+        );
+
+        RelDataTypeField countField = rowType.getField(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME, false, false);
+        if (countField == null) {
+            throw new ConversionException(
+                "Nested plan requires the implicit " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column for its parent totals"
+            );
+        }
+        RexNode parentEligible = rexBuilder.makeOver(
+            ctx.getCluster().getTypeFactory().createTypeWithNullability(bigint, true),
+            SqlStdOperatorTable.SUM,
+            List.of(rexBuilder.makeInputRef(countField.getType(), countField.getIndex())),
+            partitionKeys,
+            ImmutableList.of(), // whole partition — no ordering, unbounded frame
+            RexWindowBounds.UNBOUNDED_PRECEDING,
+            RexWindowBounds.UNBOUNDED_FOLLOWING,
+            false, // range frame
+            true,
+            false,
+            false,
+            false
+        );
+
+        List<RexNode> withWindow = new ArrayList<>(leftFieldCount + 2);
+        List<String> withWindowNames = new ArrayList<>(leftFieldCount + 2);
+        for (RelDataTypeField field : rowType.getFieldList()) {
+            withWindow.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+            withWindowNames.add(field.getName());
+        }
+        withWindow.add(parentEligible);
+        withWindowNames.add(PARENT_ELIGIBLE_NAME);
+        withWindow.add(rowNumber);
+        withWindowNames.add(ROW_NUMBER_NAME);
+        RelNode windowed = LogicalProject.create(joined, List.of(), withWindow, withWindowNames);
+
+        // 3. Keep each parent's top K.
+        RexNode rankLimit = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(bigint, leftFieldCount + 1),
+            rexBuilder.makeLiteral(metadata.getPerParentFetch(), bigint, false)
+        );
+        RelNode ranked = LogicalFilter.create(windowed, rankLimit);
+
+        // 4. Drop the transient rank column; the parent-eligible total stays for the response.
+        RelDataType rankedType = ranked.getRowType();
+        List<RexNode> visible = new ArrayList<>(leftFieldCount + 1);
+        List<String> visibleNames = new ArrayList<>(leftFieldCount + 1);
+        for (int i = 0; i <= leftFieldCount; i++) {
+            RelDataTypeField field = rankedType.getFieldList().get(i);
+            visible.add(rexBuilder.makeInputRef(field.getType(), i));
+            visibleNames.add(field.getName());
+        }
+        return LogicalProject.create(ranked, List.of(), visible, visibleNames);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/PreAggregateConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/PreAggregateConverter.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.converter;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gives group fields classic terms null semantics by inserting operators between the shared
+ * scan+filter base and the {@code LogicalAggregate}. SQL GROUP BY emits a NULL group for
+ * documents missing a group field; classic terms instead excludes those documents — or, when
+ * the aggregation configures a {@code missing} value, counts them in that value's bucket.
+ *
+ * <p>Per group field:
+ * <ul>
+ * <li>without {@code missing} — a {@code LogicalFilter(field IS NOT NULL)} below the aggregate,
+ * so a NULL group never forms. The filter must sit below the aggregate: bounded plans keep only
+ * the top-K groups, and a NULL group must never occupy a top-K slot. Non-nullable fields cannot
+ * produce a NULL group and are skipped.</li>
+ * <li>with {@code missing} — a {@code LogicalProject} replacing the field with
+ * {@code CASE WHEN field IS NOT NULL THEN field ELSE missingValue END} (not COALESCE, which the
+ * engine bridge cannot translate), so those documents group under the missing value. A missing
+ * value equal to a real value merges into that value's bucket, matching classic semantics.</li>
+ * </ul>
+ *
+ * <p>The projection preserves the input schema exactly (same field names and positions), so
+ * grouping indices resolved against the base row type stay valid. Metric columns pass through
+ * untouched: SQL aggregate functions skip NULL inputs, matching classic metric semantics.
+ */
+public class PreAggregateConverter extends AbstractDslConverter {
+
+    /** Creates a pre-aggregate converter. */
+    public PreAggregateConverter() {}
+
+    @Override
+    protected boolean isApplicable(ConversionContext ctx) {
+        return ctx.getAggregationMetadata() != null && !ctx.getAggregationMetadata().getGroupByFieldNames().isEmpty();
+    }
+
+    @Override
+    protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
+        AggregationMetadata metadata = ctx.getAggregationMetadata();
+        Map<String, Object> missingValues = metadata.getMissingValues();
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RelDataType rowType = input.getRowType();
+
+        RelNode result = input;
+
+        // IS NOT NULL for group fields without a missing value
+        List<RexNode> notNullChecks = new ArrayList<>();
+        for (String fieldName : metadata.getGroupByFieldNames()) {
+            if (missingValues.containsKey(fieldName)) {
+                continue;
+            }
+            RelDataTypeField field = rowType.getField(fieldName, false, false);
+            if (field == null) {
+                throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
+            }
+            if (!field.getType().isNullable()) {
+                continue; // a non-nullable column cannot produce a NULL group
+            }
+            notNullChecks.add(
+                rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, rexBuilder.makeInputRef(field.getType(), field.getIndex()))
+            );
+        }
+        if (!notNullChecks.isEmpty()) {
+            result = LogicalFilter.create(result, RexUtil.composeConjunction(rexBuilder, notNullChecks));
+        }
+
+        // missing-value substitution for group fields that configure one
+        if (!missingValues.isEmpty()) {
+            List<RexNode> projects = new ArrayList<>();
+            List<String> fieldNames = new ArrayList<>();
+            for (RelDataTypeField field : rowType.getFieldList()) {
+                if (missingValues.containsKey(field.getName())) {
+                    projects.add(missingSubstitution(ctx, field, missingValues.get(field.getName())));
+                } else {
+                    projects.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+                }
+                fieldNames.add(field.getName());
+            }
+            result = LogicalProject.create(result, List.of(), projects, fieldNames);
+        }
+
+        return result;
+    }
+
+    /**
+     * Builds {@code CASE WHEN field IS NOT NULL THEN field ELSE missingValue END}, typed
+     * non-nullable: neither branch can yield NULL, and the expression becomes a group key, so
+     * its type records that the key can never be null.
+     */
+    private static RexNode missingSubstitution(ConversionContext ctx, RelDataTypeField field, Object missingValue)
+        throws ConversionException {
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RexNode fieldRef = rexBuilder.makeInputRef(field.getType(), field.getIndex());
+        RexNode isNotNull = rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);
+        RelDataType nonNullableType = ctx.getCluster().getTypeFactory().createTypeWithNullability(field.getType(), false);
+        RexNode missingLiteral;
+        try {
+            missingLiteral = rexBuilder.makeLiteral(missingValue, nonNullableType, true);
+        } catch (RuntimeException | AssertionError e) {
+            throw new ConversionException(
+                "[missing] value ["
+                    + missingValue
+                    + "] for field '"
+                    + field.getName()
+                    + "' is incompatible with the field type "
+                    + field.getType().getSqlTypeName(),
+                e instanceof Exception ex ? ex : null
+            );
+        }
+        return rexBuilder.makeCall(nonNullableType, SqlStdOperatorTable.CASE, List.of(isNotNull, fieldRef, missingLiteral));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
@@ -50,6 +51,7 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
+    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -77,8 +79,13 @@ public class SearchSourceConverter {
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        var aggRegistry = AggregationRegistryFactory.create();
+        this.aggRegistry = AggregationRegistryFactory.create();
         this.treeWalker = new AggregationTreeWalker(aggRegistry);
+    }
+
+    /** Returns the aggregation registry used by this converter. */
+    public AggregationRegistry getAggregationRegistry() {
+        return aggRegistry;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -39,6 +39,7 @@ import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.SearchContext;
@@ -49,6 +50,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 /**
  * Converts {@link SearchSourceBuilder} DSL into Calcite {@link QueryPlans}.
@@ -60,7 +62,6 @@ public class SearchSourceConverter {
 
     /** Immutable after creation with stateless translators — shared across all requests. */
     private static final QueryRegistry QUERY_REGISTRY = QueryRegistryFactory.create();
-    private static final AggregationRegistry AGG_REGISTRY = AggregationRegistryFactory.create();
 
     private final RelDataTypeFactory typeFactory;
     private final CalciteCatalogReader catalogReader;
@@ -70,14 +71,27 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PreAggregateConverter preAggConverter;
     private final PostAggregateConverter postAggConverter;
+    private final AggregationRegistry aggRegistry;
     private final AggregationTreeWalker treeWalker;
+
+    /**
+     * Initializes planning infrastructure without mapping resolution — response key typing
+     * falls back to value sampling. Intended for tests.
+     *
+     * @param schema Calcite schema with index tables from the analytics engine
+     */
+    public SearchSourceConverter(SchemaPlus schema) {
+        this(schema, () -> null);
+    }
 
     /**
      * Initializes planning infrastructure from the given schema.
      *
      * @param schema Calcite schema with index tables from the analytics engine
+     * @param mapperServiceSupplier supplies the target index's MapperService for response key
+     *        type and format resolution; evaluated lazily, may supply null
      */
-    public SearchSourceConverter(SchemaPlus schema) {
+    public SearchSourceConverter(SchemaPlus schema, Supplier<MapperService> mapperServiceSupplier) {
         // TODO: Once Analytics plugin starts providing the RelOptTable, use it directly —
         // no need to reconstruct typeFactory, CatalogReader, and planning infrastructure here.
         this.typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
@@ -97,12 +111,13 @@ public class SearchSourceConverter {
         this.preAggConverter = new PreAggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        this.treeWalker = new AggregationTreeWalker(AGG_REGISTRY);
+        this.aggRegistry = AggregationRegistryFactory.create(mapperServiceSupplier);
+        this.treeWalker = new AggregationTreeWalker(aggRegistry);
     }
 
     /** Returns the aggregation registry used by this converter. */
     public AggregationRegistry getAggregationRegistry() {
-        return AGG_REGISTRY;
+        return aggRegistry;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
@@ -49,6 +50,7 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
+    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -77,8 +79,13 @@ public class SearchSourceConverter {
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        var aggRegistry = AggregationRegistryFactory.create();
+        this.aggRegistry = AggregationRegistryFactory.create();
         this.treeWalker = new AggregationTreeWalker(aggRegistry);
+    }
+
+    /** Returns the aggregation registry used by this converter. */
+    public AggregationRegistry getAggregationRegistry() {
+        return aggRegistry;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -26,6 +26,7 @@ import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -42,6 +43,10 @@ import java.util.Properties;
  */
 public class SearchSourceConverter {
 
+    /** Immutable after creation with stateless translators — shared across all requests. */
+    private static final QueryRegistry QUERY_REGISTRY = QueryRegistryFactory.create();
+    private static final AggregationRegistry AGG_REGISTRY = AggregationRegistryFactory.create();
+
     private final RelOptCluster cluster;
     private final CalciteCatalogReader catalogReader;
     private final FilterConverter filterConverter;
@@ -50,7 +55,6 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
-    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -73,19 +77,18 @@ public class SearchSourceConverter {
             new CalciteConnectionConfigImpl(new Properties())
         );
 
-        this.filterConverter = new FilterConverter(QueryRegistryFactory.create());
+        this.filterConverter = new FilterConverter(QUERY_REGISTRY);
         this.projectConverter = new ProjectConverter();
         this.sortConverter = new SortConverter();
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        this.aggRegistry = AggregationRegistryFactory.create();
-        this.treeWalker = new AggregationTreeWalker(aggRegistry);
+        this.treeWalker = new AggregationTreeWalker(AGG_REGISTRY);
     }
 
     /** Returns the aggregation registry used by this converter. */
     public AggregationRegistry getAggregationRegistry() {
-        return aggRegistry;
+        return AGG_REGISTRY;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -15,13 +15,24 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
@@ -30,9 +41,13 @@ import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.internal.SearchContext;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -47,12 +62,13 @@ public class SearchSourceConverter {
     private static final QueryRegistry QUERY_REGISTRY = QueryRegistryFactory.create();
     private static final AggregationRegistry AGG_REGISTRY = AggregationRegistryFactory.create();
 
-    private final RelOptCluster cluster;
+    private final RelDataTypeFactory typeFactory;
     private final CalciteCatalogReader catalogReader;
     private final FilterConverter filterConverter;
     private final ProjectConverter projectConverter;
     private final SortConverter sortConverter;
     private final AggregateConverter aggConverter;
+    private final PreAggregateConverter preAggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
 
@@ -64,10 +80,7 @@ public class SearchSourceConverter {
     public SearchSourceConverter(SchemaPlus schema) {
         // TODO: Once Analytics plugin starts providing the RelOptTable, use it directly —
         // no need to reconstruct typeFactory, CatalogReader, and planning infrastructure here.
-
-        RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
-        HepPlanner planner = new HepPlanner(HepProgram.builder().build());
-        this.cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+        this.typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
 
         CalciteSchema rootSchema = CalciteSchema.from(schema);
         this.catalogReader = new CalciteCatalogReader(
@@ -81,6 +94,7 @@ public class SearchSourceConverter {
         this.projectConverter = new ProjectConverter();
         this.sortConverter = new SortConverter();
         this.aggConverter = new AggregateConverter();
+        this.preAggConverter = new PreAggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
         this.treeWalker = new AggregationTreeWalker(AGG_REGISTRY);
@@ -105,11 +119,12 @@ public class SearchSourceConverter {
             throw new IllegalArgumentException("Index not found in schema: " + indexName);
         }
 
+        // Request-scoped workspace for the hits/aggregation plans. The count and eligible-count
+        // plans below build in their own workspaces: they are submitted to the engine
+        // concurrently with these plans and must not share a metadata cache (see newCluster).
+        RelOptCluster cluster = newCluster();
         ConversionContext ctx = new ConversionContext(searchSource, cluster, table);
-
-        // Shared base: Scan → Filter
-        RelNode base = LogicalTableScan.create(cluster, table, List.of());
-        base = filterConverter.convert(base, ctx);
+        RelNode base = buildBase(ctx);
 
         int size = searchSource.size() != -1 ? searchSource.size() : SearchService.DEFAULT_SIZE;
         boolean hasAggs = hasAggregations(searchSource);
@@ -124,22 +139,217 @@ public class SearchSourceConverter {
             builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, hits));
         }
 
-        // Aggregation path: Scan → Filter → Aggregate → PostAggregate (one per granularity level)
-        if (hasAggs) {
-            List<AggregationMetadata> metadataList = treeWalker.walk(
-                searchSource.aggregations().getAggregatorFactories(),
-                table.getRowType(),
-                cluster.getTypeFactory()
-            );
-            for (AggregationMetadata metadata : metadataList) {
-                ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
-                RelNode aggs = aggConverter.convert(base, metadata);
-                aggs = postAggConverter.convert(aggs, aggCtx);
-                builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
+        // Aggregation path: Scan → Filter → PreAggregate → Aggregate → [Having] → bound+order
+        // (one plan per bucket aggregation — size, min_doc_count, and order are baked in;
+        // nested levels additionally semi-join their parent level's plan for the per-parent bound)
+        List<AggregationMetadata> metadataList = hasAggs
+            ? treeWalker.walk(searchSource.aggregations().getAggregatorFactories(), table.getRowType(), cluster.getTypeFactory())
+            : List.of();
+        // The walker emits parents before their children, so a child's parent plan is
+        // always already built when the child needs it as its semi-join input.
+        Map<String, RelNode> builtPlansByPath = new LinkedHashMap<>();
+        for (AggregationMetadata metadata : metadataList) {
+            ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
+            if (metadata.getPerParentFetch() != null) {
+                List<String> path = metadata.getAggNamePath();
+                RelNode parentPlan = builtPlansByPath.get(aggPathKey(path.subList(0, path.size() - 1)));
+                if (parentPlan == null) {
+                    throw new ConversionException(
+                        "Parent plan not built before nested plan [" + String.join(",", path) + "] — walker order broken"
+                    );
+                }
+                aggCtx = aggCtx.withParentPlan(parentPlan);
             }
+            RelNode aggInput = preAggConverter.convert(base, aggCtx);
+            RelNode aggs = aggConverter.convert(aggInput, metadata);
+            aggs = postAggConverter.convert(aggs, aggCtx);
+            builtPlansByPath.put(aggPathKey(metadata.getAggNamePath()), aggs);
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
+        }
+
+        // Accounting: a bounded root plan discards its tail engine-side, so each needs the
+        // eligible-doc total that sum_other_doc_count is subtracted from. Nested levels carry
+        // theirs inline as the _parent_eligible window column; unbounded plans discard nothing.
+        Map<String, Integer> eligibleFieldByAggName = new LinkedHashMap<>();
+        boolean totalServesAsEligibleCount = false;
+        for (AggregationMetadata metadata : metadataList) {
+            if (metadata.getFetch() == null) {
+                continue;
+            }
+            String aggName = metadata.getAggNamePath().get(0); // fetch implies a root-level, single-field plan
+            if (metadata.getHavingMinDocCount() != null) {
+                // min_doc_count > 1: the eligible count must exclude below-threshold groups
+                // (classic reduce drops them without counting them as "other"), which no flat
+                // count can see — it needs its own HAVING-filtered plan. Checked before missing:
+                // the threshold trumps substitution, and the plan's pre-aggregate input applies
+                // the same substitution anyway.
+                builder.add(
+                    new QueryPlans.QueryPlan(QueryPlans.Type.COUNT, buildHavingEligibleCountPlan(searchSource, table, metadata, aggName))
+                );
+            } else if (metadata.eligibleDocCountIsTotal()) {
+                // missing substitution makes every matching doc eligible — COUNT(*) serves
+                totalServesAsEligibleCount = true;
+            } else {
+                String fieldName = metadata.getGroupByFieldNames().get(0);
+                RelDataTypeField field = base.getRowType().getField(fieldName, false, false);
+                if (field == null) {
+                    throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
+                }
+                eligibleFieldByAggName.put(aggName, field.getIndex());
+            }
+        }
+        RelNode flatCountPlan = buildFlatCountPlan(table, eligibleFieldByAggName, searchSource, totalServesAsEligibleCount);
+        if (flatCountPlan != null) {
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.COUNT, flatCountPlan));
         }
 
         return builder.build();
+    }
+
+    /** Canonical plan key — see {@link AggregationMetadata#pathKey}. */
+    private static String aggPathKey(List<String> aggNamePath) {
+        return AggregationMetadata.pathKey(aggNamePath);
+    }
+
+    /**
+     * Creates a fresh workspace (cluster) for one plan family. Calcite's per-cluster metadata
+     * cache is not thread-safe, and its cycle detection assumes a single planning thread —
+     * concurrent metadata queries over a shared cache misread each other's in-progress markers
+     * as cycles ({@code CyclicMetadataException}). Plans the engine may plan concurrently must
+     * therefore not share a cluster, nor any {@code RelNode}: a node is permanently bound to
+     * the cluster it was created in, and metadata lookups follow {@code node.getCluster()}.
+     */
+    private RelOptCluster newCluster() {
+        return RelOptCluster.create(new HepPlanner(HepProgram.builder().build()), new RexBuilder(typeFactory));
+    }
+
+    /** Builds a plan family's private base — Scan → Filter — inside the context's own workspace. */
+    private RelNode buildBase(ConversionContext ctx) throws ConversionException {
+        RelNode scan = LogicalTableScan.create(ctx.getCluster(), ctx.getTable(), List.of());
+        return filterConverter.convert(scan, ctx);
+    }
+
+    /**
+     * Builds the single-row flat COUNT plan: {@code COUNT(*)} for {@code hits.total}, plus one
+     * null-skipping {@code COUNT(field)} per bounded root aggregation as its
+     * eligible-doc count (the total {@code sum_other_doc_count} is subtracted from).
+     *
+     * <p>Returns null when nothing needs counting: {@code track_total_hits: false}, no
+     * eligible-count columns, and no {@code missing}-substituted aggregation riding on
+     * {@code COUNT(*)}.
+     */
+    private RelNode buildFlatCountPlan(
+        RelOptTable table,
+        Map<String, Integer> eligibleFieldByAggName,
+        SearchSourceBuilder searchSource,
+        boolean totalServesAsEligibleCount
+    ) throws ConversionException {
+        boolean trackTotalHitsDisabled = searchSource.trackTotalHitsUpTo() != null
+            && searchSource.trackTotalHitsUpTo() == SearchContext.TRACK_TOTAL_HITS_DISABLED;
+        if (trackTotalHitsDisabled && eligibleFieldByAggName.isEmpty() && !totalServesAsEligibleCount) {
+            return null;
+        }
+
+        // Private workspace + rebuilt Scan → Filter: this plan executes concurrently with the
+        // main plans and must not share their cluster or nodes (see newCluster). The rebuilt
+        // base has the same row type, so the eligible-count field indices stay valid.
+        ConversionContext countCtx = new ConversionContext(searchSource, newCluster(), table);
+        RelNode base = buildBase(countCtx);
+
+        RelDataType bigint = countCtx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+        List<AggregateCall> calls = new ArrayList<>();
+        calls.add(
+            AggregateCall.create(
+                SqlStdOperatorTable.COUNT,
+                false,
+                false,
+                false,
+                List.of(),
+                -1,
+                RelCollations.EMPTY,
+                bigint,
+                QueryPlans.COUNT_TOTAL_COLUMN
+            )
+        );
+        for (Map.Entry<String, Integer> entry : eligibleFieldByAggName.entrySet()) {
+            calls.add(
+                AggregateCall.create(
+                    SqlStdOperatorTable.COUNT,
+                    false,
+                    false,
+                    false,
+                    List.of(entry.getValue()),
+                    -1,
+                    RelCollations.EMPTY,
+                    bigint,
+                    QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + entry.getKey()
+                )
+            );
+        }
+        return LogicalAggregate.create(base, ImmutableBitSet.of(), null, calls);
+    }
+
+    /**
+     * Builds the eligible-count plan for a {@code min_doc_count} > 1
+     * aggregation: total documents in the groups that pass the threshold.
+     *
+     * <pre>
+     * Aggregate(SUM(_count) AS _eligible$&lt;aggName&gt;)
+     *   Filter(_count &gt;= min_doc_count)
+     *     Aggregate(GROUP BY field, COUNT(*) AS _count)
+     *       &lt;pre-aggregate input, rebuilt in this plan's own workspace&gt;
+     * </pre>
+     *
+     * Built over an identically-constructed pre-aggregate input — its own workspace and nodes
+     * (see {@link #newCluster}), same converters — so null exclusion and {@code missing}
+     * substitution agree between the aggregation plan and its eligible count.
+     */
+    private RelNode buildHavingEligibleCountPlan(
+        SearchSourceBuilder searchSource,
+        RelOptTable table,
+        AggregationMetadata metadata,
+        String aggName
+    ) throws ConversionException {
+        ConversionContext ctx = new ConversionContext(searchSource, newCluster(), table).withAggregationMetadata(metadata);
+        RelNode aggInput = preAggConverter.convert(buildBase(ctx), ctx);
+
+        RelDataType bigint = ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+
+        AggregateCall groupCount = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            false,
+            false,
+            List.of(),
+            -1,
+            RelCollations.EMPTY,
+            bigint,
+            AggregationMetadataBuilder.IMPLICIT_COUNT_NAME
+        );
+        RelNode grouped = LogicalAggregate.create(aggInput, metadata.getGroupByBitSet(), null, List.of(groupCount));
+
+        RelDataTypeField countField = grouped.getRowType().getField(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME, false, false);
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RexNode threshold = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(countField.getType(), countField.getIndex()),
+            rexBuilder.makeLiteral(metadata.getHavingMinDocCount(), bigint, false)
+        );
+        RelNode filtered = LogicalFilter.create(grouped, threshold);
+
+        RelDataType nullableBigint = ctx.getCluster().getTypeFactory().createTypeWithNullability(bigint, true);
+        AggregateCall sum = AggregateCall.create(
+            SqlStdOperatorTable.SUM,
+            false,
+            false,
+            false,
+            List.of(countField.getIndex()),
+            -1,
+            RelCollations.EMPTY,
+            nullableBigint,
+            QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + aggName
+        );
+        return LogicalAggregate.create(filtered, ImmutableBitSet.of(), null, List.of(sum));
     }
 
     private static boolean hasAggregations(SearchSourceBuilder searchSource) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -75,8 +75,8 @@ public class SearchSourceConverter {
     private final AggregationTreeWalker treeWalker;
 
     /**
-     * Initializes planning infrastructure without mapping resolution — response key typing
-     * falls back to value sampling. Intended for tests.
+     * Initializes planning infrastructure without mapping resolution — conversion-only use;
+     * terms rendering fails without a MapperService. Intended for tests.
      *
      * @param schema Calcite schema with index tables from the analytics engine
      */
@@ -89,7 +89,8 @@ public class SearchSourceConverter {
      *
      * @param schema Calcite schema with index tables from the analytics engine
      * @param mapperServiceSupplier supplies the target index's MapperService for response key
-     *        type and format resolution; evaluated lazily, may supply null
+     *        type and format resolution; evaluated lazily. Supplying null skips
+     *        mapping-dependent validation and fails terms rendering.
      */
     public SearchSourceConverter(SchemaPlus schema, Supplier<MapperService> mapperServiceSupplier) {
         // TODO: Once Analytics plugin starts providing the RelOptTable, use it directly —

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -27,6 +27,7 @@ import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -43,6 +44,10 @@ import java.util.Properties;
  */
 public class SearchSourceConverter {
 
+    /** Immutable after creation with stateless translators — shared across all requests. */
+    private static final QueryRegistry QUERY_REGISTRY = QueryRegistryFactory.create();
+    private static final AggregationRegistry AGG_REGISTRY = AggregationRegistryFactory.create();
+
     private final RelOptCluster cluster;
     private final CalciteCatalogReader catalogReader;
     private final FilterConverter filterConverter;
@@ -51,7 +56,6 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
-    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -73,19 +77,18 @@ public class SearchSourceConverter {
             new CalciteConnectionConfigImpl(new Properties())
         );
 
-        this.filterConverter = new FilterConverter(QueryRegistryFactory.create());
+        this.filterConverter = new FilterConverter(QUERY_REGISTRY);
         this.projectConverter = new ProjectConverter();
         this.sortConverter = new SortConverter();
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        this.aggRegistry = AggregationRegistryFactory.create();
-        this.treeWalker = new AggregationTreeWalker(aggRegistry);
+        this.treeWalker = new AggregationTreeWalker(AGG_REGISTRY);
     }
 
     /** Returns the aggregation registry used by this converter. */
     public AggregationRegistry getAggregationRegistry() {
-        return aggRegistry;
+        return AGG_REGISTRY;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -132,7 +132,7 @@ public class SearchSourceConverter {
                 ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
                 RelNode aggs = aggConverter.convert(base, metadata);
                 aggs = postAggConverter.convert(aggs, aggCtx);
-                builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs));
+                builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
             }
         }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -56,6 +56,22 @@ public class DslQueryPlanExecutor {
         executeNext(queryPlans, 0, results, listener);
     }
 
+    /**
+     * Executes a single plan, independent of any sequential chain. Used for the COUNT plan,
+     * which runs concurrently with the main plans so its cost is attributable separately.
+     *
+     * @param plan     the plan to execute
+     * @param listener receives the plan's result or the failure
+     */
+    public void executeOne(QueryPlans.QueryPlan plan, ActionListener<ExecutionResult> listener) {
+        RelNode relNode = plan.relNode();
+        logPlan(relNode);
+        executor.execute(relNode, null, ActionListener.wrap(rows -> {
+            logRows(rows);
+            listener.onResponse(new ExecutionResult(plan, rows));
+        }, listener::onFailure));
+    }
+
     private void executeNext(
         List<QueryPlans.QueryPlan> queryPlans,
         int index,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -56,22 +56,6 @@ public class DslQueryPlanExecutor {
         executeNext(queryPlans, 0, results, listener);
     }
 
-    /**
-     * Executes a single plan, independent of any sequential chain. Used for the COUNT plan,
-     * which runs concurrently with the main plans so its cost is attributable separately.
-     *
-     * @param plan     the plan to execute
-     * @param listener receives the plan's result or the failure
-     */
-    public void executeOne(QueryPlans.QueryPlan plan, ActionListener<ExecutionResult> listener) {
-        RelNode relNode = plan.relNode();
-        logPlan(relNode);
-        executor.execute(relNode, null, ActionListener.wrap(rows -> {
-            logRows(rows);
-            listener.onResponse(new ExecutionResult(plan, rows));
-        }, listener::onFailure));
-    }
-
     private void executeNext(
         List<QueryPlans.QueryPlan> queryPlans,
         int index,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -94,32 +94,31 @@ public class DslQueryPlanExecutor {
     }
 
     private static void logRows(Iterable<Object[]> rows) {
-        if (logger.isInfoEnabled() == false) return;
+        if (logger.isDebugEnabled() == false) return;
         List<Object[]> list = (rows instanceof List) ? (List<Object[]>) rows : null;
         int count = list != null ? list.size() : -1;
-        logger.info("Query result rowCount={}", count);
+        logger.debug("Query result rowCount={}", count);
         if (list != null) {
             int preview = Math.min(20, list.size());
             for (int i = 0; i < preview; i++) {
-                logger.info("row[{}]={}", i, Arrays.toString(list.get(i)));
+                logger.debug("row[{}]={}", i, Arrays.toString(list.get(i)));
             }
             if (list.size() > preview) {
-                logger.info("... ({} more rows)", list.size() - preview);
+                logger.debug("... ({} more rows)", list.size() - preview);
             }
         }
     }
 
-    // TODO: move plan logging behind a debug flag
     // invalidateMetadataQuery() and THREAD_PROVIDERS are only needed for explain() output
     private void logPlan(RelNode relNode) {
-        if (logger.isInfoEnabled()) {
+        if (logger.isDebugEnabled()) {
             org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.set(
                 org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.of(
                     java.util.Objects.requireNonNull(relNode.getCluster().getMetadataProvider())
                 )
             );
             relNode.getCluster().invalidateMetadataQuery();
-            logger.info("Executing RelNode:\n{}", relNode.explain());
+            logger.debug("Executing RelNode:\n{}", relNode.explain());
         }
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
@@ -25,8 +25,29 @@ public final class QueryPlans {
         /** Document hits. */
         HITS,
         /** Aggregation results. */
-        AGGREGATION
+        AGGREGATION,
+        /**
+         * Request totals: single-row aggregates supplying the counts that plan-level LIMITs
+         * remove from the main plans — {@code hits.total} and the {@code sum_other_doc_count}
+         * eligible-doc counts. A request may carry several COUNT plans (one flat plan for
+         * {@code COUNT(*)}/{@code COUNT(field)} columns, plus one per {@code min_doc_count}
+         * aggregation whose eligible count needs a HAVING-filtered sum). All execute concurrently
+         * with the main plans.
+         */
+        COUNT
     }
+
+    /** Column name of the COUNT plans' {@code COUNT(*)} — total docs matching the query. */
+    public static final String COUNT_TOTAL_COLUMN = "_total";
+
+    /**
+     * Column name prefix of a root sized aggregation's eligible-doc count, the total {@code sum_other_doc_count} is subtracted from:
+     * the documents eligible for its buckets, named {@code _eligible$<aggregationName>} (root
+     * names are unique among siblings by DSL contract). For {@code min_doc_count} ≤ 1 this is
+     * {@code COUNT(field)}; for higher thresholds it is the sum of counts over the
+     * HAVING-filtered groups, delivered by that aggregation's own COUNT plan.
+     */
+    public static final String COUNT_ELIGIBLE_COLUMN_PREFIX = "_eligible$";
 
     /**
      * A single plan pairing a {@link Type} with a Calcite {@link RelNode}.
@@ -38,8 +59,6 @@ public final class QueryPlans {
      *        so granularity matching uses the walker's exact nesting-order group fields instead
      *        of re-deriving them from the plan (which loses nesting order).
      */
-    // TODO: Nested aggregations may require multiple RelNodes per aggregation.
-    // Support linking child query plans for recursive nesting (e.g. nested sub-aggregations).
     public record QueryPlan(Type type, RelNode relNode, AggregationMetadata aggregationMetadata) {
         /**
          * Creates a query plan.
@@ -61,18 +80,6 @@ public final class QueryPlans {
          */
         public QueryPlan(Type type, RelNode relNode) {
             this(type, relNode, null);
-        }
-
-        /** Returns what part of the response this plan produces. */
-        @Override
-        public Type type() {
-            return type;
-        }
-
-        /** Returns the Calcite logical plan to execute. */
-        @Override
-        public RelNode relNode() {
-            return relNode;
         }
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.executor;
 
 import org.apache.calcite.rel.RelNode;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,19 +33,34 @@ public final class QueryPlans {
      *
      * @param type what part of the response this plan produces
      * @param relNode the Calcite logical plan to execute
+     * @param aggregationMetadata the walker-produced metadata this plan was built from, or
+     *        {@code null} for {@link Type#HITS} plans. Carried through to the response builder
+     *        so granularity matching uses the walker's exact nesting-order group fields instead
+     *        of re-deriving them from the plan (which loses nesting order).
      */
     // TODO: Nested aggregations may require multiple RelNodes per aggregation.
     // Support linking child query plans for recursive nesting (e.g. nested sub-aggregations).
-    public record QueryPlan(Type type, RelNode relNode) {
+    public record QueryPlan(Type type, RelNode relNode, AggregationMetadata aggregationMetadata) {
         /**
          * Creates a query plan.
          *
          * @param type what part of the response this plan produces
          * @param relNode the Calcite logical plan to execute
+         * @param aggregationMetadata the source metadata for AGGREGATION plans, or null
          */
         public QueryPlan {
             Objects.requireNonNull(type, "type must not be null");
             Objects.requireNonNull(relNode, "relNode must not be null");
+        }
+
+        /**
+         * Creates a query plan without aggregation metadata (HITS plans).
+         *
+         * @param type what part of the response this plan produces
+         * @param relNode the Calcite logical plan to execute
+         */
+        public QueryPlan(Type type, RelNode relNode) {
+            this(type, relNode, null);
         }
 
         /** Returns what part of the response this plan produces. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -1,0 +1,304 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.util.ComparisonUtils;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Converts execution results into OpenSearch InternalAggregations format.
+ * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
+ */
+public final class AggregationResponseBuilder {
+
+    private static final String NO_GROUPING_KEY = "";
+    private static final String AGGREGATION_LEVEL_SEPARATOR = ",";
+
+    private final AggregationRegistry registry;
+    private final Map<String, ExecutionResult> granularityMap;
+
+    public AggregationResponseBuilder(AggregationRegistry registry, List<ExecutionResult> aggResults) {
+        this.registry = registry;
+        this.granularityMap = new HashMap<>();
+        for (ExecutionResult result : aggResults) {
+            String key = computeGranularityKey(result);
+            granularityMap.put(key, result);
+        }
+    }
+
+    /**
+     * Builds InternalAggregations from the original aggregation builders.
+     */
+    public InternalAggregations build(List<AggregationBuilder> originalAggs) throws ConversionException {
+        List<InternalAggregation> aggs = buildLevel(originalAggs, new ArrayList<>(), Map.of());
+        return InternalAggregations.from(aggs);
+    }
+
+    /**
+     * Recursively builds aggregations at a specific nesting level.
+     * Routes to buildMetric or buildBucket based on aggregation type.
+     */
+    private List<InternalAggregation> buildLevel(
+        List<AggregationBuilder> aggs,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) throws ConversionException {
+
+        List<InternalAggregation> result = new ArrayList<>();
+
+        for (AggregationBuilder agg : aggs) {
+            @SuppressWarnings("unchecked")
+            AggregationTranslator<AggregationBuilder> type = (AggregationTranslator<AggregationBuilder>) registry.get(agg.getClass());
+
+            if (type instanceof MetricTranslator) {
+                result.add(buildMetric((MetricTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+            } else if (type instanceof BucketTranslator) {
+                result.add(buildBucket((BucketTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+            } else {
+                throw new ConversionException(
+                    "No response translator for aggregation [" + agg.getName() + "] of type " + agg.getClass().getSimpleName()
+                );
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Builds a metric aggregation by extracting the computed value from execution results.
+     * Finds the matching row using granularity key and parent filters.
+     */
+    private InternalAggregation buildMetric(
+        MetricTranslator<AggregationBuilder> translator,
+        AggregationBuilder agg,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) {
+
+        ExecutionResult result = granularityMap.get(granularityKey(accumulatedGroupFields));
+
+        if (result == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        Integer colIdx = colIndex.get(agg.getName());
+
+        if (colIdx == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
+        Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
+        return translator.toInternalAggregation(agg.getName(), value);
+    }
+
+    /**
+     * Builds an empty metric aggregation with no computed value.
+     */
+    private static InternalAggregation buildEmptyMetric(MetricTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
+        return translator.toInternalAggregation(agg.getName(), null);
+    }
+
+    /**
+     * Builds an empty bucket aggregation with no buckets.
+     */
+    private static InternalAggregation buildEmptyBucket(BucketTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
+        return translator.toBucketAggregation(agg, List.of());
+    }
+
+    /**
+     * Builds a bucket aggregation by grouping rows and recursively building sub-aggregations.
+     * Groups rows by bucket keys and recursively processes nested aggregations for each bucket.
+     */
+    private InternalAggregation buildBucket(
+        BucketTranslator<AggregationBuilder> translator,
+        AggregationBuilder agg,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) throws ConversionException {
+
+        GroupingInfo grouping = translator.getGrouping(agg);
+        List<String> newGroupFields = new ArrayList<>(accumulatedGroupFields);
+        newGroupFields.addAll(grouping.getFieldNames());
+
+        ExecutionResult result = granularityMap.get(granularityKey(newGroupFields));
+
+        if (result == null) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        List<Object[]> filteredRows = filterRows(rows, colIndex, parentKeyFilter);
+
+        List<String> currentGroupColumns = new ArrayList<>(grouping.getFieldNames());
+
+        Map<List<Object>, List<Object[]>> grouped = groupRowsByKeys(filteredRows, currentGroupColumns, colIndex);
+
+        List<BucketEntry> buckets = new ArrayList<>();
+        List<AggregationBuilder> subAggs = new ArrayList<>(translator.getSubAggregations(agg));
+
+        for (Map.Entry<List<Object>, List<Object[]>> entry : grouped.entrySet()) {
+            Map<String, Object> childFilter = new HashMap<>(parentKeyFilter);
+            for (int i = 0; i < currentGroupColumns.size(); i++) {
+                childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
+            }
+
+            Integer countIdx = colIndex.get("_count");
+            if (countIdx == null) {
+                throw new ConversionException("Missing _count column in aggregation result");
+            }
+            Object[] firstRowInGroup = entry.getValue().get(0);
+            long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
+
+            InternalAggregations subAggregations = subAggs.isEmpty()
+                ? InternalAggregations.EMPTY
+                : InternalAggregations.from(buildLevel(subAggs, newGroupFields, childFilter));
+
+            buckets.add(new BucketEntry(entry.getKey(), docCount, subAggregations));
+        }
+
+        return translator.toBucketAggregation(agg, buckets);
+    }
+
+    /**
+     * Builds a map from column names to their indices.
+     * Enables efficient column lookup by name during row processing.
+     */
+    private static Map<String, Integer> buildColumnIndex(ExecutionResult result) {
+        Map<String, Integer> index = new HashMap<>();
+        List<String> fieldNames = result.getFieldNames();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            index.put(fieldNames.get(i), i);
+        }
+        return index;
+    }
+
+    /**
+     * Finds the first row matching all filter criteria.
+     * Used to locate the specific row for nested metric aggregations.
+     */
+    private static Object[] findMatchingRow(List<Object[]> rows, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        for (Object[] row : rows) {
+            if (matchesFilter(row, colIndex, filter)) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Filters rows to only those matching all filter criteria.
+     * Ensures nested aggregations only process rows belonging to their parent bucket.
+     */
+    private static List<Object[]> filterRows(List<Object[]> rows, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        if (filter.isEmpty()) {
+            return rows;
+        }
+        return rows.stream().filter(row -> matchesFilter(row, colIndex, filter)).collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if a row matches all filter criteria.
+     * Uses type-coercion comparison to handle numeric type differences from execution engine.
+     */
+    private static boolean matchesFilter(Object[] row, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        for (Map.Entry<String, Object> entry : filter.entrySet()) {
+            Integer idx = colIndex.get(entry.getKey());
+            if (idx == null || !ComparisonUtils.valuesEqual(row[idx], entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Groups rows by their grouping column values (the bucket keys). Group columns are
+     * resolved by name — they are not guaranteed to be the leading row positions.
+     */
+    private static Map<List<Object>, List<Object[]>> groupRowsByKeys(
+        List<Object[]> rows,
+        List<String> groupColumns,
+        Map<String, Integer> colIndex
+    ) throws ConversionException {
+        List<Integer> keyIndices = new ArrayList<>(groupColumns.size());
+        for (String column : groupColumns) {
+            Integer idx = colIndex.get(column);
+            if (idx == null) {
+                throw new ConversionException("Group column '" + column + "' not found in aggregation result columns");
+            }
+            keyIndices.add(idx);
+        }
+
+        Map<List<Object>, List<Object[]>> grouped = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            List<Object> key = new ArrayList<>(keyIndices.size());
+            for (int idx : keyIndices) {
+                key.add(row[idx]);
+            }
+            grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
+        }
+        return grouped;
+    }
+
+    /**
+     * Computes the granularity key for an execution result from its plan's aggregate.
+     * The aggregate is found by walking down the plan's single-input spine — post-aggregate
+     * nodes (bucket-order sort, future HAVING filters) sit on top of it.
+     */
+    private static String computeGranularityKey(ExecutionResult result) {
+        RelNode node = result.getPlan().relNode();
+        while (node != null && !(node instanceof LogicalAggregate)) {
+            node = node.getInputs().isEmpty() ? null : node.getInput(0);
+        }
+        if (node instanceof LogicalAggregate agg) {
+            int groupCount = agg.getGroupCount();
+            return granularityKey(agg.getRowType().getFieldNames().stream().limit(groupCount).collect(Collectors.toList()));
+        }
+        return NO_GROUPING_KEY;
+    }
+
+    /**
+     * Canonical granularity key: sorted, comma-joined group field names. Sorted because the
+     * plan emits group columns in schema order while the request walk accumulates them in
+     * nesting order — the two must produce the same key.
+     */
+    private static String granularityKey(List<String> groupFieldNames) {
+        return groupFieldNames.stream().sorted().collect(Collectors.joining(AGGREGATION_LEVEL_SEPARATOR));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -36,7 +36,8 @@ import java.util.stream.StreamSupport;
 public final class AggregationResponseBuilder {
 
     private static final String NO_GROUPING_KEY = "";
-    private static final String AGGREGATION_LEVEL_SEPARATOR = ",";
+    /** NUL cannot appear in field names, so joined keys cannot collide. */
+    private static final String AGGREGATION_LEVEL_SEPARATOR = "\u0000";
 
     private final AggregationRegistry registry;
     private final Map<String, ExecutionResult> granularityMap;
@@ -287,8 +288,10 @@ public final class AggregationResponseBuilder {
             node = node.getInputs().isEmpty() ? null : node.getInput(0);
         }
         if (node instanceof LogicalAggregate agg) {
-            int groupCount = agg.getGroupCount();
-            return granularityKey(agg.getRowType().getFieldNames().stream().limit(groupCount).collect(Collectors.toList()));
+            // Resolve group field names against the aggregate's INPUT row type via the group
+            // set — robust against output-side renames, unlike the aggregate's own row type.
+            List<String> inputFields = agg.getInput().getRowType().getFieldNames();
+            return granularityKey(agg.getGroupSet().asList().stream().map(inputFields::get).collect(Collectors.toList()));
         }
         return NO_GROUPING_KEY;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -14,8 +14,10 @@ import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.bucket.SizedBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.MetricTranslator;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.converter.PostAggregateConverter;
 import org.opensearch.dsl.util.ComparisonUtils;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
@@ -31,28 +33,28 @@ import java.util.stream.StreamSupport;
 
 /**
  * Converts execution results into OpenSearch InternalAggregations format.
- * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
  *
- * <p>A granularity is identified by its GROUP BY field names in <b>nesting order</b> (outer
- * bucket first) — the same order the {@code AggregationTreeWalker} accumulated them in and the
- * same order the response walk re-accumulates while descending the request's aggregation tree.
- * Results are keyed by the walker-produced {@link AggregationMetadata} carried on each plan, so
- * the key round-trips losslessly: sibling trees over the same field <em>set</em> but different
- * nesting order (e.g. {@code brand→category} vs {@code category→brand}) produce distinct plans
- * AND distinct keys. Re-deriving the key from the plan's group bit set would yield schema order
- * instead, forcing an order-insensitive (sorted) key under which such siblings collide.
+ * <p>Plans are per bucket aggregation, so results are keyed by the <b>aggregation-name path</b>
+ * (outer bucket first) — the walker records it on each plan's {@link AggregationMetadata}, and
+ * the response walk re-accumulates the same path while descending the request tree, so the key
+ * matches by construction. Aggregation names are unique among siblings by DSL contract, which
+ * makes the key unambiguous: sibling aggregations over the same field, or sibling trees over
+ * the same field set in different nesting orders, all have distinct paths and distinct plans.
  */
 public final class AggregationResponseBuilder {
 
-    /** NUL cannot appear in field names, so joined keys cannot collide. */
-    private static final String AGGREGATION_LEVEL_SEPARATOR = "\u0000";
-
     private final AggregationRegistry registry;
-    private final Map<String, ExecutionResult> granularityMap;
+    private final Map<String, ExecutionResult> resultsByAggPath;
+    private final CountTotals countTotals;
 
     public AggregationResponseBuilder(AggregationRegistry registry, List<ExecutionResult> aggResults) {
+        this(registry, aggResults, null);
+    }
+
+    public AggregationResponseBuilder(AggregationRegistry registry, List<ExecutionResult> aggResults, CountTotals countTotals) {
         this.registry = registry;
-        this.granularityMap = new HashMap<>();
+        this.countTotals = countTotals;
+        this.resultsByAggPath = new HashMap<>();
         for (ExecutionResult result : aggResults) {
             AggregationMetadata metadata = result.getPlan().aggregationMetadata();
             if (metadata == null) {
@@ -61,15 +63,13 @@ public final class AggregationResponseBuilder {
                         + "response builder must be created by SearchSourceConverter"
                 );
             }
-            String key = granularityKey(metadata.getGroupByFieldNames());
-            ExecutionResult previous = granularityMap.putIfAbsent(key, result);
+            String key = pathKey(metadata.getAggNamePath());
+            ExecutionResult previous = resultsByAggPath.putIfAbsent(key, result);
             if (previous != null) {
-                // The walker produces exactly one plan per nesting-order granularity, so a
-                // duplicate key means the walker invariant broke upstream. Fail loudly instead
-                // of silently overwriting one plan's results with another's.
-                throw new IllegalStateException(
-                    "Duplicate aggregation granularity [" + String.join(",", metadata.getGroupByFieldNames()) + "]"
-                );
+                // Sibling aggregation names are unique by DSL contract, so a duplicate path
+                // means the walker invariant broke upstream. Fail loudly instead of silently
+                // overwriting one plan's results with another's.
+                throw new IllegalStateException("Duplicate aggregation plan path [" + String.join(",", metadata.getAggNamePath()) + "]");
             }
         }
     }
@@ -90,7 +90,7 @@ public final class AggregationResponseBuilder {
      */
     private List<InternalAggregation> buildLevel(
         List<AggregationBuilder> aggs,
-        List<String> accumulatedGroupFields,
+        List<String> accumulatedAggNames,
         Map<String, Object> parentKeyFilter
     ) throws ConversionException {
 
@@ -101,9 +101,9 @@ public final class AggregationResponseBuilder {
             AggregationTranslator<AggregationBuilder> type = (AggregationTranslator<AggregationBuilder>) registry.get(agg.getClass());
 
             if (type instanceof MetricTranslator) {
-                result.add(buildMetric((MetricTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+                result.add(buildMetric((MetricTranslator<AggregationBuilder>) type, agg, accumulatedAggNames, parentKeyFilter));
             } else if (type instanceof BucketTranslator) {
-                result.add(buildBucket((BucketTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+                result.add(buildBucket((BucketTranslator<AggregationBuilder>) type, agg, accumulatedAggNames, parentKeyFilter));
             } else {
                 throw new ConversionException(
                     "No response translator for aggregation [" + agg.getName() + "] of type " + agg.getClass().getSimpleName()
@@ -115,22 +115,23 @@ public final class AggregationResponseBuilder {
 
     /**
      * Builds a metric aggregation by extracting the computed value from execution results.
-     * Finds the matching row using granularity key and parent filters.
+     * Metrics ride in their enclosing bucket aggregation's plan, so the lookup uses the
+     * enclosing aggregation-name path; parent filters locate the specific row.
      */
     private InternalAggregation buildMetric(
         MetricTranslator<AggregationBuilder> translator,
         AggregationBuilder agg,
-        List<String> accumulatedGroupFields,
+        List<String> accumulatedAggNames,
         Map<String, Object> parentKeyFilter
     ) throws ConversionException {
 
-        ExecutionResult result = granularityMap.get(granularityKey(accumulatedGroupFields));
+        ExecutionResult result = resultsByAggPath.get(pathKey(accumulatedAggNames));
 
         if (result == null) {
             return buildEmptyMetric(translator, agg);
         }
 
-        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+        List<Object[]> rows = materialize(result);
 
         if (rows.isEmpty()) {
             return buildEmptyMetric(translator, agg);
@@ -145,7 +146,18 @@ public final class AggregationResponseBuilder {
 
         Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
         Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
-        return translator.toInternalAggregation(agg.getName(), value, AggregationTranslator.userMetadata(agg));
+        InternalAggregation metric = translator.toInternalAggregation(agg.getName(), value, AggregationTranslator.userMetadata(agg));
+        return metric;
+    }
+
+    /**
+     * Drains one granularity's rows into a re-readable list. The builder makes several passes over
+     * them (filter, group, per-bucket recursion), so the executor's iterable is materialized once
+     * per call.
+     */
+    private static List<Object[]> materialize(ExecutionResult result) {
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+        return rows;
     }
 
     /**
@@ -169,21 +181,21 @@ public final class AggregationResponseBuilder {
     private InternalAggregation buildBucket(
         BucketTranslator<AggregationBuilder> translator,
         AggregationBuilder agg,
-        List<String> accumulatedGroupFields,
+        List<String> accumulatedAggNames,
         Map<String, Object> parentKeyFilter
     ) throws ConversionException {
 
         GroupingInfo grouping = translator.getGrouping(agg);
-        List<String> newGroupFields = new ArrayList<>(accumulatedGroupFields);
-        newGroupFields.addAll(grouping.getFieldNames());
+        List<String> newAggNames = new ArrayList<>(accumulatedAggNames);
+        newAggNames.add(agg.getName());
 
-        ExecutionResult result = granularityMap.get(granularityKey(newGroupFields));
+        ExecutionResult result = resultsByAggPath.get(pathKey(newAggNames));
 
         if (result == null) {
             return buildEmptyBucket(translator, agg);
         }
 
-        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+        List<Object[]> rows = materialize(result);
 
         if (rows.isEmpty()) {
             return buildEmptyBucket(translator, agg);
@@ -215,12 +227,73 @@ public final class AggregationResponseBuilder {
 
             InternalAggregations subAggregations = subAggs.isEmpty()
                 ? InternalAggregations.EMPTY
-                : InternalAggregations.from(buildLevel(subAggs, newGroupFields, childFilter));
+                : InternalAggregations.from(buildLevel(subAggs, newAggNames, childFilter));
 
             buckets.add(new BucketEntry(entry.getKey(), docCount, subAggregations));
         }
 
-        return translator.toBucketAggregation(agg, buckets);
+        Long eligibleDocCount = resolveEligibleDocCount(result, filteredRows, colIndex);
+        if (eligibleDocCount != null && (translator instanceof SizedBucketTranslator) == false) {
+            // Fetch is only granted to granularities defined by a SizedBucketTranslator; a
+            // truncated plan rendered through the base contract would tail-sum a tail that
+            // never left the engine.
+            throw new ConversionException(
+                "Plan for aggregation [" + agg.getName() + "] carried a fetch but its translator is not a SizedBucketTranslator"
+            );
+        }
+
+        InternalAggregation bucketAgg = eligibleDocCount != null
+            ? ((SizedBucketTranslator<AggregationBuilder>) translator).toBucketAggregation(agg, buckets, eligibleDocCount)
+            : translator.toBucketAggregation(agg, buckets);
+        return bucketAgg;
+    }
+
+    /**
+     * Resolves the eligible-document total for a level whose plan is bounded. Root-level plans (a flat
+     * LIMIT) take the aggregation's eligible-document count from the COUNT plans
+     * ({@code COUNT(*)} when a {@code missing} value makes every matching doc eligible).
+     * Nested levels (a per-parent bound) read the parent's eligible total off the rows — the
+     * plan's window {@code SUM(_count) OVER (PARTITION BY parent)} rides every surviving row,
+     * constant within the parent. Returns null for unbounded plans, where the translator's own
+     * tail arithmetic is exact. A bounded level with no reachable eligible count is a wiring
+     * bug — rendering would silently understate {@code sum_other_doc_count}, so it fails
+     * loudly.
+     */
+    private Long resolveEligibleDocCount(ExecutionResult result, List<Object[]> filteredRows, Map<String, Integer> colIndex)
+        throws ConversionException {
+        AggregationMetadata metadata = result.getPlan().aggregationMetadata();
+
+        if (metadata.getPerParentFetch() != null) {
+            Integer eligibleIdx = colIndex.get(PostAggregateConverter.PARENT_ELIGIBLE_NAME);
+            if (eligibleIdx == null) {
+                throw new ConversionException(
+                    "Nested bounded plan result is missing the "
+                        + PostAggregateConverter.PARENT_ELIGIBLE_NAME
+                        + " column for aggregation ["
+                        + String.join(",", metadata.getAggNamePath())
+                        + "]"
+                );
+            }
+            if (filteredRows.isEmpty()) {
+                return 0L;
+            }
+            Object eligible = filteredRows.get(0)[eligibleIdx];
+            return eligible instanceof Number count ? count.longValue() : 0L;
+        }
+
+        if (metadata.getFetch() == null) {
+            return null;
+        }
+        // a flat-LIMIT plan is root-level and single-field by eligibility
+        String aggName = metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1);
+        Long eligibleDocCount = null;
+        if (countTotals != null) {
+            eligibleDocCount = metadata.eligibleDocCountIsTotal() ? countTotals.totalDocs() : countTotals.eligibleDocCounts().get(aggName);
+        }
+        if (eligibleDocCount == null) {
+            throw new ConversionException("COUNT plan result is missing the eligible-doc count for bounded aggregation [" + aggName + "]");
+        }
+        return eligibleDocCount;
     }
 
     /**
@@ -306,13 +379,12 @@ public final class AggregationResponseBuilder {
     }
 
     /**
-     * Canonical granularity key: group field names in nesting order (outer bucket first),
-     * NUL-joined. Insertion uses the walker's {@link AggregationMetadata#getGroupByFieldNames()}
-     * and lookup uses the response walk's accumulated fields — both are built in nesting order,
-     * so the key matches by construction. Not sorted: sorting would erase nesting order, the
-     * one thing distinguishing sibling trees over the same field set (see class javadoc).
+     * Canonical plan key: aggregation names in nesting order (outer bucket first), NUL-joined.
+     * Insertion uses the walker's {@link AggregationMetadata#getAggNamePath()} and lookup uses
+     * the response walk's accumulated names — both are built in nesting order, so the key
+     * matches by construction.
      */
-    private static String granularityKey(List<String> groupFieldNames) {
-        return String.join(AGGREGATION_LEVEL_SEPARATOR, groupFieldNames);
+    private static String pathKey(List<String> aggNames) {
+        return AggregationMetadata.pathKey(aggNames);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.dsl.result;
 
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.GroupingInfo;
@@ -32,10 +32,18 @@ import java.util.stream.StreamSupport;
 /**
  * Converts execution results into OpenSearch InternalAggregations format.
  * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
+ *
+ * <p>A granularity is identified by its GROUP BY field names in <b>nesting order</b> (outer
+ * bucket first) — the same order the {@code AggregationTreeWalker} accumulated them in and the
+ * same order the response walk re-accumulates while descending the request's aggregation tree.
+ * Results are keyed by the walker-produced {@link AggregationMetadata} carried on each plan, so
+ * the key round-trips losslessly: sibling trees over the same field <em>set</em> but different
+ * nesting order (e.g. {@code brand→category} vs {@code category→brand}) produce distinct plans
+ * AND distinct keys. Re-deriving the key from the plan's group bit set would yield schema order
+ * instead, forcing an order-insensitive (sorted) key under which such siblings collide.
  */
 public final class AggregationResponseBuilder {
 
-    private static final String NO_GROUPING_KEY = "";
     /** NUL cannot appear in field names, so joined keys cannot collide. */
     private static final String AGGREGATION_LEVEL_SEPARATOR = "\u0000";
 
@@ -46,8 +54,23 @@ public final class AggregationResponseBuilder {
         this.registry = registry;
         this.granularityMap = new HashMap<>();
         for (ExecutionResult result : aggResults) {
-            String key = computeGranularityKey(result);
-            granularityMap.put(key, result);
+            AggregationMetadata metadata = result.getPlan().aggregationMetadata();
+            if (metadata == null) {
+                throw new IllegalArgumentException(
+                    "AGGREGATION plan is missing its AggregationMetadata — plans consumed by the "
+                        + "response builder must be created by SearchSourceConverter"
+                );
+            }
+            String key = granularityKey(metadata.getGroupByFieldNames());
+            ExecutionResult previous = granularityMap.putIfAbsent(key, result);
+            if (previous != null) {
+                // The walker produces exactly one plan per nesting-order granularity, so a
+                // duplicate key means the walker invariant broke upstream. Fail loudly instead
+                // of silently overwriting one plan's results with another's.
+                throw new IllegalStateException(
+                    "Duplicate aggregation granularity [" + String.join(",", metadata.getGroupByFieldNames()) + "]"
+                );
+            }
         }
     }
 
@@ -180,9 +203,11 @@ public final class AggregationResponseBuilder {
                 childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
             }
 
-            Integer countIdx = colIndex.get("_count");
+            Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
             if (countIdx == null) {
-                throw new ConversionException("Missing _count column in aggregation result");
+                throw new ConversionException(
+                    "Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result"
+                );
             }
             Object[] firstRowInGroup = entry.getValue().get(0);
             long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
@@ -278,30 +303,13 @@ public final class AggregationResponseBuilder {
     }
 
     /**
-     * Computes the granularity key for an execution result from its plan's aggregate.
-     * The aggregate is found by walking down the plan's single-input spine — post-aggregate
-     * nodes (bucket-order sort, future HAVING filters) sit on top of it.
-     */
-    private static String computeGranularityKey(ExecutionResult result) {
-        RelNode node = result.getPlan().relNode();
-        while (node != null && !(node instanceof LogicalAggregate)) {
-            node = node.getInputs().isEmpty() ? null : node.getInput(0);
-        }
-        if (node instanceof LogicalAggregate agg) {
-            // Resolve group field names against the aggregate's INPUT row type via the group
-            // set — robust against output-side renames, unlike the aggregate's own row type.
-            List<String> inputFields = agg.getInput().getRowType().getFieldNames();
-            return granularityKey(agg.getGroupSet().asList().stream().map(inputFields::get).collect(Collectors.toList()));
-        }
-        return NO_GROUPING_KEY;
-    }
-
-    /**
-     * Canonical granularity key: sorted, comma-joined group field names. Sorted because the
-     * plan emits group columns in schema order while the request walk accumulates them in
-     * nesting order — the two must produce the same key.
+     * Canonical granularity key: group field names in nesting order (outer bucket first),
+     * NUL-joined. Insertion uses the walker's {@link AggregationMetadata#getGroupByFieldNames()}
+     * and lookup uses the response walk's accumulated fields — both are built in nesting order,
+     * so the key matches by construction. Not sorted: sorting would erase nesting order, the
+     * one thing distinguishing sibling trees over the same field set (see class javadoc).
      */
     private static String granularityKey(List<String> groupFieldNames) {
-        return groupFieldNames.stream().sorted().collect(Collectors.joining(AGGREGATION_LEVEL_SEPARATOR));
+        return String.join(AGGREGATION_LEVEL_SEPARATOR, groupFieldNames);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -194,6 +194,11 @@ public final class AggregationResponseBuilder {
 
         Map<List<Object>, List<Object[]>> grouped = groupRowsByKeys(filteredRows, currentGroupColumns, colIndex);
 
+        Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
+        if (countIdx == null) {
+            throw new ConversionException("Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result");
+        }
+
         List<BucketEntry> buckets = new ArrayList<>();
         List<AggregationBuilder> subAggs = new ArrayList<>(translator.getSubAggregations(agg));
 
@@ -203,12 +208,6 @@ public final class AggregationResponseBuilder {
                 childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
             }
 
-            Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
-            if (countIdx == null) {
-                throw new ConversionException(
-                    "Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result"
-                );
-            }
             Object[] firstRowInGroup = entry.getValue().get(0);
             long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -120,7 +120,7 @@ public final class AggregationResponseBuilder {
         AggregationBuilder agg,
         List<String> accumulatedGroupFields,
         Map<String, Object> parentKeyFilter
-    ) {
+    ) throws ConversionException {
 
         ExecutionResult result = granularityMap.get(granularityKey(accumulatedGroupFields));
 
@@ -138,19 +138,19 @@ public final class AggregationResponseBuilder {
         Integer colIdx = colIndex.get(agg.getName());
 
         if (colIdx == null) {
-            return buildEmptyMetric(translator, agg);
+            throw new ConversionException("Metric column '" + agg.getName() + "' not found in aggregation result columns");
         }
 
         Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
         Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
-        return translator.toInternalAggregation(agg.getName(), value);
+        return translator.toInternalAggregation(agg.getName(), value, AggregationTranslator.userMetadata(agg));
     }
 
     /**
      * Builds an empty metric aggregation with no computed value.
      */
     private static InternalAggregation buildEmptyMetric(MetricTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
-        return translator.toInternalAggregation(agg.getName(), null);
+        return translator.toInternalAggregation(agg.getName(), null, AggregationTranslator.userMetadata(agg));
     }
 
     /**
@@ -248,6 +248,8 @@ public final class AggregationResponseBuilder {
         return null;
     }
 
+    // TODO: Avoid re-scanning the full row list on every recursion (here and in findMatchingRow).
+    // Index each granularity's rows by parent bucket key once, then look buckets up directly.
     /**
      * Filters rows to only those matching all filter criteria.
      * Ensures nested aggregations only process rows belonging to their parent bucket.

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -74,6 +74,8 @@ public final class AggregationResponseBuilder {
         }
     }
 
+    // TODO: Support pipeline aggregations. They post-process the assembled aggregation tree;
+    // currently they are ignored.
     /**
      * Builds InternalAggregations from the original aggregation builders.
      */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/BucketEntry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/BucketEntry.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * A single bucket entry for response construction.
  *
- * @param keys the bucket key values (single for terms, multiple for multi_terms)
+ * @param keys the bucket key values — one per field in the declaring translator's grouping, in declaration order
  * @param docCount the document count for this bucket
  * @param subAggs the sub-aggregation results for this bucket
  */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/CountTotals.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/CountTotals.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.opensearch.dsl.executor.QueryPlans;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Merged result of the request's COUNT plans: the totals that plan-level LIMITs remove from
+ * the main plans.
+ *
+ * @param totalDocs total documents matching the query ({@code COUNT(*)}), or null when no
+ *        count plan carried a total
+ * @param eligibleDocCounts eligible-doc count per root aggregation name (the total {@code sum_other_doc_count} is subtracted from):
+ *        the documents eligible for that aggregation's buckets
+ */
+public record CountTotals(Long totalDocs, Map<String, Long> eligibleDocCounts) {
+
+    /**
+     * Creates count totals.
+     *
+     * @param totalDocs total matching documents, or null
+     * @param eligibleDocCounts eligible-document counts by root aggregation name
+     */
+    public CountTotals {
+        eligibleDocCounts = Map.copyOf(eligibleDocCounts);
+    }
+
+    /** Returns the total matching documents, or null when no count plan carried a total. */
+    @Override
+    public Long totalDocs() {
+        return totalDocs;
+    }
+
+    /** Returns the eligible-document counts by root aggregation name. */
+    @Override
+    public Map<String, Long> eligibleDocCounts() {
+        return eligibleDocCounts;
+    }
+
+    /**
+     * Parses and merges the COUNT plans' single result rows by the column-name contract
+     * ({@link QueryPlans#COUNT_TOTAL_COLUMN}, {@link QueryPlans#COUNT_ELIGIBLE_COLUMN_PREFIX}).
+     * A present-but-null eligible cell (a {@code SUM} over zero passing groups) counts as zero
+     * eligible documents.
+     *
+     * @param countResults the COUNT plans' execution results
+     * @return the merged totals
+     */
+    public static CountTotals from(List<ExecutionResult> countResults) {
+        Long totalDocs = null;
+        Map<String, Long> eligibleDocCounts = new HashMap<>();
+        for (ExecutionResult countResult : countResults) {
+            Iterator<Object[]> rows = countResult.getRows().iterator();
+            if (!rows.hasNext()) {
+                continue;
+            }
+            Object[] row = rows.next();
+            List<String> columnNames = countResult.getFieldNames();
+            for (int i = 0; i < columnNames.size() && i < row.length; i++) {
+                String column = columnNames.get(i);
+                if (QueryPlans.COUNT_TOTAL_COLUMN.equals(column)) {
+                    if (row[i] instanceof Number count) {
+                        totalDocs = count.longValue();
+                    }
+                } else if (column.startsWith(QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX)) {
+                    String aggName = column.substring(QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX.length());
+                    long count = row[i] instanceof Number number ? number.longValue() : 0L;
+                    eligibleDocCounts.put(aggName, count);
+                }
+            }
+        }
+        return new CountTotals(totalDocs, eligibleDocCounts);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
@@ -8,38 +8,75 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Builds a {@link SearchResponse} from execution results.
+ * Handles conversion of flat execution results into OpenSearch response format.
  */
 public class SearchResponseBuilder {
 
     private SearchResponseBuilder() {}
 
     /**
-     * Builds a SearchResponse from the given results and timing.
+     * Builds a SearchResponse from execution results.
      *
-     * @param results execution results from the plan executor
-     * @param convertTimeNanos time spent in DSL-to-RelNode conversion, in nanoseconds
+     * @param results execution results from the query executor
+     * @param request the original search request
+     * @param registry aggregation registry for building aggregations
+     * @param tookInMillis total execution time in milliseconds
      * @return a SearchResponse
      */
-    // TODO: Analytics plugin should return execution metadata alongside Iterable<Object[]> rows:
-    // - executionTimeNanos: query execution time
-    // - totalDocCount: total matching documents for hits.total
-    // - terminatedEarly: whether execution was terminated early
-    // - timedOut: whether execution timed out
-    // - shardInfo: total/successful/skipped/failed shard counts
-    public static SearchResponse build(List<ExecutionResult> results, long convertTimeNanos) {
-        // TODO: populate HITS and AGGREGATION plan types from results
-        long tookInMillis = convertTimeNanos / 1_000_000;
-        SearchHits hits = SearchHits.empty(true);
-        SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 0);
-        return new SearchResponse(sections, null, 0, 0, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    public static SearchResponse build(
+        List<ExecutionResult> results,
+        SearchRequest request,
+        AggregationRegistry registry,
+        long tookInMillis
+    ) throws ConversionException {
+
+        SearchHits hits = buildHits(results);
+        InternalAggregations aggregations = buildAggregations(results, request, registry);
+
+        SearchResponseSections sections = new SearchResponseSections(hits, aggregations, null, false, null, null, 0);
+
+        // TODO: shard counts, timed_out, and engine-side took require execution metadata from
+        // the analytics plugin (returned alongside rows). Until then report a constant 1/1 —
+        // the analytics path has no per-shard fan-out to report.
+        return new SearchResponse(sections, null, 1, 1, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
+
+    private static SearchHits buildHits(List<ExecutionResult> results) {
+        // TODO: Build hits from HITS results
+        return SearchHits.empty(true);
+    }
+
+    private static InternalAggregations buildAggregations(
+        List<ExecutionResult> results,
+        SearchRequest request,
+        AggregationRegistry registry
+    ) throws ConversionException {
+
+        List<ExecutionResult> aggResults = results.stream()
+            .filter(r -> r.getType() == QueryPlans.Type.AGGREGATION)
+            .collect(Collectors.toList());
+
+        if (aggResults.isEmpty() || request.source() == null || request.source().aggregations() == null) {
+            return null;
+        }
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults);
+        return builder.build(new ArrayList<>(request.source().aggregations().getAggregatorFactories()));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.result;
 
+import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
@@ -15,8 +16,10 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.SearchContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +49,9 @@ public class SearchResponseBuilder {
         long tookInMillis
     ) throws ConversionException {
 
-        SearchHits hits = buildHits(results);
-        InternalAggregations aggregations = buildAggregations(results, request, registry);
+        CountTotals countTotals = extractCountTotals(results);
+        SearchHits hits = buildHits(results, request, countTotals);
+        InternalAggregations aggregations = buildAggregations(results, request, registry, countTotals);
 
         SearchResponseSections sections = new SearchResponseSections(hits, aggregations, null, false, null, null, 0);
 
@@ -57,15 +61,43 @@ public class SearchResponseBuilder {
         return new SearchResponse(sections, null, 1, 1, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
     }
 
-    private static SearchHits buildHits(List<ExecutionResult> results) {
-        // TODO: Build hits from HITS results
-        return SearchHits.empty(true);
+    private static CountTotals extractCountTotals(List<ExecutionResult> results) {
+        List<ExecutionResult> countResults = results.stream().filter(r -> r.getType() == QueryPlans.Type.COUNT).toList();
+        return countResults.isEmpty() ? null : CountTotals.from(countResults);
+    }
+
+    /**
+     * Builds the hits section. Hit documents are still stubbed (TODO below), but
+     * {@code hits.total} renders classic {@code track_total_hits} semantics from the COUNT
+     * plan's {@code COUNT(*)}: exact ({@code eq}) up to the threshold, a {@code gte} lower
+     * bound past it, omitted when tracking is disabled.
+     */
+    private static SearchHits buildHits(List<ExecutionResult> results, SearchRequest request, CountTotals countTotals) {
+        // TODO: Build hit documents from HITS results
+        return new SearchHits(new SearchHit[0], resolveTotalHits(request, countTotals), Float.NaN);
+    }
+
+    private static TotalHits resolveTotalHits(SearchRequest request, CountTotals countTotals) {
+        Integer trackUpTo = request.source() == null ? null : request.source().trackTotalHitsUpTo();
+        int threshold = trackUpTo == null ? SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO : trackUpTo;
+        if (threshold == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+            return null; // track_total_hits: false — total omitted, like classic search
+        }
+        if (countTotals == null || countTotals.totalDocs() == null) {
+            // No count ran (nothing requested it) — preserve the pre-count stub value.
+            return new TotalHits(0, TotalHits.Relation.EQUAL_TO);
+        }
+        long count = countTotals.totalDocs();
+        return count <= threshold
+            ? new TotalHits(count, TotalHits.Relation.EQUAL_TO)
+            : new TotalHits(threshold, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     }
 
     private static InternalAggregations buildAggregations(
         List<ExecutionResult> results,
         SearchRequest request,
-        AggregationRegistry registry
+        AggregationRegistry registry,
+        CountTotals countTotals
     ) throws ConversionException {
 
         List<ExecutionResult> aggResults = results.stream()
@@ -76,7 +108,7 @@ public class SearchResponseBuilder {
             return null;
         }
 
-        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults);
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults, countTotals);
         return builder.build(new ArrayList<>(request.source().aggregations().getAggregatorFactories()));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import java.util.Objects;
+
+/**
+ * Utility methods for comparing values.
+ */
+public final class ComparisonUtils {
+
+    private ComparisonUtils() {}
+
+    /**
+     * Compares two values for equality, coercing numeric types (the engine may box the same
+     * column differently across plans). Integral pairs compare as long to avoid precision
+     * loss; floating-point pairs via {@link Double#compare}. No cross-type string coercion —
+     * bucket keys are typed by the schema.
+     */
+    public static boolean valuesEqual(Object a, Object b) {
+        if (Objects.equals(a, b)) return true;
+
+        if (a instanceof Number na && b instanceof Number nb) {
+            if (isIntegral(na) && isIntegral(nb)) {
+                return na.longValue() == nb.longValue();
+            }
+            return Double.compare(na.doubleValue(), nb.doubleValue()) == 0;
+        }
+
+        return false;
+    }
+
+    private static boolean isIntegral(Number n) {
+        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/package-info.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/** Shared utilities for the DSL execution path. */
+package org.opensearch.dsl.util;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/RequestScopedMapperServiceTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/RequestScopedMapperServiceTests.java
@@ -9,10 +9,7 @@
 package org.opensearch.dsl.action;
 
 import org.opensearch.Version;
-import org.opensearch.cluster.ClusterName;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.OpenSearchTestCase;
@@ -30,40 +27,37 @@ public class RequestScopedMapperServiceTests extends OpenSearchTestCase {
 
     private static final String INDEX = "probe";
 
-    private ClusterState stateWithIndex() {
-        IndexMetadata indexMetadata = IndexMetadata.builder(INDEX)
+    private IndexMetadata indexMetadata() {
+        return IndexMetadata.builder(INDEX)
             .settings(
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(IndexMetadata.SETTING_INDEX_UUID, "uuid")
             )
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        return ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().put(indexMetadata, false)).build();
     }
 
     /**
      * The load-bearing regression test: a MapperService fresh out of
-     * {@code createIndexMapperService} is empty, so the holder must merge the index mapping
-     * before handing the service to response building — otherwise every fieldType() lookup
-     * returns null and terms responses silently degrade to sampled typing.
+     * {@code createIndexMapperService} is empty, so the holder must merge the pinned index
+     * mapping before handing the service to response building — otherwise every fieldType()
+     * lookup returns null and response building fails on the first typed key.
      */
     public void testMergesIndexMappingIntoCreatedMapperService() {
-        ClusterState state = stateWithIndex();
-        IndexMetadata indexMetadata = state.metadata().index(INDEX);
+        IndexMetadata indexMetadata = indexMetadata();
         MapperService created = mock(MapperService.class);
 
-        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created)) {
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata, metadata -> created)) {
             assertSame(created, holder.get());
             verify(created).merge(eq(indexMetadata), eq(MapperService.MergeReason.MAPPING_RECOVERY));
         }
     }
 
     public void testCreatesAtMostOneMapperServicePerRequest() {
-        ClusterState state = stateWithIndex();
         MapperService created = mock(MapperService.class);
         AtomicInteger creations = new AtomicInteger();
 
-        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata(), metadata -> {
             creations.incrementAndGet();
             return created;
         })) {
@@ -73,23 +67,12 @@ public class RequestScopedMapperServiceTests extends OpenSearchTestCase {
         }
     }
 
-    public void testReturnsNullWhenIndexMissingFromClusterState() {
-        ClusterState empty = ClusterState.builder(new ClusterName("test")).build();
-        AtomicInteger creations = new AtomicInteger();
-
-        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> empty, metadata -> {
-            creations.incrementAndGet();
-            return mock(MapperService.class);
-        })) {
-            assertNull(holder.get());
-            assertEquals("factory must not run for a deleted index", 0, creations.get());
-        }
+    public void testRejectsNullIndexMetadata() {
+        expectThrows(NullPointerException.class, () -> new RequestScopedMapperService(null, metadata -> mock(MapperService.class)));
     }
 
     public void testReturnsNullWhenCreationFails() {
-        ClusterState state = stateWithIndex();
-
-        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata(), metadata -> {
             throw new IOException("simulated createIndexMapperService failure");
         })) {
             assertNull(holder.get());
@@ -98,22 +81,21 @@ public class RequestScopedMapperServiceTests extends OpenSearchTestCase {
     }
 
     public void testClosesCreatedServiceWhenMergeFails() throws IOException {
-        ClusterState state = stateWithIndex();
+        IndexMetadata indexMetadata = indexMetadata();
         MapperService created = mock(MapperService.class);
         doThrow(new IllegalArgumentException("simulated merge failure")).when(created)
-            .merge(eq(state.metadata().index(INDEX)), eq(MapperService.MergeReason.MAPPING_RECOVERY));
+            .merge(eq(indexMetadata), eq(MapperService.MergeReason.MAPPING_RECOVERY));
 
-        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created)) {
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata, metadata -> created)) {
             assertNull(holder.get());
             verify(created).close();
         }
     }
 
     public void testCloseReleasesMapperServiceAndSubsequentGetReturnsNull() throws IOException {
-        ClusterState state = stateWithIndex();
         MapperService created = mock(MapperService.class);
 
-        RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created);
+        RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata(), metadata -> created);
         assertSame(created, holder.get());
 
         holder.close();
@@ -124,11 +106,10 @@ public class RequestScopedMapperServiceTests extends OpenSearchTestCase {
     }
 
     public void testCloseBeforeGetIsNoOp() throws IOException {
-        ClusterState state = stateWithIndex();
         MapperService created = mock(MapperService.class);
         AtomicInteger creations = new AtomicInteger();
 
-        RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+        RequestScopedMapperService holder = new RequestScopedMapperService(indexMetadata(), metadata -> {
             creations.incrementAndGet();
             return created;
         });

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/RequestScopedMapperServiceTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/RequestScopedMapperServiceTests.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class RequestScopedMapperServiceTests extends OpenSearchTestCase {
+
+    private static final String INDEX = "probe";
+
+    private ClusterState stateWithIndex() {
+        IndexMetadata indexMetadata = IndexMetadata.builder(INDEX)
+            .settings(
+                Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(IndexMetadata.SETTING_INDEX_UUID, "uuid")
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        return ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().put(indexMetadata, false)).build();
+    }
+
+    /**
+     * The load-bearing regression test: a MapperService fresh out of
+     * {@code createIndexMapperService} is empty, so the holder must merge the index mapping
+     * before handing the service to response building — otherwise every fieldType() lookup
+     * returns null and terms responses silently degrade to sampled typing.
+     */
+    public void testMergesIndexMappingIntoCreatedMapperService() {
+        ClusterState state = stateWithIndex();
+        IndexMetadata indexMetadata = state.metadata().index(INDEX);
+        MapperService created = mock(MapperService.class);
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created)) {
+            assertSame(created, holder.get());
+            verify(created).merge(eq(indexMetadata), eq(MapperService.MergeReason.MAPPING_RECOVERY));
+        }
+    }
+
+    public void testCreatesAtMostOneMapperServicePerRequest() {
+        ClusterState state = stateWithIndex();
+        MapperService created = mock(MapperService.class);
+        AtomicInteger creations = new AtomicInteger();
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+            creations.incrementAndGet();
+            return created;
+        })) {
+            assertSame(created, holder.get());
+            assertSame(created, holder.get());
+            assertEquals("supplier must memoize the MapperService within a request", 1, creations.get());
+        }
+    }
+
+    public void testReturnsNullWhenIndexMissingFromClusterState() {
+        ClusterState empty = ClusterState.builder(new ClusterName("test")).build();
+        AtomicInteger creations = new AtomicInteger();
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> empty, metadata -> {
+            creations.incrementAndGet();
+            return mock(MapperService.class);
+        })) {
+            assertNull(holder.get());
+            assertEquals("factory must not run for a deleted index", 0, creations.get());
+        }
+    }
+
+    public void testReturnsNullWhenCreationFails() {
+        ClusterState state = stateWithIndex();
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+            throw new IOException("simulated createIndexMapperService failure");
+        })) {
+            assertNull(holder.get());
+            assertNull("failure must be memoized, not retried", holder.get());
+        }
+    }
+
+    public void testClosesCreatedServiceWhenMergeFails() throws IOException {
+        ClusterState state = stateWithIndex();
+        MapperService created = mock(MapperService.class);
+        doThrow(new IllegalArgumentException("simulated merge failure")).when(created)
+            .merge(eq(state.metadata().index(INDEX)), eq(MapperService.MergeReason.MAPPING_RECOVERY));
+
+        try (RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created)) {
+            assertNull(holder.get());
+            verify(created).close();
+        }
+    }
+
+    public void testCloseReleasesMapperServiceAndSubsequentGetReturnsNull() throws IOException {
+        ClusterState state = stateWithIndex();
+        MapperService created = mock(MapperService.class);
+
+        RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> created);
+        assertSame(created, holder.get());
+
+        holder.close();
+        verify(created).close();
+        assertNull("a closed holder must not resurrect the MapperService", holder.get());
+
+        holder.close(); // second close is a no-op
+    }
+
+    public void testCloseBeforeGetIsNoOp() throws IOException {
+        ClusterState state = stateWithIndex();
+        MapperService created = mock(MapperService.class);
+        AtomicInteger creations = new AtomicInteger();
+
+        RequestScopedMapperService holder = new RequestScopedMapperService(INDEX, () -> state, metadata -> {
+            creations.incrementAndGet();
+            return created;
+        });
+        holder.close();
+
+        assertEquals(0, creations.get());
+        verify(created, never()).close();
+        assertNull(holder.get());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -151,7 +151,17 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
     private EngineContextProvider buildEngineContext() {
         QueryRequestContext ctx = new QueryRequestContext(null, buildSchema());
-        return () -> ctx;
+        return new EngineContextProvider() {
+            @Override
+            public QueryRequestContext getContext(ClusterState clusterState) {
+                return ctx;
+            }
+
+            @Override
+            public QueryRequestContext getContext() {
+                return ctx;
+            }
+        };
     }
 
     private SchemaPlus buildSchema() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -14,14 +14,19 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.Version;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.QueryRequestContext;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexNotFoundException;
@@ -110,8 +115,24 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     }
 
     private TransportDslExecuteAction createAction(Index... resolvedIndices) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (Index index : resolvedIndices) {
+            metadata.put(
+                IndexMetadata.builder(index.getName())
+                    .settings(
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                            .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+                    )
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .build(),
+                false
+            );
+        }
+        ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -25,6 +25,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
@@ -87,6 +88,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             buildEngineContext(),
             (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
+            mock(IndicesService.class),
             resolver,
             mockThreadPool()
         );
@@ -120,6 +122,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             buildEngineContext(),
             (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
+            mock(IndicesService.class),
             resolver,
             mockThreadPool()
         );

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationTreeWalkerTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationTreeWalkerTests.java
@@ -11,15 +11,18 @@ package org.opensearch.dsl.aggregation;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
+import java.util.Map;
 
 public class AggregationTreeWalkerTests extends OpenSearchTestCase {
 
@@ -188,5 +191,127 @@ public class AggregationTreeWalkerTests extends OpenSearchTestCase {
         List<AggregationBuilder> aggs = List.of(new HistogramAggregationBuilder("by_price").field("price").interval(100));
 
         expectThrows(ConversionException.class, () -> walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory()));
+    }
+
+    // ---- Fetch pushdown eligibility, HAVING, and missing (top-K pushdown) ----
+
+    public void testRootTermsGranularityGetsFetch() throws ConversionException {
+        List<AggregationBuilder> aggs = List.of(new TermsAggregationBuilder("by_brand").field("brand").size(7));
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(Integer.valueOf(7), result.get(0).getFetch());
+        assertNull(result.get(0).getHavingMinDocCount());
+        assertTrue(result.get(0).getMissingValues().isEmpty());
+    }
+
+    public void testMinDocCountAboveOneGetsHavingAndFetch() throws ConversionException {
+        // Both bounds bake into the plan: HAVING filters before the LIMIT truncates. The
+        // eligible count (which must exclude below-threshold groups) comes from the
+        // aggregation's own HAVING-filtered COUNT plan, built by the converter.
+        List<AggregationBuilder> aggs = List.of(new TermsAggregationBuilder("by_brand").field("brand").minDocCount(5));
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(Long.valueOf(5), result.get(0).getHavingMinDocCount());
+        assertNotNull(result.get(0).getFetch());
+    }
+
+    public void testNestedGranularityGetsPerParentFetch() throws ConversionException {
+        // A flat LIMIT on the child level would keep top groups globally, not per parent —
+        // nested levels are bounded per parent instead (ROW_NUMBER over the parent partition).
+        List<AggregationBuilder> aggs = List.of(
+            new TermsAggregationBuilder("by_brand").field("brand")
+                .subAggregation(new TermsAggregationBuilder("by_name").field("name").size(3))
+        );
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(2, result.size());
+        assertEquals(List.of("brand"), result.get(0).getGroupByFieldNames());
+        assertNotNull("root level carries the flat limit", result.get(0).getFetch());
+        assertNull(result.get(0).getPerParentFetch());
+        assertEquals(List.of("brand", "name"), result.get(1).getGroupByFieldNames());
+        assertNull("nested level must not carry a flat limit", result.get(1).getFetch());
+        assertEquals("nested level is bounded per parent", Integer.valueOf(3), result.get(1).getPerParentFetch());
+    }
+
+    public void testSameFieldSiblingsGetSeparateBoundedPlans() throws ConversionException {
+        // A plan is defined by its aggregation, not its GROUP BY columns: siblings over the
+        // same field each get their own plan with their own order and LIMIT baked in.
+        List<AggregationBuilder> aggs = List.of(
+            new TermsAggregationBuilder("top_brands").field("brand").order(BucketOrder.count(false)),
+            new TermsAggregationBuilder("brands_by_key").field("brand").order(BucketOrder.key(true))
+        );
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(2, result.size());
+        assertEquals(List.of("top_brands"), result.get(0).getAggNamePath());
+        assertNotNull(result.get(0).getFetch());
+        assertEquals(List.of("brands_by_key"), result.get(1).getAggNamePath());
+        assertNotNull(result.get(1).getFetch());
+    }
+
+    public void testMissingCapturedAndFetchKept() throws ConversionException {
+        List<AggregationBuilder> aggs = List.of(new TermsAggregationBuilder("by_brand").field("brand").missing("unknown"));
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(Map.of("brand", "unknown"), result.get(0).getMissingValues());
+        assertNotNull(result.get(0).getFetch());
+    }
+
+    public void testSameFieldSiblingsCarryTheirOwnMissing() throws ConversionException {
+        // Separate plans per sibling: each substitutes its own missing value — no conflict possible.
+        List<AggregationBuilder> aggs = List.of(
+            new TermsAggregationBuilder("first").field("brand").missing("a"),
+            new TermsAggregationBuilder("second").field("brand").missing("b")
+        );
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(2, result.size());
+        assertEquals(Map.of("brand", "a"), result.get(0).getMissingValues());
+        assertEquals(Map.of("brand", "b"), result.get(1).getMissingValues());
+    }
+
+    // ---- Parameter gate: silently ignored parameters must reject loudly ----
+
+    public void testValidateRejectsIncludeExclude() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").field("brand");
+        agg.includeExclude(new IncludeExclude("Brand.*", null));
+
+        ConversionException e = expectThrows(
+            ConversionException.class,
+            () -> walker.walk(List.of(agg), ctx.getRowType(), ctx.getCluster().getTypeFactory())
+        );
+        assertTrue(e.getMessage().contains("include"));
+    }
+
+    public void testValidateRejectsTermsScript() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").script(new Script("doc['brand'].value"));
+
+        expectThrows(ConversionException.class, () -> walker.walk(List.of(agg), ctx.getRowType(), ctx.getCluster().getTypeFactory()));
+    }
+
+    public void testValidateRejectsMinDocCountZero() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").field("brand").minDocCount(0);
+
+        ConversionException e = expectThrows(
+            ConversionException.class,
+            () -> walker.walk(List.of(agg), ctx.getRowType(), ctx.getCluster().getTypeFactory())
+        );
+        assertTrue(e.getMessage().contains("min_doc_count"));
+    }
+
+    public void testValidateRejectsMetricMissing() {
+        AvgAggregationBuilder agg = new AvgAggregationBuilder("avg_price").field("price").missing(42);
+
+        ConversionException e = expectThrows(
+            ConversionException.class,
+            () -> walker.walk(List.of(agg), ctx.getRowType(), ctx.getCluster().getTypeFactory())
+        );
+        assertTrue(e.getMessage().contains("missing"));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -18,6 +18,7 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
@@ -123,6 +124,18 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals(3, terms.getBuckets().get(0).getDocCount());
         assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
         assertEquals(2, terms.getBuckets().get(1).getDocCount());
+    }
+
+    /** Legacy parity: docs with a missing field form no bucket — a SQL NULL group is dropped. */
+    public void testNullKeyBucketExcluded() {
+        List<BucketEntry> entries = new ArrayList<>();
+        entries.add(new BucketEntry(java.util.Collections.singletonList(null), 4L, InternalAggregations.EMPTY));
+        entries.add(new BucketEntry(List.of("BrandA"), 3L, InternalAggregations.EMPTY));
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
+
+        assertEquals(1, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
     }
 
     public void testToBucketAggregationEmptyBuckets() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -8,8 +8,12 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
+import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalOrder;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -103,7 +107,27 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertTrue(InternalOrder.isKeyAsc(compound.orderElements().get(1)));
     }
 
-    public void testToBucketAggregationNotYetImplemented() {
-        expectThrows(UnsupportedOperationException.class, () -> translator.toBucketAggregation(brandAgg, List.of()));
+    public void testToBucketAggregationBuildsStringTerms() {
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
+        );
+
+        InternalAggregation agg = translator.toBucketAggregation(brandAgg, entries);
+
+        assertTrue(agg instanceof StringTerms);
+        StringTerms terms = (StringTerms) agg;
+        assertEquals(brandAgg.getName(), terms.getName());
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals(3, terms.getBuckets().get(0).getDocCount());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals(2, terms.getBuckets().get(1).getDocCount());
+    }
+
+    public void testToBucketAggregationEmptyBuckets() {
+        InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
+        assertTrue(agg instanceof StringTerms);
+        assertTrue(((StringTerms) agg).getBuckets().isEmpty());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
 
-    private final TermsBucketTranslator translator = new TermsBucketTranslator();
+    private final TermsBucketTranslator translator = new TermsBucketTranslator(() -> null);
     private final TermsAggregationBuilder brandAgg = new TermsAggregationBuilder("by_brand").field("brand");
 
     public void testGetGrouping() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.opensearch.dsl.result.BucketEntry;
-import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -19,10 +18,8 @@ import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
-import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -119,7 +116,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
             new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
         );
 
-        InternalAggregation agg = translator.toBucketAggregation(brandAgg, entries);
+        InternalAggregation agg = translator.toBucketAggregation(brandAgg, entries, 5L);
 
         assertTrue(agg instanceof StringTerms);
         StringTerms terms = (StringTerms) agg;
@@ -131,17 +128,8 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals(2, terms.getBuckets().get(1).getDocCount());
     }
 
-    /** Legacy parity: docs with a missing field form no bucket — a SQL NULL group is dropped. */
-    public void testNullKeyBucketExcluded() {
-        List<BucketEntry> entries = new ArrayList<>();
-        entries.add(new BucketEntry(java.util.Collections.singletonList(null), 4L, InternalAggregations.EMPTY));
-        entries.add(new BucketEntry(List.of("BrandA"), 3L, InternalAggregations.EMPTY));
-
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
-
-        assertEquals(1, terms.getBuckets().size());
-        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
-    }
+    // Null-key exclusion is a plan contract (pre-aggregate IS NOT NULL filter, see
+    // SearchSourceConverterTests) — the translator no longer re-implements it.
 
     public void testToBucketAggregationEmptyBuckets() {
         InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
@@ -149,86 +137,21 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
     }
 
-    public void testBucketsSortedByRequestedOrder() {
-        TermsAggregationBuilder aggKeyDesc = new TermsAggregationBuilder("by_brand").field("brand").order(BucketOrder.key(false));
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandA"), 1, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
-        );
+    // Ordering, min_doc_count, and truncation are plan contracts (SORT, HAVING, and LIMIT baked
+    // into every plan) — the translator renders entries in received order and never re-filters,
+    // re-sorts, or truncates.
 
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggKeyDesc, entries);
+    /**
+     * Every terms plan is bounded, so a non-empty render without plan totals means the sized
+     * dispatch was bypassed — an internal wiring bug. Truncating and tail-summing client-side
+     * would mask it with a silently wrong sum_other_doc_count; fail loudly instead.
+     */
+    public void testNonEmptyRenderWithoutTotalsFailsLoudly() {
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY));
 
-        assertEquals("BrandC", terms.getBuckets().get(0).getKeyAsString());
-        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
-        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
-    }
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> translator.toBucketAggregation(brandAgg, entries));
 
-    public void testDefaultOrderSortsByCountDescThenKeyAsc() {
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandB"), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandA"), 2, InternalAggregations.EMPTY)
-        );
-
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
-
-        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
-        // tie on doc_count 2 broken by key asc
-        assertEquals("BrandA", terms.getBuckets().get(1).getKeyAsString());
-        assertEquals("BrandC", terms.getBuckets().get(2).getKeyAsString());
-    }
-
-    public void testSizeTruncationReportsOtherDocCount() {
-        TermsAggregationBuilder aggSized = new TermsAggregationBuilder("by_brand").field("brand").size(2);
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandD"), 1, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
-        );
-
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggSized, entries);
-
-        assertEquals(2, terms.getBuckets().size());
-        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
-        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
-        assertEquals(3L, terms.getSumOfOtherDocCounts());
-    }
-
-    public void testMinDocCountExcludesBuckets() {
-        TermsAggregationBuilder aggMinCount = new TermsAggregationBuilder("by_brand").field("brand").minDocCount(3);
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
-        );
-
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMinCount, entries);
-
-        assertEquals(1, terms.getBuckets().size());
-        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
-        // min_doc_count drops are excluded entirely, not counted as "other"
-        assertEquals(0L, terms.getSumOfOtherDocCounts());
-    }
-
-    public void testMetricOrderSortsBySubAggregation() {
-        TermsAggregationBuilder aggMetricOrder = new TermsAggregationBuilder("by_brand").field("brand")
-            .order(BucketOrder.aggregation("avg_price", true));
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandA"), 1, avgSubAgg(30.0)),
-            new BucketEntry(List.of("BrandB"), 1, avgSubAgg(10.0)),
-            new BucketEntry(List.of("BrandC"), 1, avgSubAgg(20.0))
-        );
-
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMetricOrder, entries);
-
-        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
-        assertEquals("BrandC", terms.getBuckets().get(1).getKeyAsString());
-        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
-    }
-
-    private static InternalAggregations avgSubAgg(double value) {
-        return InternalAggregations.from(List.of(new InternalAvg("avg_price", value, 1, DocValueFormat.RAW, null)));
+        assertTrue(e.getMessage().contains("sized path"));
     }
 
     /** User-supplied meta must be echoed back on the response aggregation, like classic search. */
@@ -245,7 +168,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         TermsAggregationBuilder numWithMeta = new TermsAggregationBuilder("by_price").field("price");
         numWithMeta.setMetadata(meta);
         List<BucketEntry> numeric = List.of(new BucketEntry(List.of(1L), 1, InternalAggregations.EMPTY));
-        assertEquals(meta, translator.toBucketAggregation(numWithMeta, numeric).getMetadata());
+        assertEquals(meta, translator.toBucketAggregation(numWithMeta, numeric, 1L).getMetadata());
     }
 
     public void testIntegralKeysProduceLongTermsWithNumericKeys() {
@@ -255,7 +178,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
             new BucketEntry(List.of(7), 2, InternalAggregations.EMPTY)
         );
 
-        InternalAggregation agg = translator.toBucketAggregation(priceAgg, entries);
+        InternalAggregation agg = translator.toBucketAggregation(priceAgg, entries, 5L);
 
         assertTrue(agg instanceof LongTerms);
         LongTerms terms = (LongTerms) agg;
@@ -268,7 +191,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         TermsAggregationBuilder ratingAgg = new TermsAggregationBuilder("by_rating").field("rating");
         List<BucketEntry> entries = List.of(new BucketEntry(List.of(1.5), 3, InternalAggregations.EMPTY));
 
-        InternalAggregation agg = translator.toBucketAggregation(ratingAgg, entries);
+        InternalAggregation agg = translator.toBucketAggregation(ratingAgg, entries, 3L);
 
         assertTrue(agg instanceof DoubleTerms);
         assertEquals(1.5, ((DoubleTerms) agg).getBuckets().get(0).getKey());
@@ -281,7 +204,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
             new BucketEntry(List.of(false), 2, InternalAggregations.EMPTY)
         );
 
-        LongTerms terms = (LongTerms) translator.toBucketAggregation(boolAgg, entries);
+        LongTerms terms = (LongTerms) translator.toBucketAggregation(boolAgg, entries, 5L);
 
         assertEquals(1L, terms.getBuckets().get(0).getKey());
         assertEquals("true", terms.getBuckets().get(0).getKeyAsString());
@@ -300,7 +223,7 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
             )
         );
 
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries);
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries, 5L);
 
         assertEquals("10.0.0.1", terms.getBuckets().get(0).getKeyAsString());
         assertEquals("10.0.0.2", terms.getBuckets().get(1).getKeyAsString());
@@ -310,27 +233,61 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         TermsAggregationBuilder ipAgg = new TermsAggregationBuilder("by_ip").field("ip");
         List<BucketEntry> entries = List.of(new BucketEntry(List.of(new byte[] { 1, 2, 3 }), 1, InternalAggregations.EMPTY));
 
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries);
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries, 1L);
 
         assertEquals("AQID", terms.getBuckets().get(0).getKeyAsString());
     }
 
-    /** Order, size truncation, and sum_other_doc_count apply to typed key paths too. */
-    public void testNumericKeysRespectOrderSizeAndOtherDocCount() {
-        TermsAggregationBuilder priceAgg = new TermsAggregationBuilder("by_price").field("price").size(2);
+    // ---- Pushdown mode: totals-derived sum_other_doc_count ----
+
+    /** Under fetch pushdown the tail never leaves the engine — sum_other = eligible − Σ(rendered). */
+    public void testPushdownSumOtherDerivedFromTotals() {
         List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of(100L), 1, InternalAggregations.EMPTY),
-            new BucketEntry(List.of(200L), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of(300L), 2, InternalAggregations.EMPTY),
-            new BucketEntry(List.of(400L), 3, InternalAggregations.EMPTY)
+            new BucketEntry(List.of("BrandA"), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
         );
 
-        LongTerms terms = (LongTerms) translator.toBucketAggregation(priceAgg, entries);
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries, 100L);
 
-        // Default order: count desc; size=2 keeps 200(5) and 400(3); 300(2)+100(1) become "other"
         assertEquals(2, terms.getBuckets().size());
-        assertEquals(200L, terms.getBuckets().get(0).getKey());
-        assertEquals(400L, terms.getBuckets().get(1).getKey());
+        assertEquals(95L, terms.getSumOfOtherDocCounts());
+    }
+
+    /**
+     * The count plan and the main plan are separate engine queries — a refresh between them can
+     * make the eligible count smaller than the rendered sum. Clamp instead of going negative.
+     */
+    public void testPushdownSumOtherClampedAtZero() {
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY));
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries, 2L);
+
+        assertEquals(0L, terms.getSumOfOtherDocCounts());
+    }
+
+    /** The sized path renders entries as received — plan order and truncation are authoritative. */
+    public void testSizedPathRendersEntriesAsReceived() {
+        // Deliberately not in the default count-desc order: the translator must not re-sort.
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries, 10L);
+
+        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandA", terms.getBuckets().get(1).getKeyAsString());
         assertEquals(3L, terms.getSumOfOtherDocCounts());
     }
+
+    /** Totals arithmetic applies to typed key paths too. */
+    public void testPushdownNumericKeysUseTotals() {
+        TermsAggregationBuilder priceAgg = new TermsAggregationBuilder("by_price").field("price");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of(200L), 5, InternalAggregations.EMPTY));
+
+        LongTerms terms = (LongTerms) translator.toBucketAggregation(priceAgg, entries, 12L);
+
+        assertEquals(7L, terms.getSumOfOtherDocCounts());
+    }
+
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -14,6 +14,8 @@ import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalOrder;
+import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
@@ -238,5 +240,97 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals(meta, translator.toBucketAggregation(aggWithMeta, List.of()).getMetadata());
         // No meta on the request → none in the response
         assertNull(translator.toBucketAggregation(brandAgg, List.of()).getMetadata());
+
+        // Typed key paths echo meta too
+        TermsAggregationBuilder numWithMeta = new TermsAggregationBuilder("by_price").field("price");
+        numWithMeta.setMetadata(meta);
+        List<BucketEntry> numeric = List.of(new BucketEntry(List.of(1L), 1, InternalAggregations.EMPTY));
+        assertEquals(meta, translator.toBucketAggregation(numWithMeta, numeric).getMetadata());
+    }
+
+    public void testIntegralKeysProduceLongTermsWithNumericKeys() {
+        TermsAggregationBuilder priceAgg = new TermsAggregationBuilder("by_price").field("price");
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of(42L), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(7), 2, InternalAggregations.EMPTY)
+        );
+
+        InternalAggregation agg = translator.toBucketAggregation(priceAgg, entries);
+
+        assertTrue(agg instanceof LongTerms);
+        LongTerms terms = (LongTerms) agg;
+        assertEquals(42L, terms.getBuckets().get(0).getKey());
+        assertEquals("42", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals(7L, terms.getBuckets().get(1).getKey());
+    }
+
+    public void testFloatingKeysProduceDoubleTerms() {
+        TermsAggregationBuilder ratingAgg = new TermsAggregationBuilder("by_rating").field("rating");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of(1.5), 3, InternalAggregations.EMPTY));
+
+        InternalAggregation agg = translator.toBucketAggregation(ratingAgg, entries);
+
+        assertTrue(agg instanceof DoubleTerms);
+        assertEquals(1.5, ((DoubleTerms) agg).getBuckets().get(0).getKey());
+    }
+
+    public void testBooleanKeysRenderLikeClassicBooleanTerms() {
+        TermsAggregationBuilder boolAgg = new TermsAggregationBuilder("by_flag").field("flag");
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of(true), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(false), 2, InternalAggregations.EMPTY)
+        );
+
+        LongTerms terms = (LongTerms) translator.toBucketAggregation(boolAgg, entries);
+
+        assertEquals(1L, terms.getBuckets().get(0).getKey());
+        assertEquals("true", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals(0L, terms.getBuckets().get(1).getKey());
+        assertEquals("false", terms.getBuckets().get(1).getKeyAsString());
+    }
+
+    public void testBinaryKeysDecodeToIpAddressStrings() {
+        TermsAggregationBuilder ipAgg = new TermsAggregationBuilder("by_ip").field("ip");
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of(new byte[] { 10, 0, 0, 1 }), 3, InternalAggregations.EMPTY),
+            new BucketEntry(
+                List.of(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 2 }),
+                2,
+                InternalAggregations.EMPTY
+            )
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries);
+
+        assertEquals("10.0.0.1", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("10.0.0.2", terms.getBuckets().get(1).getKeyAsString());
+    }
+
+    public void testUndecodableBinaryKeyFallsBackToBase64() {
+        TermsAggregationBuilder ipAgg = new TermsAggregationBuilder("by_ip").field("ip");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of(new byte[] { 1, 2, 3 }), 1, InternalAggregations.EMPTY));
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries);
+
+        assertEquals("AQID", terms.getBuckets().get(0).getKeyAsString());
+    }
+
+    /** Order, size truncation, and sum_other_doc_count apply to typed key paths too. */
+    public void testNumericKeysRespectOrderSizeAndOtherDocCount() {
+        TermsAggregationBuilder priceAgg = new TermsAggregationBuilder("by_price").field("price").size(2);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of(100L), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(200L), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(300L), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(400L), 3, InternalAggregations.EMPTY)
+        );
+
+        LongTerms terms = (LongTerms) translator.toBucketAggregation(priceAgg, entries);
+
+        // Default order: count desc; size=2 keeps 200(5) and 400(3); 300(2)+100(1) become "other"
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals(200L, terms.getBuckets().get(0).getKey());
+        assertEquals(400L, terms.getBuckets().get(1).getKey());
+        assertEquals(3L, terms.getSumOfOtherDocCounts());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -8,7 +8,15 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.BooleanFieldMapper;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.IpFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -23,10 +31,37 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
 
-    private final TermsBucketTranslator translator = new TermsBucketTranslator(() -> null);
+    /** Field types the mapped translator resolves, mirroring a real index mapping. */
+    private static final Map<String, MappedFieldType> FIELD_TYPES = Map.of(
+        "brand",
+        new KeywordFieldMapper.KeywordFieldType("brand"),
+        "price",
+        new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG),
+        "rating",
+        new NumberFieldMapper.NumberFieldType("rating", NumberFieldMapper.NumberType.DOUBLE),
+        "flag",
+        new BooleanFieldMapper.BooleanFieldType("flag"),
+        "ip",
+        new IpFieldMapper.IpFieldType("ip"),
+        "created",
+        new DateFieldMapper.DateFieldType("created")
+    );
+
+    private final TermsBucketTranslator translator = new TermsBucketTranslator(TermsBucketTranslatorTests::mappedService);
+    private final TermsBucketTranslator unmappedTranslator = new TermsBucketTranslator(() -> null);
     private final TermsAggregationBuilder brandAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+    private static MapperService mappedService() {
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType(anyString())).thenAnswer(invocation -> FIELD_TYPES.get(invocation.<String>getArgument(0)));
+        return mapperService;
+    }
 
     public void testGetGrouping() {
         assertEquals(List.of("brand"), translator.getGrouping(brandAgg).getFieldNames());
@@ -137,6 +172,16 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
     }
 
+    /** An empty result renders through the mapping too — a numeric field yields empty LongTerms, not StringTerms. */
+    public void testEmptyBucketsAreTypedByMapping() {
+        TermsAggregationBuilder priceAgg = new TermsAggregationBuilder("by_price").field("price");
+
+        InternalAggregation agg = translator.toBucketAggregation(priceAgg, List.of());
+
+        assertTrue(agg instanceof LongTerms);
+        assertTrue(((LongTerms) agg).getBuckets().isEmpty());
+    }
+
     // Ordering, min_doc_count, and truncation are plan contracts (SORT, HAVING, and LIMIT baked
     // into every plan) — the translator renders entries in received order and never re-filters,
     // re-sorts, or truncates.
@@ -212,10 +257,15 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals("false", terms.getBuckets().get(1).getKeyAsString());
     }
 
+    /** ip keys arrive as 16-byte encoded addresses and render through the mapping's IP format. */
     public void testBinaryKeysDecodeToIpAddressStrings() {
         TermsAggregationBuilder ipAgg = new TermsAggregationBuilder("by_ip").field("ip");
         List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of(new byte[] { 10, 0, 0, 1 }), 3, InternalAggregations.EMPTY),
+            new BucketEntry(
+                List.of(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 1 }),
+                3,
+                InternalAggregations.EMPTY
+            ),
             new BucketEntry(
                 List.of(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 2 }),
                 2,
@@ -229,13 +279,73 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals("10.0.0.2", terms.getBuckets().get(1).getKeyAsString());
     }
 
+    /** Binary keys under a RAW-formatted (keyword) mapping render as address strings or Base64. */
     public void testUndecodableBinaryKeyFallsBackToBase64() {
-        TermsAggregationBuilder ipAgg = new TermsAggregationBuilder("by_ip").field("ip");
         List<BucketEntry> entries = List.of(new BucketEntry(List.of(new byte[] { 1, 2, 3 }), 1, InternalAggregations.EMPTY));
 
-        StringTerms terms = (StringTerms) translator.toBucketAggregation(ipAgg, entries, 1L);
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries, 1L);
 
         assertEquals("AQID", terms.getBuckets().get(0).getKeyAsString());
+    }
+
+    // ---- Mapping resolution is required for rendering ----
+
+    /** Without a MapperService the key type cannot be resolved — rendering fails loudly. */
+    public void testRenderWithoutMapperServiceFailsLoudly() {
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA"), 3, InternalAggregations.EMPTY));
+
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> unmappedTranslator.toBucketAggregation(brandAgg, entries, 5L)
+        );
+
+        assertTrue(e.getMessage().contains("index mapping unavailable"));
+    }
+
+    /** A field the mapping does not know cannot be typed — rendering fails loudly. */
+    public void testRenderOfUnmappedFieldFailsLoudly() {
+        TermsAggregationBuilder unknownAgg = new TermsAggregationBuilder("by_unknown").field("unknown");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("x"), 1, InternalAggregations.EMPTY));
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> translator.toBucketAggregation(unknownAgg, entries, 1L));
+
+        assertTrue(e.getMessage().contains("not present in the index mapping"));
+    }
+
+    // ---- validate(): date fields are rejected at conversion time ----
+
+    /** The engine returns date group keys as strings — reject at conversion with a clear 400. */
+    public void testValidateRejectsDateField() {
+        TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created");
+
+        ConversionException e = expectThrows(ConversionException.class, () -> translator.validate(dateAgg));
+
+        assertTrue(e.getMessage().contains("date field [created]"));
+    }
+
+    public void testValidateRejectsDateNanosField() {
+        MappedFieldType nanosType = mock(MappedFieldType.class);
+        when(nanosType.typeName()).thenReturn(DateFieldMapper.DATE_NANOS_CONTENT_TYPE);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType("created_nanos")).thenReturn(nanosType);
+        TermsBucketTranslator nanosTranslator = new TermsBucketTranslator(() -> mapperService);
+
+        TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created_nanos");
+
+        ConversionException e = expectThrows(ConversionException.class, () -> nanosTranslator.validate(dateAgg));
+
+        assertTrue(e.getMessage().contains("date field [created_nanos]"));
+    }
+
+    /** Mapping-dependent validation is skipped when no MapperService is supplied (conversion-only use). */
+    public void testValidateSkipsMappingChecksWithoutMapperService() throws Exception {
+        TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created");
+
+        unmappedTranslator.validate(dateAgg); // must not throw
+    }
+
+    public void testValidateAcceptsNonDateMappedField() throws Exception {
+        translator.validate(brandAgg); // must not throw
     }
 
     // ---- Pushdown mode: totals-derived sum_other_doc_count ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -16,6 +17,7 @@ import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
@@ -143,6 +145,88 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
         assertTrue(agg instanceof StringTerms);
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
+    }
+
+    public void testBucketsSortedByRequestedOrder() {
+        TermsAggregationBuilder aggKeyDesc = new TermsAggregationBuilder("by_brand").field("brand").order(BucketOrder.key(false));
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggKeyDesc, entries);
+
+        assertEquals("BrandC", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    public void testDefaultOrderSortsByCountDescThenKeyAsc() {
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandA"), 2, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
+
+        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
+        // tie on doc_count 2 broken by key asc
+        assertEquals("BrandA", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandC", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    public void testSizeTruncationReportsOtherDocCount() {
+        TermsAggregationBuilder aggSized = new TermsAggregationBuilder("by_brand").field("brand").size(2);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandD"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggSized, entries);
+
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals(3L, terms.getSumOfOtherDocCounts());
+    }
+
+    public void testMinDocCountExcludesBuckets() {
+        TermsAggregationBuilder aggMinCount = new TermsAggregationBuilder("by_brand").field("brand").minDocCount(3);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMinCount, entries);
+
+        assertEquals(1, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        // min_doc_count drops are excluded entirely, not counted as "other"
+        assertEquals(0L, terms.getSumOfOtherDocCounts());
+    }
+
+    public void testMetricOrderSortsBySubAggregation() {
+        TermsAggregationBuilder aggMetricOrder = new TermsAggregationBuilder("by_brand").field("brand")
+            .order(BucketOrder.aggregation("avg_price", true));
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 1, avgSubAgg(30.0)),
+            new BucketEntry(List.of("BrandB"), 1, avgSubAgg(10.0)),
+            new BucketEntry(List.of("BrandC"), 1, avgSubAgg(20.0))
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMetricOrder, entries);
+
+        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandC", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    private static InternalAggregations avgSubAgg(double value) {
+        return InternalAggregations.from(List.of(new InternalAvg("avg_price", value, 1, DocValueFormat.RAW, null)));
     }
 
     /** User-supplied meta must be echoed back on the response aggregation, like classic search. */

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -20,6 +20,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
 
@@ -142,5 +143,16 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
         assertTrue(agg instanceof StringTerms);
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
+    }
+
+    /** User-supplied meta must be echoed back on the response aggregation, like classic search. */
+    public void testMetadataEchoedInBucketAggregation() {
+        Map<String, Object> meta = Map.of("source", "dashboard");
+        TermsAggregationBuilder aggWithMeta = new TermsAggregationBuilder("by_brand").field("brand");
+        aggWithMeta.setMetadata(meta);
+
+        assertEquals(meta, translator.toBucketAggregation(aggWithMeta, List.of()).getMetadata());
+        // No meta on the request → none in the response
+        assertNull(translator.toBucketAggregation(brandAgg, List.of()).getMetadata());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
@@ -19,6 +19,8 @@ import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Map;
+
 public class MetricTranslatorTests extends OpenSearchTestCase {
 
     private final ConversionContext ctx = TestUtils.createContext();
@@ -69,5 +71,24 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
     public void testAggregateFieldName() {
         AvgMetricTranslator translator = new AvgMetricTranslator();
         assertEquals("avg_price", translator.getAggregateFieldName(new AvgAggregationBuilder("avg_price").field("price")));
+    }
+
+    /** User-supplied meta must be echoed back on the response aggregation, like classic search. */
+    public void testMetadataEchoedInInternalAggregation() {
+        Map<String, Object> meta = Map.of("owner", "pricing-team", "revision", 3);
+
+        assertEquals(meta, new AvgMetricTranslator().toInternalAggregation("a", 1.0, meta).getMetadata());
+        assertEquals(meta, new SumMetricTranslator().toInternalAggregation("s", 1.0, meta).getMetadata());
+        assertEquals(meta, new MinMetricTranslator().toInternalAggregation("mn", 1.0, meta).getMetadata());
+        assertEquals(meta, new MaxMetricTranslator().toInternalAggregation("mx", 1.0, meta).getMetadata());
+
+        // Echoed even when the metric has no value (empty result)
+        assertEquals(meta, new AvgMetricTranslator().toInternalAggregation("a", null, meta).getMetadata());
+    }
+
+    /** Requests without meta keep rendering without a meta section. */
+    public void testNullMetadataStaysNull() {
+        assertNull(new AvgMetricTranslator().toInternalAggregation("a", 1.0, null).getMetadata());
+        assertNull(new MaxMetricTranslator().toInternalAggregation("mx", null, null).getMetadata());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -69,8 +69,10 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
     public void testConvertProducesHitsPlan() throws ConversionException {
         QueryPlans plans = converter.convert(new SearchSourceBuilder(), "test-index");
 
-        assertEquals(1, plans.getAll().size());
+        // hits plan plus the COUNT plan that supplies hits.total
+        assertEquals(2, plans.getAll().size());
         assertTrue(plans.has(QueryPlans.Type.HITS));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
 
         QueryPlans.QueryPlan plan = plans.get(QueryPlans.Type.HITS).get(0);
         assertTrue(plan.relNode() instanceof LogicalTableScan);
@@ -88,40 +90,54 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> converter.convert(new SearchSourceBuilder(), "nonexistent-index"));
     }
 
-    public void testAggsWithSizeZeroProducesOnlyAggregationPlan() throws ConversionException {
+    public void testAggsWithSizeZeroProducesAggregationAndCountPlans() throws ConversionException {
         SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(new AvgAggregationBuilder("avg_price").field("price"));
         QueryPlans plans = converter.convert(source, "test-index");
 
-        assertEquals(1, plans.getAll().size());
+        assertEquals(2, plans.getAll().size());
         assertFalse(plans.has(QueryPlans.Type.HITS));
         assertTrue(plans.has(QueryPlans.Type.AGGREGATION));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
     }
 
-    public void testAggsWithSizeGreaterThanZeroProducesBothPlans() throws ConversionException {
+    public void testAggsWithSizeGreaterThanZeroProducesAllPlans() throws ConversionException {
         SearchSourceBuilder source = new SearchSourceBuilder().size(10).aggregation(new AvgAggregationBuilder("avg_price").field("price"));
         QueryPlans plans = converter.convert(source, "test-index");
 
-        assertEquals(2, plans.getAll().size());
+        assertEquals(3, plans.getAll().size());
         assertTrue(plans.has(QueryPlans.Type.HITS));
         assertTrue(plans.has(QueryPlans.Type.AGGREGATION));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
     }
 
-    public void testNoAggsProducesOnlyHitsPlan() throws ConversionException {
+    public void testNoAggsProducesHitsAndCountPlans() throws ConversionException {
         QueryPlans plans = converter.convert(new SearchSourceBuilder(), "test-index");
 
-        assertEquals(1, plans.getAll().size());
+        assertEquals(2, plans.getAll().size());
         assertTrue(plans.has(QueryPlans.Type.HITS));
         assertFalse(plans.has(QueryPlans.Type.AGGREGATION));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
     }
 
-    public void testSizeZeroNoAggsProducesNoPlans() throws ConversionException {
-        // size=0 with no aggs produces no plans — total doc count comes from analytics plugin metadata
+    public void testSizeZeroNoAggsProducesOnlyCountPlan() throws ConversionException {
+        // size=0 with no aggs is the count-only query: hits.total comes from the COUNT plan
         SearchSourceBuilder source = new SearchSourceBuilder().size(0);
         QueryPlans plans = converter.convert(source, "test-index");
 
-        assertEquals(0, plans.getAll().size());
+        assertEquals(1, plans.getAll().size());
         assertFalse(plans.has(QueryPlans.Type.HITS));
         assertFalse(plans.has(QueryPlans.Type.AGGREGATION));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
+    }
+
+    public void testTrackTotalHitsDisabledSkipsCountPlan() throws ConversionException {
+        // no eligible counts needed and totals explicitly not tracked → nothing to count
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false);
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        assertEquals(1, plans.getAll().size());
+        assertTrue(plans.has(QueryPlans.Type.HITS));
+        assertFalse(plans.has(QueryPlans.Type.COUNT));
     }
 
     public void testAggPlanIncludesPostAggSort() throws ConversionException {
@@ -145,6 +161,187 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         assertTrue(plans.has(QueryPlans.Type.AGGREGATION));
         // Metric-only agg has no bucket orders, so no LogicalSort wrapper
         assertFalse(plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode() instanceof LogicalSort);
+    }
+
+    // ---- Top-K pushdown plan shapes ----
+
+    public void testTermsSizeBecomesFetchOnAggregationSort() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").size(7));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        String plan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        assertTrue("sort must carry the fetch: " + plan, plan.contains("fetch=[7]"));
+    }
+
+    public void testTermsDefaultNullExclusionBecomesPreAggFilter() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(new TermsAggregationBuilder("by_brand").field("brand"));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        // brand is column 2 in the test schema
+        String plan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        assertTrue("null keys must be excluded below the aggregate: " + plan, plan.contains("LogicalFilter(condition=[IS NOT NULL($2)])"));
+    }
+
+    public void testMinDocCountBecomesHavingWithFetch() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").minDocCount(5));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        // post-agg schema is [brand, _count] — the HAVING filter references _count at $1,
+        // and the LIMIT rides the sort above it (filter-before-truncate)
+        String plan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        assertTrue("min_doc_count must become a HAVING filter: " + plan, plan.contains(">=($1, 5)"));
+        assertTrue("the plan stays bounded: " + plan, plan.contains("fetch=[10]"));
+    }
+
+    public void testMinDocCountGetsOwnEligibleCountPlan() throws ConversionException {
+        // The eligible count must exclude below-threshold groups, which COUNT(field)
+        // cannot see — the aggregation gets its own HAVING-filtered SUM plan.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").minDocCount(5));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        assertEquals(2, countPlans.size());
+        // flat plan: hits.total only — the eligible count moved to the dedicated plan
+        QueryPlans.QueryPlan flat = countPlanWithColumn(countPlans, QueryPlans.COUNT_TOTAL_COLUMN);
+        assertEquals(List.of(QueryPlans.COUNT_TOTAL_COLUMN), flat.relNode().getRowType().getFieldNames());
+        // dedicated plan: SUM over the HAVING-filtered per-group counts
+        QueryPlans.QueryPlan eligibleCountPlan = countPlanWithColumn(countPlans, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand");
+        assertEquals(
+            List.of(QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand"),
+            eligibleCountPlan.relNode().getRowType().getFieldNames()
+        );
+        String plan = eligibleCountPlan.relNode().explain();
+        assertTrue("eligible count must be HAVING-filtered: " + plan, plan.contains(">=($1, 5)"));
+        assertTrue("eligible count must sum the surviving group counts: " + plan, plan.contains("SUM($1)"));
+    }
+
+    public void testMissingWithMinDocCountGetsOwnEligibleCountPlan() throws ConversionException {
+        // missing + min_doc_count together: substitution makes every matching doc form a group,
+        // but the threshold still drops whole groups from eligibility — the eligible count must be
+        // the HAVING-filtered SUM, not COUNT(*) (which would count dropped groups' docs).
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").minDocCount(5).missing("N/A"));
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        assertEquals(2, countPlans.size());
+        // flat plan: hits.total only — the eligible count must not ride COUNT(*)
+        QueryPlans.QueryPlan flat = countPlanWithColumn(countPlans, QueryPlans.COUNT_TOTAL_COLUMN);
+        assertEquals(List.of(QueryPlans.COUNT_TOTAL_COLUMN), flat.relNode().getRowType().getFieldNames());
+        QueryPlans.QueryPlan eligibleCountPlan = countPlanWithColumn(countPlans, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand");
+        assertEquals(
+            List.of(QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand"),
+            eligibleCountPlan.relNode().getRowType().getFieldNames()
+        );
+        String plan = eligibleCountPlan.relNode().explain();
+        assertTrue("eligible count must be HAVING-filtered: " + plan, plan.contains(">=($1, 5)"));
+        assertTrue("eligible count must carry the missing substitution: " + plan, plan.contains("CASE(IS NOT NULL($2)"));
+        assertTrue("eligible count must sum the surviving group counts: " + plan, plan.contains("SUM($1)"));
+    }
+
+    /** Finds the COUNT plan carrying the given output column — plan order is not part of the contract. */
+    private static QueryPlans.QueryPlan countPlanWithColumn(List<QueryPlans.QueryPlan> countPlans, String column) {
+        return countPlans.stream()
+            .filter(p -> p.relNode().getRowType().getFieldNames().contains(column))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no COUNT plan with column [" + column + "]"));
+    }
+
+    public void testSameFieldSiblingsProduceTwoBoundedPlans() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("top_brands").field("brand"))
+            .aggregation(new TermsAggregationBuilder("brands_by_key").field("brand").order(BucketOrder.key(true)));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, aggPlans.size());
+        for (QueryPlans.QueryPlan plan : aggPlans) {
+            assertTrue("each sibling's plan is bounded: " + plan.relNode().explain(), plan.relNode().explain().contains("fetch=[10]"));
+        }
+        // one eligible-count column per sibling, keyed by aggregation name
+        List<String> countColumns = plans.get(QueryPlans.Type.COUNT).get(0).relNode().getRowType().getFieldNames();
+        assertEquals(
+            List.of(
+                QueryPlans.COUNT_TOTAL_COLUMN,
+                QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "top_brands",
+                QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "brands_by_key"
+            ),
+            countColumns
+        );
+    }
+
+    public void testMissingBecomesCaseProjectionWithoutNullFilter() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").missing("unknown"));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        String plan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        assertTrue("missing must substitute via CASE: " + plan, plan.contains("CASE(IS NOT NULL($2)"));
+        assertFalse("missing fields keep their null keys: " + plan, plan.contains("LogicalFilter(condition=[IS NOT NULL($2)])"));
+    }
+
+    public void testCountPlanCarriesTotalAndEligibleColumns() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(new TermsAggregationBuilder("by_brand").field("brand"));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<String> columns = plans.get(QueryPlans.Type.COUNT).get(0).relNode().getRowType().getFieldNames();
+        assertEquals(List.of(QueryPlans.COUNT_TOTAL_COLUMN, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand"), columns);
+    }
+
+    public void testCountPlanWithMissingCarriesOnlyTotal() throws ConversionException {
+        // missing substitution makes every matching doc eligible — COUNT(*) is the eligible count
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_brand").field("brand").missing("unknown"));
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<String> columns = plans.get(QueryPlans.Type.COUNT).get(0).relNode().getRowType().getFieldNames();
+        assertEquals(List.of(QueryPlans.COUNT_TOTAL_COLUMN), columns);
+    }
+
+    public void testNestedTermsPlanIsBoundedPerParent() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new TermsAggregationBuilder("by_brand").field("brand")
+                    .size(2)
+                    .subAggregation(new TermsAggregationBuilder("by_name").field("name").size(3))
+            );
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, aggPlans.size());
+
+        String parentPlan = aggPlans.get(0).relNode().explain();
+        assertTrue("parent is a flat top-N: " + parentPlan, parentPlan.contains("fetch=[2]"));
+
+        QueryPlans.QueryPlan child = aggPlans.get(1);
+        String childPlan = child.relNode().explain();
+        // restricted to the parent plan's winners
+        assertTrue("child must semi-join the parent plan: " + childPlan, childPlan.contains("joinType=[semi]"));
+        // bounded per parent, ordered by the child's bucket order inside the window
+        assertTrue("child must rank within the parent partition: " + childPlan, childPlan.contains("ROW_NUMBER() OVER (PARTITION BY"));
+        assertTrue("rank filter must keep the per-parent top K: " + childPlan, childPlan.contains("<=($"));
+        // the eligible count rides the rows
+        assertTrue("per-parent eligible total must ride the rows: " + childPlan, childPlan.contains("SUM($"));
+        assertTrue(
+            "child schema carries the parent-eligible column",
+            child.relNode().getRowType().getFieldNames().contains("_parent_eligible")
+        );
+        // The child's own bound is the window rank, not a flat LIMIT: its size (3) must never
+        // appear as a fetch. (The parent's fetch=[2] legitimately appears inside the child
+        // plan — the parent top-N subtree is the semi-join input.)
+        assertFalse("child size must not be a flat fetch: " + childPlan, childPlan.contains("fetch=[3]"));
+        assertNull(child.aggregationMetadata().getFetch());
+    }
+
+    public void testUnsupportedTermsParameterRejectedEndToEnd() {
+        TermsAggregationBuilder terms = new TermsAggregationBuilder("by_brand").field("brand");
+        terms.includeExclude(new org.opensearch.search.aggregations.bucket.terms.IncludeExclude("Brand.*", null));
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(terms);
+
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
+        assertTrue(e.getMessage().contains("include"));
     }
 
     // ---- Golden file driven RelNode generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
@@ -28,6 +28,7 @@ public class GoldenTestCase {
     private List<String> expectedRelNodePlan;
     private List<String> mockResultFieldNames;
     private List<List<Object>> mockResultRows;
+    private Map<String, Object> mockCountRow;
     private Map<String, Object> expectedOutputDsl;
     private String planType;
 
@@ -85,6 +86,19 @@ public class GoldenTestCase {
 
     public void setMockResultRows(List<List<Object>> mockResultRows) {
         this.mockResultRows = mockResultRows;
+    }
+
+    /**
+     * Column name → value for the request's COUNT plan single result row
+     * (e.g. {@code {"_total": 5, "_notnull$brand": 5}}). Null when the scenario expects no
+     * COUNT plan.
+     */
+    public Map<String, Object> getMockCountRow() {
+        return mockCountRow;
+    }
+
+    public void setMockCountRow(Map<String, Object> mockCountRow) {
+        this.mockCountRow = mockCountRow;
     }
 
     public Map<String, Object> getExpectedOutputDsl() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/TestMapperServices.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/TestMapperServices.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import org.opensearch.index.mapper.BooleanFieldMapper;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.NumberFieldMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Builds a stubbed {@link MapperService} from a golden file's {@code indexMapping}
+ * (field name → SQL type name), mirroring how {@link CalciteTestInfra} builds the schema
+ * from the same map. Terms rendering resolves key types and formats through it exactly
+ * as production resolves them through the real index mapping.
+ */
+public final class TestMapperServices {
+
+    private TestMapperServices() {}
+
+    /**
+     * Creates a MapperService supplier whose {@code fieldType(name)} resolves each mapped
+     * field to the {@link MappedFieldType} matching its golden SQL type; unmapped names
+     * resolve to null.
+     *
+     * @param indexMapping field name → SQL type name, as in golden files
+     */
+    public static Supplier<MapperService> fromSqlMapping(Map<String, String> indexMapping) {
+        Map<String, MappedFieldType> fieldTypes = new HashMap<>();
+        for (Map.Entry<String, String> entry : indexMapping.entrySet()) {
+            fieldTypes.put(entry.getKey(), toFieldType(entry.getKey(), entry.getValue()));
+        }
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType(anyString())).thenAnswer(invocation -> fieldTypes.get(invocation.<String>getArgument(0)));
+        return () -> mapperService;
+    }
+
+    private static MappedFieldType toFieldType(String name, String sqlType) {
+        switch (sqlType) {
+            case "VARCHAR":
+                return new KeywordFieldMapper.KeywordFieldType(name);
+            case "INTEGER":
+                return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.INTEGER);
+            case "BIGINT":
+            case "UNSIGNED_LONG":
+                return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.LONG);
+            case "DOUBLE":
+                return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.DOUBLE);
+            case "FLOAT":
+                return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.FLOAT);
+            case "BOOLEAN":
+                return new BooleanFieldMapper.BooleanFieldType(name);
+            case "DATE":
+            case "TIMESTAMP":
+            case "TIMESTAMP_NANOS":
+                return new DateFieldMapper.DateFieldType(name);
+            default:
+                if (sqlType.startsWith("SCALED_FLOAT")) {
+                    return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.DOUBLE);
+                }
+                return new KeywordFieldMapper.KeywordFieldType(name);
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AggregationResponseBuilderTests extends OpenSearchTestCase {
+
+    public void testBuildEmptyAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        InternalAggregations aggs = builder.build(List.of());
+        assertNotNull(aggs);
+        assertEquals(0, aggs.asList().size());
+    }
+
+    public void testBuildMetricWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("avg_price", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildBucketWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildMultipleAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg, termsAgg));
+        assertEquals(2, aggs.asList().size());
+    }
+
+    public void testBuildNestedAggregation() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand")
+            .subAggregation(new AvgAggregationBuilder("avg_price").field("price"));
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> MetricTranslator<T> createMetricTranslator(Class<T> aggClass) {
+        MetricTranslator<T> translator = mock(MetricTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+        when(translator.toInternalAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(inv.getArgument(0));
+            return agg;
+        });
+        return translator;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> BucketTranslator<T> createBucketTranslator(Class<T> aggClass, String fieldName) {
+        BucketTranslator<T> translator = mock(BucketTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+
+        GroupingInfo grouping = mock(GroupingInfo.class);
+        when(grouping.getFieldNames()).thenReturn(List.of(fieldName));
+        when(translator.getGrouping(any())).thenReturn(grouping);
+        when(translator.getSubAggregations(any())).thenReturn(List.of());
+
+        when(translator.toBucketAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(((AggregationBuilder) inv.getArgument(0)).getName());
+            return agg;
+        });
+        return translator;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -93,7 +93,7 @@ public class AggregationResponseBuilderTests extends OpenSearchTestCase {
     private <T extends AggregationBuilder> MetricTranslator<T> createMetricTranslator(Class<T> aggClass) {
         MetricTranslator<T> translator = mock(MetricTranslator.class);
         when(translator.getAggregationType()).thenReturn(aggClass);
-        when(translator.toInternalAggregation(any(), any())).thenAnswer(inv -> {
+        when(translator.toInternalAggregation(any(), any(), any())).thenAnswer(inv -> {
             InternalAggregation agg = mock(InternalAggregation.class);
             when(agg.getName()).thenReturn(inv.getArgument(0));
             return agg;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -17,12 +18,16 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
 import org.opensearch.dsl.golden.GoldenFileLoader;
 import org.opensearch.dsl.golden.GoldenTestCase;
 import org.opensearch.search.SearchModule;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -39,13 +44,161 @@ import java.util.stream.Collectors;
 
 public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
-    public void testBuildReturnsEmptyResponse() {
-        SearchResponse response = SearchResponseBuilder.build(List.of(), 42L * 1_000_000);
+    public void testBuildWithNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 42L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
         assertEquals(0, response.getHits().getHits().length);
         assertEquals(42L, response.getTook().millis());
+        assertNull(response.getAggregations());
+        assertEquals(1, response.getTotalShards());
+        assertEquals(1, response.getSuccessfulShards());
+    }
+
+    public void testBuildWithEmptyRequest() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 100L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertEquals(100L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testBuildWithNullSource() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 50L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertNull(response.getAggregations());
+        assertEquals(1, response.getTotalShards());
+    }
+
+    public void testBuildWithAggregationsButNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        source.aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        request.source(source);
+
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 75L);
+
+        assertNotNull(response);
+        assertEquals(75L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testShardCountsWithNoAggregations() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertEquals(1, response.getTotalShards());
+        assertEquals(1, response.getSuccessfulShards());
+        assertEquals(0, response.getSkippedShards());
+        assertEquals(0, response.getFailedShards());
+    }
+
+    public void testTimingPreserved() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response1 = SearchResponseBuilder.build(List.of(), request, registry, 0L);
+        assertEquals(0L, response1.getTook().millis());
+
+        SearchResponse response2 = SearchResponseBuilder.build(List.of(), request, registry, 999L);
+        assertEquals(999L, response2.getTook().millis());
+    }
+
+    public void testEmptyHitsAlwaysReturned() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertNotNull(response.getHits());
+        assertEquals(0, response.getHits().getHits().length);
+        assertNotNull(response.getHits().getTotalHits());
+    }
+
+    /**
+     * Regression: granularity keys must match even when the schema's column order opposes
+     * the request's nesting order (schema declares category before brand; request nests
+     * brand → category). Before key canonicalization this returned empty aggregations.
+     */
+    public void testNestedGroupFieldsWithOpposingSchemaOrder() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("category", "VARCHAR"); // lower column index than brand — the crux
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand")
+                    .field("brand")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_category")
+                            .field("category")
+                            .subAggregation(AggregationBuilders.avg("avg_price").field("price"))
+                    )
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, aggPlans.size());
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            if (fields.contains("avg_price")) {
+                // Group columns arrive in schema order (category first) despite brand-first nesting.
+                assertEquals(List.of("category", "brand", "avg_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "Cat1", "BrandA", 850.0, 2L }, new Object[] { "Cat2", "BrandA", 700.0, 1L })
+                    )
+                );
+            } else {
+                assertEquals(List.of("brand", "_count"), fields);
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
+            }
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertNotNull("by_brand must be present", byBrand);
+        assertEquals(1, byBrand.getBuckets().size());
+        assertEquals("BrandA", byBrand.getBuckets().get(0).getKeyAsString());
+        assertEquals(3L, byBrand.getBuckets().get(0).getDocCount());
+
+        StringTerms byCategory = byBrand.getBuckets().get(0).getAggregations().get("by_category");
+        assertNotNull("by_category must be present inside the brand bucket", byCategory);
+        assertEquals(2, byCategory.getBuckets().size());
+        assertEquals("Cat1", byCategory.getBuckets().get(0).getKeyAsString());
+        assertEquals(2L, byCategory.getBuckets().get(0).getDocCount());
+        InternalAvg avg1 = byCategory.getBuckets().get(0).getAggregations().get("avg_price");
+        assertEquals(850.0, avg1.getValue(), 0.0);
+        InternalAvg avg2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
+        assertEquals(700.0, avg2.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----
@@ -91,7 +244,14 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 ExecutionResult result = new ExecutionResult(matchingPlans.get(0), rows);
 
                 // Build and serialize SearchResponse
-                SearchResponse response = SearchResponseBuilder.build(List.of(result), 0L);
+                SearchRequest searchRequest = new SearchRequest(tc.getIndexName());
+                searchRequest.source(searchSource);
+                SearchResponse response = SearchResponseBuilder.build(
+                    List.of(result),
+                    searchRequest,
+                    converter.getAggregationRegistry(),
+                    0L
+                );
                 String responseJson = Strings.toString(MediaTypeRegistry.JSON, response);
 
                 Map<String, Object> actualOutput = XContentHelper.convertToMap(JsonXContent.jsonXContent, responseJson, false);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -26,6 +26,8 @@ import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
 import org.opensearch.dsl.golden.GoldenFileLoader;
 import org.opensearch.dsl.golden.GoldenTestCase;
+import org.opensearch.dsl.golden.TestMapperServices;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
@@ -43,6 +45,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class SearchResponseBuilderTests extends OpenSearchTestCase {
@@ -160,7 +163,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                     )
             );
 
-        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema(), TestMapperServices.fromSqlMapping(mapping));
         QueryPlans plans = converter.convert(source, "products");
         List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
         assertEquals(2, aggPlans.size());
@@ -222,6 +225,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         mapping.put("category", "VARCHAR");
         mapping.put("price", "INTEGER");
         CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+        Supplier<MapperService> mappers = TestMapperServices.fromSqlMapping(mapping);
 
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(
@@ -243,7 +247,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                     )
             );
 
-        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema(), mappers);
         QueryPlans plans = converter.convert(source, "products");
         List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
         assertEquals(4, aggPlans.size());
@@ -331,7 +335,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(AggregationBuilders.terms("by_brand").field("brand").size(1));
 
-        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema(), TestMapperServices.fromSqlMapping(mapping));
         QueryPlans plans = converter.convert(source, "products");
 
         List<ExecutionResult> results = new ArrayList<>();
@@ -404,7 +408,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                     .subAggregation(AggregationBuilders.avg("avg_price").field("price").setMetadata(avgMeta))
             );
 
-        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema(), TestMapperServices.fromSqlMapping(mapping));
         QueryPlans plans = converter.convert(source, "products");
 
         List<ExecutionResult> results = new ArrayList<>();
@@ -522,7 +526,10 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
                 // Build QueryPlan via forward path (needed to construct ExecutionResult)
                 SearchSourceBuilder searchSource = parseSearchSource(tc.getInputDsl());
-                SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+                SearchSourceConverter converter = new SearchSourceConverter(
+                    infra.schema(),
+                    TestMapperServices.fromSqlMapping(tc.getIndexMapping())
+                );
                 QueryPlans plans = converter.convert(searchSource, tc.getIndexName());
 
                 QueryPlans.Type expectedType = QueryPlans.Type.valueOf(tc.getPlanType());

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.result;
 
+import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
@@ -168,12 +169,13 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         for (QueryPlans.QueryPlan plan : aggPlans) {
             List<String> fields = plan.relNode().getRowType().getFieldNames();
             if (fields.contains("avg_price")) {
-                // Group columns arrive in schema order (category first) despite brand-first nesting.
-                assertEquals(List.of("category", "brand", "avg_price", "_count"), fields);
+                // Group columns arrive in schema order (category first) despite brand-first
+                // nesting; the per-parent eligible total rides the bounded child plan's rows.
+                assertEquals(List.of("category", "brand", "avg_price", "_count", "_parent_eligible"), fields);
                 results.add(
                     new ExecutionResult(
                         plan,
-                        List.of(new Object[] { "Cat1", "BrandA", 850.0, 2L }, new Object[] { "Cat2", "BrandA", 700.0, 1L })
+                        List.of(new Object[] { "Cat1", "BrandA", 850.0, 2L, 5L }, new Object[] { "Cat2", "BrandA", 700.0, 1L, 5L })
                     )
                 );
             } else {
@@ -181,6 +183,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
             }
         }
+        addCountResult(plans, results, Map.of(QueryPlans.COUNT_TOTAL_COLUMN, 3, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand", 3));
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
@@ -201,6 +204,8 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(850.0, avg1.getValue(), 0.0);
         InternalAvg avg2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
         assertEquals(700.0, avg2.getValue(), 0.0);
+        // per-parent eligible total 5 vs 3 rendered docs → 2 in truncated child groups
+        assertEquals(2L, byCategory.getSumOfOtherDocCounts());
     }
 
     /**
@@ -249,20 +254,21 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
             List<String> fields = plan.relNode().getRowType().getFieldNames();
             if (fields.contains("avg_price")) {
                 // Both deep plans group by {brand, category} and emit columns in schema order —
-                // identical layouts, distinguished ONLY by the metadata's nesting order.
-                assertEquals(List.of("brand", "category", "avg_price", "_count"), fields);
+                // identical layouts, distinguished ONLY by the metadata's aggregation-name path.
+                assertEquals(List.of("brand", "category", "avg_price", "_count", "_parent_eligible"), fields);
                 results.add(
                     new ExecutionResult(
                         plan,
-                        List.of(new Object[] { "BrandA", "Cat1", 850.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                        List.of(new Object[] { "BrandA", "Cat1", 850.0, 2L, 3L }, new Object[] { "BrandA", "Cat2", 700.0, 1L, 3L })
                     )
                 );
             } else if (fields.contains("sum_price")) {
-                assertEquals(List.of("brand", "category", "sum_price", "_count"), fields);
+                // cat_first tree: the parent is category, so each row carries its category's total
+                assertEquals(List.of("brand", "category", "sum_price", "_count", "_parent_eligible"), fields);
                 results.add(
                     new ExecutionResult(
                         plan,
-                        List.of(new Object[] { "BrandA", "Cat1", 1700.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                        List.of(new Object[] { "BrandA", "Cat1", 1700.0, 2L, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L, 1L })
                     )
                 );
             } else if (fields.equals(List.of("brand", "_count"))) {
@@ -272,6 +278,18 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 results.add(new ExecutionResult(plan, List.of(new Object[] { "Cat1", 2L }, new Object[] { "Cat2", 1L })));
             }
         }
+        addCountResult(
+            plans,
+            results,
+            Map.of(
+                QueryPlans.COUNT_TOTAL_COLUMN,
+                3,
+                QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "brand_first",
+                3,
+                QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "cat_first",
+                3
+            )
+        );
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
@@ -300,7 +318,11 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(700.0, sumCat2.getValue(), 0.0);
     }
 
-    /** Terms {@code size} truncates to the top-N buckets and reports the rest as sum_other_doc_count. */
+    /**
+     * Terms {@code size} is enforced by the plan's LIMIT — the engine returns only the top
+     * bucket — and {@code sum_other_doc_count} comes from the count plan's eligible count
+     * ({@code eligible − Σ rendered}), since the tail never leaves the engine.
+     */
     public void testTermsSizeTruncation() throws Exception {
         Map<String, String> mapping = new java.util.LinkedHashMap<>();
         mapping.put("brand", "VARCHAR");
@@ -315,8 +337,11 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         List<ExecutionResult> results = new ArrayList<>();
         for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
             assertEquals(List.of("brand", "_count"), plan.relNode().getRowType().getFieldNames());
-            results.add(new ExecutionResult(plan, List.of(new Object[] { "BrandA", 3L }, new Object[] { "BrandB", 2L })));
+            assertTrue("plan must be bounded to size", plan.relNode().explain().contains("fetch=[1]"));
+            // the engine honors the LIMIT: only the top bucket comes back
+            results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
         }
+        addCountResult(plans, results, Map.of(QueryPlans.COUNT_TOTAL_COLUMN, 5, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand", 5));
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
@@ -399,6 +424,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
             }
             results.add(new ExecutionResult(plan, List.<Object[]>of(row)));
         }
+        addCountResult(plans, results, Map.of(QueryPlans.COUNT_TOTAL_COLUMN, 3, QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_brand", 3));
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
@@ -412,6 +438,63 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertNotNull(avg);
         assertEquals(avgMeta, avg.getMetadata());
         assertEquals(850.0, avg.getValue(), 0.0);
+    }
+
+    // ---- hits.total: classic track_total_hits semantics from the COUNT plan ----
+
+    public void testHitsTotalExactUnderDefaultThreshold() throws Exception {
+        SearchResponse response = countOnlyResponse(new SearchSourceBuilder().size(0), 42L);
+
+        assertEquals(42L, response.getHits().getTotalHits().value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, response.getHits().getTotalHits().relation());
+    }
+
+    public void testHitsTotalLowerBoundOverDefaultThreshold() throws Exception {
+        SearchResponse response = countOnlyResponse(new SearchSourceBuilder().size(0), 25_000L);
+
+        assertEquals(10_000L, response.getHits().getTotalHits().value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, response.getHits().getTotalHits().relation());
+    }
+
+    public void testHitsTotalExactWhenTrackTotalHitsTrue() throws Exception {
+        SearchResponse response = countOnlyResponse(new SearchSourceBuilder().size(0).trackTotalHits(true), 25_000L);
+
+        assertEquals(25_000L, response.getHits().getTotalHits().value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, response.getHits().getTotalHits().relation());
+    }
+
+    public void testHitsTotalOmittedWhenTrackTotalHitsFalse() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).trackTotalHits(false);
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+        assertTrue("nothing to count, nothing to run", plans.getAll().isEmpty());
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, converter.getAggregationRegistry(), 1L);
+
+        assertNull(response.getHits().getTotalHits());
+    }
+
+    /** Runs a count-only request (size 0, no aggs) with a fabricated engine count. */
+    private SearchResponse countOnlyResponse(SearchSourceBuilder source, long total) throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        addCountResult(plans, results, Map.of(QueryPlans.COUNT_TOTAL_COLUMN, total));
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        return SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----
@@ -454,17 +537,16 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 for (List<Object> row : tc.getMockResultRows()) {
                     rows.add(row.toArray());
                 }
-                ExecutionResult result = new ExecutionResult(matchingPlans.get(0), rows);
+                List<ExecutionResult> allResults = new ArrayList<>();
+                allResults.add(new ExecutionResult(matchingPlans.get(0), rows));
+                if (tc.getMockCountRow() != null) {
+                    addCountResult(plans, allResults, tc.getMockCountRow());
+                }
 
                 // Build and serialize SearchResponse
                 SearchRequest searchRequest = new SearchRequest(tc.getIndexName());
                 searchRequest.source(searchSource);
-                SearchResponse response = SearchResponseBuilder.build(
-                    List.of(result),
-                    searchRequest,
-                    converter.getAggregationRegistry(),
-                    0L
-                );
+                SearchResponse response = SearchResponseBuilder.build(allResults, searchRequest, converter.getAggregationRegistry(), 0L);
                 String responseJson = Strings.toString(MediaTypeRegistry.JSON, response);
 
                 Map<String, Object> actualOutput = XContentHelper.convertToMap(JsonXContent.jsonXContent, responseJson, false);
@@ -508,6 +590,24 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
     }
 
     // ---- Helpers ----
+
+    /**
+     * Fabricates the COUNT plan's single-row result from a columnName→value map, mirroring
+     * what the engine would return for it. Fails the test if the plan carries a column the
+     * map does not provide.
+     */
+    private static void addCountResult(QueryPlans plans, List<ExecutionResult> results, Map<String, Object> countsByColumn) {
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.COUNT)) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                Object value = countsByColumn.get(fields.get(i));
+                assertNotNull("count fabrication missing column: " + fields.get(i), value);
+                row[i] = value instanceof Number n ? n.longValue() : value;
+            }
+            results.add(new ExecutionResult(plan, List.<Object[]>of(row)));
+        }
+    }
 
     private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {
         String json;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -19,6 +19,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
@@ -297,6 +298,91 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         StringTerms byBrandCat2 = catFirst.getBuckets().get(1).getAggregations().get("by_brand");
         InternalSum sumCat2 = byBrandCat2.getBuckets().get(0).getAggregations().get("sum_price");
         assertEquals(700.0, sumCat2.getValue(), 0.0);
+    }
+
+    /** A result table missing a requested metric's column is a broken invariant — throw, don't render {@code "value": null}. */
+    public void testMissingMetricColumnThrows() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        // Results computed for a metric named "other"
+        SearchSourceBuilder executedSource = new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("other").field("price"));
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(executedSource, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            int columnCount = plan.relNode().getRowType().getFieldCount();
+            results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[columnCount])));
+        }
+
+        // Response requested for "avg_price" — same granularity, but no such column in the result
+        SearchRequest request = new SearchRequest("products");
+        request.source(new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("avg_price").field("price")));
+
+        expectThrows(
+            ConversionException.class,
+            () -> SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L)
+        );
+    }
+
+    /**
+     * User-supplied {@code meta} on an aggregation request must be echoed back verbatim on the
+     * corresponding response aggregation — classic search parity — for both bucket and metric
+     * aggregations, through the full plan/response round trip.
+     */
+    public void testUserMetaEchoedInAggregations() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        Map<String, Object> termsMeta = Map.of("source", "dashboard");
+        Map<String, Object> avgMeta = Map.of("owner", "pricing-team");
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand")
+                    .field("brand")
+                    .setMetadata(termsMeta)
+                    .subAggregation(AggregationBuilders.avg("avg_price").field("price").setMetadata(avgMeta))
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                if ("brand".equals(fields.get(i))) {
+                    row[i] = "BrandA";
+                } else if ("avg_price".equals(fields.get(i))) {
+                    row[i] = 850.0;
+                } else if ("_count".equals(fields.get(i))) {
+                    row[i] = 3L;
+                } else {
+                    fail("Unexpected column: " + fields.get(i));
+                }
+            }
+            results.add(new ExecutionResult(plan, List.<Object[]>of(row)));
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertNotNull(byBrand);
+        assertEquals(termsMeta, byBrand.getMetadata());
+
+        InternalAvg avg = byBrand.getBuckets().get(0).getAggregations().get("avg_price");
+        assertNotNull(avg);
+        assertEquals(avgMeta, avg.getMetadata());
+        assertEquals(850.0, avg.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -300,6 +300,35 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(700.0, sumCat2.getValue(), 0.0);
     }
 
+    /** Terms {@code size} truncates to the top-N buckets and reports the rest as sum_other_doc_count. */
+    public void testTermsSizeTruncation() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.terms("by_brand").field("brand").size(1));
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            assertEquals(List.of("brand", "_count"), plan.relNode().getRowType().getFieldNames());
+            results.add(new ExecutionResult(plan, List.of(new Object[] { "BrandA", 3L }, new Object[] { "BrandB", 2L })));
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertEquals(1, byBrand.getBuckets().size());
+        assertEquals("BrandA", byBrand.getBuckets().get(0).getKeyAsString());
+        assertEquals(3L, byBrand.getBuckets().get(0).getDocCount());
+        assertEquals(2L, byBrand.getSumOfOtherDocCounts());
+    }
+
     /** A result table missing a requested metric's column is a broken invariant — throw, don't render {@code "value": null}. */
     public void testMissingMetricColumnThrows() throws Exception {
         Map<String, String> mapping = new java.util.LinkedHashMap<>();

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -28,6 +28,7 @@ import org.opensearch.search.SearchModule;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
+import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -199,6 +200,103 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(850.0, avg1.getValue(), 0.0);
         InternalAvg avg2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
         assertEquals(700.0, avg2.getValue(), 0.0);
+    }
+
+    /**
+     * Regression: sibling aggregation trees over the same field SET but opposite nesting order
+     * (brand→category vs category→brand) produce two distinct plans and must resolve to two
+     * distinct results. Under the old order-insensitive (sorted) granularity keys, both deep
+     * plans collapsed onto one map slot: the second plan's result silently overwrote the
+     * first's, and the losing tree's metric came back empty ({@code "value": null}) beneath
+     * correct-looking buckets.
+     */
+    public void testReversedNestingSiblingTreesDoNotCollide() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("category", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("brand_first")
+                    .field("brand")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_category")
+                            .field("category")
+                            .subAggregation(AggregationBuilders.avg("avg_price").field("price"))
+                    )
+            )
+            .aggregation(
+                AggregationBuilders.terms("cat_first")
+                    .field("category")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_brand")
+                            .field("brand")
+                            .subAggregation(AggregationBuilders.sum("sum_price").field("price"))
+                    )
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(4, aggPlans.size());
+
+        // Data story: 3 docs — BrandA/Cat1/800, BrandA/Cat1/900, BrandA/Cat2/700.
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            if (fields.contains("avg_price")) {
+                // Both deep plans group by {brand, category} and emit columns in schema order —
+                // identical layouts, distinguished ONLY by the metadata's nesting order.
+                assertEquals(List.of("brand", "category", "avg_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "BrandA", "Cat1", 850.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                    )
+                );
+            } else if (fields.contains("sum_price")) {
+                assertEquals(List.of("brand", "category", "sum_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "BrandA", "Cat1", 1700.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                    )
+                );
+            } else if (fields.equals(List.of("brand", "_count"))) {
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
+            } else {
+                assertEquals(List.of("category", "_count"), fields);
+                results.add(new ExecutionResult(plan, List.of(new Object[] { "Cat1", 2L }, new Object[] { "Cat2", 1L })));
+            }
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        // brand_first → BrandA → by_category → Cat1 (avg 850), Cat2 (avg 700)
+        StringTerms brandFirst = response.getAggregations().get("brand_first");
+        assertNotNull("brand_first must be present", brandFirst);
+        assertEquals(1, brandFirst.getBuckets().size());
+        StringTerms byCategory = brandFirst.getBuckets().get(0).getAggregations().get("by_category");
+        assertEquals(2, byCategory.getBuckets().size());
+        InternalAvg avgCat1 = byCategory.getBuckets().get(0).getAggregations().get("avg_price");
+        assertEquals("brand_first's metric must not be lost to the sibling tree", 850.0, avgCat1.getValue(), 0.0);
+        InternalAvg avgCat2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
+        assertEquals(700.0, avgCat2.getValue(), 0.0);
+
+        // cat_first → Cat1 → by_brand → BrandA (sum 1700); Cat2 → by_brand → BrandA (sum 700)
+        StringTerms catFirst = response.getAggregations().get("cat_first");
+        assertNotNull("cat_first must be present", catFirst);
+        assertEquals(2, catFirst.getBuckets().size());
+        StringTerms byBrandCat1 = catFirst.getBuckets().get(0).getAggregations().get("by_brand");
+        InternalSum sumCat1 = byBrandCat1.getBuckets().get(0).getAggregations().get("sum_price");
+        assertEquals(1700.0, sumCat1.getValue(), 0.0);
+        StringTerms byBrandCat2 = catFirst.getBuckets().get(1).getAggregations().get("by_brand");
+        InternalSum sumCat2 = byBrandCat2.getBuckets().get(0).getAggregations().get("sum_price");
+        assertEquals(700.0, sumCat2.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ComparisonUtilsTests extends OpenSearchTestCase {
+
+    public void testBothNull() {
+        assertTrue(ComparisonUtils.valuesEqual(null, null));
+    }
+
+    public void testFirstNull() {
+        assertFalse(ComparisonUtils.valuesEqual(null, "value"));
+    }
+
+    public void testSecondNull() {
+        assertFalse(ComparisonUtils.valuesEqual("value", null));
+    }
+
+    public void testEqualStrings() {
+        assertTrue(ComparisonUtils.valuesEqual("test", "test"));
+    }
+
+    public void testDifferentValues() {
+        assertFalse(ComparisonUtils.valuesEqual("foo", "bar"));
+    }
+
+    public void testIntegerAndLong() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42L));
+    }
+
+    public void testIntegerAndDouble() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42.0));
+    }
+
+    public void testDoubleAndFloat() {
+        assertTrue(ComparisonUtils.valuesEqual(42.0, 42.0f));
+    }
+
+    public void testDifferentNumbers() {
+        assertFalse(ComparisonUtils.valuesEqual(42, 43));
+    }
+
+    public void testNumberAndStringAreNotEqual() {
+        // No cross-type stringification: bucket keys are schema-typed, "42" != 42.
+        assertFalse(ComparisonUtils.valuesEqual(42, "42"));
+    }
+
+    public void testLargeLongsBeyondDoublePrecision() {
+        // 2^53 + 1 vs 2^53: indistinguishable as doubles, distinct as longs.
+        assertFalse(ComparisonUtils.valuesEqual(9007199254740993L, 9007199254740992L));
+        assertTrue(ComparisonUtils.valuesEqual(9007199254740993L, 9007199254740993L));
+    }
+
+    public void testBooleanComparison() {
+        assertTrue(ComparisonUtils.valuesEqual(true, true));
+        assertFalse(ComparisonUtils.valuesEqual(true, false));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
@@ -21,14 +21,17 @@
     ["laptop", 999, "BrandA", 4.5],
     ["phone", 699, "BrandB", 4.2]
   ],
+  "mockCountRow": {
+    "_total": 2
+  },
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_boolean.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_boolean.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date_nanos.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date_nanos.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_decimal_on_integer_truncate_adjust.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_decimal_on_integer_truncate_adjust.json
@@ -34,7 +34,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_double.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_double.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_keyword_lexicographic.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_keyword_lexicographic.json
@@ -33,7 +33,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_no_bounds_is_not_null.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_no_bounds_is_not_null.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_exclusive.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_exclusive.json
@@ -34,7 +34,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_inclusive.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_inclusive.json
@@ -34,7 +34,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_scaled_float.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_scaled_float.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_timestamp.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_timestamp.json
@@ -35,7 +35,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_unsigned_long.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_unsigned_long.json
@@ -31,7 +31,7 @@
         "value": 0,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     }
   }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_numeric_keys_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_numeric_keys_aggregation.json
@@ -1,0 +1,58 @@
+{
+  "testName": "terms_numeric_keys_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "by_price": {
+        "terms": {
+          "field": "price"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{1}], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["price", "_count"],
+  "mockResultRows": [
+    [100, 3],
+    [200, 2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "by_price": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": 100,
+            "doc_count": 3
+          },
+          {
+            "key": 200,
+            "doc_count": 2
+          }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_numeric_keys_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_numeric_keys_aggregation.json
@@ -19,23 +19,28 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
     "  LogicalAggregate(group=[{1}], _count=[COUNT()])",
-    "    LogicalTableScan(table=[[test-index]])"
+    "    LogicalFilter(condition=[IS NOT NULL($1)])",
+    "      LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["price", "_count"],
   "mockResultRows": [
     [100, 3],
     [200, 2]
   ],
+  "mockCountRow": {
+    "_total": 5,
+    "_eligible$by_price": 5
+  },
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 5,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     },
     "aggregations": {

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
@@ -44,6 +44,28 @@
       },
       "max_score": 0.0,
       "hits": []
+    },
+    "aggregations": {
+      "by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "BrandA",
+            "doc_count": 3,
+            "avg_price": {
+              "value": 850.0
+            }
+          },
+          {
+            "key": "BrandB",
+            "doc_count": 2,
+            "avg_price": {
+              "value": 1100.0
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
@@ -26,23 +26,28 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
     "  LogicalAggregate(group=[{2}], avg_price=[AVG($1)], _count=[COUNT()])",
-    "    LogicalTableScan(table=[[test-index]])"
+    "    LogicalFilter(condition=[IS NOT NULL($2)])",
+    "      LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["brand", "avg_price", "_count"],
   "mockResultRows": [
     ["BrandA", 850.0, 3],
     ["BrandB", 1100.0, 2]
   ],
+  "mockCountRow": {
+    "_total": 5,
+    "_eligible$by_brand": 5
+  },
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 5,
         "relation": "eq"
       },
-      "max_score": 0.0,
+      "max_score": null,
       "hits": []
     },
     "aggregations": {


### PR DESCRIPTION
### Description

Converts analytics engine execution results into OpenSearch `InternalAggregations` and pushes terms top-K semantics into the engine plans, enabling correct, legacy-shaped aggregation responses in the DSL query executor. Supersedes #21346.

#### Response building
- **AggregationResponseBuilder**: converts flat execution results into the client's nested aggregation response, walking the original request as template. Results are keyed by aggregation-name path (outer bucket first), so sibling aggregations over the same field — or sibling trees with reversed nesting order — resolve to their own plans without collisions.
- **Metric translators** (`InternalAvg`/`InternalSum`/`InternalMin`/`InternalMax`): response conversion with legacy empty-result sentinels (avg → `value: null`, sum → 0.0, min → +Inf, max → −Inf). User-supplied `meta` is echoed back verbatim.
- **SearchResponseBuilder / TransportDslExecuteAction**: wire the response builder into the search flow. `hits.total` renders classic `track_total_hits` semantics: exact (`eq`) up to the threshold, `gte` lower bound past it, omitted when disabled.

#### Terms top-K pushdown
Previously every group materialized out of the engine and was truncated client-side, capping results at the sink row limit and inflating latency. Now each bucket aggregation gets its own bounded plan:
- `size`, `min_doc_count`, and order bake in as LIMIT, HAVING, and SORT — the engine returns exactly the response's bucket set.
- Root levels sort with a fetch (bounded top-K); nested levels semi-join the parent's top-N plan and rank per parent via a `ROW_NUMBER()` window.
- **PreAggregateConverter** gives group fields classic terms null semantics: `IS NOT NULL` filter below the aggregate by default, `CASE` substitution when `missing` is configured.

#### Exact accounting under truncation
- Bounded plans discard their tail engine-side, so eligible-doc counts arrive from dedicated COUNT plans: a shared flat plan (`COUNT(*)` for `hits.total`, `COUNT(field)` per bounded root aggregation), HAVING-filtered SUM plans for `min_doc_count > 1`, and a per-parent `SUM(_count) OVER (PARTITION BY parent)` window column for nested levels.
- `sum_other_doc_count` = eligible − Σ(rendered doc counts), clamped at zero.
- COUNT plans execute concurrently with the main plans.

#### Typed terms responses
- **TermsResponseStrategy** registry maps field types to `StringTerms`/`LongTerms`/`DoubleTerms` builders, mirroring the `ValuesSourceRegistry` pattern — supporting a new field type is a registry entry, not a new switch branch.
- `MapperService` is wired through the transport for mapping-resolved key types and `DocValueFormat` rendering (dates, booleans, ip addresses); Java-type sampling is the fallback when no mapping resolves.

#### Request validation
- `AggregationTranslator.validate()` rejects parameters this path doesn't implement (`include`/`exclude`, `script`, `min_doc_count: 0` on terms; `missing`/`script` on metrics) with a 400. Ignoring them would return well-formed responses whose numbers differ from classic search.

#### Stability
- Calcite clusters are request-scoped, and concurrently planned COUNT plans build in private clusters: the per-cluster metadata cache is not thread-safe and shared caches caused `CyclicMetadataException`.
- Plan dumps and per-row previews demoted from INFO to DEBUG.

### Testing
- Unit tests cover tree walking (bounds, HAVING, `missing`, sibling plans), plan shapes (fetch, semi-join + window, COUNT plans), response building (nesting-order collisions, truncation accounting, meta echo, `hits.total` semantics), typed terms strategies, and numeric comparison; golden-file scenarios extended with COUNT rows.
- Verified end to end on a live composite index: terms + metrics, filtered global metrics, and two-level nested aggregations return correct legacy-shaped responses.
- Validated against ClickBench (100M docs): previously failing and truncated queries return exact results at PPL-twin parity (2–4%).

### Related Issues
Supersedes #21346

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).