### PR TITLE
Add option to attach restored backing indices to their data stream

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
@@ -29,9 +29,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Verifies that restoring a data stream backing index auto-attaches it to a pre-existing data stream of the same name,
- * advancing the stream's generation in the same cluster-state update. This is the mechanism cross-cluster replication
- * relies on to bring a leader's rolled-over backing index onto a follower whose stream is a generation behind.
+ * Verifies that restoring a data stream backing index attaches it to a pre-existing data stream of the same name in the
+ * same cluster-state update when {@code attach_to_data_stream} is set, advancing the stream generation when the
+ * attached index has a higher counter than the current write index.
  */
 public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase {
 
@@ -54,13 +54,9 @@ public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase
     }
 
     private List<String> backingIndices() throws Exception {
-        return backingIndices(DS);
-    }
-
-    private List<String> backingIndices(String dataStream) throws Exception {
         return client().admin()
             .indices()
-            .getDataStreams(new GetDataStreamAction.Request(new String[] { dataStream }))
+            .getDataStreams(new GetDataStreamAction.Request(new String[] { DS }))
             .get()
             .getDataStreams()
             .get(0)
@@ -82,7 +78,7 @@ public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase
             .getGeneration();
     }
 
-    public void testRestoreReattachesBackingIndexAndAdvancesGeneration() throws Exception {
+    public void testRestoreReattachesDetachedBackingIndex() throws Exception {
         createRepository(REPO, "fs");
         createTemplate();
         assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(DS)).get());
@@ -131,42 +127,44 @@ public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase
         assertThat(generation(), equalTo(4L));
     }
 
-    public void testRestoreWithRenameAttachesToRenamedStream() throws Exception {
+    public void testRestoreWithRenameAdvancesGenerationOfRenamedStream() throws Exception {
+        // Exercises the two things a unit test of attachRestoredBackingIndices cannot: that the restore pipeline feeds
+        // the post-rename index name into attach, and that attaching a higher-generation index passes cluster-state
+        // validation atomically and leaves rollover working. The source is a generation ahead of the target.
         createRepository(REPO, "fs");
         createTemplate();
 
-        // Source stream logs-attach at generation 2.
+        // Source stream rolled to generation 3, snapshotted; its gen-3 index is the write index.
+        String source = "logs-source";
+        assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(source)).get());
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(source, null)).get().isRolledOver(), equalTo(true)); // 2
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(source, null)).get().isRolledOver(), equalTo(true)); // 3
+        createSnapshot(REPO, "snap", List.of(source));
+
+        // Target stream logs-attach is a generation behind at 2 (backing [1, 2]).
         assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(DS)).get());
-        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // gen 2
-        createSnapshot(REPO, "snap", List.of(DS));
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // 2
+        assertThat(generation(), equalTo(2L));
 
-        // A separate target stream logs-renamed also at generation 2, missing its gen-1 backing index.
-        String renamedStream = "logs-renamed";
-        assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(renamedStream)).get());
-        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(renamedStream, null)).get().isRolledOver(), equalTo(true));
-        String renamedGen1 = DataStream.getDefaultBackingIndexName(renamedStream, 1);
-        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(renamedStream, null)).get().isRolledOver(), equalTo(true));
-        assertAcked(
-            client().execute(
-                ModifyDataStreamsAction.INSTANCE,
-                new ModifyDataStreamsAction.Request(List.of(DataStreamAction.removeBackingIndex(renamedStream, renamedGen1)))
-            ).get()
-        );
-        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(renamedGen1)).get());
-
-        // Restore logs-attach's gen-1 index, renaming it to logs-renamed's gen-1 name. Auto-attach keys off the
-        // post-rename name, so it joins the renamed stream, not the source stream.
+        // Restore the source's gen-3 index, renamed into the target stream. Auto-attach keys off the post-rename name,
+        // and the higher counter advances the target generation to 3, making it the new write index.
+        String targetGen3 = DataStream.getDefaultBackingIndexName(DS, 3);
         RestoreSnapshotResponse restore = client().admin()
             .cluster()
             .prepareRestoreSnapshot(REPO, "snap")
