### PR TITLE
Reject explicitly empty index store type

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
@@ -58,6 +58,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
@@ -212,6 +213,16 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
                 e.getMessage()
             );
         }
+    }
+
+    public void testExplicitEmptyStoreTypeIsRejected() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> prepareCreate("test").setSettings(Settings.builder().put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), ""))
+                .setWaitForActiveShards(ActiveShardCount.NONE)
+                .get()
+        );
+        assertThat(exception.getMessage(), equalTo("Unknown store type []"));
     }
 
     public void testPrivateSettingFails() {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
@@ -93,6 +93,24 @@ public class UpdateSettingsIT extends OpenSearchIntegTestCase {
         assertEquals(exception.getMessage(), "Unknown char_filter type [invalid] for [invalid_char]");
     }
 
+    public void testExplicitEmptyStoreTypeIsRejectedOnClosedIndex() {
+        createIndex("test");
+        assertAcked(client().admin().indices().prepareClose("test").get());
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder().put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), ""))
+                .get()
+        );
+        assertThat(exception.getMessage(), equalTo("Unknown store type []"));
+
+        IndexMetadata indexMetadata = client().admin().cluster().prepareState().get().getState().metadata().index("test");
+        assertFalse(IndexModule.INDEX_STORE_TYPE_SETTING.exists(indexMetadata.getSettings()));
+    }
+
     public void testInvalidDynamicUpdate() {
         createIndex("test");
         IllegalArgumentException exception = expectThrows(

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -1132,7 +1132,7 @@ public final class IndexModule {
             throw new IllegalArgumentException("store type [" + storeType + "] is not allowed because mmap is disabled");
         }
         final IndexStorePlugin.DirectoryFactory factory;
-        if (storeType.isEmpty()) {
+        if (storeType.isEmpty() && INDEX_STORE_TYPE_SETTING.exists(indexSettings.getSettings()) == false) {
             factory = DEFAULT_DIRECTORY_FACTORY;
         } else {
             factory = indexStoreFactories.get(storeType);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Explicitly setting `index.store.type` to an empty string currently bypasses the registered directory factory lookup. The create-index request is acknowledged, but shard creation later fails with `no matching store type for []`, leaving the index red.

This change distinguishes an omitted store type from an explicitly configured empty value:

- When `index.store.type` is absent, the internal empty default continues to select the default directory factory.
- When `index.store.type` is explicitly set to `""`, it enters the existing directory factory lookup and fails with `IllegalArgumentException: Unknown store type []`.
- Valid built-in and plugin-provided store types are unaffected.

The failure occurs while creating the temporary `IndexService`, before the index is added to the cluster state.

This change adds an internal-cluster test verifying that an explicitly empty store type is rejected during index creation.

Validation performed:

```text
./gradlew :server:internalClusterTest \
  --tests "org.opensearch.action.admin.indices.create.CreateIndexIT.testExplicitEmptyStoreTypeIsRejected"

./gradlew :server:test \
  --tests "org.opensearch.index.IndexModuleTests"

./gradlew :server:spotlessJavaCheck
```

### Related Issues
Resolves #22550
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
