### PR TITLE
Unify analytics cache interfaces behind one management plane

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/custom_cache_manager.rs
@@ -7,11 +7,12 @@
  */
 
 use crate::cache::metadata_cache::MutexFileMetadataCache;
+use crate::cache::page_index;
 use crate::cache::statistics_cache::CustomStatisticsCache;
 use crate::cache::statistics_cache::{
     compute_parquet_statistics, compute_parquet_statistics_from_metadata,
 };
-use crate::cache::{metadata_cache, page_index};
+use crate::cache::unified::{CacheKind, CacheStats, ManagedCache};
 use crate::indexed_table::parquet_bridge;
 use datafusion::datasource::physical_plan::parquet::metadata::DFParquetMetadata;
 use datafusion::execution::cache::cache_manager::{
@@ -19,7 +20,7 @@ use datafusion::execution::cache::cache_manager::{
 };
 use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::execution::cache::CacheAccessor;
-use log::{debug, error};
+use log::error;
 use native_bridge_common::log_debug;
 use object_store::path::Path;
 use object_store::ObjectMeta;
@@ -127,35 +128,56 @@ fn create_object_meta_from_file(
     Ok(vec![object_meta])
 }
 
-/// Custom CacheManager that holds cache references directly
+/// Custom CacheManager: a [`CacheKind`]-keyed registry of [`ManagedCache`]s
+/// plus the typed references the domain flows (warming, statistics
+/// derivation, DataFusion wiring) need.
+///
+/// Management operations (clear, limits, stats, per-file removal, contains)
+/// dispatch uniformly through the registry — adding a cache type means
+/// registering one more `Arc<dyn ManagedCache>`, not new match arms.
 pub struct CustomCacheManager {
-    /// Direct reference to the file metadata cache
+    /// Uniform management handles, one per registered cache kind.
+    caches: std::collections::HashMap<CacheKind, Arc<dyn ManagedCache>>,
+    /// Typed reference for the metadata warm/wiring flows (also in `caches`).
     file_metadata_cache: Option<Arc<MutexFileMetadataCache>>,
-    /// Direct reference to the statistics cache
+    /// Typed reference for the statistics flows (also in `caches`).
     statistics_cache: Option<Arc<CustomStatisticsCache>>,
-    column_index_registered: bool,
-    offset_index_registered: bool,
 }
 
 impl CustomCacheManager {
     /// Create a new CustomCacheManager
     pub fn new() -> Self {
         Self {
+            caches: std::collections::HashMap::new(),
             file_metadata_cache: None,
             statistics_cache: None,
-            column_index_registered: false,
-            offset_index_registered: false,
         }
+    }
+
+    /// Look up the management handle for a cache kind, if registered.
+    pub fn managed(&self, kind: CacheKind) -> Option<&Arc<dyn ManagedCache>> {
+        self.caches.get(&kind)
+    }
+
+    fn managed_or_err(&self, kind: CacheKind) -> Result<&Arc<dyn ManagedCache>, String> {
+        self.managed(kind)
+            .ok_or_else(|| format!("No {} cache configured", kind))
     }
 
     /// Set the file metadata cache
     pub fn set_file_metadata_cache(&mut self, cache: Arc<MutexFileMetadataCache>) {
+        self.caches
+            .insert(CacheKind::Metadata, cache.clone() as Arc<dyn ManagedCache>);
         self.file_metadata_cache = Some(cache);
         log_debug!("[CACHE INFO] File metadata cache set in CustomCacheManager");
     }
 
     /// Set the statistics cache
     pub fn set_statistics_cache(&mut self, cache: Arc<CustomStatisticsCache>) {
+        self.caches.insert(
+            CacheKind::Statistics,
+            cache.clone() as Arc<dyn ManagedCache>,
+        );
         self.statistics_cache = Some(cache);
         log_debug!("[CACHE INFO] Statistics cache set in CustomCacheManager");
     }
@@ -163,8 +185,9 @@ impl CustomCacheManager {
     /// Register the column index cache with the given size limit.
     /// Sets the limit on the process-global `COLUMN_INDEX_CACHE` singleton.
     pub fn set_column_index_cache(&mut self, size_limit: usize) {
-        crate::cache::page_index::set_column_index_cache_limit(size_limit);
-        self.column_index_registered = true;
+        let handle: Arc<dyn ManagedCache> = Arc::new(page_index::ColumnIndexCacheHandle);
+        handle.set_limit(size_limit);
+        self.caches.insert(CacheKind::ColumnIndex, handle);
         log_debug!(
             "[CACHE INFO] Column index cache registered (limit={} bytes)",
             size_limit
@@ -174,8 +197,9 @@ impl CustomCacheManager {
     /// Register the offset index cache with the given size limit.
     /// Sets the limit on the process-global `OFFSET_INDEX_CACHE` singleton.
     pub fn set_offset_index_cache(&mut self, size_limit: usize) {
-        crate::cache::page_index::set_offset_index_cache_limit(size_limit);
-        self.offset_index_registered = true;
+        let handle: Arc<dyn ManagedCache> = Arc::new(page_index::OffsetIndexCacheHandle);
+        handle.set_limit(size_limit);
+        self.caches.insert(CacheKind::OffsetIndex, handle);
         log_debug!(
             "[CACHE INFO] Offset index cache registered (limit={} bytes)",
             size_limit
@@ -294,225 +318,102 @@ impl CustomCacheManager {
 
         for file_path in file_paths {
             let mut any_removed = false;
-            let mut errors = Vec::new();
 
-            // Remove from metadata cache
-            {
-                let path = Path::from(file_path.clone());
-                if let Some(cache) = &self.file_metadata_cache {
-                    match cache.inner.lock() {
-                        Ok(cache_guard) => {
-                            if cache_guard.remove(&path).is_some() {
-                                any_removed = true;
-                            } else {
-                                log_debug!(
-                                    "[CACHE INFO] File not found in metadata cache: {}",
-                                    file_path
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            errors.push(format!("Metadata cache: Cache remove failed: {}", e));
-                        }
-                    }
-                } else {
-                    errors.push("No metadata cache configured".to_string());
-                }
-            }
-
-            // Remove from statistics cache
-            if let Some(cache) = &self.statistics_cache {
-                let path = Path::from(file_path.clone());
-                if cache.remove(&path).is_some() {
+            for cache in self.caches.values() {
+                if cache.remove_file(file_path) {
                     any_removed = true;
+                } else {
+                    log_debug!(
+                        "[CACHE INFO] File not found in {} cache: {}",
+                        cache.kind(),
+                        file_path
+                    );
                 }
             }
 
-            // Evict from scoped page-index caches (CI + OI) by file prefix
-            if self.column_index_registered || self.offset_index_registered {
-                page_index::evict_file_from_scoped_cache(file_path);
-                any_removed = true;
-            }
-
-            let removed = if !errors.is_empty() && !any_removed {
-                false
-            } else {
-                any_removed
-            };
-
-            results.push((file_path.clone(), removed));
+            results.push((file_path.clone(), any_removed));
         }
 
         Ok(results)
     }
 
-    /// Check if a file exists in any cache
+    /// Check if a file exists in the file-keyed caches (metadata, statistics).
+    ///
+    /// The cell-keyed page-index caches are intentionally excluded — their
+    /// `contains_file` is an entries>0 approximation, which would make this
+    /// whole-manager probe report false positives.
     pub fn contains_file(&self, file_path: &str) -> bool {
-        let mut found = false;
-
-        // Check metadata cache
-        {
-            let path = Path::from(file_path);
-            if let Some(cache) = &self.file_metadata_cache {
-                if cache.get(&path).is_some() {
-                    found = true;
-                }
-            }
-        }
-
-        // Check statistics cache
-        if let Some(cache) = &self.statistics_cache {
-            let path = Path::from(file_path);
-            if cache.contains_key(&path) {
-                found = true;
-            }
-        }
-
-        found
+        [CacheKind::Metadata, CacheKind::Statistics]
+            .iter()
+            .filter_map(|kind| self.managed(*kind))
+            .any(|cache| cache.contains_file(file_path))
     }
 
     /// Check if a file exists in a specific cache type
     pub fn contains_file_by_type(&self, file_path: &str, cache_type: &str) -> bool {
-        match cache_type {
-            crate::cache::metadata_cache::CACHE_TYPE_METADATA => {
-                let path = Path::from(file_path);
-                self.file_metadata_cache
-                    .as_ref()
-                    .and_then(|cache| cache.get(&path))
-                    .is_some()
-            }
-            crate::cache::metadata_cache::CACHE_TYPE_STATS => self
-                .statistics_cache
-                .as_ref()
-                .map_or(false, |cache| cache.contains_key(&Path::from(file_path))),
-            metadata_cache::CACHE_TYPE_COLUMN_INDEX => {
-                if !self.column_index_registered {
-                    return false;
-                }
-                let stats = page_index::column_index_cache_stats();
-                // CI is keyed by (file, col) — a file is "present" if entries > 0 and
-                // we match by prefix; check via evict-probe is heavy so we approximate
-                // with entries > 0. A per-file lookup requires iterating DashMap — not
-                // worth it for a boolean check; callers use this for diagnostics only.
-                stats.entries > 0
-            }
-            metadata_cache::CACHE_TYPE_OFFSET_INDEX => {
-                if !self.offset_index_registered {
-                    return false;
-                }
-                let stats = page_index::offset_index_cache_stats();
-                stats.entries > 0
-            }
-            _ => false,
-        }
+        let Ok(kind) = CacheKind::parse(cache_type) else {
+            return false;
+        };
+        self.managed(kind)
+            .map_or(false, |cache| cache.contains_file(file_path))
+    }
+
+    /// Update a cache's size limit by kind.
+    pub fn update_cache_limit(&self, kind: CacheKind, new_limit: usize) -> Result<(), String> {
+        self.managed_or_err(kind)?.set_limit(new_limit);
+        Ok(())
     }
 
     /// Update the file metadata cache size limit
     pub fn update_metadata_cache_limit(&self, new_limit: usize) {
-        if let Some(cache) = &self.file_metadata_cache {
-            cache.update_cache_limit(new_limit);
-        }
+        let _ = self.update_cache_limit(CacheKind::Metadata, new_limit);
     }
 
     /// Update the statistics cache size limit
     pub fn update_statistics_cache_limit(&self, new_limit: usize) -> Result<(), String> {
-        if let Some(cache) = &self.statistics_cache {
-            cache
-                .update_size_limit(new_limit)
-                .map_err(|e| format!("Failed to update statistics cache limit: {:?}", e))
-        } else {
-            Err("No statistics cache configured".to_string())
-        }
+        self.update_cache_limit(CacheKind::Statistics, new_limit)
     }
 
-    /// Get total memory consumed by all caches
+    /// Get total memory consumed by the manager-owned caches.
+    ///
+    /// Sums metadata + statistics only — the CI/OI page-index caches are
+    /// process-global singletons budgeted separately, matching the historical
+    /// semantics of this API (surfaced as the manager-level memory number).
     pub fn get_total_memory_consumed(&self) -> usize {
-        let mut total = 0;
-
-        // Add metadata cache memory
-        if let Some(cache) = &self.file_metadata_cache {
-            if let Ok(cache_guard) = cache.inner.lock() {
-                total += cache_guard.memory_used();
-            }
-        }
-
-        // Add statistics cache memory
-        if let Some(cache) = &self.statistics_cache {
-            total += cache.memory_consumed();
-        }
-
-        total
+        [CacheKind::Metadata, CacheKind::Statistics]
+            .iter()
+            .filter_map(|kind| self.managed(*kind))
+            .map(|cache| cache.stats().used_bytes)
+            .sum()
     }
 
     /// Clear all caches
     pub fn clear_all(&self) {
-        if let Some(cache) = &self.file_metadata_cache {
+        for cache in self.caches.values() {
             cache.clear();
-        }
-        if let Some(cache) = &self.statistics_cache {
-            cache.clear();
-        }
-        if self.column_index_registered || self.offset_index_registered {
-            page_index::clear_scoped_cache();
         }
     }
 
     /// Clear specific cache type
     pub fn clear_cache_type(&self, cache_type: &str) -> Result<(), String> {
-        match cache_type {
-            metadata_cache::CACHE_TYPE_METADATA => {
-                if let Some(cache) = &self.file_metadata_cache {
-                    cache.clear();
-                    Ok(())
-                } else {
-                    Err("No metadata cache configured".to_string())
-                }
-            }
-            metadata_cache::CACHE_TYPE_STATS => {
-                if let Some(cache) = &self.statistics_cache {
-                    cache.clear();
-                    Ok(())
-                } else {
-                    Err("No statistics cache configured".to_string())
-                }
-            }
-            metadata_cache::CACHE_TYPE_COLUMN_INDEX | metadata_cache::CACHE_TYPE_OFFSET_INDEX => {
-                page_index::clear_scoped_cache();
-                Ok(())
-            }
-            _ => Err(format!("Unknown cache type: {}", cache_type)),
-        }
+        let kind = CacheKind::parse(cache_type)
+            .map_err(|_| format!("Unknown cache type: {}", cache_type))?;
+        self.managed_or_err(kind)?.clear();
+        Ok(())
+    }
+
+    /// Uniform stats snapshot for a cache kind (zeros when not registered).
+    pub fn cache_stats(&self, kind: CacheKind) -> CacheStats {
+        self.managed(kind)
+            .map(|cache| cache.stats())
+            .unwrap_or_default()
     }
 
     /// Get memory consumed by specific cache type
     pub fn get_memory_consumed_by_type(&self, cache_type: &str) -> Result<usize, String> {
-        match cache_type {
-            metadata_cache::CACHE_TYPE_METADATA => {
-                if let Some(cache) = &self.file_metadata_cache {
-                    if let Ok(cache_guard) = cache.inner.lock() {
-                        Ok(cache_guard.memory_used())
-                    } else {
-                        Err("Failed to lock metadata cache".to_string())
-                    }
-                } else {
-                    Err("No metadata cache configured".to_string())
-                }
-            }
-            metadata_cache::CACHE_TYPE_STATS => {
-                if let Some(cache) = &self.statistics_cache {
-                    Ok(cache.memory_consumed())
-                } else {
-                    Err("No statistics cache configured".to_string())
-                }
-            }
-            metadata_cache::CACHE_TYPE_COLUMN_INDEX => {
-                Ok(page_index::column_index_cache_stats().used_bytes)
-            }
-            metadata_cache::CACHE_TYPE_OFFSET_INDEX => {
-                Ok(page_index::offset_index_cache_stats().used_bytes)
-            }
-            _ => Err(format!("Unknown cache type: {}", cache_type)),
-        }
+        let kind = CacheKind::parse(cache_type)
+            .map_err(|_| format!("Unknown cache type: {}", cache_type))?;
+        Ok(self.managed_or_err(kind)?.stats().used_bytes)
     }
 
     /// Fetch a parquet file's footer, warm the metadata cache, and return the
@@ -901,90 +802,32 @@ impl CustomCacheManager {
         self.statistics_cache_compute_and_put(file_path)
     }
 
-    /// Get statistics cache hit count
-    pub fn statistics_cache_hit_count(&self) -> usize {
-        self.statistics_cache
-            .as_ref()
-            .map(|cache| cache.hit_count())
-            .unwrap_or(0)
-    }
-
-    /// Get statistics cache miss count
-    pub fn statistics_cache_miss_count(&self) -> usize {
-        self.statistics_cache
-            .as_ref()
-            .map(|cache| cache.miss_count())
-            .unwrap_or(0)
-    }
-
     /// Get statistics cache hit rate
     pub fn statistics_cache_hit_rate(&self) -> f64 {
-        self.statistics_cache
-            .as_ref()
-            .map(|cache| cache.hit_rate())
-            .unwrap_or(0.0)
+        let stats = self.cache_stats(CacheKind::Statistics);
+        let total = stats.hits + stats.misses;
+        if total == 0 {
+            0.0
+        } else {
+            stats.hits as f64 / total as f64
+        }
     }
 
-    /// Get statistics cache entry count
-    pub fn statistics_cache_entry_count(&self) -> usize {
-        self.statistics_cache
-            .as_ref()
-            .map(|cache| <CustomStatisticsCache as CacheAccessor<_, _>>::len(cache))
-            .unwrap_or(0)
-    }
-
-    /// Get statistics cache size limit in bytes
-    pub fn statistics_cache_size_limit(&self) -> usize {
-        self.statistics_cache
-            .as_ref()
-            .map(|cache| cache.current_size_limit())
-            .unwrap_or(0)
+    /// Reset a cache's diagnostic counters by kind (no-op when not registered).
+    pub fn reset_cache_stats(&self, kind: CacheKind) {
+        if let Some(cache) = self.managed(kind) {
+            cache.reset_counters();
+        }
     }
 
     /// Reset statistics cache stats
     pub fn statistics_cache_reset_stats(&self) {
-        if let Some(cache) = &self.statistics_cache {
-            cache.reset_stats();
-        }
-    }
-
-    /// Get metadata cache hit count
-    pub fn metadata_cache_hit_count(&self) -> usize {
-        self.file_metadata_cache
-            .as_ref()
-            .map(|cache| cache.hit_count())
-            .unwrap_or(0)
-    }
-
-    /// Get metadata cache miss count
-    pub fn metadata_cache_miss_count(&self) -> usize {
-        self.file_metadata_cache
-            .as_ref()
-            .map(|cache| cache.miss_count())
-            .unwrap_or(0)
-    }
-
-    /// Get metadata cache entry count
-    pub fn metadata_cache_entry_count(&self) -> usize {
-        self.file_metadata_cache
-            .as_ref()
-            .map(|cache| <MutexFileMetadataCache as CacheAccessor<_, _>>::len(cache))
-            .unwrap_or(0)
-    }
-
-    /// Get metadata cache size limit in bytes
-    pub fn metadata_cache_size_limit(&self) -> usize {
-        self.file_metadata_cache
-            .as_ref()
-            .map(|cache| cache.get_cache_limit())
-            .unwrap_or(0)
+        self.reset_cache_stats(CacheKind::Statistics);
     }
 
     /// Reset metadata cache stats
     pub fn metadata_cache_reset_stats(&self) {
-        if let Some(cache) = &self.file_metadata_cache {
-            cache.reset_stats();
-        }
+        self.reset_cache_stats(CacheKind::Metadata);
     }
 }
 
@@ -1004,13 +847,14 @@ mod tests {
         clear_scoped_cache_for_test();
 
         let mut mgr = CustomCacheManager::new();
-        assert!(!mgr.column_index_registered);
+        assert!(mgr.managed(CacheKind::ColumnIndex).is_none());
 
         let limit = 16 * 1024 * 1024; // 16 MB
         mgr.set_column_index_cache(limit);
 
-        assert!(mgr.column_index_registered);
+        assert!(mgr.managed(CacheKind::ColumnIndex).is_some());
         assert_eq!(column_index_cache_stats().limit_bytes, limit);
+        assert_eq!(mgr.cache_stats(CacheKind::ColumnIndex).limit_bytes, limit);
 
         clear_scoped_cache_for_test();
     }
@@ -1021,13 +865,14 @@ mod tests {
         clear_scoped_cache_for_test();
 
         let mut mgr = CustomCacheManager::new();
-        assert!(!mgr.offset_index_registered);
+        assert!(mgr.managed(CacheKind::OffsetIndex).is_none());
 
         let limit = 32 * 1024 * 1024; // 32 MB
         mgr.set_offset_index_cache(limit);
 
-        assert!(mgr.offset_index_registered);
+        assert!(mgr.managed(CacheKind::OffsetIndex).is_some());
         assert_eq!(offset_index_cache_stats().limit_bytes, limit);
+        assert_eq!(mgr.cache_stats(CacheKind::OffsetIndex).limit_bytes, limit);
 
         clear_scoped_cache_for_test();
     }
@@ -1039,11 +884,14 @@ mod tests {
 
         let mut mgr = CustomCacheManager::new();
         mgr.set_column_index_cache(16 * 1024 * 1024);
+        mgr.set_offset_index_cache(16 * 1024 * 1024);
 
         // clear_cache_type must succeed for COLUMN_INDEX
         assert!(mgr.clear_cache_type(CACHE_TYPE_COLUMN_INDEX).is_ok());
-        // and for OFFSET_INDEX too (both route to clear_scoped_cache)
+        // and for OFFSET_INDEX (each kind clears independently now)
         assert!(mgr.clear_cache_type(CACHE_TYPE_OFFSET_INDEX).is_ok());
+        // unregistered / unknown types are errors
+        assert!(mgr.clear_cache_type("BOGUS").is_err());
 
         clear_scoped_cache_for_test();
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/eviction_policy.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/eviction_policy.rs
@@ -8,10 +8,19 @@
 
 //! # Cache Policy Module
 //!
-//! Simple pluggable cache eviction policies for statistics cache.
+//! One pluggable eviction-policy trait shared by every cache in this crate.
+//!
+//! [`EvictionPolicy<K>`] is generic over the cache's key type, so the same
+//! trait serves the `String`-keyed statistics cache and the typed-key
+//! (`CiCellKey` / `OiCellKey`) page-index caches. Adding a new policy
+//! (e.g. S3-FIFO) means implementing this one trait and adding a
+//! [`CacheEvictionPolicy`] variant — no cache implementation changes.
 
 use datafusion::common::instant;
 use instant::Instant;
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::hash::Hash;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use thiserror::Error;
@@ -26,42 +35,11 @@ pub enum CacheError {
 /// Result type for cache operations
 pub type CacheResult<T> = Result<T, CacheError>;
 
-/// Core trait for cache eviction policies.
-///
-/// All methods take `&self` — implementations use interior mutability
-/// (`DashMap`, atomics) so the trait object can be shared as `Arc<dyn CachePolicy>`
-/// without an outer `Mutex`. This means `get` on the parent cache never contends
-/// on a global lock, only on the per-shard DashMap locks inside the policy.
-pub trait CachePolicy: Send + Sync {
-    /// Called when a cache entry is accessed (updates recency/frequency metadata).
-    fn on_access(&self, key: &str, size: usize);
-
-    /// Called when a cache entry is inserted.
-    fn on_insert(&self, key: &str, size: usize);
-
-    /// Called when a cache entry is removed.
-    fn on_remove(&self, key: &str);
-
-    /// Select entries for eviction to free at least `target_size` bytes.
-    /// Returns string keys ordered by eviction priority (lowest-priority first).
-    fn select_for_eviction(&self, target_size: usize) -> Vec<String>;
-
-    /// Reset all policy state (called on cache clear).
-    fn clear(&self);
-
-    /// Name of this policy, for logging/stats.
-    fn policy_name(&self) -> &'static str;
-}
-
 /// Unified eviction policy selector for all caches in this crate.
 ///
-/// - `Lru` / `Lfu` — used by `CustomStatisticsCache` and the metadata cache
-///   (backed by [`CachePolicy`] + [`create_policy`]).
-/// - `Fifo` — used by `BoundedCache` (CI/OI scoped caches) via
-///   `ScopedEvictionPolicy` + `FifoPolicy`.
-///
 /// One enum for all caches means `df_create_cache` parses the Java-supplied
-/// eviction string once and routes uniformly without separate enums per family.
+/// eviction string once and routes uniformly. Which policies are valid for
+/// which cache is enforced in one place: [`crate::cache::CacheKind::validate_policy`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheEvictionPolicy {
     Lru,
@@ -69,8 +47,67 @@ pub enum CacheEvictionPolicy {
     Fifo,
 }
 
+impl CacheEvictionPolicy {
+    /// Parse the Java-supplied eviction string ("LRU"/"LFU"/"FIFO", any case).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_uppercase().as_str() {
+            "LRU" => Ok(CacheEvictionPolicy::Lru),
+            "LFU" => Ok(CacheEvictionPolicy::Lfu),
+            "FIFO" => Ok(CacheEvictionPolicy::Fifo),
+            _ => Err(format!("unsupported eviction type: {}", s)),
+        }
+    }
+}
+
 /// Backward-compatible alias — will be removed once all call sites are migrated.
 pub type PolicyType = CacheEvictionPolicy;
+
+/// Core trait for cache eviction policies, generic over the cache key type.
+///
+/// All methods take `&self` — implementations use interior mutability
+/// (`DashMap`, `Mutex`, atomics) so the trait object can be shared as
+/// `Arc<dyn EvictionPolicy<K>>` without an outer lock.
+///
+/// # Eviction protocol
+///
+/// The owning cache drives eviction by calling [`Self::next_victim`] in a loop
+/// until it has freed enough bytes. `next_victim` **pops** the candidate from
+/// the policy's bookkeeping; the cache then removes it from its own store and
+/// must NOT call `on_remove` for that key (the policy already forgot it).
+/// Caches that tolerate stale policy entries (lazy deletion on overwrite, see
+/// `BoundedCache`) simply skip victims that are no longer present and call
+/// `next_victim` again.
+///
+/// # Implementing a new policy (e.g. S3-FIFO)
+///
+/// 1. Implement this trait with interior mutability.
+/// 2. Add a [`CacheEvictionPolicy`] variant and wire it in [`create_policy`]
+///    (the exhaustive match makes the compiler flag the missing arm).
+/// 3. Allow it for the target caches in `CacheKind::validate_policy`.
+pub trait EvictionPolicy<K>: Send + Sync {
+    /// Called when a cache entry is accessed (updates recency/frequency
+    /// metadata). Policies that don't track access (FIFO) treat this as a
+    /// no-op so the cache read path stays lock-free.
+    fn on_access(&self, key: &K, size: usize);
+
+    /// Called when a cache entry is inserted (or an existing key overwritten).
+    fn on_insert(&self, key: &K, size: usize);
+
+    /// Called when an entry is explicitly removed (file eviction, clear).
+    /// NOT called for victims returned by [`Self::next_victim`].
+    fn on_remove(&self, key: &K);
+
+    /// Pop and return the next eviction candidate (lowest-priority entry),
+    /// removing it from the policy's bookkeeping. Returns `None` when the
+    /// policy has no more candidates.
+    fn next_victim(&self) -> Option<K>;
+
+    /// Reset all policy state (called on cache clear).
+    fn clear(&self);
+
+    /// Name of this policy, for logging/stats.
+    fn policy_name(&self) -> &'static str;
+}
 
 /// Metadata tracked per cached entry for eviction ordering.
 /// Stored inside the policy's `DashMap`, mutated via `get_mut`.
@@ -82,7 +119,7 @@ pub struct CacheEntryMetadata {
 }
 
 impl CacheEntryMetadata {
-    pub fn new(_key: String, size: usize) -> Self {
+    pub fn new(size: usize) -> Self {
         Self {
             size,
             last_accessed: Instant::now(),
@@ -99,12 +136,12 @@ impl CacheEntryMetadata {
 }
 
 /// LRU (Least Recently Used) policy
-pub struct LruPolicy {
-    entries: dashmap::DashMap<String, CacheEntryMetadata>,
+pub struct LruPolicy<K: Eq + Hash> {
+    entries: dashmap::DashMap<K, CacheEntryMetadata>,
     total_size: std::sync::atomic::AtomicUsize,
 }
 
-impl LruPolicy {
+impl<K: Eq + Hash> LruPolicy<K> {
     pub fn new() -> Self {
         Self {
             entries: dashmap::DashMap::new(),
@@ -113,75 +150,55 @@ impl LruPolicy {
     }
 }
 
-impl Default for LruPolicy {
+impl<K: Eq + Hash> Default for LruPolicy<K> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl CachePolicy for LruPolicy {
-    fn on_access(&self, key: &str, size: usize) {
+impl<K: Eq + Hash + Clone + Send + Sync> EvictionPolicy<K> for LruPolicy<K> {
+    fn on_access(&self, key: &K, size: usize) {
         match self.entries.get_mut(key) {
             Some(mut entry) => {
                 entry.on_access();
             }
             None => {
                 // Entry missing from policy metadata (can happen transiently) — insert it.
-                let metadata = CacheEntryMetadata::new(key.to_string(), size);
-                self.entries.insert(key.to_string(), metadata);
+                self.entries
+                    .insert(key.clone(), CacheEntryMetadata::new(size));
                 self.total_size.fetch_add(size, Ordering::Relaxed);
             }
         }
     }
 
-    fn on_insert(&self, key: &str, size: usize) {
-        let metadata = CacheEntryMetadata::new(key.to_string(), size);
-        if let Some(old_entry) = self.entries.insert(key.to_string(), metadata) {
+    fn on_insert(&self, key: &K, size: usize) {
+        if let Some(old_entry) = self
+            .entries
+            .insert(key.clone(), CacheEntryMetadata::new(size))
+        {
             self.total_size.fetch_sub(old_entry.size, Ordering::Relaxed);
         }
         self.total_size.fetch_add(size, Ordering::Relaxed);
     }
 
-    fn on_remove(&self, key: &str) {
+    fn on_remove(&self, key: &K) {
         if let Some((_, entry)) = self.entries.remove(key) {
             self.total_size.fetch_sub(entry.size, Ordering::Relaxed);
         }
     }
 
-    fn select_for_eviction(&self, target_size: usize) -> Vec<String> {
-        if target_size == 0 {
-            return Vec::new();
-        }
-
-        // Collect entries with access times
-        let mut entries: Vec<_> = self
+    fn next_victim(&self) -> Option<K> {
+        // Least recently accessed entry. O(n) scan per victim — same asymptotic
+        // work as the previous batch-sort selection, spread across calls.
+        let victim = self
             .entries
             .iter()
-            .map(|entry| {
-                let key = entry.key().clone();
-                let last_accessed = entry.value().last_accessed;
-                (key, last_accessed)
-            })
-            .collect();
-
-        // Sort by access time (oldest first)
-        entries.sort_by_key(|(_, last_accessed)| *last_accessed);
-
-        // Select entries for eviction until target size is reached
-        let mut candidates = Vec::new();
-        let mut freed_size = 0;
-
-        for (key, _) in entries {
-            if freed_size >= target_size {
-                break;
-            }
-            if let Some(entry) = self.entries.get(&key) {
-                freed_size += entry.size;
-                candidates.push(key);
-            }
+            .min_by_key(|entry| entry.value().last_accessed)
+            .map(|entry| entry.key().clone())?;
+        if let Some((_, entry)) = self.entries.remove(&victim) {
+            self.total_size.fetch_sub(entry.size, Ordering::Relaxed);
         }
-
-        candidates
+        Some(victim)
     }
 
     fn clear(&self) {
@@ -195,12 +212,12 @@ impl CachePolicy for LruPolicy {
 }
 
 /// LFU (Least Frequently Used) policy
-pub struct LfuPolicy {
-    entries: dashmap::DashMap<String, CacheEntryMetadata>,
+pub struct LfuPolicy<K: Eq + Hash> {
+    entries: dashmap::DashMap<K, CacheEntryMetadata>,
     total_size: std::sync::atomic::AtomicUsize,
 }
 
-impl LfuPolicy {
+impl<K: Eq + Hash> LfuPolicy<K> {
     pub fn new() -> Self {
         Self {
             entries: dashmap::DashMap::new(),
@@ -209,77 +226,59 @@ impl LfuPolicy {
     }
 }
 
-impl Default for LfuPolicy {
+impl<K: Eq + Hash> Default for LfuPolicy<K> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl CachePolicy for LfuPolicy {
-    fn on_access(&self, key: &str, size: usize) {
+impl<K: Eq + Hash + Clone + Send + Sync> EvictionPolicy<K> for LfuPolicy<K> {
+    fn on_access(&self, key: &K, size: usize) {
         match self.entries.get_mut(key) {
             Some(mut entry) => {
                 entry.on_access();
             }
             None => {
-                let metadata = CacheEntryMetadata::new(key.to_string(), size);
-                self.entries.insert(key.to_string(), metadata);
+                self.entries
+                    .insert(key.clone(), CacheEntryMetadata::new(size));
                 self.total_size.fetch_add(size, Ordering::Relaxed);
             }
         }
     }
 
-    fn on_insert(&self, key: &str, size: usize) {
-        let metadata = CacheEntryMetadata::new(key.to_string(), size);
-        if let Some(old_entry) = self.entries.insert(key.to_string(), metadata) {
+    fn on_insert(&self, key: &K, size: usize) {
+        if let Some(old_entry) = self
+            .entries
+            .insert(key.clone(), CacheEntryMetadata::new(size))
+        {
             self.total_size.fetch_sub(old_entry.size, Ordering::Relaxed);
         }
         self.total_size.fetch_add(size, Ordering::Relaxed);
     }
 
-    fn on_remove(&self, key: &str) {
+    fn on_remove(&self, key: &K) {
         if let Some((_, entry)) = self.entries.remove(key) {
             self.total_size.fetch_sub(entry.size, Ordering::Relaxed);
         }
     }
 
-    fn select_for_eviction(&self, target_size: usize) -> Vec<String> {
-        if target_size == 0 {
-            return Vec::new();
-        }
-
-        // Collect entries with access counts
-        let mut entries: Vec<_> = self
+    fn next_victim(&self) -> Option<K> {
+        // Least frequently accessed entry; recency breaks ties (same ordering
+        // as the previous batch-sort selection).
+        let victim = self
             .entries
             .iter()
-            .map(|entry| {
-                let key = entry.key().clone();
-                let access_count = entry.value().access_count;
-                let last_accessed = entry.value().last_accessed;
-                (key, access_count, last_accessed)
+            .min_by(|a, b| {
+                let (av, bv) = (a.value(), b.value());
+                av.access_count
+                    .cmp(&bv.access_count)
+                    .then(av.last_accessed.cmp(&bv.last_accessed))
             })
-            .collect();
-
-        // Sort by access count (least frequent first), then by time for tie-breaking
-        entries.sort_by(|(_, count_a, time_a), (_, count_b, time_b)| {
-            count_a.cmp(count_b).then(time_a.cmp(time_b))
-        });
-
-        // Select entries for eviction until target size is reached
-        let mut candidates = Vec::new();
-        let mut freed_size = 0;
-
-        for (key, _, _) in entries {
-            if freed_size >= target_size {
-                break;
-            }
-            if let Some(entry) = self.entries.get(&key) {
-                freed_size += entry.size;
-                candidates.push(key);
-            }
+            .map(|entry| entry.key().clone())?;
+        if let Some((_, entry)) = self.entries.remove(&victim) {
+            self.total_size.fetch_sub(entry.size, Ordering::Relaxed);
         }
-
-        candidates
+        Some(victim)
     }
 
     fn clear(&self) {
@@ -292,19 +291,75 @@ impl CachePolicy for LfuPolicy {
     }
 }
 
-/// Create a [`CachePolicy`] (LRU or LFU) from `CacheEvictionPolicy`.
+/// Insert-order (FIFO) eviction policy.
 ///
-/// Returns `None` for `Fifo` — FIFO uses `ScopedEvictionPolicy` via
-/// `BoundedCache::with_named_policy`, not this trait. Callers that receive
-/// `None` should route to `BoundedCache` instead.
+/// Oldest-inserted entry is evicted first. Access order is not tracked —
+/// `on_access` is a no-op, so cache reads never touch the queue. Stale entries
+/// (from overwrites) are left in the queue and skipped by the owning cache's
+/// eviction loop (lazy deletion; see `BoundedCache::drain_to_limit`).
+pub struct FifoPolicy<K> {
+    /// Uncontended in practice: all mutating policy calls happen inside the
+    /// owning cache's write path.
+    queue: Mutex<VecDeque<K>>,
+}
+
+impl<K> FifoPolicy<K> {
+    pub fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
+impl<K> Default for FifoPolicy<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: Clone + PartialEq + Send + Sync> EvictionPolicy<K> for FifoPolicy<K> {
+    fn on_access(&self, _key: &K, _size: usize) {
+        // FIFO does not track access order — reads stay lock-free.
+    }
+
+    fn on_insert(&self, key: &K, _size: usize) {
+        self.queue.lock().push_back(key.clone());
+    }
+
+    fn on_remove(&self, key: &K) {
+        // O(n) scan — only called from evict_by_prefix (cold path).
+        self.queue.lock().retain(|k| k != key);
+    }
+
+    fn next_victim(&self) -> Option<K> {
+        self.queue.lock().pop_front()
+    }
+
+    fn clear(&self) {
+        self.queue.lock().clear();
+    }
+
+    fn policy_name(&self) -> &'static str {
+        "fifo"
+    }
+}
+
+/// Create an [`EvictionPolicy`] from a [`CacheEvictionPolicy`] selector.
+///
+/// Total over the enum: every cache accepts every policy object; which
+/// policies are *allowed* per cache type is validated separately in
+/// `CacheKind::validate_policy` (so the rule lives in one place).
 ///
 /// When a new variant is added to `CacheEvictionPolicy`, the compiler will
 /// flag the missing arm here.
-pub fn create_policy(policy_type: CacheEvictionPolicy) -> Option<Arc<dyn CachePolicy>> {
+pub fn create_policy<K>(policy_type: CacheEvictionPolicy) -> Arc<dyn EvictionPolicy<K>>
+where
+    K: Eq + Hash + Clone + PartialEq + Send + Sync + 'static,
+{
     match policy_type {
-        CacheEvictionPolicy::Lru => Some(Arc::new(LruPolicy::new())),
-        CacheEvictionPolicy::Lfu => Some(Arc::new(LfuPolicy::new())),
-        CacheEvictionPolicy::Fifo => None,
+        CacheEvictionPolicy::Lru => Arc::new(LruPolicy::new()),
+        CacheEvictionPolicy::Lfu => Arc::new(LfuPolicy::new()),
+        CacheEvictionPolicy::Fifo => Arc::new(FifoPolicy::new()),
     }
 }
 
@@ -316,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_cache_entry_metadata() {
-        let mut metadata = CacheEntryMetadata::new("test_key".to_string(), 1024);
+        let mut metadata = CacheEntryMetadata::new(1024);
         assert_eq!(metadata.size, 1024);
         assert_eq!(metadata.access_count, 1);
 
@@ -330,42 +385,79 @@ mod tests {
 
     #[test]
     fn test_create_policy() {
-        let lru_policy = create_policy(PolicyType::Lru).unwrap();
+        let lru_policy = create_policy::<String>(PolicyType::Lru);
         assert_eq!(lru_policy.policy_name(), "lru");
 
-        let lfu_policy = create_policy(PolicyType::Lfu).unwrap();
+        let lfu_policy = create_policy::<String>(PolicyType::Lfu);
         assert_eq!(lfu_policy.policy_name(), "lfu");
+
+        let fifo_policy = create_policy::<String>(PolicyType::Fifo);
+        assert_eq!(fifo_policy.policy_name(), "fifo");
+    }
+
+    #[test]
+    fn test_parse_eviction_policy() {
+        assert_eq!(
+            CacheEvictionPolicy::parse("lru").unwrap(),
+            CacheEvictionPolicy::Lru
+        );
+        assert_eq!(
+            CacheEvictionPolicy::parse("LFU").unwrap(),
+            CacheEvictionPolicy::Lfu
+        );
+        assert_eq!(
+            CacheEvictionPolicy::parse("Fifo").unwrap(),
+            CacheEvictionPolicy::Fifo
+        );
+        assert!(CacheEvictionPolicy::parse("clock").is_err());
     }
 
     #[test]
     fn test_lru_policy_basic_operations() {
-        let mut policy = LruPolicy::new();
-        assert_eq!(policy.policy_name(), "lru");
+        let policy: LruPolicy<String> = LruPolicy::new();
+        assert_eq!(EvictionPolicy::policy_name(&policy), "lru");
 
-        policy.on_insert("key1", 100);
-        policy.on_insert("key2", 200);
-        policy.on_access("key1", 100);
-        policy.on_remove("key1");
-        policy.clear();
+        policy.on_insert(&"key1".to_string(), 100);
+        policy.on_insert(&"key2".to_string(), 200);
+        policy.on_access(&"key1".to_string(), 100);
+        policy.on_remove(&"key1".to_string());
+        EvictionPolicy::clear(&policy);
+    }
+
+    /// Drain victims until at least `target_size` bytes would be freed —
+    /// mirrors how the owning caches drive `next_victim`.
+    fn drain_for<K: Clone>(
+        policy: &dyn EvictionPolicy<K>,
+        sizes: &dyn Fn(&K) -> usize,
+        target_size: usize,
+    ) -> Vec<K> {
+        let mut freed = 0;
+        let mut victims = Vec::new();
+        while freed < target_size {
+            let Some(v) = policy.next_victim() else { break };
+            freed += sizes(&v);
+            victims.push(v);
+        }
+        victims
     }
 
     #[test]
     fn test_lru_policy_victim_selection() {
-        let mut policy = LruPolicy::new();
+        let policy: LruPolicy<String> = LruPolicy::new();
 
-        policy.on_insert("oldest", 100);
+        policy.on_insert(&"oldest".to_string(), 100);
         thread::sleep(Duration::from_millis(1));
 
-        policy.on_insert("middle", 100);
+        policy.on_insert(&"middle".to_string(), 100);
         thread::sleep(Duration::from_millis(1));
 
-        policy.on_insert("newest", 100);
+        policy.on_insert(&"newest".to_string(), 100);
         thread::sleep(Duration::from_millis(1));
 
         // Access middle entry to make it more recent
-        policy.on_access("middle", 100);
+        policy.on_access(&"middle".to_string(), 100);
 
-        let candidates = policy.select_for_eviction(150);
+        let candidates = drain_for(&policy, &|_| 100, 150);
         assert_eq!(candidates.len(), 2);
         assert!(candidates.contains(&"oldest".to_string()));
         assert!(!candidates.contains(&"middle".to_string()));
@@ -373,23 +465,34 @@ mod tests {
 
     #[test]
     fn test_lfu_policy_victim_selection() {
-        let mut policy = LfuPolicy::new();
+        let policy: LfuPolicy<String> = LfuPolicy::new();
 
-        policy.on_insert("rarely_used", 100);
-        policy.on_insert("sometimes_used", 100);
-        policy.on_insert("frequently_used", 100);
+        policy.on_insert(&"rarely_used".to_string(), 100);
+        policy.on_insert(&"sometimes_used".to_string(), 100);
+        policy.on_insert(&"frequently_used".to_string(), 100);
 
         // Create frequency patterns
-        policy.on_access("sometimes_used", 100);
+        policy.on_access(&"sometimes_used".to_string(), 100);
 
         for _ in 0..3 {
-            policy.on_access("frequently_used", 100);
+            policy.on_access(&"frequently_used".to_string(), 100);
         }
 
-        let candidates = policy.select_for_eviction(150);
+        let candidates = drain_for(&policy, &|_| 100, 150);
         assert_eq!(candidates.len(), 2);
         assert!(candidates.contains(&"rarely_used".to_string()));
         assert!(candidates.contains(&"sometimes_used".to_string()));
         assert!(!candidates.contains(&"frequently_used".to_string()));
+    }
+
+    #[test]
+    fn test_fifo_policy_victim_order() {
+        let policy: FifoPolicy<String> = FifoPolicy::new();
+        policy.on_insert(&"first".to_string(), 10);
+        policy.on_insert(&"second".to_string(), 10);
+        policy.on_access(&"first".to_string(), 10); // no-op for FIFO
+        assert_eq!(policy.next_victim(), Some("first".to_string()));
+        assert_eq!(policy.next_victim(), Some("second".to_string()));
+        assert_eq!(policy.next_victim(), None);
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/metadata_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/metadata_cache.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+use crate::cache::unified::{CacheKind, CacheStats, ManagedCache};
 use crate::parquet_page_cache::is_scoped_page_index_enabled;
 use datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData;
 use datafusion::execution::cache::cache_manager::{
@@ -20,11 +21,10 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 use native_bridge_common::log_error;
 use object_store::path::Path;
 
-// Cache type constants
-pub const CACHE_TYPE_METADATA: &str = "METADATA";
-pub const CACHE_TYPE_STATS: &str = "STATISTICS";
-pub const CACHE_TYPE_COLUMN_INDEX: &str = "COLUMN_INDEX";
-pub const CACHE_TYPE_OFFSET_INDEX: &str = "OFFSET_INDEX";
+// Re-exported for backward compatibility; canonical home is `cache::unified`.
+pub use crate::cache::unified::{
+    CACHE_TYPE_COLUMN_INDEX, CACHE_TYPE_METADATA, CACHE_TYPE_OFFSET_INDEX, CACHE_TYPE_STATS,
+};
 
 fn log_cache_error(operation: &str, error: &str) {
     log_error!("[CACHE ERROR] {} operation failed: {}", operation, error);
@@ -201,6 +201,52 @@ impl CacheAccessor<Path, CachedFileMetadataEntry> for MutexFileMetadataCache {
                 "cache_error".to_string()
             }
         }
+    }
+}
+
+/// Management plane — see [`crate::cache::unified`]. DataFusion's query path
+/// keeps using the `FileMetadataCache` / `CacheAccessor` impls below.
+impl ManagedCache for MutexFileMetadataCache {
+    fn kind(&self) -> CacheKind {
+        CacheKind::Metadata
+    }
+
+    fn stats(&self) -> CacheStats {
+        let (entries, used_bytes, limit_bytes) = match self.inner.lock() {
+            Ok(cache) => (cache.len(), cache.memory_used(), cache.cache_limit()),
+            Err(e) => {
+                log_cache_error("stats", &e.to_string());
+                (0, 0, 0)
+            }
+        };
+        CacheStats {
+            hits: self.hit_count() as u64,
+            misses: self.miss_count() as u64,
+            evictions: 0, // not tracked by DefaultFilesMetadataCache
+            entries,
+            used_bytes,
+            limit_bytes,
+        }
+    }
+
+    fn set_limit(&self, limit: usize) {
+        self.update_cache_limit(limit);
+    }
+
+    fn clear(&self) {
+        self.clear_cache();
+    }
+
+    fn reset_counters(&self) {
+        self.reset_stats();
+    }
+
+    fn remove_file(&self, file_path: &str) -> bool {
+        CacheAccessor::remove(self, &Path::from(file_path)).is_some()
+    }
+
+    fn contains_file(&self, file_path: &str) -> bool {
+        CacheAccessor::contains_key(self, &Path::from(file_path))
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/mod.rs
@@ -10,31 +10,39 @@
 //!
 //! # Structure
 //!
-//! - [`eviction_policy`] — pluggable eviction policy trait (`CachePolicy`) and
-//!   built-in implementations (`LruPolicy`, `LfuPolicy`). Add new policies here
-//!   (e.g. S3-FIFO) without touching the cache implementations.
+//! - [`unified`] — the crate-wide cache management interface: [`unified::CacheKind`]
+//!   (the closed set of cache types, with per-kind policy rules) and
+//!   [`unified::ManagedCache`] (limits, clearing, stats, per-file removal).
+//!   Every cache below implements `ManagedCache`; `CustomCacheManager`
+//!   dispatches management operations through it uniformly.
+//! - [`eviction_policy`] — ONE pluggable eviction policy trait
+//!   (`EvictionPolicy<K>`) shared by all caches, with built-in `LruPolicy`,
+//!   `LfuPolicy`, and `FifoPolicy`. Add new policies here (e.g. S3-FIFO)
+//!   without touching the cache implementations.
 //! - [`metadata_cache`] — `MutexFileMetadataCache`: wraps DataFusion's
 //!   `DefaultFilesMetadataCache` with hit/miss counters and enforces the
 //!   footer-only invariant via `strip_page_index` at every `put`.
 //! - [`statistics_cache`] — `CustomStatisticsCache`: byte-bounded LRU cache
 //!   for per-file `Statistics` (row-group min/max/null-count).
-//! - [`custom_manager`] — `CustomCacheManager`: ties the metadata and
-//!   statistics caches together for pre-warming and lifecycle management.
+//! - [`custom_cache_manager`] — `CustomCacheManager`: registry of
+//!   `Arc<dyn ManagedCache>` plus the domain flows (warming, file add/remove).
 //! - [`page_index`] — scoped parquet page-index caches (ColumnIndex +
-//!   OffsetIndex), cell-granular and backed by `BoundedCache` /
-//!   `Box<dyn CachePolicy>`.
+//!   OffsetIndex), cell-granular and backed by `BoundedCache` over the same
+//!   `EvictionPolicy` trait.
 
 pub mod custom_cache_manager;
 pub mod eviction_policy;
 pub mod metadata_cache;
 pub mod page_index;
 pub mod statistics_cache;
+pub mod unified;
 
 // Flat re-exports so existing call sites keep working without path changes.
 pub use custom_cache_manager::CustomCacheManager;
-pub use eviction_policy::{create_policy, CachePolicy, CacheResult, PolicyType};
-pub use metadata_cache::{
-    MutexFileMetadataCache, CACHE_TYPE_COLUMN_INDEX, CACHE_TYPE_METADATA, CACHE_TYPE_OFFSET_INDEX,
-    CACHE_TYPE_STATS,
-};
+pub use eviction_policy::{create_policy, CacheResult, EvictionPolicy, PolicyType};
+pub use metadata_cache::MutexFileMetadataCache;
 pub use statistics_cache::{compute_parquet_statistics, CustomStatisticsCache};
+pub use unified::{
+    CacheKind, CacheStats, ManagedCache, CACHE_TYPE_COLUMN_INDEX, CACHE_TYPE_METADATA,
+    CACHE_TYPE_OFFSET_INDEX, CACHE_TYPE_STATS,
+};

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/cache_store.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/cache_store.rs
@@ -11,20 +11,24 @@
 //! # Architecture
 //!
 //! ```text
-//!  BoundedCache<K, V, P: ScopedEvictionPolicy<K>>
-//!  ├── DashMap<K, (V, usize)>        ← lock-free concurrent reads
-//!  ├── Mutex<{ used_bytes, limit }>  ← write-path accounting only
-//!  └── P (eviction policy)           ← owns the eviction queue, uses interior mutability
+//!  BoundedCache<K, V>
+//!  ├── DashMap<K, (V, usize)>          ← lock-free concurrent reads
+//!  ├── Mutex<{ used_bytes, limit }>    ← write-path accounting only
+//!  └── Arc<dyn EvictionPolicy<K>>      ← owns the eviction queue, interior mutability
 //! ```
 //!
-//! **Reads are lock-free** — `get` only touches the `DashMap` shard lock.
+//! **Reads are lock-free** — `get` only touches the `DashMap` shard lock
+//! (FIFO's `on_access` is a no-op).
 //!
 //! **Writes take one `parking_lot::Mutex`** for `used_bytes` + limit accounting.
 //! The eviction policy is called inside the lock for consistency.
 //!
-//! **Pluggable eviction**: [`ScopedEvictionPolicy`] is the trait. Today
-//! [`FifoPolicy`] is the only implementation. S3-FIFO (ghost-set promotion)
-//! can be added later by implementing the same trait.
+//! **Pluggable eviction**: the crate-wide
+//! [`EvictionPolicy`](crate::cache::eviction_policy::EvictionPolicy) trait —
+//! the same trait the statistics cache uses. Today CI/OI run
+//! [`FifoPolicy`](crate::cache::eviction_policy::FifoPolicy); a new policy
+//! (e.g. S3-FIFO) plugs in by implementing that one trait and allowing it in
+//! `CacheKind::validate_policy`.
 //!
 //! **Lazy deletion on overwrite**: re-inserting an existing key leaves a stale
 //! entry in the eviction queue. [`BoundedCache::drain_to_limit`] skips stale
@@ -35,13 +39,13 @@
 //! queue to remove all cells for a deleted/replaced file. This is a rare
 //! cold-path operation (file deletion or merge), not on the query hot path.
 
-use std::cell::UnsafeCell;
-use std::collections::VecDeque;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed};
+use std::sync::Arc;
 
-use crate::eviction_policy::CacheEvictionPolicy;
+use crate::cache::unified::CacheStats;
+use crate::eviction_policy::{create_policy, CacheEvictionPolicy, EvictionPolicy};
 use dashmap::DashMap;
 use parking_lot::Mutex;
 
@@ -51,120 +55,6 @@ use parking_lot::Mutex;
 /// plugin initialization before any query runs, so this value is never used
 /// outside tests.
 pub(crate) const DEFAULT_SCOPED_CACHE_LIMIT: usize = 150 * 1024 * 1024;
-
-// ── Eviction policy trait ────────────────────────────────────────────────────
-
-/// Pluggable eviction policy for [`BoundedCache`].
-///
-/// Implementations must use interior mutability (`Mutex`, atomics, etc.) so
-/// they can be called through a shared reference. All methods are called from
-/// inside the `BoundedCache` write lock, so implementations do not need their
-/// own locks — but must still be `Send + Sync` for the `Lazy<BoundedCache>`
-/// statics.
-///
-/// # Implementing a new policy
-///
-/// 1. Implement this trait with interior mutability.
-/// 2. Wire it in `mod.rs` by passing it to `BoundedCache::new`.
-/// 3. Expose a `PolicyType` variant in the Java API and route it from
-///    `df_create_cache` in `ffm.rs`.
-pub(super) trait ScopedEvictionPolicy<K>: Send + Sync {
-    /// Called when a new entry is inserted (or an existing key is overwritten).
-    /// The policy should record `key` as the most-recently inserted entry.
-    fn on_insert(&self, key: K);
-
-    /// Called when an entry is accessed on the hot read path.
-    /// FIFO ignores this; frequency-aware policies (LFU, S3-FIFO) update
-    /// access counts here.
-    fn on_access(&self, key: &K);
-
-    /// Pop and return the next eviction candidate.
-    ///
-    /// Called repeatedly by [`BoundedCache::drain_to_limit`] until
-    /// `used_bytes <= limit`. The caller performs lazy deletion: if the
-    /// returned key is no longer in the `DashMap` (stale entry from an
-    /// overwrite), `drain_to_limit` skips it and calls `next_victim` again.
-    fn next_victim(&self) -> Option<K>;
-
-    /// Called when an entry is explicitly removed (prefix eviction, clear).
-    /// Allows the policy to remove the entry from its internal bookkeeping.
-    fn on_remove(&self, key: &K);
-
-    /// Reset all internal state (called on `clear_keep_limit`).
-    fn clear(&self);
-}
-
-// ── FIFO policy ──────────────────────────────────────────────────────────────
-
-/// Insert-order (FIFO) eviction policy.
-///
-/// Oldest-inserted entry is evicted first. Access order is not tracked — reads
-/// are fully lock-free. Stale entries (from overwrites) are left in the queue
-/// and skipped by the `BoundedCache` eviction loop (lazy deletion).
-///
-/// # No inner lock
-///
-/// All `ScopedEvictionPolicy` methods are called exclusively from inside
-/// `BoundedCache`'s outer `Mutex<WriteState>` lock, which already serializes
-/// all mutations. An additional inner lock on the queue would be a
-/// no-contention lock/unlock cycle with zero benefit. We use `UnsafeCell`
-/// instead, with the outer lock as the synchronization invariant.
-///
-/// # Safety invariant
-///
-/// Every method that calls `queue_mut()` or `queue_ref()` must be called while
-/// the `BoundedCache` write lock is held. `on_access` is a no-op for FIFO and
-/// is called from the lock-free `get` path — it does not touch the queue.
-///
-/// S3-FIFO (planned successor) wraps two FIFO queues with a ghost set. If its
-/// `on_access` needs to update state from the read path, it would need its own
-/// interior mutability (e.g. atomics for frequency counters).
-pub(super) struct FifoPolicy<K> {
-    /// Guarded by the outer `BoundedCache` write lock — no inner lock needed.
-    queue: UnsafeCell<VecDeque<K>>,
-}
-
-// SAFETY: `FifoPolicy` is only mutated under `BoundedCache`'s `Mutex<WriteState>`.
-unsafe impl<K: Send> Send for FifoPolicy<K> {}
-unsafe impl<K: Send> Sync for FifoPolicy<K> {}
-
-impl<K> FifoPolicy<K> {
-    pub(super) fn new() -> Self {
-        Self {
-            queue: UnsafeCell::new(VecDeque::new()),
-        }
-    }
-
-    /// Borrow the queue mutably. Caller must hold the outer write lock.
-    #[inline]
-    fn queue_mut(&self) -> &mut VecDeque<K> {
-        // SAFETY: caller holds the `BoundedCache` write lock.
-        unsafe { &mut *self.queue.get() }
-    }
-}
-
-impl<K: Clone + PartialEq + Send + Sync> ScopedEvictionPolicy<K> for FifoPolicy<K> {
-    fn on_insert(&self, key: K) {
-        self.queue_mut().push_back(key);
-    }
-
-    fn on_access(&self, _key: &K) {
-        // FIFO does not track access order — no queue mutation, reads stay lock-free.
-    }
-
-    fn next_victim(&self) -> Option<K> {
-        self.queue_mut().pop_front()
-    }
-
-    fn on_remove(&self, key: &K) {
-        // O(n) scan — only called from evict_by_prefix (cold path).
-        self.queue_mut().retain(|k| k != key);
-    }
-
-    fn clear(&self) {
-        self.queue_mut().clear();
-    }
-}
 
 // ── Write-lock state ─────────────────────────────────────────────────────────
 
@@ -187,33 +77,25 @@ impl WriteState {
 // ── BoundedCache ─────────────────────────────────────────────────────────────
 
 /// Snapshot of one scoped cache's counters plus occupancy.
-/// Surfaced on node-stats and used by tests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ScopedCacheStats {
-    pub hits: u64,
-    pub misses: u64,
-    pub evictions: u64,
-    pub entries: usize,
-    pub used_bytes: usize,
-    pub limit_bytes: usize,
-}
+/// Alias of the crate-wide unified [`CacheStats`]; kept for existing call sites.
+pub type ScopedCacheStats = CacheStats;
 
-/// Byte-bounded concurrent cache parameterised over an eviction policy `P`.
+/// Byte-bounded concurrent cache with a pluggable [`EvictionPolicy`].
 ///
 /// `K` must implement `Display` so `evict_by_prefix` can match keys by their
 /// string representation (e.g. `"path:col:rg"` → prefix `"path"`).
-pub(super) struct BoundedCache<K, V, P = FifoPolicy<K>>
+pub(super) struct BoundedCache<K, V>
 where
     K: Eq + Hash + Clone + Display + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    P: ScopedEvictionPolicy<K>,
 {
     /// Value store — DashMap for lock-free concurrent reads.
     map: DashMap<K, (V, usize)>,
     /// Byte accounting under one lock. The eviction queue lives in `policy`.
     write: Mutex<WriteState>,
-    /// Eviction policy — uses interior mutability, called inside `write` lock.
-    policy: P,
+    /// Eviction policy — uses interior mutability; mutating calls happen
+    /// inside the `write` lock.
+    policy: Arc<dyn EvictionPolicy<K>>,
     /// Byte cap snapshot for lock-free `stats()`.
     limit_snapshot: AtomicUsize,
     // Lock-free diagnostic counters.
@@ -223,39 +105,28 @@ where
     used_bytes_snapshot: AtomicUsize,
 }
 
-impl<K, V> BoundedCache<K, V, FifoPolicy<K>>
+impl<K, V> BoundedCache<K, V>
 where
     K: Eq + Hash + Clone + Display + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
     /// Create a `BoundedCache` with the named eviction policy.
     ///
-    /// Only `Fifo` is accepted — `Lru`/`Lfu` belong to `CustomStatisticsCache`.
-    /// The match is exhaustive over `CacheEvictionPolicy` so adding a new
-    /// variant (e.g. `S3Fifo`) will be a compile error here until it's wired.
+    /// Policy validity per cache type is enforced at the FFI boundary via
+    /// `CacheKind::validate_policy`; this constructor accepts any policy.
     pub(crate) fn with_named_policy(limit: usize, policy: CacheEvictionPolicy) -> Self {
-        use crate::cache::eviction_policy::CacheEvictionPolicy;
-        let CacheEvictionPolicy::Fifo = policy else {
-            unreachable!("BoundedCache only supports Fifo; use CustomStatisticsCache for Lru/Lfu");
-        };
-        Self::with_policy(limit, FifoPolicy::new())
+        Self::with_policy(limit, create_policy::<K>(policy))
     }
 
     /// Create a new cache with FIFO eviction — shorthand for tests.
+    #[cfg(test)]
     pub(super) fn new(limit: usize) -> Self {
         Self::with_named_policy(limit, CacheEvictionPolicy::Fifo)
     }
-}
 
-impl<K, V, P> BoundedCache<K, V, P>
-where
-    K: Eq + Hash + Clone + Display + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-    P: ScopedEvictionPolicy<K>,
-{
-    /// Create a cache with an explicit policy. Use this when plugging in a
-    /// non-default policy (e.g. S3-FIFO in a future PR).
-    pub(super) fn with_policy(limit: usize, policy: P) -> Self {
+    /// Create a cache with an explicit policy object. Use this when plugging
+    /// in a custom policy implementation.
+    pub(super) fn with_policy(limit: usize, policy: Arc<dyn EvictionPolicy<K>>) -> Self {
         Self {
             map: DashMap::new(),
             write: Mutex::new(WriteState::new(limit)),
@@ -272,7 +143,7 @@ where
     pub(super) fn get(&self, key: &K) -> Option<V> {
         match self.map.get(key) {
             Some(entry) => {
-                self.policy.on_access(key);
+                self.policy.on_access(key, entry.1);
                 self.hits.fetch_add(1, Relaxed);
                 Some(entry.0.clone())
             }
@@ -308,7 +179,7 @@ where
         }
 
         w.used_bytes += size;
-        self.policy.on_insert(key);
+        self.policy.on_insert(&key, size);
 
         let evicted = self.drain_to_limit(&mut w);
         self.used_bytes_snapshot.store(w.used_bytes, Relaxed);
@@ -351,7 +222,7 @@ where
                 w.used_bytes = w.used_bytes.saturating_sub(old_size);
             }
             w.used_bytes += size;
-            self.policy.on_insert(key);
+            self.policy.on_insert(&key, size);
         }
 
         let evicted = self.drain_to_limit(&mut w);
@@ -412,7 +283,8 @@ where
     /// Used when a parquet file is deleted or replaced.
     ///
     /// O(n) scan of the eviction queue — cold path only (file deletion/merge).
-    pub(super) fn evict_by_prefix(&self, prefix: &str) {
+    /// Returns whether any entry was removed.
+    pub(super) fn evict_by_prefix(&self, prefix: &str) -> bool {
         // Collect victims by iterating the DashMap (avoids holding the write
         // lock while doing string comparisons on every FIFO entry).
         let victims: Vec<K> = self
@@ -423,7 +295,7 @@ where
             .collect();
 
         if victims.is_empty() {
-            return;
+            return false;
         }
 
         let mut w = self.write.lock();
@@ -441,6 +313,7 @@ where
         if evicted > 0 {
             self.evictions.fetch_add(evicted, Relaxed);
         }
+        evicted > 0
     }
 
     /// Lock-free stats snapshot.
@@ -461,6 +334,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eviction_policy::FifoPolicy;
     use std::sync::Arc;
 
     #[derive(Clone, PartialEq, Eq, Hash)]
@@ -529,11 +403,12 @@ mod tests {
         c.insert(Key::new("file1:col0"), vec![], 10);
         c.insert(Key::new("file1:col1"), vec![], 10);
         c.insert(Key::new("file2:col0"), vec![], 10);
-        c.evict_by_prefix("file1");
+        assert!(c.evict_by_prefix("file1"));
         assert_eq!(c.get(&Key::new("file1:col0")), None);
         assert_eq!(c.get(&Key::new("file1:col1")), None);
         assert_eq!(c.get(&Key::new("file2:col0")), Some(vec![]));
         assert_eq!(c.stats().used_bytes, 10);
+        assert!(!c.evict_by_prefix("file1"), "already evicted");
     }
 
     #[test]
@@ -572,13 +447,13 @@ mod tests {
 
     // ── pluggable policy ──────────────────────────────────────────────────────
 
-    /// Verify that `with_policy` compiles and works with a custom policy,
-    /// proving the extensibility point works without modifying `BoundedCache`.
+    /// Verify that `with_policy` compiles and works with an explicit policy
+    /// object, proving the extensibility point works without modifying
+    /// `BoundedCache`.
     #[test]
     fn custom_policy_compiles_and_works() {
-        // A trivial "always evict the first key ever inserted" policy (same as FIFO).
-        let cache: BoundedCache<Key, Vec<u8>, FifoPolicy<Key>> =
-            BoundedCache::with_policy(20, FifoPolicy::new());
+        let cache: BoundedCache<Key, Vec<u8>> =
+            BoundedCache::with_policy(20, Arc::new(FifoPolicy::new()));
         cache.insert(Key::new("x"), vec![], 10);
         cache.insert(Key::new("y"), vec![], 10);
         cache.insert(Key::new("z"), vec![], 10); // triggers eviction of "x"

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/mod.rs
@@ -78,6 +78,7 @@ pub mod column_schema_resolver;
 pub mod page_index_io;
 
 use crate::cache::eviction_policy::CacheEvictionPolicy;
+use crate::cache::unified::{CacheKind, CacheStats, ManagedCache};
 use cache_keys::{CiCellKey, OiCellKey, OiColumn};
 use cache_store::{BoundedCache, DEFAULT_SCOPED_CACHE_LIMIT};
 
@@ -182,6 +183,83 @@ pub fn clear_scoped_cache() {
 pub fn evict_file_from_scoped_cache(file_path: &str) {
     COLUMN_INDEX_CACHE.evict_by_prefix(file_path);
     OFFSET_INDEX_CACHE.evict_by_prefix(file_path);
+}
+
+// ── ManagedCache handles ─────────────────────────────────────────────────────
+//
+// The CI/OI caches are process-global singletons (queries reach them without a
+// manager reference), so the unified management interface is implemented on
+// zero-sized handle types that forward to the statics. `CustomCacheManager`
+// registers these handles like any other `Arc<dyn ManagedCache>`.
+
+/// [`ManagedCache`] handle over the global [`COLUMN_INDEX_CACHE`].
+pub struct ColumnIndexCacheHandle;
+
+/// [`ManagedCache`] handle over the global [`OFFSET_INDEX_CACHE`].
+pub struct OffsetIndexCacheHandle;
+
+impl ManagedCache for ColumnIndexCacheHandle {
+    fn kind(&self) -> CacheKind {
+        CacheKind::ColumnIndex
+    }
+
+    fn stats(&self) -> CacheStats {
+        COLUMN_INDEX_CACHE.stats()
+    }
+
+    fn set_limit(&self, limit: usize) {
+        set_column_index_cache_limit(limit);
+    }
+
+    fn clear(&self) {
+        COLUMN_INDEX_CACHE.clear_keep_limit();
+    }
+
+    fn reset_counters(&self) {
+        // clear_keep_limit is the only counter reset the scoped caches expose;
+        // entries and counters reset together (as before this interface).
+        COLUMN_INDEX_CACHE.clear_keep_limit();
+    }
+
+    fn remove_file(&self, file_path: &str) -> bool {
+        COLUMN_INDEX_CACHE.evict_by_prefix(file_path)
+    }
+
+    fn contains_file(&self, _file_path: &str) -> bool {
+        // Cell-keyed cache — a per-file scan is not worth a boolean probe;
+        // approximate with "has any entries" (diagnostics only, as before).
+        COLUMN_INDEX_CACHE.stats().entries > 0
+    }
+}
+
+impl ManagedCache for OffsetIndexCacheHandle {
+    fn kind(&self) -> CacheKind {
+        CacheKind::OffsetIndex
+    }
+
+    fn stats(&self) -> CacheStats {
+        OFFSET_INDEX_CACHE.stats()
+    }
+
+    fn set_limit(&self, limit: usize) {
+        set_offset_index_cache_limit(limit);
+    }
+
+    fn clear(&self) {
+        OFFSET_INDEX_CACHE.clear_keep_limit();
+    }
+
+    fn reset_counters(&self) {
+        OFFSET_INDEX_CACHE.clear_keep_limit();
+    }
+
+    fn remove_file(&self, file_path: &str) -> bool {
+        OFFSET_INDEX_CACHE.evict_by_prefix(file_path)
+    }
+
+    fn contains_file(&self, _file_path: &str) -> bool {
+        OFFSET_INDEX_CACHE.stats().entries > 0
+    }
 }
 
 /// Crate-wide guard so every test that touches the process-global caches mutually

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/statistics_cache.rs
@@ -6,7 +6,8 @@
  * compatible open source license.
  */
 
-use crate::eviction_policy::{create_policy, CacheError, CachePolicy, CacheResult, PolicyType};
+use crate::cache::unified::{CacheKind, CacheStats, ManagedCache};
+use crate::eviction_policy::{create_policy, CacheError, CacheResult, EvictionPolicy, PolicyType};
 use arrow_array::Array;
 use dashmap::DashMap;
 use datafusion::common::stats::{ColumnStatistics, Precision};
@@ -130,7 +131,7 @@ pub struct CustomStatisticsCache {
     /// Current eviction policy. `Mutex` guards atomic swaps in `set_policy`;
     /// hot-path callers clone the `Arc` while holding the lock briefly, then call
     /// through the clone without holding the lock.
-    policy: Mutex<Arc<dyn CachePolicy>>,
+    policy: Mutex<Arc<dyn EvictionPolicy<String>>>,
     /// Size limit for the cache in bytes
     size_limit: AtomicUsize,
     /// Eviction threshold (0.0 to 1.0)
@@ -148,9 +149,7 @@ impl CustomStatisticsCache {
     pub fn new(policy_type: PolicyType, size_limit: usize, eviction_threshold: f64) -> Self {
         Self {
             inner_cache: DashMap::new(),
-            policy: Mutex::new(
-                create_policy(policy_type).expect("statistics cache requires Lru or Lfu"),
-            ),
+            policy: Mutex::new(create_policy::<String>(policy_type)),
             size_limit: AtomicUsize::new(size_limit),
             eviction_threshold,
             memory_state: Arc::new(Mutex::new(MemoryState {
@@ -210,7 +209,7 @@ impl CustomStatisticsCache {
 
     /// Clone the policy Arc without holding the Mutex. Hot-path callers use this
     /// so they don't hold the lock while calling policy methods.
-    fn policy(&self) -> Arc<dyn CachePolicy> {
+    fn policy(&self) -> Arc<dyn EvictionPolicy<String>> {
         self.policy
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -224,14 +223,36 @@ impl CustomStatisticsCache {
         if current_size > new_limit {
             let target_eviction =
                 current_size - (new_limit as f64 * self.eviction_threshold) as usize;
-            let candidates = self.policy().select_for_eviction(target_eviction);
-            for candidate_key in candidates {
-                if let Ok(path) = self.parse_key_to_path(&candidate_key) {
-                    self.remove_internal(&path);
+            self.evict_victims(target_eviction);
+        }
+        Ok(())
+    }
+
+    /// Drain policy victims until at least `target_size` bytes are freed (or
+    /// the policy runs out of candidates). Victims are popped from the policy
+    /// by [`EvictionPolicy::next_victim`]; stale victims (already removed from
+    /// the store) are skipped. Returns the bytes actually freed.
+    fn evict_victims(&self, target_size: usize) -> usize {
+        if target_size == 0 {
+            return 0;
+        }
+        let policy = self.policy();
+        let mut freed_size = 0;
+        while freed_size < target_size {
+            let Some(victim) = policy.next_victim() else {
+                break;
+            };
+            let path = Path::from(victim.as_str());
+            if self.inner_cache.remove(&path).is_some() {
+                if let Ok(mut state) = self.memory_state.lock() {
+                    if let Some(old_size) = state.tracker.remove(&victim) {
+                        state.total = state.total.saturating_sub(old_size);
+                        freed_size += old_size;
+                    }
                 }
             }
         }
-        Ok(())
+        freed_size
     }
 
     /// Switch to a different eviction policy, rebuilding state from current entries.
@@ -245,7 +266,10 @@ impl CustomStatisticsCache {
                 })?;
             state.tracker.iter().map(|(k, v)| (k.clone(), *v)).collect()
         };
-        let new_policy = create_policy(policy_type).expect("statistics cache requires Lru or Lfu");
+        CacheKind::Statistics
+            .validate_policy(policy_type)
+            .map_err(|reason| CacheError::PolicyLockError { reason })?;
+        let new_policy = create_policy::<String>(policy_type);
         for (key, size) in entries {
             new_policy.on_insert(&key, size);
         }
@@ -276,40 +300,7 @@ impl CustomStatisticsCache {
 
     /// Manually trigger eviction.
     pub fn evict(&mut self, target_size: usize) -> CacheResult<usize> {
-        if target_size == 0 {
-            return Ok(0);
-        }
-        let candidates = self.policy().select_for_eviction(target_size);
-
-        let mut freed_size = 0;
-        for key in candidates {
-            let entry_size = {
-                let state = self
-                    .memory_state
-                    .lock()
-                    .map_err(|e| CacheError::PolicyLockError {
-                        reason: format!("Failed to acquire memory_state lock: {}", e),
-                    })?;
-                state.tracker.get(&key).copied().unwrap_or(0)
-            };
-
-            if entry_size > 0 {
-                if let Ok(path) = self.parse_key_to_path(&key) {
-                    if self.inner_cache.remove(&path).is_some() {
-                        if let Ok(mut state) = self.memory_state.lock() {
-                            state.tracker.remove(&key);
-                            state.total = state.total.saturating_sub(entry_size);
-                        }
-                        self.policy().on_remove(&key);
-                        freed_size += entry_size;
-                    }
-                    if freed_size >= target_size {
-                        break;
-                    }
-                }
-            }
-        }
-        Ok(freed_size)
+        Ok(self.evict_victims(target_size))
     }
 
     /// Convenience method: put statistics with associated metadata (replaces old put_with_extra)
@@ -326,26 +317,6 @@ impl CustomStatisticsCache {
     /// Convenience method: get just the statistics Arc (for callers that don't need full CachedFileMetadata)
     pub fn get_statistics(&self, k: &Path) -> Option<Arc<Statistics>> {
         self.get(k).map(|c| c.statistics)
-    }
-
-    /// Parse cache key back to Path
-    fn parse_key_to_path(&self, key: &str) -> CacheResult<Path> {
-        Ok(Path::from(key))
-    }
-
-    /// Remove entry internally (works with &self since inner_cache is thread-safe)
-    fn remove_internal(&self, k: &Path) -> Option<CachedFileMetadata> {
-        let key = k.to_string();
-        let result = self.inner_cache.remove(k);
-        if result.is_some() {
-            if let Ok(mut state) = self.memory_state.lock() {
-                if let Some(old_size) = state.tracker.remove(&key) {
-                    state.total = state.total.saturating_sub(old_size);
-                }
-            }
-            self.policy().on_remove(&key);
-        }
-        result.map(|x| x.1)
     }
 }
 
@@ -382,21 +353,13 @@ impl CustomStatisticsCache {
 
         let current_size = self.memory_state.lock().map(|s| s.total).unwrap_or(0);
 
-        let eviction_candidates = {
+        {
             let size_limit = self.size_limit.load(Ordering::Relaxed);
             let threshold = (size_limit as f64 * self.eviction_threshold) as usize;
             if current_size + memory_size > threshold {
                 let target_eviction =
                     (current_size + memory_size) - (size_limit as f64 * 0.6) as usize;
-                self.policy().select_for_eviction(target_eviction)
-            } else {
-                vec![]
-            }
-        };
-
-        for candidate_key in eviction_candidates {
-            if let Ok(path) = self.parse_key_to_path(&candidate_key) {
-                self.remove_internal(&path);
+                self.evict_victims(target_eviction);
             }
         }
 
@@ -514,6 +477,47 @@ impl FileStatisticsCache for CustomStatisticsCache {
 impl Default for CustomStatisticsCache {
     fn default() -> Self {
         Self::with_default_config()
+    }
+}
+
+/// Management plane — see [`crate::cache::unified`]. Query-path access stays
+/// on the typed `Path`-keyed inherent methods above.
+impl ManagedCache for CustomStatisticsCache {
+    fn kind(&self) -> CacheKind {
+        CacheKind::Statistics
+    }
+
+    fn stats(&self) -> CacheStats {
+        CacheStats {
+            hits: self.hit_count() as u64,
+            misses: self.miss_count() as u64,
+            evictions: 0, // not tracked by this cache
+            entries: self.len(),
+            used_bytes: self.memory_consumed(),
+            limit_bytes: self.current_size_limit(),
+        }
+    }
+
+    fn set_limit(&self, limit: usize) {
+        // evict_victims drains best-effort; lock poisoning is already handled
+        // inside, so the Result is always Ok.
+        let _ = self.update_size_limit(limit);
+    }
+
+    fn clear(&self) {
+        CustomStatisticsCache::clear(self);
+    }
+
+    fn reset_counters(&self) {
+        self.reset_stats();
+    }
+
+    fn remove_file(&self, file_path: &str) -> bool {
+        self.remove(&Path::from(file_path)).is_some()
+    }
+
+    fn contains_file(&self, file_path: &str) -> bool {
+        self.contains_key(&Path::from(file_path))
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/unified.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/unified.rs
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Unified management interface over all four analytics caches.
+//!
+//! Every cache in this crate (footer metadata, statistics, column-index,
+//! offset-index) is managed through the same two abstractions:
+//!
+//! - [`CacheKind`] — the closed set of cache types. Parses the Java-supplied
+//!   type string once at the FFI boundary and carries per-kind rules
+//!   ([`CacheKind::validate_policy`]) so they live in exactly one place.
+//! - [`ManagedCache`] — the lifecycle/observability surface each cache
+//!   implements: byte-limit updates, clearing, stats snapshots, per-file
+//!   removal. `CustomCacheManager` holds these as `Arc<dyn ManagedCache>` and
+//!   dispatches by kind instead of per-cache match arms.
+//!
+//! Query-path access (get/put) intentionally stays on each cache's own typed
+//! API — the key/value shapes differ per cache and erasing them would cost
+//! hot-path performance for no management benefit. This trait unifies the
+//! *management* plane only, which is also where a future eviction-policy
+//! swap plugs in: one [`crate::cache::eviction_policy::EvictionPolicy`]
+//! implementation + one [`CacheEvictionPolicy`] variant covers every cache.
+
+use crate::cache::eviction_policy::CacheEvictionPolicy;
+
+// Cache type constants — the exact strings the Java side passes over FFI.
+pub const CACHE_TYPE_METADATA: &str = "METADATA";
+pub const CACHE_TYPE_STATS: &str = "STATISTICS";
+pub const CACHE_TYPE_COLUMN_INDEX: &str = "COLUMN_INDEX";
+pub const CACHE_TYPE_OFFSET_INDEX: &str = "OFFSET_INDEX";
+
+/// The four analytics caches, as a closed enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheKind {
+    Metadata,
+    Statistics,
+    ColumnIndex,
+    OffsetIndex,
+}
+
+impl CacheKind {
+    pub const ALL: [CacheKind; 4] = [
+        CacheKind::Metadata,
+        CacheKind::Statistics,
+        CacheKind::ColumnIndex,
+        CacheKind::OffsetIndex,
+    ];
+
+    /// Parse the Java-supplied cache type string.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            CACHE_TYPE_METADATA => Ok(CacheKind::Metadata),
+            CACHE_TYPE_STATS => Ok(CacheKind::Statistics),
+            CACHE_TYPE_COLUMN_INDEX => Ok(CacheKind::ColumnIndex),
+            CACHE_TYPE_OFFSET_INDEX => Ok(CacheKind::OffsetIndex),
+            _ => Err(format!("invalid cache type: {}", s)),
+        }
+    }
+
+    /// The FFI string for this kind (inverse of [`Self::parse`]).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CacheKind::Metadata => CACHE_TYPE_METADATA,
+            CacheKind::Statistics => CACHE_TYPE_STATS,
+            CacheKind::ColumnIndex => CACHE_TYPE_COLUMN_INDEX,
+            CacheKind::OffsetIndex => CACHE_TYPE_OFFSET_INDEX,
+        }
+    }
+
+    /// Which eviction policies each cache currently supports. This encodes the
+    /// SAME rules the per-cache match arms in `df_create_cache` used to
+    /// enforce — centralized so a future policy (e.g. S3-FIFO) is enabled by
+    /// editing one function.
+    ///
+    /// - `Metadata` accepts any value: `DefaultFilesMetadataCache` has its own
+    ///   built-in LRU, the setting is accepted but not forwarded (unchanged).
+    /// - `Statistics` runs the pluggable policy: LRU or LFU.
+    /// - `ColumnIndex` / `OffsetIndex` are FIFO-only today (lock-free read
+    ///   path relies on `on_access` being a no-op).
+    pub fn validate_policy(&self, policy: CacheEvictionPolicy) -> Result<(), String> {
+        match self {
+            CacheKind::Metadata => Ok(()),
+            CacheKind::Statistics => match policy {
+                CacheEvictionPolicy::Lru | CacheEvictionPolicy::Lfu => Ok(()),
+                CacheEvictionPolicy::Fifo => {
+                    Err("STATISTICS cache does not support FIFO eviction".to_string())
+                }
+            },
+            CacheKind::ColumnIndex | CacheKind::OffsetIndex => match policy {
+                CacheEvictionPolicy::Fifo => Ok(()),
+                _ => Err(format!(
+                    "{} cache only supports FIFO eviction",
+                    self.as_str()
+                )),
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for CacheKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Uniform stats snapshot for any managed cache. Surfaced on node-stats.
+///
+/// Caches that don't track a counter report 0 (e.g. the metadata and
+/// statistics caches don't count evictions today).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    pub entries: usize,
+    pub used_bytes: usize,
+    pub limit_bytes: usize,
+}
+
+/// Management-plane interface implemented by all four caches.
+///
+/// `CustomCacheManager` keeps one `Arc<dyn ManagedCache>` per registered
+/// [`CacheKind`] and dispatches every per-type operation through this trait.
+pub trait ManagedCache: Send + Sync {
+    /// Which cache this is.
+    fn kind(&self) -> CacheKind;
+
+    /// Lock-free-ish counters + occupancy snapshot.
+    fn stats(&self) -> CacheStats;
+
+    /// Update the byte cap; implementations evict immediately if over budget.
+    fn set_limit(&self, limit: usize);
+
+    /// Drop all entries (counters reset where the cache supports it), keeping
+    /// the current limit.
+    fn clear(&self);
+
+    /// Reset hit/miss diagnostic counters without touching entries.
+    fn reset_counters(&self);
+
+    /// Remove all entries belonging to `file_path` (exact key for file-keyed
+    /// caches, key prefix for cell-keyed page-index caches). Returns whether
+    /// anything was removed.
+    fn remove_file(&self, file_path: &str) -> bool;
+
+    /// Whether this cache currently holds entries for `file_path`.
+    ///
+    /// Diagnostics only. The page-index caches approximate (entries > 0) —
+    /// a per-file scan of the cell keys is not worth it for a boolean probe.
+    fn contains_file(&self, file_path: &str) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_roundtrips_all_kinds() {
+        for kind in CacheKind::ALL {
+            assert_eq!(CacheKind::parse(kind.as_str()).unwrap(), kind);
+        }
+        assert!(CacheKind::parse("BOGUS").is_err());
+    }
+
+    #[test]
+    fn validate_policy_preserves_per_cache_rules() {
+        use CacheEvictionPolicy::*;
+        // Metadata accepts everything (setting not forwarded).
+        for p in [Lru, Lfu, Fifo] {
+            assert!(CacheKind::Metadata.validate_policy(p).is_ok());
+        }
+        // Statistics: LRU/LFU only.
+        assert!(CacheKind::Statistics.validate_policy(Lru).is_ok());
+        assert!(CacheKind::Statistics.validate_policy(Lfu).is_ok());
+        assert!(CacheKind::Statistics.validate_policy(Fifo).is_err());
+        // CI/OI: FIFO only.
+        for kind in [CacheKind::ColumnIndex, CacheKind::OffsetIndex] {
+            assert!(kind.validate_policy(Fifo).is_ok());
+            assert!(kind.validate_policy(Lru).is_err());
+            assert!(kind.validate_policy(Lfu).is_err());
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -847,60 +847,36 @@ pub unsafe extern "C" fn df_create_cache(
     let eviction_type = str_from_raw(eviction_type_ptr, eviction_type_len)
         .map_err(|e| format!("df_create_cache: eviction_type: {}", e))?;
 
-    // Parse the eviction type string into the unified CacheEvictionPolicy enum.
-    // All four cache types share one enum — the per-cache match below enforces
-    // which policies are valid for each type.
-    let policy = match eviction_type.to_uppercase().as_str() {
-        "LRU" => CacheEvictionPolicy::Lru,
-        "LFU" => CacheEvictionPolicy::Lfu,
-        "FIFO" => CacheEvictionPolicy::Fifo,
-        _ => {
-            return Err(format!(
-                "df_create_cache: unsupported eviction type: {}",
-                eviction_type
-            ))
-        }
-    };
+    // Parse the type + eviction strings once into the unified enums; which
+    // policies are valid per cache is enforced centrally by validate_policy.
+    let kind =
+        cache::CacheKind::parse(cache_type).map_err(|e| format!("df_create_cache: {}", e))?;
+    let policy =
+        CacheEvictionPolicy::parse(eviction_type).map_err(|e| format!("df_create_cache: {}", e))?;
+    kind.validate_policy(policy)
+        .map_err(|e| format!("df_create_cache: {}", e))?;
 
     // Safety: cache_manager_ptr must be a valid pointer from df_create_custom_cache_manager
     let manager = &mut *(cache_manager_ptr as *mut CustomCacheManager);
 
-    match cache_type {
-        cache::CACHE_TYPE_METADATA => {
+    match kind {
+        cache::CacheKind::Metadata => {
             // METADATA uses DefaultFilesMetadataCache (has its own LRU); eviction
             // type is accepted but not forwarded.
             let inner_cache = DefaultFilesMetadataCache::new(size_limit as usize);
             let metadata_cache = Arc::new(cache::MutexFileMetadataCache::new(inner_cache));
             manager.set_file_metadata_cache(metadata_cache);
         }
-        cache::CACHE_TYPE_STATS => {
-            if policy == CacheEvictionPolicy::Fifo {
-                return Err(
-                    "df_create_cache: STATISTICS cache does not support FIFO eviction".to_string(),
-                );
-            }
+        cache::CacheKind::Statistics => {
             let stats_cache =
                 Arc::new(CustomStatisticsCache::new(policy, size_limit as usize, 0.8));
             manager.set_statistics_cache(stats_cache);
         }
-        cache::CACHE_TYPE_COLUMN_INDEX => {
-            // CI/OI use BoundedCache<FIFO>; eviction type must be FIFO.
-            if policy != CacheEvictionPolicy::Fifo {
-                return Err(format!("df_create_cache: COLUMN_INDEX cache only supports FIFO eviction, got {eviction_type}"));
-            }
+        cache::CacheKind::ColumnIndex => {
             manager.set_column_index_cache(size_limit as usize);
         }
-        cache::CACHE_TYPE_OFFSET_INDEX => {
-            if policy != CacheEvictionPolicy::Fifo {
-                return Err(format!("df_create_cache: OFFSET_INDEX cache only supports FIFO eviction, got {eviction_type}"));
-            }
+        cache::CacheKind::OffsetIndex => {
             manager.set_offset_index_cache(size_limit as usize);
-        }
-        _ => {
-            return Err(format!(
-                "df_create_cache: invalid cache type: {}",
-                cache_type
-            ));
         }
     }
     Ok(0)
@@ -1268,22 +1244,15 @@ pub unsafe extern "C" fn df_cache_manager_update_size_limit(
     let manager = runtime.custom_cache_manager.as_ref().ok_or_else(|| {
         "df_cache_manager_update_size_limit: no cache manager configured".to_string()
     })?;
-    match cache_type {
-        cache::CACHE_TYPE_METADATA => {
-            manager.update_metadata_cache_limit(new_limit as usize);
-            Ok(0)
-        }
-        cache::CACHE_TYPE_STATS => {
-            manager
-                .update_statistics_cache_limit(new_limit as usize)
-                .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
-            Ok(0)
-        }
-        _ => Err(format!(
-            "df_cache_manager_update_size_limit: unsupported cache type: {}",
-            cache_type
-        )),
-    }
+    // Uniform routing: any registered cache kind can have its limit updated
+    // through this one entry point (previously METADATA/STATISTICS only; CI/OI
+    // went through the separate df_set_*_cache_limit globals, which remain).
+    let kind = cache::CacheKind::parse(cache_type)
+        .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+    manager
+        .update_cache_limit(kind, new_limit as usize)
+        .map_err(|e| format!("df_cache_manager_update_size_limit: {}", e))?;
+    Ok(0)
 }
 
 #[no_mangle]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/stats.rs
@@ -274,56 +274,31 @@ pub fn pack_adaptive_budget() -> AdaptiveBudgetRepr {
 }
 
 /// Snapshot the [`CustomCacheManager`] caches and return a populated
-/// [`CacheStatsRepr`]. Disabled caches return all-zeros via the manager's
-/// `unwrap_or(0)` accessor fallbacks.
+/// [`CacheStatsRepr`]. Every group is filled from the unified
+/// [`crate::cache::CacheStats`] snapshot; unregistered caches report
+/// all-zeros via [`CustomCacheManager::cache_stats`]'s default.
 ///
-/// | Field            | Source                                              |
-/// |------------------|-----------------------------------------------------|
-/// | hit_count        | `mgr.{metadata,statistics}_cache_hit_count()`       |
-/// | miss_count       | `mgr.{metadata,statistics}_cache_miss_count()`      |
-/// | entry_count      | `mgr.{metadata,statistics}_cache_entry_count()`     |
-/// | memory_bytes     | `mgr.get_memory_consumed_by_type({METADATA,STATS})` |
-/// | size_limit_bytes | `mgr.{metadata,statistics}_cache_size_limit()`      |
+/// CI/OI stats come from the process-global caches directly so they are
+/// populated even when the manager hasn't registered them (matches the
+/// previous behavior of reading the singletons' stats unconditionally).
 pub fn pack_cache_stats(mgr: &CustomCacheManager) -> CacheStatsRepr {
-    let metadata_memory = mgr
-        .get_memory_consumed_by_type(crate::cache::CACHE_TYPE_METADATA)
-        .unwrap_or(0) as i64;
-    let statistics_memory = mgr
-        .get_memory_consumed_by_type(crate::cache::CACHE_TYPE_STATS)
-        .unwrap_or(0) as i64;
+    use crate::cache::CacheKind;
 
-    let ci = crate::cache::page_index::column_index_cache_stats();
-    let oi = crate::cache::page_index::offset_index_cache_stats();
+    fn group(stats: crate::cache::CacheStats) -> CacheGroupRepr {
+        CacheGroupRepr {
+            hit_count: stats.hits as i64,
+            miss_count: stats.misses as i64,
+            entry_count: stats.entries as i64,
+            memory_bytes: stats.used_bytes as i64,
+            size_limit_bytes: stats.limit_bytes as i64,
+        }
+    }
 
     CacheStatsRepr {
-        metadata_cache: CacheGroupRepr {
-            hit_count: mgr.metadata_cache_hit_count() as i64,
-            miss_count: mgr.metadata_cache_miss_count() as i64,
-            entry_count: mgr.metadata_cache_entry_count() as i64,
-            memory_bytes: metadata_memory,
-            size_limit_bytes: mgr.metadata_cache_size_limit() as i64,
-        },
-        statistics_cache: CacheGroupRepr {
-            hit_count: mgr.statistics_cache_hit_count() as i64,
-            miss_count: mgr.statistics_cache_miss_count() as i64,
-            entry_count: mgr.statistics_cache_entry_count() as i64,
-            memory_bytes: statistics_memory,
-            size_limit_bytes: mgr.statistics_cache_size_limit() as i64,
-        },
-        column_index_cache: CacheGroupRepr {
-            hit_count: ci.hits as i64,
-            miss_count: ci.misses as i64,
-            entry_count: ci.entries as i64,
-            memory_bytes: ci.used_bytes as i64,
-            size_limit_bytes: ci.limit_bytes as i64,
-        },
-        offset_index_cache: CacheGroupRepr {
-            hit_count: oi.hits as i64,
-            miss_count: oi.misses as i64,
-            entry_count: oi.entries as i64,
-            memory_bytes: oi.used_bytes as i64,
-            size_limit_bytes: oi.limit_bytes as i64,
-        },
+        metadata_cache: group(mgr.cache_stats(CacheKind::Metadata)),
+        statistics_cache: group(mgr.cache_stats(CacheKind::Statistics)),
+        column_index_cache: group(crate::cache::page_index::column_index_cache_stats()),
+        offset_index_cache: group(crate::cache::page_index::offset_index_cache_stats()),
     }
 }
 


### PR DESCRIPTION
### Description

Unifies the interfaces of all four DataFusion analytics-backend caches (footer metadata, statistics, column-index, offset-index) so a future eviction-policy change is a one-place plug-in — **without changing any eviction policy or behavior**, and **without adding any new dependency** (no foyer).

Previously each cache had its own eviction trait, stats shape, and per-type match arms in the cache manager and FFI layer, so introducing a new policy (e.g. S3-FIFO) meant touching four places.

#### 1. One eviction-policy trait
`EvictionPolicy<K>` replaces the two previous traits (`CachePolicy` with hardcoded `String` keys for the statistics cache, and `ScopedEvictionPolicy<K>` private to `BoundedCache`). `LruPolicy`, `LfuPolicy`, and `FifoPolicy` all implement it; the eviction protocol is unified on `next_victim()` (pop one candidate), so the statistics cache's batch `select_for_eviction` API is gone. `FifoPolicy` moves from `cache_store.rs` into `eviction_policy.rs` and swaps its `UnsafeCell` for an uncontended `parking_lot::Mutex` so it is sound as a shared trait object.

**Adding a new policy = one trait impl + one `CacheEvictionPolicy` variant.**

#### 2. New `cache/unified.rs` — the management plane
- `CacheKind` — closed enum for the four cache types. Parses the Java FFI type string once, and `validate_policy()` centralizes the per-cache validity rules that used to be scattered as match-arm guards in `df_create_cache` (statistics = LRU/LFU, CI/OI = FIFO-only, metadata = accepted but not forwarded).
- `ManagedCache` — the uniform lifecycle/observability surface (`stats`, `set_limit`, `clear`, `reset_counters`, `remove_file`, `contains_file`) with a shared `CacheStats` snapshot. All four caches implement it; the process-global CI/OI singletons via zero-sized handles.

Query-path get/put intentionally stays on each cache's typed API — the key/value shapes differ per cache and erasing them would cost hot-path performance for no management benefit.

#### 3. Registry-based `CustomCacheManager`
The manager now holds a `CacheKind → Arc<dyn ManagedCache>` registry; `clear_cache_type`, `get_memory_consumed_by_type`, `contains_file_by_type`, `remove_files`, and the ~10 per-cache stat accessors collapse into registry dispatch. `df_create_cache` and `df_cache_manager_update_size_limit` route via `CacheKind::parse`; the latter now accepts all four kinds (previously METADATA/STATISTICS only). The separate CI/OI limit FFIs are unchanged.

#### Non-changes
- No new dependencies; no foyer.
- Java side untouched: same settings, same FFI signatures, same `CacheType` enum.
- Eviction behavior, sizes, and defaults are identical.
- One per-type correction: `clear_cache_type("COLUMN_INDEX")` now clears only CI instead of both CI+OI (the Java caller clears both via the same path, so nothing user-visible changes).

### Related Issues

Interface-unification slice of #22282 (which additionally swapped the implementations to foyer + S3-FIFO); this PR does only the unification so policy changes can land separately.

### Check List
- [x] Functionality includes unit tests — `cargo test --lib`: 1273 passed; rustfmt + clippy clean on touched files; plugin `compileJava`/`compileTestJava`/`test` pass.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.