-            .setIndices(DataStream.getDefaultBackingIndexName(DS, 1))
-            .setRenamePattern(DS)
-            .setRenameReplacement(renamedStream)
+            .setIndices(DataStream.getDefaultBackingIndexName(source, 3))
+            .setRenamePattern(source)
+            .setRenameReplacement(DS)
             .setAttachToDataStream(true)
             .setWaitForCompletion(true)
             .get();
         assertThat(restore.getRestoreInfo().successfulShards(), equalTo(restore.getRestoreInfo().totalShards()));
 
-        assertTrue(backingIndices(renamedStream).contains(renamedGen1));
+        assertTrue(backingIndices().contains(targetGen3));
+        assertThat(generation(), equalTo(3L));
+        assertThat(backingIndices().get(backingIndices().size() - 1), equalTo(targetGen3));
+        // A subsequent rollover advances off the new write index, confirming generation stayed in sync.
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true));
+        assertThat(generation(), equalTo(4L));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
@@ -54,9 +54,13 @@ public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase
     }
 
     private List<String> backingIndices() throws Exception {
+        return backingIndices(DS);
+    }
+
+    private List<String> backingIndices(String dataStream) throws Exception {
         return client().admin()
             .indices()
-            .getDataStreams(new GetDataStreamAction.Request(new String[] { DS }))
+            .getDataStreams(new GetDataStreamAction.Request(new String[] { dataStream }))
             .get()
             .getDataStreams()
             .get(0)
@@ -125,5 +129,44 @@ public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase
         );
         // Generation stays at 4 (gen-3 is not the write index); reattaching a lower-counter index does not change it.
         assertThat(generation(), equalTo(4L));
