### PR TITLE
Make ICache keys() iteration safe under concurrent mutation

### DIFF
--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
@@ -89,7 +89,7 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
     public void invalidate(ICacheKey<K> key) {
         V value = this.cache.remove(key);
         if (value != null) {
-            removalListener.onRemoval(new RemovalNotification<>(key, cache.get(key), RemovalReason.INVALIDATED));
+            removalListener.onRemoval(new RemovalNotification<>(key, value, RemovalReason.INVALIDATED));
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
@@ -31,6 +31,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -132,9 +133,16 @@ public class OpenSearchOnHeapCache<K, V> implements ICache<K, V>, RemovalListene
         cacheStatsHolder.reset();
     }
 
+    /**
+     * Returns a point-in-time copy of the keys in the cache rather than the live {@link Cache#keys()} view. The
+     * live iterator walks the LRU linked list without holding the LRU lock, so a concurrent cache hit relinking
+     * a not-yet-visited entry to the head of the list can cause iteration to silently skip it. The copy is
+     * unmodifiable, so {@link java.util.Iterator#remove()} — which would be a silent no-op against a copy —
+     * fails fast; use {@link #invalidate(ICacheKey)} to remove entries.
+     */
     @Override
     public Iterable<ICacheKey<K>> keys() {
-        return cache.keys();
+        return Collections.unmodifiableList(cache.keysSnapshot());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -785,23 +785,26 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
 
             Set<List<String>> dimensionListsToDrop = new HashSet<>();
 
-            for (Iterator<ICacheKey<Key>> iterator = cache.keys().iterator(); iterator.hasNext();) {
-                ICacheKey<Key> key = iterator.next();
+            // The cleanup marks are consumed above before this scan, so a key skipped here would stay in the
+            // cache until size-based eviction reaches it. Remove matches with exact-key invalidate() rather
+            // than through the keys() iterator, which may be walking a point-in-time copy that does not support
+            // removal (see OpenSearchOnHeapCache#keys()); invalidating a concurrently removed key is a no-op.
+            for (ICacheKey<Key> key : cache.keys()) {
                 Key delegatingKey = key.key;
                 Tuple<ShardId, Integer> shardIdInfo = new Tuple<>(delegatingKey.shardId, delegatingKey.indexShardHashCode);
                 if (cleanupKeysFromFullClean.contains(shardIdInfo) || cleanupKeysFromClosedShards.contains(shardIdInfo)) {
-                    iterator.remove();
+                    cache.invalidate(key);
                 } else {
                     CacheEntity cacheEntity = cacheEntityLookup.apply(delegatingKey.shardId).orElse(null);
                     if (cacheEntity == null) {
                         // If cache entity is null, it means that index or shard got deleted/closed meanwhile.
                         // So we will delete this key.
                         dimensionListsToDrop.add(key.dimensions);
-                        iterator.remove();
+                        cache.invalidate(key);
                     } else {
                         CleanupKey cleanupKey = new CleanupKey(cacheEntity, delegatingKey.readerCacheKeyId);
                         if (cleanupKeysFromOutdatedReaders.contains(cleanupKey)) {
-                            iterator.remove();
+                            cache.invalidate(key);
                         }
                     }
                 }

--- a/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
@@ -25,8 +25,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.opensearch.common.cache.store.settings.OpenSearchOnHeapCacheSettings.MAXIMUM_SIZE_IN_BYTES_KEY;
@@ -249,6 +252,48 @@ public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
         public void onRemoval(RemovalNotification<ICacheKey<K>, V> notification) {
             numRemovals.inc();
         }
+    }
+
+    /**
+     * keys() must be a point-in-time view that is safe to iterate under concurrent mutation: a cache hit
+     * mid-iteration relinks the accessed entry to the head of the underlying LRU list, and the live
+     * Cache#keys() iterator silently skips an entry promoted from behind the not-yet-visited portion of the
+     * list. This test fails if keys() exposes the live LRU iteration and passes with a point-in-time copy.
+     */
+    public void testKeysIsSafeToIterateUnderConcurrentPromotion() throws Exception {
+        MockRemovalListener<String, String> listener = new MockRemovalListener<>();
+        OpenSearchOnHeapCache<String, String> cache = getCache(100, listener, true);
+        List<ICacheKey<String>> insertedKeys = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            ICacheKey<String> key = getICacheKey("key" + i);
+            cache.computeIfAbsent(key, getLoadAwareCacheLoader());
+            insertedKeys.add(key);
+        }
+
+        Iterator<ICacheKey<String>> iterator = cache.keys().iterator();
+        Set<ICacheKey<String>> observedKeys = new HashSet<>();
+        observedKeys.add(iterator.next());
+        // A hit on the least-recently-used key relinks it at the head of the LRU list, behind a live
+        // iterator's cursor
+        assertNotNull(cache.get(insertedKeys.get(0)));
+        while (iterator.hasNext()) {
+            observedKeys.add(iterator.next());
+        }
+        assertEquals(new HashSet<>(insertedKeys), observedKeys);
+    }
+
+    public void testKeysIteratorDoesNotSupportRemoval() throws Exception {
+        MockRemovalListener<String, String> listener = new MockRemovalListener<>();
+        OpenSearchOnHeapCache<String, String> cache = getCache(100, listener, true);
+        ICacheKey<String> key = getICacheKey("key");
+        cache.computeIfAbsent(key, getLoadAwareCacheLoader());
+
+        Iterator<ICacheKey<String>> iterator = cache.keys().iterator();
+        iterator.next();
+        // Removing through the keys() iterator would be a silent no-op on the point-in-time copy; it must
+        // fail fast so callers use invalidate(key) instead
+        expectThrows(UnsupportedOperationException.class, iterator::remove);
+        assertEquals(1, cache.count());
     }
 
     private ICacheKey<String> getICacheKey(String key) {

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -115,6 +115,7 @@ import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -410,6 +411,72 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(1, cache.count());
 
         IOUtils.close(secondReader);
+    }
+
+    /**
+     * Reproduces stale-entry retention in the cleanup sweep: a cache hit during the sweep relinks the
+     * accessed entry to the head of the on-heap cache's LRU list, and a live LRU iteration silently skips
+     * a not-yet-visited entry promoted behind its cursor. Because the cleanup marks are consumed before
+     * the scan, the skipped entry is never revisited and survives until size-based eviction. The hit is
+     * triggered deterministically from the entity lookup of the first swept entry, mimicking a concurrent
+     * search request. This test fails if the sweep iterates the live LRU view of the on-heap cache's keys
+     * and passes with the point-in-time snapshot.
+     */
+    public void testCleanCacheIsNotDefeatedByCacheHitPromotingEntryMidSweep() throws Exception {
+        threadPool = getThreadPool();
+        IndexShard secondShard = createIndex("second-test").getShard(0);
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        AtomicReference<Runnable> onFirstLookup = new AtomicReference<>();
+        try (NodeEnvironment env = newNodeEnvironment(Settings.EMPTY)) {
+            cache = new IndicesRequestCache(Settings.EMPTY, shardId -> {
+                Runnable hook = onFirstLookup.getAndSet(null);
+                if (hook != null) {
+                    hook.run();
+                }
+                return indicesService.indicesRequestCache.cacheEntityLookup.apply(shardId);
+            },
+                new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
+                threadPool,
+                ClusterServiceUtils.createClusterService(threadPool),
+                env
+            );
+        }
+        writer.addDocument(newDoc(0, "foo"));
+        DirectoryReader readerB1 = getReader(writer, secondShard.shardId());
+        DirectoryReader readerA1 = getReader(writer, indexShard.shardId());
+        DirectoryReader readerA2 = getReader(writer, indexShard.shardId());
+        DirectoryReader readerB2 = getReader(writer, secondShard.shardId());
+
+        // LRU order after insertion, head to tail: B2, A2, A1, B1
+        cache.getOrCompute(getEntity(secondShard), getLoader(readerB1), readerB1, getTermBytes());
+        cache.getOrCompute(getEntity(indexShard), getLoader(readerA1), readerA1, getTermBytes());
+        cache.getOrCompute(getEntity(indexShard), getLoader(readerA2), readerA2, getTermBytes());
+        cache.getOrCompute(getEntity(secondShard), getLoader(readerB2), readerB2, getTermBytes());
+        assertEquals(4, cache.count());
+
+        // Mark all of the second shard's entries for cleanup; the marks are consumed by the next sweep
+        cache.clear(getEntity(secondShard));
+
+        // While the sweep processes its first entry, a concurrent request hits the second shard's
+        // not-yet-visited entry, relinking it at the head of the LRU list. The loader throws so the hit
+        // cannot re-insert the entry if the sweep already removed it (snapshot order is arbitrary).
+        onFirstLookup.set(() -> {
+            try {
+                cache.getOrCompute(
+                    getEntity(secondShard),
+                    () -> { throw new IOException("no reload during sweep"); },
+                    readerB1,
+                    getTermBytes()
+                );
+            } catch (Exception ignored) {
+                // a miss means the sweep already removed the entry; nothing to promote
+            }
+        });
+        cache.cacheCleanupManager.cleanCache();
+
+        // Both second-shard entries must be removed; only the two live first-shard entries remain
+        assertEquals(2, cache.count());
+        IOUtils.close(readerB1, readerA1, readerA2, readerB2);
     }
 
     // when a cache entry that is Stale is evicted for any reason, we have to deduct the count from our staleness count


### PR DESCRIPTION
### Description

Builds on `Cache#keysSnapshot()`, introduced in #22499, which has now merged — this PR is rebased onto `main` and is down to the single new commit (`Make ICache keys() iteration safe under concurrent mutation`). Not stacked on #22498, which has since been reworked to remove the async `BitsetCacheCleaner` and no longer touches `Cache`.

Third instance of the `Cache.keys()` iteration hazard fixed in #22491 / #22499 (fielddata cache) and #22498 (bitset filter cache), this time reaching the request cache through the pluggable cache layer:

- `OpenSearchOnHeapCache#keys()` returned the live `Cache#keys()` LRU iteration through the `ICache` interface. The live iterator walks the LRU linked list without holding the LRU lock; a concurrent cache hit relinks a not-yet-visited entry to the head of the list, behind the iterator's cursor, and iteration silently skips it.
- `IndicesRequestCache`'s cleanup sweep (`cleanCache`) consumes `keysToClean` *before* scanning `cache.keys()`. An entry skipped by the sweep is not re-marked — a reader closes only once — so a stale entry promoted mid-sweep by a concurrent request survives the sweep.

**Impact, stated plainly:** unlike the fielddata cache, the request cache is size-bounded (`indices.requests.cache.size`, default 1% of heap), so a skipped entry is retained until size-based eviction reaches it rather than indefinitely. The consequences are wasted cache capacity holding an entry no future request can reach, and a `staleKeysCount` that never decrements for the skipped entry (the decrement is driven by the removal notification). That leaves the count permanently inflated, so `canSkipCacheCleanup` stops skipping sweeps that then return early at the empty-`keysToClean` check. This is a correctness bug worth fixing, but it is not the unbounded growth that motivated #22491 — I have no production measurements for this path.

Change:

- `OpenSearchOnHeapCache#keys()` returns a point-in-time copy built on `Cache#keysSnapshot()`. The copy is wrapped unmodifiable so a caller using `Iterator#remove` — which would silently no-op against a copy — fails fast instead.
- That behavior — point-in-time copy, iterator removal unsupported — is documented on `OpenSearchOnHeapCache#keys()` rather than on the `ICache` interface, so the `ICache` SPI is left untouched (per review feedback). The other implementations already iterate safely (`TieredSpilloverCache` composes per-tier `keys()`; ehcache's iterator is weakly consistent) and keep their existing removal behavior.
- The request-cache sweep removes matches with exact-key `invalidate(key)` instead of `Iterator#remove()`. `IndicesRequestCache` is the only caller in `server/src/main` that removed while iterating `ICache#keys()`.

### Behavior change for the tiered cache

Switching the sweep from `Iterator#remove()` to `invalidate(key)` is not a no-op under `TieredSpilloverCache`. `ConcatenatedIterator#remove()` delegates to the current tier's iterator, removing the entry from only the tier being iterated; `TieredSpilloverCache#invalidate(key)` invalidates in both tiers under the write lock. For stale-reader cleanup, removing from both tiers is the intended outcome — a key whose reader has closed should not survive on disk — and a key present in both tiers was yielded (and removed) twice by the concatenated iterator anyway. Flagging it explicitly rather than claiming semantics are unchanged. The `INVALIDATED` removal notification and stats accounting path are unchanged, and invalidating a concurrently removed key is a no-op.

### Verification

Two new deterministic regression tests (no threads, no races — the promotion is triggered at a controlled point mid-iteration):

- `OpenSearchOnHeapCacheTests#testKeysIsSafeToIterateUnderConcurrentPromotion` — begins iterating `keys()`, then hits the LRU-tail entry (relinking it at the head behind the cursor), and asserts every inserted key is still observed. Against the live view the promoted key vanishes from iteration (4 of 5 keys observed); with the snapshot all 5 are observed.
- `IndicesRequestCacheTests#testCleanCacheIsNotDefeatedByCacheHitPromotingEntryMidSweep` — four entries across two shards, one shard's entries marked for cleanup, and a cache hit fired from the first swept entry's entity lookup promotes the not-yet-visited stale entry. Against the live view the promoted stale entry survives the sweep (3 entries remain instead of 2, and the suite's teardown leak checks trip); with the snapshot the sweep removes both stale entries.
- `OpenSearchOnHeapCacheTests#testKeysIteratorDoesNotSupportRemoval` pins the fail-fast contract.

`IndicesRequestCacheTests`, `OpenSearchOnHeapCacheTests`, and `CacheTests` pass, as does `:modules:cache-common:test` (50 tests, including `TieredSpilloverCacheTests` 40/40) — re-verified after rebasing onto `main`.

### Related Issues

Same defect class as #22522; follow-up to #22491, #22499 and #22498.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

