### PR TITLE
Add periodic fielddata cache accounting audit

### DIFF
--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -583,7 +583,13 @@ public class IndicesService extends AbstractLifecycleComponent
             }
         }, clusterService, threadPool);
         this.cleanInterval = INDICES_CACHE_CLEAN_INTERVAL_SETTING.get(settings);
-        this.cacheCleaner = new CacheCleaner(indicesFieldDataCache, logger, threadPool, this.cleanInterval);
+        this.cacheCleaner = new CacheCleaner(
+            indicesFieldDataCache,
+            circuitBreakerService.getBreaker(CircuitBreaker.FIELDDATA),
+            logger,
+            threadPool,
+            this.cleanInterval
+        );
         this.indicesBitsetFilterCache = new IndicesBitsetFilterCache(settings, threadPool);
         this.metaStateService = metaStateService;
         this.engineFactoryProviders = engineFactoryProviders;
@@ -2015,13 +2021,21 @@ public class IndicesService extends AbstractLifecycleComponent
     private static final class CacheCleaner implements Runnable, Releasable {
 
         private final IndicesFieldDataCache cache;
+        private final CircuitBreaker fieldDataBreaker;
         private final Logger logger;
         private final ThreadPool threadPool;
         private final TimeValue interval;
         private final AtomicBoolean closed = new AtomicBoolean(false);
 
-        CacheCleaner(IndicesFieldDataCache cache, Logger logger, ThreadPool threadPool, TimeValue interval) {
+        CacheCleaner(
+            IndicesFieldDataCache cache,
+            CircuitBreaker fieldDataBreaker,
+            Logger logger,
+            ThreadPool threadPool,
+            TimeValue interval
+        ) {
             this.cache = cache;
+            this.fieldDataBreaker = fieldDataBreaker;
             this.logger = logger;
             this.threadPool = threadPool;
             this.interval = interval;
@@ -2037,6 +2051,11 @@ public class IndicesService extends AbstractLifecycleComponent
                 this.cache.clear();
             } catch (Exception e) {
                 logger.warn("Exception during periodic field data cache cleanup:", e);
+            }
+            try {
+                this.cache.auditAccounting(fieldDataBreaker);
+            } catch (Exception e) {
+                logger.warn("Exception during periodic field data cache accounting audit:", e);
             }
             if (logger.isTraceEnabled()) {
                 logger.trace(

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -54,6 +54,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.RatioValue;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -268,6 +269,52 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             iterator.remove();
         } catch (Exception e) {
             logger.warn("Exception occurred while removing key from cache", e);
+        }
+    }
+
+    // Number of consecutive audits that must observe drift before warning: a single observation can
+    // race an in-flight load (breaker charged before the entry is inserted) or removal (entry removed
+    // before the breaker decrement fires), but such transients do not persist across audits.
+    static final int DRIFT_AUDITS_BEFORE_WARN = 2;
+
+    // Only mutated by auditAccounting, which has a single caller (the periodic cache cleaner thread).
+    private int consecutiveDriftAudits = 0;
+
+    /**
+     * Compares this cache's accounted weight against the field data circuit breaker's estimate and warns
+     * when the two have drifted. Every byte accounted to this cache is also charged to the field data
+     * breaker while the entry is live and released only when the entry's removal notification runs, so
+     * the cache's accounted weight should never exceed the breaker's estimate for long. Sustained drift
+     * means accounting has leaked (e.g. a removal decrement that never fired), silently eroding the
+     * breaker's protection of the node.
+     *
+     * @param fieldDataBreaker the {@link CircuitBreaker#FIELDDATA} breaker to compare against
+     */
+    public void auditAccounting(CircuitBreaker fieldDataBreaker) {
+        final long entries = cache.count();
+        final long accountedBytes = cache.weight();
+        final long breakerEstimateBytes = fieldDataBreaker.getUsed();
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                "field data cache holds [{}] entries accounting for [{}] bytes; field data breaker estimates [{}] bytes",
+                entries,
+                accountedBytes,
+                breakerEstimateBytes
+            );
+        }
+        if (accountedBytes > breakerEstimateBytes) {
+            consecutiveDriftAudits++;
+            if (consecutiveDriftAudits >= DRIFT_AUDITS_BEFORE_WARN) {
+                logger.warn(
+                    "field data cache accounts for [{}] bytes but the field data circuit breaker estimates [{}] bytes; "
+                        + "accounting has drifted for [{}] consecutive audits",
+                    accountedBytes,
+                    breakerEstimateBytes,
+                    consecutiveDriftAudits
+                );
+            }
+        } else {
+            consecutiveDriftAudits = 0;
         }
     }
 