+    }
+
+    public void testRestoreWithRenameAttachesToRenamedStream() throws Exception {
+        createRepository(REPO, "fs");
+        createTemplate();
+
+        // Source stream logs-attach at generation 2.
+        assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(DS)).get());
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // gen 2
+        createSnapshot(REPO, "snap", List.of(DS));
+
+        // A separate target stream logs-renamed also at generation 2, missing its gen-1 backing index.
+        String renamedStream = "logs-renamed";
+        assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(renamedStream)).get());
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(renamedStream, null)).get().isRolledOver(), equalTo(true));
+        String renamedGen1 = DataStream.getDefaultBackingIndexName(renamedStream, 1);
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(renamedStream, null)).get().isRolledOver(), equalTo(true));
+        assertAcked(
+            client().execute(
+                ModifyDataStreamsAction.INSTANCE,
+                new ModifyDataStreamsAction.Request(List.of(DataStreamAction.removeBackingIndex(renamedStream, renamedGen1)))
+            ).get()
+        );
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(renamedGen1)).get());
+
+        // Restore logs-attach's gen-1 index, renaming it to logs-renamed's gen-1 name. Auto-attach keys off the
+        // post-rename name, so it joins the renamed stream, not the source stream.
+        RestoreSnapshotResponse restore = client().admin()
+            .cluster()
+            .prepareRestoreSnapshot(REPO, "snap")
+            .setIndices(DataStream.getDefaultBackingIndexName(DS, 1))
+            .setRenamePattern(DS)
+            .setRenameReplacement(renamedStream)
+            .setAttachToDataStream(true)
+            .setWaitForCompletion(true)
+            .get();
+        assertThat(restore.getRestoreInfo().successfulShards(), equalTo(restore.getRestoreInfo().totalShards()));
+
+        assertTrue(backingIndices(renamedStream).contains(renamedGen1));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DataStreamRestoreAutoAttachIT.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
+import org.opensearch.action.admin.indices.datastream.DataStreamAction;
+import org.opensearch.action.admin.indices.datastream.GetDataStreamAction;
+import org.opensearch.action.admin.indices.datastream.ModifyDataStreamsAction;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.rollover.RolloverRequest;
+import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
+import org.opensearch.cluster.metadata.DataStream;
+import org.opensearch.cluster.metadata.Template;
+import org.opensearch.common.settings.Settings;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that restoring a data stream backing index auto-attaches it to a pre-existing data stream of the same name,
+ * advancing the stream's generation in the same cluster-state update. This is the mechanism cross-cluster replication
+ * relies on to bring a leader's rolled-over backing index onto a follower whose stream is a generation behind.
+ */
+public class DataStreamRestoreAutoAttachIT extends AbstractSnapshotIntegTestCase {
+
+    private static final String REPO = "test-repo";
+    private static final String DS = "logs-attach";
+
+    private void createTemplate() throws Exception {
+        ComposableIndexTemplate template = new ComposableIndexTemplate(
+            List.of("logs-*"),
+            new Template(Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build(), null, null),
+            null,
+            null,
+            null,
+            null,
+            new ComposableIndexTemplate.DataStreamTemplate(new DataStream.TimestampField("@timestamp"))
+        );
+        PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request("ds-template");
+        request.indexTemplate(template);
+        assertAcked(client().execute(PutComposableIndexTemplateAction.INSTANCE, request).get());
+    }
+
+    private List<String> backingIndices() throws Exception {
+        return client().admin()
+            .indices()
+            .getDataStreams(new GetDataStreamAction.Request(new String[] { DS }))
+            .get()
+            .getDataStreams()
+            .get(0)
+            .getDataStream()
+            .getIndices()
+            .stream()
+            .map(i -> i.getName())
+            .collect(Collectors.toList());
+    }
+
+    private long generation() throws Exception {
+        return client().admin()
+            .indices()
+            .getDataStreams(new GetDataStreamAction.Request(new String[] { DS }))
+            .get()
+            .getDataStreams()
+            .get(0)
+            .getDataStream()
+            .getGeneration();
+    }
+
+    public void testRestoreReattachesBackingIndexAndAdvancesGeneration() throws Exception {
+        createRepository(REPO, "fs");
+        createTemplate();
+        assertAcked(client().admin().indices().createDataStream(new CreateDataStreamAction.Request(DS)).get());
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // gen 2
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // gen 3
+        assertThat(generation(), equalTo(3L));
+
+        // Snapshot the whole data stream (includes the gen-3 backing index).
+        createSnapshot(REPO, "snap", List.of(DS));
+
+        // Roll once more so the gen-3 index is no longer the write index, then detach and delete it to model a backing
+        // index that is missing locally but present in the snapshot.
+        String gen3 = DataStream.getDefaultBackingIndexName(DS, 3);
+        assertThat(client().admin().indices().rolloverIndex(new RolloverRequest(DS, null)).get().isRolledOver(), equalTo(true)); // gen 4
+        assertAcked(
+            client().execute(
+                ModifyDataStreamsAction.INSTANCE,
+                new ModifyDataStreamsAction.Request(List.of(DataStreamAction.removeBackingIndex(DS, gen3)))
+            ).get()
+        );
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(gen3)).get());
+        assertThat(backingIndices().contains(gen3), equalTo(false));
+
+        // Restore just the detached backing index; with attach_to_data_stream it re-attaches to the stream.
+        RestoreSnapshotResponse restore = client().admin()
+            .cluster()
+            .prepareRestoreSnapshot(REPO, "snap")
+            .setIndices(gen3)
+            .setAttachToDataStream(true)
+            .setWaitForCompletion(true)
+            .get();
+        assertThat(restore.getRestoreInfo().successfulShards(), equalTo(restore.getRestoreInfo().totalShards()));
+
+        // The restored index is back in the stream, in generation order.
+        assertThat(backingIndices().contains(gen3), equalTo(true));
+        assertThat(
+            backingIndices(),
+            contains(
+                DataStream.getDefaultBackingIndexName(DS, 1),
+                DataStream.getDefaultBackingIndexName(DS, 2),
+                DataStream.getDefaultBackingIndexName(DS, 3),
+                DataStream.getDefaultBackingIndexName(DS, 4)
+            )
+        );
+        // Generation stays at 4 (gen-3 is not the write index); reattaching a lower-counter index does not change it.
+        assertThat(generation(), equalTo(4L));
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -155,6 +155,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
 
     private AliasWriteIndexPolicy aliasWriteIndexPolicy = AliasWriteIndexPolicy.PRESERVE;
 
