### PR TITLE
fix(shard): Clear stuck primaryReplicaResyncInProgress flag

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/PrimaryReplicaResyncIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/PrimaryReplicaResyncIT.java
@@ -1,0 +1,237 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.action.admin.cluster.reroute.ClusterRerouteResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexService;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for {@link IndexShard#primaryReplicaResyncInProgress} flag liveness.
+ * Validates the fix for <a href="https://github.com/opensearch-project/OpenSearch/issues/21692">#21692</a>.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class PrimaryReplicaResyncIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends org.opensearch.plugins.Plugin>> nodePlugins() {
+        return Collections.singletonList(MockTransportService.TestPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            // Use a short resync timeout for testing so the test doesn't wait 30 minutes
+            .put(IndexShard.PRIMARY_RESYNC_TIMEOUT_SETTING.getKey(), "10s")
+            .build();
+    }
+
+    /**
+     * Path B: Verifies that when the resync transport response is lost (simulated by silently
+     * consuming the request without responding), the primaryReplicaResyncInProgress flag is
+     * eventually cleared by the timeout watchdog, allowing subsequent primary relocation to succeed.
+     */
+    public void testResyncTimeoutClearsStuckFlag() throws Exception {
+        // Start cluster: 1 cluster-manager + 3 data nodes
+        String clusterManager = internalCluster().startClusterManagerOnlyNode();
+        String nodeA = internalCluster().startDataOnlyNode();
+        String nodeB = internalCluster().startDataOnlyNode();
+        String nodeC = internalCluster().startDataOnlyNode();
+
+        // Create index pinned to nodeA and nodeB, excluding nodeC
+        assertAcked(
+            prepareCreate("test").setSettings(
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 1)
+                    .put("index.routing.allocation.include._name", nodeA + "," + nodeB)
+                    .put("index.routing.allocation.exclude._name", nodeC)
+            )
+        );
+        ensureGreen("test");
+
+        // Index some documents so the resync has operations to send
+        for (int i = 0; i < 100; i++) {
+            client().prepareIndex("test").setSource("field", "value" + i).get();
+        }
+        client().admin().indices().prepareFlush("test").setForce(true).get();
+
+        // Determine which node holds the primary and which holds the replica
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ShardRouting primaryShard = state.routingTable().index("test").shard(0).primaryShard();
+        String primaryNodeId = primaryShard.currentNodeId();
+        String primaryNodeName = state.nodes().get(primaryNodeId).getName();
+        String replicaNodeName = primaryNodeName.equals(nodeA) ? nodeB : nodeA;
+
+        // Install a request-handling drop on the future-primary (replicaNodeName) for the resync action.
+        // This simulates a lost transport response — the sender's listener never fires.
+        CountDownLatch resyncDropped = new CountDownLatch(1);
+        MockTransportService futurePrimaryTransport = (MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            replicaNodeName
+        );
+        futurePrimaryTransport.addRequestHandlingBehavior(
+            "internal:index/seq_no/resync[p]",
+            (handler, request, channel, task) -> {
+                // Silently consume; do not call handler.messageReceived; do not reply on channel.
+                // This simulates a lost transport response — the sender's listener never fires.
+                resyncDropped.countDown();
+            }
+        );
+
+        // Stop the current primary — the replica on replicaNodeName gets promoted
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName));
+
+        // Wait for the replica to become the new primary
+        assertBusy(() -> {
+            ClusterState s = client().admin().cluster().prepareState().get().getState();
+            ShardRouting newPrimary = s.routingTable().index("test").shard(0).primaryShard();
+            assertNotNull(newPrimary);
+            assertTrue(newPrimary.started());
+            assertEquals(replicaNodeName, s.nodes().get(newPrimary.currentNodeId()).getName());
+        }, 30, TimeUnit.SECONDS);
+
+        // Verify the resync request was indeed dropped
+        assertTrue("resync request should have been intercepted", resyncDropped.await(10, TimeUnit.SECONDS));
+
+        // Verify the flag is initially stuck (before timeout fires)
+        IndexShard shard = getIndexShard(replicaNodeName, "test");
+        assertTrue(
+            "primaryReplicaResyncInProgress should be true immediately after promotion with dropped resync",
+            shard.isPrimaryReplicaResyncInProgress()
+        );
+
+        // Wait for the timeout watchdog to clear the flag (configured to 10s in nodeSettings)
+        assertBusy(() -> {
+            assertFalse(
+                "primaryReplicaResyncInProgress should be cleared by timeout watchdog",
+                shard.isPrimaryReplicaResyncInProgress()
+            );
+        }, 30, TimeUnit.SECONDS);
+
+        // Clear the transport interception so future requests succeed
+        futurePrimaryTransport.clearAllRules();
+
+        // Now open allocation to nodeC and verify relocation succeeds
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(
+                    Settings.builder()
+                        .put("index.routing.allocation.include._name", replicaNodeName + "," + nodeC)
+                        .putNull("index.routing.allocation.exclude._name")
+                )
+        );
+
+        // Issue a reroute to move the primary from replicaNodeName to nodeC
+        ClusterRerouteResponse rerouteResponse = client().admin()
+            .cluster()
+            .prepareReroute()
+            .add(new MoveAllocationCommand("test", 0, replicaNodeName, nodeC))
+            .get();
+        assertTrue(rerouteResponse.isAcknowledged());
+
+        // Wait for relocation to complete — this should succeed now that the flag is cleared
+        ensureGreen("test");
+
+        // Verify the primary ended up on nodeC
+        ClusterState finalState = client().admin().cluster().prepareState().get().getState();
+        ShardRouting finalPrimary = finalState.routingTable().index("test").shard(0).primaryShard();
+        assertThat(finalState.nodes().get(finalPrimary.currentNodeId()).getName(), equalTo(nodeC));
+    }
+
+    /**
+     * Path A: Verifies that when AlreadyClosedException is thrown before the syncer listener
+     * is registered (simulated by closing the index during promotion), the flag is properly cleared.
+     */
+    public void testAlreadyClosedExceptionClearsFlag() throws Exception {
+        // Start cluster: 1 cluster-manager + 2 data nodes
+        String clusterManager = internalCluster().startClusterManagerOnlyNode();
+        String nodeA = internalCluster().startDataOnlyNode();
+        String nodeB = internalCluster().startDataOnlyNode();
+
+        // Create index on nodeA and nodeB
+        assertAcked(
+            prepareCreate("test").setSettings(
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 1)
+                    .put("index.routing.allocation.include._name", nodeA + "," + nodeB)
+            )
+        );
+        ensureGreen("test");
+
+        // Index some documents
+        for (int i = 0; i < 50; i++) {
+            client().prepareIndex("test").setSource("field", "value" + i).get();
+        }
+        client().admin().indices().prepareFlush("test").setForce(true).get();
+
+        // Determine which node holds the primary
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ShardRouting primaryShard = state.routingTable().index("test").shard(0).primaryShard();
+        String primaryNodeId = primaryShard.currentNodeId();
+        String primaryNodeName = state.nodes().get(primaryNodeId).getName();
+        String replicaNodeName = primaryNodeName.equals(nodeA) ? nodeB : nodeA;
+
+        // Delete the index right after stopping the primary — this triggers AlreadyClosedException
+        // during the promotion path on the replica node
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName));
+
+        // Give a brief moment for promotion to start
+        Thread.sleep(500);
+
+        // Delete the index to trigger AlreadyClosedException in the promotion callback
+        try {
+            assertAcked(client().admin().indices().prepareDelete("test"));
+        } catch (Exception e) {
+            // Index might already be gone if the shard failed, that's fine
+        }
+
+        // The key assertion: the node should not have a leaked flag preventing future relocations.
+        // Since we deleted the index, verify the node is healthy and can create new indices.
+        assertAcked(
+            prepareCreate("test2").setSettings(
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.routing.allocation.include._name", replicaNodeName)
+            )
+        );
+        ensureGreen("test2");
+    }
+
+    private IndexShard getIndexShard(String nodeName, String indexName) {
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, nodeName);
+        IndexService indexService = indicesService.indexServiceSafe(
+            client().admin().cluster().prepareState().get().getState().metadata().index(indexName).getIndex()
+        );
+        return indexService.getShard(0);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -125,6 +125,7 @@ import org.opensearch.index.autoforcemerge.ForceMergeManagerSettings;
 import org.opensearch.index.compositeindex.CompositeIndexSettings;
 import org.opensearch.index.remote.RemoteStorePressureSettings;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.remote.filecache.FileCacheSettings;
 import org.opensearch.indices.ClusterMergeSchedulerConfig;
 import org.opensearch.indices.IndexingMemoryController;
