### PR TITLE
Add relative path setting validation

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.compound.HyphenationCompoundWordTokenFilter;
 import org.apache.lucene.analysis.compound.hyphenation.HyphenationTree;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
@@ -54,6 +55,8 @@ import org.xml.sax.InputSource;
  */
 public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundWordTokenFilterFactory {
 
+    private static final Setting<String> HYPHENATION_PATTERNS_PATH_SETTING = Setting.relativePathSetting("hyphenation_patterns_path");
+
     private final boolean noSubMatches;
     private final boolean noOverlappingMatches;
     private final HyphenationTree hyphenationTree;
@@ -64,10 +67,10 @@ public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundW
         noSubMatches = settings.getAsBoolean("no_sub_matches", false);
         noOverlappingMatches = settings.getAsBoolean("no_overlapping_matches", false);
 
-        String hyphenationPatternsPath = settings.get("hyphenation_patterns_path", null);
-        if (hyphenationPatternsPath == null) {
+        if (HYPHENATION_PATTERNS_PATH_SETTING.exists(settings) == false) {
             throw new IllegalArgumentException("hyphenation_patterns_path is a required setting.");
         }
+        String hyphenationPatternsPath = HYPHENATION_PATTERNS_PATH_SETTING.get(settings);
 
         Path hyphenationPatternsFile = Analysis.resolveAnalyzerPath(env, hyphenationPatternsPath);
 

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -58,6 +58,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2047,6 +2048,66 @@ public class Setting<T> implements ToXContentObject {
      */
     public static Setting<String> simpleString(String key, String defaultValue, Property... properties) {
         return new Setting<>(key, s -> defaultValue, Function.identity(), properties);
+    }
+
+    /**
+     * Creates a string setting whose value must be a relative path that does not escape its base directory.
+     * Empty values are accepted so that optional path settings can retain the same semantics as
+     * {@link #simpleString(String, Property...)}.
+     *
+     * <p>The validation is platform independent: both {@code /} and {@code \\} are treated as path separators,
+     * and Windows drive paths are rejected even when OpenSearch is running on a Unix-like host.</p>
+     *
+     * @param key        the settings key for this setting
+     * @param properties properties for this setting like scope or filtering
+     * @return the relative-path setting
+     */
+    public static Setting<String> relativePathSetting(String key, Property... properties) {
+        return simpleString(key, value -> validateRelativePath(key, value), properties);
+    }
+
+    private static void validateRelativePath(String key, String value) {
+        if (Strings.hasLength(value) == false) {
+            return;
+        }
+
+        final boolean absolute;
+        try {
+            absolute = Path.of(value).isAbsolute();
+        } catch (IllegalArgumentException e) {
+            throw invalidRelativePath(key, value, e);
+        }
+        if (absolute || value.startsWith("/") || value.startsWith("\\") || value.matches("^[A-Za-z]:.*")) {
+            throw invalidRelativePath(key, value);
+        }
+
+        int depth = 0;
+        for (String segment : value.split("[/\\\\]+")) {
+            if (segment.isEmpty() || segment.equals(".")) {
+                continue;
+            }
+            if (segment.equals("..")) {
+                if (depth == 0) {
+                    throw invalidRelativePath(key, value);
+                }
+                depth--;
+            } else {
+                depth++;
+            }
+        }
+    }
+
+    private static IllegalArgumentException invalidRelativePath(String key, String value) {
+        return new IllegalArgumentException(
+            "setting [" + key + "] must be a relative path that does not escape its base directory; got [" + value + "]"
+        );
+    }
+
+    private static IllegalArgumentException invalidRelativePath(String key, String value, Exception cause) {
+        return new IllegalArgumentException(
+            "setting [" + key + "] must be a relative path that does not escape its base directory; got [" + value + "]",
+            cause
+        );
     }
 
     public static TimeValue parseTimeValue(String s, TimeValue minValue, String key) {

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -69,6 +69,7 @@ import org.apache.lucene.analysis.ru.RussianAnalyzer;
 import org.apache.lucene.analysis.sv.SwedishAnalyzer;
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
 import org.opensearch.env.Environment;
@@ -274,7 +275,8 @@ public class Analysis {
      *          If the word list cannot be found at either key.
      */
     private static List<String> getWordList(Environment env, Settings settings, String settingPath, String settingList) {
-        String wordListPath = settings.get(settingPath, null);
+        final Setting<String> pathSetting = Setting.relativePathSetting(settingPath);
+        String wordListPath = pathSetting.exists(settings) ? pathSetting.get(settings) : null;
 
         if (wordListPath == null) {
             return settings.getAsList(settingList, null);
@@ -319,7 +321,8 @@ public class Analysis {
      *          If the Reader can not be instantiated.
      */
     public static Reader getReaderFromFile(Environment env, Settings settings, String settingPrefix) {
-        String filePath = settings.get(settingPrefix, null);
+        final Setting<String> pathSetting = Setting.relativePathSetting(settingPrefix);
+        String filePath = pathSetting.exists(settings) ? pathSetting.get(settings) : null;
 
         if (filePath == null) {
             return null;

--- a/server/src/main/java/org/opensearch/index/analysis/HunspellTokenFilterFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/HunspellTokenFilterFactory.java
@@ -34,6 +34,7 @@ package org.opensearch.index.analysis;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.hunspell.Dictionary;
 import org.apache.lucene.analysis.hunspell.HunspellStemFilter;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.analysis.HunspellService;
@@ -71,6 +72,8 @@ import java.util.regex.Pattern;
  */
 public class HunspellTokenFilterFactory extends AbstractTokenFilterFactory {
 
+    private static final Setting<String> REF_PATH_SETTING = Setting.relativePathSetting("ref_path");
+
     private final Dictionary dictionary;
     private final boolean dedup;
     private final boolean longestOnly;
@@ -83,7 +86,7 @@ public class HunspellTokenFilterFactory extends AbstractTokenFilterFactory {
         super(indexSettings, name, settings);
 
         // Get both ref_path and locale parameters
-        String refPath = settings.get("ref_path");
+        String refPath = REF_PATH_SETTING.exists(settings) ? REF_PATH_SETTING.get(settings) : null;
         String locale = settings.get("locale", settings.get("language", settings.get("lang", null)));
 
         // Check for updateable flag

--- a/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
@@ -102,19 +102,7 @@ public class FsRepository extends BlobStoreRepository {
         Property.Deprecated
     );
 
-    public static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path", value -> {
-        // CWE-22 hardening (string-only fail-fast; avoids constructing a Path from a raw user-supplied string):
-        // reject absolute base_path values (POSIX "/", Windows "\\"/UNC, drive-letter "C:..") and any parent-directory
-        // ("..") segment. An absolute base_path makes Path.resolve discard the path.repo-validated location, escaping
-        // containment; a ".." segment lets the resolved path climb above it. The authoritative, location-aware
-        // containment check is performed in validateBasePathWithinRepo().
-        if (Strings.hasLength(value)
-            && (value.startsWith("/") || value.startsWith("\\") || value.matches("^[A-Za-z]:.*") || value.contains(".."))) {
-            throw new IllegalArgumentException(
-                "[base_path] must be a relative path that does not contain '..' segments; got [" + value + "]"
-            );
-        }
-    });
+    public static final Setting<String> BASE_PATH_SETTING = Setting.relativePathSetting("base_path");
 
     protected final Environment environment;
 

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -1420,6 +1420,45 @@ public class SettingTests extends OpenSearchTestCase {
         assertThat(setting.hasNodeScope(), is(true));
     }
 
+    public void testRelativePathSetting() {
+        Setting<String> setting = Setting.relativePathSetting("path", Property.NodeScope);
+
+        for (String path : List.of("", "dictionary", "nested/dictionary", "./dictionary", "nested/../dictionary", "foo..bar")) {
+            assertThat(setting.get(Settings.builder().put("path", path).build()), equalTo(path));
+        }
+    }
+
+    public void testRelativePathSettingRejectsAbsoluteAndEscapingPaths() {
+        Setting<String> setting = Setting.relativePathSetting("path", Property.NodeScope);
+
+        for (String path : List.of(
+            "/absolute/path",
+            "\\absolute\\path",
+            "C:\\absolute\\path",
+            "C:/absolute/path",
+            "C:drive-relative-path",
+            "..",
+            "../escape",
+            "nested/../../escape",
+            "nested\\..\\..\\escape"
+        )) {
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> setting.get(Settings.builder().put("path", path).build())
+            );
+            assertThat(exception.getMessage(), containsString("setting [path] must be a relative path"));
+        }
+    }
+
+    public void testRelativePathSettingRejectsInvalidPath() {
+        Setting<String> setting = Setting.relativePathSetting("path", Property.NodeScope);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> setting.get(Settings.builder().put("path", "invalid\0path").build())
+        );
+        assertThat(exception.getMessage(), containsString("setting [path] must be a relative path"));
+    }
+
     /**
      * We can't have Null properties
      */

--- a/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
@@ -71,7 +71,7 @@ public class AnalysisTests extends OpenSearchTestCase {
         Path config = home.resolve("config");
         Files.createDirectory(config);
         Settings nodeSettings = Settings.builder()
-            .put("foo.bar_path", config.resolve("foo.dict"))
+            .put("foo.bar_path", "foo.dict")
             .put(Environment.PATH_HOME_SETTING.getKey(), home)
             .build();
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
@@ -88,7 +88,10 @@ public class AnalysisTests extends OpenSearchTestCase {
         Path config = home.resolve("config");
         Files.createDirectory(config);
         Path dict = config.resolve("foo.dict");
-        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", "foo.dict")
+            .put(Environment.PATH_HOME_SETTING.getKey(), home)
+            .build();
         try (OutputStream writer = Files.newOutputStream(dict)) {
             writer.write(new byte[] { (byte) 0xff, 0x00, 0x00 }); // some invalid UTF-8
             writer.write('\n');
@@ -107,7 +110,10 @@ public class AnalysisTests extends OpenSearchTestCase {
         Path config = home.resolve("config");
         Files.createDirectory(config);
         Path dict = config.resolve("foo.dict");
-        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", "foo.dict")
+            .put(Environment.PATH_HOME_SETTING.getKey(), home)
+            .build();
         try (BufferedWriter writer = Files.newBufferedWriter(dict, StandardCharsets.UTF_8)) {
             writer.write("hello");
             writer.write('\n');
@@ -124,7 +130,10 @@ public class AnalysisTests extends OpenSearchTestCase {
         Path config = home.resolve("config");
         Files.createDirectory(config);
         Path dict = config.resolve("foo.dict");
-        Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        Settings nodeSettings = Settings.builder()
+            .put("foo.bar_path", "foo.dict")
+            .put(Environment.PATH_HOME_SETTING.getKey(), home)
+            .build();
         try (BufferedWriter writer = Files.newBufferedWriter(dict, StandardCharsets.UTF_8)) {
             writer.write("abcd");
             writer.write('\n');
@@ -150,7 +159,7 @@ public class AnalysisTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> Analysis.parseWordList(env, nodeSettings, "foo.bar", s -> s)
         );
-        assertTrue(ex.getMessage().contains("Resource path must be inside config directory"));
+        assertTrue(ex.getMessage().contains("setting [foo.bar_path] must be a relative path"));
     }
 
     public void testResolveAnalyzerPathRejectsPathTraversal() {

--- a/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
@@ -177,7 +177,7 @@ public class AnalysisModuleTests extends OpenSearchTestCase {
 
         Path wordListFile = generateWordList(home, words);
         settings = Settings.builder()
-            .loadFromSource("index: \n  word_list_path: " + wordListFile.toAbsolutePath(), XContentType.YAML)
+            .loadFromSource("index: \n  word_list_path: " + env.configDir().relativize(wordListFile), XContentType.YAML)
             .build();
 
         Set<?> wordList = Analysis.getWordSet(env, settings, "index.word_list");

--- a/server/src/test/java/org/opensearch/repositories/fs/FsRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/fs/FsRepositoryTests.java
@@ -273,9 +273,7 @@ public class FsRepositoryTests extends OpenSearchTestCase {
             "/usr/share/opensearch/data/nodes/0",    // absolute path (the reported POC payload)
             "..",                                    // parent-directory traversal
             "../escape",
-            "nested/../../escape",
-            "foo/../bar",                            // interior '..' is rejected by the strict string validator
-            "a/b/../c"
+            "nested/../../escape"
         );
         for (String basePath : maliciousBasePaths) {
             final Settings settings = Settings.builder()
@@ -301,21 +299,23 @@ public class FsRepositoryTests extends OpenSearchTestCase {
 
     public void testRelativeBasePathWithinPathRepoIsAccepted() {
         final Path repo = createTempDir();
-        final Settings settings = Settings.builder()
-            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
-            .put(Environment.PATH_REPO_SETTING.getKey(), repo.toAbsolutePath())
-            .put("location", repo)
-            .put(FsRepository.BASE_PATH_SETTING.getKey(), "nested/base/path")
-            .build();
-        final RepositoryMetadata metadata = new RepositoryMetadata("test", "fs", settings);
-        // A well-formed relative base_path that stays within path.repo must construct without throwing.
-        new FsRepository(
-            metadata,
-            new Environment(settings, null),
-            NamedXContentRegistry.EMPTY,
-            BlobStoreTestUtil.mockClusterService(),
-            new RecoverySettings(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
-        );
+        for (String basePath : List.of("nested/base/path", "foo/../bar", "a/b/../c")) {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
+                .put(Environment.PATH_REPO_SETTING.getKey(), repo.toAbsolutePath())
+                .put("location", repo)
+                .put(FsRepository.BASE_PATH_SETTING.getKey(), basePath)
+                .build();
+            final RepositoryMetadata metadata = new RepositoryMetadata("test", "fs", settings);
+            // A relative base_path that normalizes within path.repo must construct without throwing.
+            new FsRepository(
+                metadata,
+                new Environment(settings, null),
+                NamedXContentRegistry.EMPTY,
+                BlobStoreTestUtil.mockClusterService(),
+                new RecoverySettings(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
+            );
+        }
     }
 
     private void runGeneric(ThreadPool threadPool, Runnable runnable) throws InterruptedException {


### PR DESCRIPTION
## Description

Adds `Setting.relativePathSetting(...)`, a reusable convention for settings that must contain a relative path without escaping their caller-provided base directory.

The validator:

- rejects absolute POSIX, Windows, UNC, and drive-relative paths;
- treats both `/` and `\` as separators on every platform;
- rejects parent traversal only when normalization would escape the base directory;
- rejects malformed filesystem paths; and
- preserves empty-string semantics for optional settings.

The new setting is used by filesystem repository `base_path`, analysis file settings, Hunspell `ref_path`, and hyphenation pattern paths. Environment-aware containment checks remain in place as defense in depth, and Hunspell retains its stricter naming and cache-key allowlist.

## Motivation

Several path settings had independently implemented similar validation. Centralizing the common relative-path invariant makes the secure behavior conventional and reduces the chance that new path settings omit traversal validation.

This also replaces the filesystem repository's bespoke string validator while preserving its authoritative `path.repo` containment check. Safe paths containing an interior parent segment, such as `nested/../dictionary`, are accepted because they normalize without escaping the base.

Analysis file settings now consistently require paths relative to the OpenSearch configuration directory. Absolute paths that happen to resolve inside `config/` are no longer accepted.

## Validation

- `./gradlew :server:test --tests org.opensearch.common.settings.SettingTests --tests org.opensearch.index.analysis.AnalysisTests --tests org.opensearch.index.analysis.HunspellTokenFilterFactoryTests --tests org.opensearch.repositories.fs.FsRepositoryTests -Pcrypto.standard=FIPS-140-3`
- `./gradlew :modules:analysis-common:test --tests org.opensearch.analysis.common.CompoundAnalysisTests -Pcrypto.standard=FIPS-140-3`
- `./gradlew :server:spotlessJavaCheck :modules:analysis-common:spotlessJavaCheck`
- `git diff --check`

Signed-off-by: Craig Perkins <craig5008@gmail.com>