+    private boolean attachToDataStream = false;
+
     public RestoreSnapshotRequest() {}
 
     /**
@@ -201,6 +203,9 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (in.getVersion().onOrAfter(Version.V_3_3_0)) {
             aliasWriteIndexPolicy = in.readEnum(AliasWriteIndexPolicy.class);
         }
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            attachToDataStream = in.readBoolean();
+        }
     }
 
     @Override
@@ -236,6 +241,9 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         }
         if (out.getVersion().onOrAfter(Version.V_3_3_0)) {
             out.writeEnum(aliasWriteIndexPolicy);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeBoolean(attachToDataStream);
         }
     }
 
@@ -704,6 +712,26 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
     }
 
     /**
+     * When {@code true}, a restored index whose name matches the data stream backing-index convention
+     * ({@code .ds-<dataStream>-NNNNNN}) is attached to a pre-existing data stream of the same name as part of the
+     * restore. Defaults to {@code false}, in which case such an index is restored as a standalone index.
+     *
+     * @param attachToDataStream whether to attach matching restored indices to their data stream
+     * @return this request
+     */
+    public RestoreSnapshotRequest attachToDataStream(boolean attachToDataStream) {
+        this.attachToDataStream = attachToDataStream;
+        return this;
+    }
+
+    /**
+     * Returns whether matching restored indices are attached to their data stream.
+     */
+    public boolean attachToDataStream() {
+        return attachToDataStream;
+    }
+
+    /**
      * Parses restore definition
      *
      * @param source restore definition
@@ -794,6 +822,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
                 }
             } else if ("alias_write_index_policy".equals(name)) {
                 aliasWriteIndexPolicy(AliasWriteIndexPolicy.fromString((String) entry.getValue()));
+            } else if (name.equals("attach_to_data_stream")) {
+                attachToDataStream(nodeBooleanValue(entry.getValue(), "attach_to_data_stream"));
             } else {
                 if (IndicesOptions.isIndicesOptions(name) == false) {
                     throw new IllegalArgumentException("Unknown parameter " + name);
@@ -852,6 +882,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             builder.field("source_remote_translog_repository", sourceRemoteTranslogRepository);
         }
         builder.field("alias_write_index_policy", aliasWriteIndexPolicy.name().toLowerCase(Locale.ROOT));
+        builder.field("attach_to_data_stream", attachToDataStream);
         builder.endObject();
         return builder;
     }
@@ -884,7 +915,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             && Objects.equals(storageType, that.storageType)
             && Objects.equals(sourceRemoteStoreRepository, that.sourceRemoteStoreRepository)
             && Objects.equals(sourceRemoteTranslogRepository, that.sourceRemoteTranslogRepository)
-            && aliasWriteIndexPolicy == that.aliasWriteIndexPolicy;
+            && aliasWriteIndexPolicy == that.aliasWriteIndexPolicy
+            && attachToDataStream == that.attachToDataStream;
         return equals;
     }
 
@@ -908,7 +940,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             storageType,
             sourceRemoteStoreRepository,
             sourceRemoteTranslogRepository,
-            aliasWriteIndexPolicy
+            aliasWriteIndexPolicy,
+            attachToDataStream
         );
         result = 31 * result + Arrays.hashCode(indices);
         result = 31 * result + Arrays.hashCode(ignoreIndexSettings);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -302,4 +302,13 @@ public class RestoreSnapshotRequestBuilder extends ClusterManagerNodeOperationRe
         request.setSourceRemoteTranslogRepository(repositoryName);
         return this;
     }
+
+    /**
+     * If set to true, a restored index whose name matches the data stream backing-index convention is attached to a
+     * pre-existing data stream of the same name instead of being restored as a standalone index.
+     */
+    public RestoreSnapshotRequestBuilder setAttachToDataStream(boolean attachToDataStream) {
+        request.attachToDataStream(attachToDataStream);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamAction.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.action.admin.indices.datastream;
 
-import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -27,7 +27,7 @@ import java.util.Objects;
  *
  * @opensearch.api
  */
-@PublicApi(since = "3.8.0")
+@ExperimentalApi
 public record DataStreamAction(Type type, String dataStream, String index) implements Writeable, ToXContentObject {
 
     /**
@@ -35,7 +35,7 @@ public record DataStreamAction(Type type, String dataStream, String index) imple
      *
      * @opensearch.api
      */
-    @PublicApi(since = "3.8.0")
+    @ExperimentalApi
     public enum Type {
         ADD_BACKING_INDEX((byte) 0, "add_backing_index"),
         REMOVE_BACKING_INDEX((byte) 1, "remove_backing_index");

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamAction.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * A single add- or remove-backing-index operation within a {@link ModifyDataStreamsAction} request.
  *
- * @opensearch.api
+ * @opensearch.experimental
  */
 @ExperimentalApi
 public record DataStreamAction(Type type, String dataStream, String index) implements Writeable, ToXContentObject {
@@ -33,7 +33,7 @@ public record DataStreamAction(Type type, String dataStream, String index) imple
     /**
      * The type of modification applied to a data stream.
      *
-     * @opensearch.api
+     * @opensearch.experimental
      */
     @ExperimentalApi
     public enum Type {

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/ModifyDataStreamsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/ModifyDataStreamsAction.java
@@ -39,7 +39,7 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 /**
  * Applies a batch of {@link DataStreamAction} operations (add/remove backing index) to data-stream metadata atomically.
  *
- * @opensearch.api
+ * @opensearch.experimental
  */
 @ExperimentalApi
 public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
@@ -54,7 +54,7 @@ public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
     /**
      * Request carrying the data-stream actions to apply.
      *
-     * @opensearch.api
+     * @opensearch.experimental
      */
     @ExperimentalApi
     public static class Request extends AcknowledgedRequest<Request> {

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/ModifyDataStreamsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/ModifyDataStreamsAction.java
@@ -21,7 +21,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataDataStreamsService;
 import org.opensearch.cluster.metadata.MetadataDataStreamsService.ModifyDataStreamsClusterStateUpdateRequest;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -41,7 +41,7 @@ import static org.opensearch.action.ValidateActions.addValidationError;
  *
  * @opensearch.api
  */
-@PublicApi(since = "3.8.0")
+@ExperimentalApi
 public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
 
     public static final ModifyDataStreamsAction INSTANCE = new ModifyDataStreamsAction();
@@ -56,7 +56,7 @@ public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
      *
      * @opensearch.api
      */
-    @PublicApi(since = "3.8.0")
+    @ExperimentalApi
     public static class Request extends AcknowledgedRequest<Request> {
 
         private final List<DataStreamAction> actions;

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -668,28 +668,8 @@ public class RestoreService implements ClusterStateApplier {
                                 .map(ds -> updateDataStream(ds, mdBuilder, request))
                                 .collect(Collectors.toMap(DataStream::getName, Function.identity()))
                         );
-                        // Attach each restored ".ds-<streamName>-NNNNNN" index to a pre-existing data stream of the same
-                        // name. Adding the index and advancing the generation in this same update avoids the transient
-                        // state Metadata#validateDataStreams rejects (a convention-named index above the generation).
-                        for (String renamedIndexName : request.attachToDataStream() ? indices.keySet() : Set.<String>of()) {
-                            String streamName = DataStream.parseDataStreamName(renamedIndexName);
-                            if (streamName == null) {
-                                continue;
-                            }
-                            DataStream currentDs = updatedDataStreams.get(streamName);
-                            IndexMetadata restoredIndexMetadata = mdBuilder.get(renamedIndexName);
-                            if (currentDs == null || restoredIndexMetadata == null) {
-                                continue;
-                            }
-                            if (currentDs.getIndices().contains(restoredIndexMetadata.getIndex())) {
-                                continue;
-                            }
-                            // A backing index must map the timestamp field as a date, or data stream search breaks.
-                            MetadataDataStreamsService.validateTimestampFieldMapping(
-                                restoredIndexMetadata,
-                                currentDs.getTimeStampField().getName()
-                            );
-                            updatedDataStreams.put(streamName, currentDs.addBackingIndex(restoredIndexMetadata.getIndex()));
+                        if (request.attachToDataStream()) {
+                            attachRestoredBackingIndices(indices.keySet(), mdBuilder, updatedDataStreams);
                         }
                         mdBuilder.dataStreams(updatedDataStreams);
 
@@ -1046,6 +1026,36 @@ public class RestoreService implements ClusterStateApplier {
                 e
             );
             listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Attaches each restored ".ds-&lt;streamName&gt;-NNNNNN" index to a pre-existing data stream of the same name, in the
+     * same cluster-state update as the restore. Adding the index and advancing the generation together avoids the
+     * transient state {@link Metadata.Builder} validation rejects (a convention-named index above the generation).
+     * Updates {@code updatedDataStreams} in place. Visible for testing.
+     */
+    static void attachRestoredBackingIndices(
+        Set<String> restoredIndexNames,
+        Metadata.Builder metadata,
+        Map<String, DataStream> updatedDataStreams
+    ) {
+        for (String restoredIndexName : restoredIndexNames) {
+            String streamName = DataStream.parseDataStreamName(restoredIndexName);
+            if (streamName == null) {
+                continue;
+            }
+            DataStream currentDs = updatedDataStreams.get(streamName);
+            IndexMetadata restoredIndexMetadata = metadata.get(restoredIndexName);
+            if (currentDs == null || restoredIndexMetadata == null) {
+                continue;
+            }
+            if (currentDs.getIndices().contains(restoredIndexMetadata.getIndex())) {
+                continue;
+            }
+            // A backing index must map the timestamp field as a date, or data stream search breaks.
+            MetadataDataStreamsService.validateTimestampFieldMapping(restoredIndexMetadata, currentDs.getTimeStampField().getName());
+            updatedDataStreams.put(streamName, currentDs.addBackingIndex(restoredIndexMetadata.getIndex()));
         }
     }
 

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -57,6 +57,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataCreateIndexService;
+import org.opensearch.cluster.metadata.MetadataDataStreamsService;
 import org.opensearch.cluster.metadata.MetadataIndexStateService;
 import org.opensearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.opensearch.cluster.metadata.RepositoriesMetadata;
@@ -667,6 +668,33 @@ public class RestoreService implements ClusterStateApplier {
                                 .map(ds -> updateDataStream(ds, mdBuilder, request))
                                 .collect(Collectors.toMap(DataStream::getName, Function.identity()))
                         );
+                        // When requested, attach any restored backing index (".ds-<streamName>-NNNNNN") to a pre-existing
+                        // data stream of the same name, in the same cluster-state update as the restore. Adding the index
+                        // and advancing the stream generation together avoids the transient state that
+                        // Metadata#validateDataStreams forbids (a convention-named index above the stream's generation).
+                        // Opt-in via attachToDataStream so the default behavior (restoring the index as a standalone
+                        // index) is preserved.
+                        for (String renamedIndexName : request.attachToDataStream() ? indices.keySet() : Set.<String>of()) {
+                            String streamName = DataStream.parseDataStreamName(renamedIndexName);
+                            if (streamName == null) {
+                                continue;
+                            }
+                            DataStream currentDs = updatedDataStreams.get(streamName);
+                            IndexMetadata restoredIndexMetadata = mdBuilder.get(renamedIndexName);
+                            if (currentDs == null || restoredIndexMetadata == null) {
+                                continue;
+                            }
+                            if (currentDs.getIndices().contains(restoredIndexMetadata.getIndex())) {
+                                continue;
+                            }
+                            // A backing index must map the stream's timestamp field as a date, or data stream search
+                            // breaks; enforce the same check as the add-backing-index API.
+                            MetadataDataStreamsService.validateTimestampFieldMapping(
+                                restoredIndexMetadata,
+                                currentDs.getTimeStampField().getName()
+                            );
+                            updatedDataStreams.put(streamName, currentDs.addBackingIndex(restoredIndexMetadata.getIndex()));
+                        }
                         mdBuilder.dataStreams(updatedDataStreams);
 
                         // Restore global state if needed

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -668,12 +668,9 @@ public class RestoreService implements ClusterStateApplier {
                                 .map(ds -> updateDataStream(ds, mdBuilder, request))
                                 .collect(Collectors.toMap(DataStream::getName, Function.identity()))
                         );
-                        // When requested, attach any restored backing index (".ds-<streamName>-NNNNNN") to a pre-existing
-                        // data stream of the same name, in the same cluster-state update as the restore. Adding the index
-                        // and advancing the stream generation together avoids the transient state that
-                        // Metadata#validateDataStreams forbids (a convention-named index above the stream's generation).
-                        // Opt-in via attachToDataStream so the default behavior (restoring the index as a standalone
-                        // index) is preserved.
+                        // Attach each restored ".ds-<streamName>-NNNNNN" index to a pre-existing data stream of the same
+                        // name. Adding the index and advancing the generation in this same update avoids the transient
+                        // state Metadata#validateDataStreams rejects (a convention-named index above the generation).
                         for (String renamedIndexName : request.attachToDataStream() ? indices.keySet() : Set.<String>of()) {
                             String streamName = DataStream.parseDataStreamName(renamedIndexName);
                             if (streamName == null) {
@@ -687,8 +684,7 @@ public class RestoreService implements ClusterStateApplier {
                             if (currentDs.getIndices().contains(restoredIndexMetadata.getIndex())) {
                                 continue;
                             }
-                            // A backing index must map the stream's timestamp field as a date, or data stream search
-                            // breaks; enforce the same check as the add-backing-index API.
+                            // A backing index must map the timestamp field as a date, or data stream search breaks.
                             MetadataDataStreamsService.validateTimestampFieldMapping(
                                 restoredIndexMetadata,
                                 currentDs.getTimeStampField().getName()

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -1030,8 +1030,8 @@ public class RestoreService implements ClusterStateApplier {
     }
 
     /**
-     * Attaches each restored ".ds-&lt;streamName&gt;-NNNNNN" index to a pre-existing data stream of the same name, in the
-     * same cluster-state update as the restore. Adding the index and advancing the generation together avoids the
+     * Attaches each restored {@code .ds-<streamName>-NNNNNN} index to a pre-existing data stream of the same name, in
+     * the same cluster-state update as the restore. Adding the index and advancing the generation together avoids the
      * transient state {@link Metadata.Builder} validation rejects (a convention-named index above the generation).
      * Updates {@code updatedDataStreams} in place. Visible for testing.
      */

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -126,6 +126,8 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
             instance.setSourceRemoteStoreRepository(randomAlphaOfLengthBetween(5, 10));
         }
 
+        instance.attachToDataStream(randomBoolean());
+
         return instance;
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -149,17 +149,6 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
         return randomState(copy);
     }
 
-    public void testAttachToDataStreamDefaultAndBuilder() {
-        // Default is false.
-        assertFalse(new RestoreSnapshotRequest("repo", "snap").attachToDataStream());
-
-        // Builder setter toggles the request field.
-        RestoreSnapshotRequestBuilder builder = new RestoreSnapshotRequestBuilder(null, RestoreSnapshotAction.INSTANCE, "repo", "snap");
-        assertFalse(builder.request().attachToDataStream());
-        builder.setAttachToDataStream(true);
-        assertTrue(builder.request().attachToDataStream());
-    }
-
     public void testSource() throws IOException {
         RestoreSnapshotRequest original = createTestInstance();
         original.snapshotUuid(null); // cannot be set via the REST API

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -149,6 +149,17 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
         return randomState(copy);
     }
 
+    public void testAttachToDataStreamDefaultAndBuilder() {
+        // Default is false.
+        assertFalse(new RestoreSnapshotRequest("repo", "snap").attachToDataStream());
+
+        // Builder setter toggles the request field.
+        RestoreSnapshotRequestBuilder builder = new RestoreSnapshotRequestBuilder(null, RestoreSnapshotAction.INSTANCE, "repo", "snap");
+        assertFalse(builder.request().attachToDataStream());
+        builder.setAttachToDataStream(true);
+        assertTrue(builder.request().attachToDataStream());
+    }
+
     public void testSource() throws IOException {
         RestoreSnapshotRequest original = createTestInstance();
         original.snapshotUuid(null); // cannot be set via the REST API

--- a/server/src/test/java/org/opensearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RestoreServiceTests.java
@@ -41,10 +41,16 @@ import org.opensearch.core.index.Index;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.opensearch.cluster.DataStreamTestHelper.createBackingIndex;
 import static org.opensearch.cluster.DataStreamTestHelper.createTimestampField;
+import static org.opensearch.cluster.DataStreamTestHelper.generateMapping;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.mockito.Mockito.eq;
@@ -125,6 +131,78 @@ public class RestoreServiceTests extends OpenSearchTestCase {
 
         assertEquals(renamedDataStreamName, renamedDataStream.getName());
         assertEquals(Collections.singletonList(renamedIndex), renamedDataStream.getIndices());
+    }
+
+    private static IndexMetadata backingIndex(String dataStreamName, int generation) {
+        try {
+            return createBackingIndex(dataStreamName, generation).putMapping(generateMapping("@timestamp")).build();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testAttachRestoredBackingIndexAdvancesGeneration() {
+        String ds = "logs-attach";
+        IndexMetadata b1 = backingIndex(ds, 1);
+        IndexMetadata b2 = backingIndex(ds, 2);
+        // Stream is at generation 1; the restored gen-2 index is present in the builder but not yet a member.
+        Metadata.Builder metadata = Metadata.builder().put(b1, false).put(b2, false);
+        Map<String, DataStream> updatedDataStreams = new HashMap<>();
+        updatedDataStreams.put(ds, new DataStream(ds, createTimestampField("@timestamp"), List.of(b1.getIndex()), 1));
+
+        RestoreService.attachRestoredBackingIndices(Set.of(b2.getIndex().getName()), metadata, updatedDataStreams);
+
+        DataStream result = updatedDataStreams.get(ds);
+        assertEquals(List.of(b1.getIndex(), b2.getIndex()), result.getIndices());
+        assertEquals(2L, result.getGeneration());
+    }
+
+    public void testAttachSkipsNonConventionAndNonMemberCases() {
+        String ds = "logs-attach";
+        IndexMetadata b1 = backingIndex(ds, 1);
+        Metadata.Builder metadata = Metadata.builder().put(b1, false);
+        DataStream original = new DataStream(ds, createTimestampField("@timestamp"), List.of(b1.getIndex()), 1);
+        Map<String, DataStream> updatedDataStreams = new HashMap<>();
+        updatedDataStreams.put(ds, original);
+
+        // A non-convention name (no matching stream) and an already-member index are both skipped, leaving the
+        // stream unchanged.
+        RestoreService.attachRestoredBackingIndices(Set.of("some-regular-index", b1.getIndex().getName()), metadata, updatedDataStreams);
+
+        assertEquals(original, updatedDataStreams.get(ds));
+    }
+
+    public void testAttachSkipsWhenStreamDoesNotExist() {
+        // Restored index parses to a stream name, but no such stream exists on the target: skipped, no exception.
+        String ds = "logs-missing";
+        IndexMetadata b1 = backingIndex(ds, 1);
+        Metadata.Builder metadata = Metadata.builder().put(b1, false);
+        Map<String, DataStream> updatedDataStreams = new HashMap<>();
+
+        RestoreService.attachRestoredBackingIndices(Set.of(b1.getIndex().getName()), metadata, updatedDataStreams);
+
+        assertTrue(updatedDataStreams.isEmpty());
+    }
+
+    public void testAttachRejectsIndexWithoutTimestampMapping() {
+        String ds = "logs-attach";
+        IndexMetadata b1 = backingIndex(ds, 1);
+        // A convention-named gen-2 index whose @timestamp is not a date type.
+        IndexMetadata bad;
+        try {
+            bad = createBackingIndex(ds, 2).putMapping(generateMapping("@timestamp", "text")).build();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        Metadata.Builder metadata = Metadata.builder().put(b1, false).put(bad, false);
+        Map<String, DataStream> updatedDataStreams = new HashMap<>();
+        updatedDataStreams.put(ds, new DataStream(ds, createTimestampField("@timestamp"), List.of(b1.getIndex()), 1));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> RestoreService.attachRestoredBackingIndices(Set.of(bad.getIndex().getName()), metadata, updatedDataStreams)
+        );
+        assertTrue(e.getMessage().contains("does not have a [@timestamp] field mapped as a date type"));
     }
 
     public void testValidateReplicationTypeRestoreSettings_WhenSnapshotIsDocument_RestoreToDocument() {


### PR DESCRIPTION
### Description
Adds an opt-in `attach_to_data_stream` flag to the restore snapshot API. When set, a restored `.ds-<stream>-NNNNNN` index is attached to a pre-existing data stream of the same name in the same cluster-state update, advancing the generation as needed. Default is off, preserving today's behavior (the index is restored as a standalone index), so this is non-breaking. The attached index must map the stream's timestamp field as a date.

### Related Issues
Follow-up to #22487.
  
### Check List
  * [x] Functionality includes testing.
  * [ ] API changes companion pull request created, if applicable.
  * [ ] Public documentation issue/PR created, if applicable.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