@@ -482,6 +483,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING,
                 TransportReplicationAction.REPLICATION_INITIAL_RETRY_BACKOFF_BOUND,
                 TransportReplicationAction.REPLICATION_RETRY_TIMEOUT,
+                IndexShard.PRIMARY_RESYNC_TIMEOUT_SETTING,
                 PublishCheckpointAction.PUBLISH_CHECK_POINT_RETRY_TIMEOUT,
                 TransportSettings.HOST,
                 TransportSettings.PUBLISH_HOST,

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -98,6 +98,7 @@ import org.opensearch.common.lucene.index.DerivedSourceDirectoryReader;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.metrics.MeanMetric;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
@@ -229,6 +230,7 @@ import org.opensearch.indices.replication.common.ReplicationTimer;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.search.suggest.completion.CompletionStats;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -290,6 +292,19 @@ import static org.opensearch.index.translog.Translog.TRANSLOG_UUID_KEY;
  */
 @PublicApi(since = "1.0.0")
 public class IndexShard extends AbstractIndexShardComponent implements IndicesClusterStateService.Shard {
+
+    /**
+     * Timeout for the primary-replica resync operation. If the resync listener does not fire within this
+     * duration, the {@code primaryReplicaResyncInProgress} flag is forcibly cleared to prevent permanently
+     * blocking primary relocation. Defaults to 30 minutes.
+     */
+    public static final Setting<TimeValue> PRIMARY_RESYNC_TIMEOUT_SETTING = Setting.timeSetting(
+        "indices.replication.resync_timeout",
+        TimeValue.timeValueMinutes(30),
+        TimeValue.timeValueSeconds(10),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
 
     private final ThreadPool threadPool;
     private final MapperService mapperService;
@@ -889,6 +904,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             + ", new routing: "
                             + newRouting;
                         assert getOperationPrimaryTerm() == newPrimaryTerm;
+                        final AtomicBoolean listenerRegistered = new AtomicBoolean(false);
                         try {
                             if (indexSettings.isSegRepEnabledOrRemoteNode()) {
                                 // this Shard's engine was read only, we need to update its engine before restoring local history from xlog.
@@ -946,27 +962,68 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             engine.translogManager().rollTranslogGeneration();
                             engine.fillSeqNoGaps(newPrimaryTerm);
                             replicationTracker.updateLocalCheckpoint(currentRouting.allocationId().getId(), getLocalCheckpoint());
+
+                            // Path B fix: wrap the resync listener with a watchdog timeout so that a lost transport
+                            // response cannot leave primaryReplicaResyncInProgress stuck forever.
+                            final TimeValue resyncTimeout = PRIMARY_RESYNC_TIMEOUT_SETTING.get(
+                                indexSettings.getNodeSettings()
+                            );
+                            final AtomicBoolean resyncListenerFired = new AtomicBoolean(false);
+                            final Scheduler.ScheduledCancellable timeoutTask = threadPool.schedule(() -> {
+                                if (resyncListenerFired.compareAndSet(false, true)) {
+                                    logger.warn(
+                                        "[{}] primary-replica resync timed out after [{}], forcibly clearing "
+                                            + "primaryReplicaResyncInProgress flag to unblock primary relocation",
+                                        shardId,
+                                        resyncTimeout
+                                    );
+                                    boolean cleared = primaryReplicaResyncInProgress.compareAndSet(true, false);
+                                    assert cleared : "resync timeout fired but flag was already cleared";
+                                }
+                            }, resyncTimeout, ThreadPool.Names.GENERIC);
+
+                            listenerRegistered.set(true);
                             primaryReplicaSyncer.accept(this, new ActionListener<ResyncTask>() {
                                 @Override
                                 public void onResponse(ResyncTask resyncTask) {
-                                    logger.info("primary-replica resync completed with {} operations", resyncTask.getResyncedOperations());
-                                    boolean resyncCompleted = primaryReplicaResyncInProgress.compareAndSet(true, false);
-                                    assert resyncCompleted : "primary-replica resync finished but was not started";
+                                    timeoutTask.cancel();
+                                    if (resyncListenerFired.compareAndSet(false, true)) {
+                                        logger.info(
+                                            "primary-replica resync completed with {} operations",
+                                            resyncTask.getResyncedOperations()
+                                        );
+                                        boolean resyncCompleted = primaryReplicaResyncInProgress.compareAndSet(true, false);
+                                        assert resyncCompleted : "primary-replica resync finished but was not started";
+                                    }
                                 }
 
                                 @Override
                                 public void onFailure(Exception e) {
-                                    boolean resyncCompleted = primaryReplicaResyncInProgress.compareAndSet(true, false);
-                                    assert resyncCompleted : "primary-replica resync finished but was not started";
-                                    if (state == IndexShardState.CLOSED) {
-                                        // ignore, shutting down
-                                    } else {
-                                        failShard("exception during primary-replica resync", e);
+                                    timeoutTask.cancel();
+                                    if (resyncListenerFired.compareAndSet(false, true)) {
+                                        boolean resyncCompleted = primaryReplicaResyncInProgress.compareAndSet(true, false);
+                                        assert resyncCompleted : "primary-replica resync finished but was not started";
+                                        if (state == IndexShardState.CLOSED) {
+                                            // ignore, shutting down
+                                        } else {
+                                            failShard("exception during primary-replica resync", e);
+                                        }
                                     }
                                 }
                             });
                         } catch (final AlreadyClosedException e) {
-                            // okay, the index was deleted
+                            // Path A fix: if we reach here before the syncer listener was registered,
+                            // the flag will never be cleared by the listener. Clear it now.
+                            if (listenerRegistered.get() == false) {
+                                boolean cleared = primaryReplicaResyncInProgress.compareAndSet(true, false);
+                                if (cleared) {
+                                    logger.debug(
+                                        "[{}] cleared primaryReplicaResyncInProgress flag after AlreadyClosedException "
+                                            + "before resync listener registration",
+                                        shardId
+                                    );
+                                }
+                            }
                         }
                     }, null);
                 }
@@ -1026,6 +1083,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     private final AtomicBoolean primaryReplicaResyncInProgress = new AtomicBoolean();
+
+    /**
+     * Returns whether a primary-replica resync is currently in progress on this shard.
+     * Exposed for testing and diagnostic purposes.
+     */
+    public boolean isPrimaryReplicaResyncInProgress() {
+        return primaryReplicaResyncInProgress.get();
+    }
 
     /**
      * Completes the relocation. Operations are blocked and current operations are drained before changing state to


### PR DESCRIPTION
After a replica-to-primary promotion, the primaryReplicaResyncInProgress flag could get permanently stuck in two ways:

Path A: An AlreadyClosedException thrown before primaryReplicaSyncer.accept() registers its listener meant no code path would ever clear the flag.

Path B: If the resync transport response is lost (network partition, dead replica), the syncer's listener never fires, leaving the flag true forever.

Once stuck, verifyRelocatingState() rejects every subsequent primary relocation attempt until the source node is restarted.

Fix:
- Path A: Clear the flag in the catch(AlreadyClosedException) block when the syncer listener was never registered.
- Path B: Schedule a watchdog timeout (configurable via indices.replication.resync_timeout, default 30m) that forcibly clears the flag if neither the success nor failure callback fires in time. The timeout is cancelled immediately on normal completion.
- Add isPrimaryReplicaResyncInProgress() accessor for diagnostics.

Signed-off-by: Varun Bansal <bansvaru@amazon.com>

Resolves #21692

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