--- a/server/src/test/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCacheAccountingAuditTests.java
+++ b/server/src/test/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCacheAccountingAuditTests.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.fielddata.cache;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.core.common.breaker.NoopCircuitBreaker;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.fielddata.IndexFieldDataCache;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class IndicesFieldDataCacheAccountingAuditTests extends OpenSearchTestCase {
+
+    public void testAuditWarnsOnlyOnSustainedDrift() throws Exception {
+        final IndicesFieldDataCache fdCache = new IndicesFieldDataCache(Settings.EMPTY, new IndexFieldDataCache.Listener() {
+        }, null, null);
+        // A noop breaker always estimates 0 used bytes, so any cached entry registers as drift.
+        final CircuitBreaker underestimatingBreaker = new NoopCircuitBreaker(CircuitBreaker.FIELDDATA);
+        try (Directory directory = newDirectory(); IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig())) {
+            writer.addDocument(new Document());
+            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                IndicesFieldDataCache.IndexFieldCache indexCache = (IndicesFieldDataCache.IndexFieldCache) fdCache.buildIndexFieldDataCache(
+                    new IndexFieldDataCache.Listener() {
+                    },
+                    new Index("index", "_na_"),
+                    "field"
+                );
+                IndicesFieldDataCache.Key key = new IndicesFieldDataCache.Key(indexCache, reader.getReaderCacheHelper().getKey(), null);
+                fdCache.getCache().put(key, () -> 1024L);
+
+                // A single drifting audit can be a transient race with an in-flight load or removal: no warning.
+                auditExpectingWarning(fdCache, underestimatingBreaker, false);
+                // Drift persisting across consecutive audits is a leak: warn.
+                auditExpectingWarning(fdCache, underestimatingBreaker, true);
+
+                // Accounting agreeing again resets the streak.
+                fdCache.getCache().invalidateAll();
+                auditExpectingWarning(fdCache, underestimatingBreaker, false);
+
+                // New drift must again persist for DRIFT_AUDITS_BEFORE_WARN audits before warning.
+                fdCache.getCache().put(key, () -> 2048L);
+                auditExpectingWarning(fdCache, underestimatingBreaker, false);
+                auditExpectingWarning(fdCache, underestimatingBreaker, true);
+            }
+        } finally {
+            fdCache.close();
+        }
+    }
+
+    private void auditExpectingWarning(IndicesFieldDataCache fdCache, CircuitBreaker breaker, boolean expectWarning) throws Exception {
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(IndicesFieldDataCache.class))) {
+            final String loggerName = IndicesFieldDataCache.class.getCanonicalName();
+            final String pattern = "*accounting has drifted*";
+            appender.addExpectation(
+                expectWarning
+                    ? new MockLogAppender.SeenEventExpectation("drift warning", loggerName, Level.WARN, pattern)
+                    : new MockLogAppender.UnseenEventExpectation("no drift warning", loggerName, Level.WARN, pattern)
+            );
+            fdCache.auditAccounting(breaker);
+            appender.assertAllExpectationsMatched();
+        }
+    }
+}


### PR DESCRIPTION
### Description

First slice of #22543 (accounting drift observability, follow-up from #22522).

The fielddata cache's self-reported accounting can silently diverge from reality — #22522 sat invisible for years because nothing compared the cache's numbers against any independent signal. This adds a cheap, always-on cross-check between the two accounting systems that are supposed to agree:

- After each periodic cleanup run, `CacheCleaner` now calls `IndicesFieldDataCache#auditAccounting(CircuitBreaker)` with the fielddata breaker.
- The audit logs entry count, cache accounted weight, and breaker estimate at DEBUG on every run.
- It WARNs when the cache's accounted weight exceeds the breaker's estimate for consecutive runs. Every byte accounted to the cache is charged to the fielddata breaker while the entry is live and released only when the removal notification runs, so sustained drift in this direction means a decrement was leaked (the #20363 failure class) and the breaker's protection has silently eroded.

A single observation can legitimately race an in-flight load (breaker charged before insert) or removal (entry removed before the breaker decrement fires), so the audit only warns when drift persists across consecutive audits — transient races don't survive a one-minute cleanup interval.

Costs: two `long` reads and a breaker read once per cleanup interval (default 1m); no new settings, APIs, or serialization.

Scope note: this detects cache-vs-breaker drift. It intentionally does not detect accounting-vs-retained-heap divergence (the #22522 mechanism itself) — that requires retained-graph accounting and is tracked separately in #22544, with the broader observability design space in #22543.

### Verification

`IndicesFieldDataCacheAccountingAuditTests#testAuditWarnsOnlyOnSustainedDrift` — drives the audit against a breaker that always underestimates (a noop breaker reporting 0 used bytes) and asserts via log expectations that: the first drifting audit does not warn, the second consecutive one does, agreement resets the streak, and new drift again requires two consecutive audits before warning.

### Related Issues

Part of #22543. Related: #22522, #22544, #20363.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
