### PR TITLE
[Analytics] Add optional liquid cache seam for indexed parquet scans (cargo feature)

### DIFF
--- a/sandbox/libs/dataformat-native/build.gradle
+++ b/sandbox/libs/dataformat-native/build.gradle
@@ -77,6 +77,11 @@ task buildRustLibrary(type: Exec) {
 
     def cargoArgs = [cargoExecutable, 'build', '-p', 'opensearch-native-lib']
     if (buildType == 'release') { cargoArgs.add('--release') }
+    // Liquid Cache: -PliquidCache (or LIQUID_CACHE=1) turns on the liquid_cache cargo feature (off by default).
+    if (project.hasProperty('liquidCache') || System.getenv('LIQUID_CACHE') == '1') {
+        logger.lifecycle('Liquid Cache: feature enabled')
+        cargoArgs.addAll(['--features', 'opensearch-datafusion/liquid_cache'])
+    }
     commandLine cargoArgs
 
     inputs.files fileTree("${rustWorkspaceDir}/common/src")

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -95,6 +95,13 @@ crc32fast = { workspace = true }
 # rewrite. STANDARD alphabet matches the OpenSearch `binary` field wire contract.
 base64 = "0.22"
 
+# Liquid Cache (off by default): uncomment the dep + the dep: entry below and build with -PliquidCache to use liquid cache.
+# opensearch-liquid-cache = { path = "../../liquid-cache/src/main/rust", optional = true }
+
+[features]
+# Off by default; when on, the hook in src/liquid_cache.rs engages the process-global cache.
+liquid_cache = [] # ["dep:opensearch-liquid-cache"]
+
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -250,9 +250,11 @@ fn create_stream_with_access_plan(
         }
     }
 
-    let mut config_builder =
-        FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(parquet_source))
-            .with_file(partitioned_file);
+    // Liquid Cache: wrap the ParquetSource with LiquidParquetSource for eligible scans when the feature is on; a no-op otherwise.
+    let file_source: Arc<dyn datafusion::datasource::physical_plan::FileSource> =
+        crate::liquid_cache::maybe_wrap_parquet_source(parquet_source, config);
+    let mut config_builder = FileScanConfigBuilder::new(config.store_url.clone(), file_source)
+        .with_file(partitioned_file);
 
     if let Some(ref proj) = config.projection {
         // Empty projection (e.g. COUNT(*)) is honoured as "read no

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ffm;
 pub mod helper;
 pub mod indexed_executor;
 pub mod indexed_table;
+pub mod liquid_cache;
 pub mod local_executor;
 pub mod memory;
 pub mod memory_guard;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/liquid_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/liquid_cache.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Liquid Cache hook for the indexed scan path; gated behind the `liquid_cache` feature (off by default = inlined no-op). Policy and cache live in the `opensearch-liquid-cache` crate.
+
+use std::sync::Arc;
+
+use datafusion::datasource::physical_plan::{FileSource, ParquetSource};
+
+use crate::indexed_table::parquet_bridge::RowGroupStreamConfig;
+
+/// Wrap the source with LiquidParquetSource when the `liquid_cache` feature is
+/// compiled in and the cache is enabled for an eligible scan; otherwise (and
+/// always in the default build) return the plain source unchanged.
+pub(crate) fn maybe_wrap_parquet_source(
+    parquet_source: ParquetSource,
+    config: &RowGroupStreamConfig,
+) -> Arc<dyn FileSource> {
+    #[cfg(feature = "liquid_cache")]
+    {
+        use opensearch_liquid_cache::{
+            indexed_scan_eligible, LiquidOnlyRuntime, LiquidParquetSource,
+        };
+
+        if LiquidOnlyRuntime::is_enabled_globally() {
+            if let Some(cache_ref) = LiquidOnlyRuntime::cache_ref_globally() {
+                if indexed_scan_eligible(
+                    &config.full_schema,
+                    config.projection.as_deref(),
+                    config.predicate.as_ref(),
+                ) {
+                    return Arc::new(LiquidParquetSource::from_parquet_source(
+                        parquet_source,
+                        cache_ref,
+                    ));
+                }
+            }
+        }
+    }
+    #[cfg(not(feature = "liquid_cache"))]
+    let _ = config;
+
+    Arc::new(parquet_source)
+}


### PR DESCRIPTION
### Description

Adds an opt-in, in-memory decoded-batch cache ("liquid cache") for the DataFusion analytics backend, wired behind a **cargo feature** so it is completely absent from the default build.

- **Feature off (default):** the integration is an inlined no-op. Eligible scans use the plain `ParquetSource` unchanged, and the build declares no liquid cache dependency, so it resolves and compiles exactly as before.
- **Feature on (`-PliquidCache` / `LIQUID_CACHE=1`):** an eligible indexed row-group scan is wrapped with `LiquidParquetSource`, so decoded batches are served from and populated into the process-global cache.

The hook (`liquid_cache.rs`) is already in its **final form**: when the feature is on it delegates to the `opensearch-liquid-cache` crate. That crate is provided by the liquid-cache plugin later in the stack, so here the dependency is left commented in `Cargo.toml` (Cargo resolves every declared path dependency even when its feature is off, which would otherwise break this build). The integration PR only flips the dependency on — it does not modify this hook.

This is the first PR in a 3-part stack that keeps each change small and independently reviewable. The stack is a straight split of the final code, not an evolution — each file lands in its final shape:

1. **This PR — seam:** the feature-gated in-process hook (no-op by default).
2. **Library (#22569):** vendors the liquid-cache library crates in isolation.
3. **Integration (#22595):** turns the dependency on, adds the plugin + Java wiring + integration test.

### Changes

| File | What |
|------|------|
| `sandbox/libs/dataformat-native/build.gradle` | `-PliquidCache` / `LIQUID_CACHE=1` build flag that forwards the cargo feature |
| `.../analytics-backend-datafusion/rust/Cargo.toml` | commented optional `opensearch-liquid-cache` dep + bare `liquid_cache = []` feature (default build resolves no dep) |
| `.../rust/src/indexed_table/parquet_bridge.rs` | call site for the `maybe_wrap_parquet_source` hook (no-op when feature off) |
| `.../rust/src/lib.rs` | `pub mod liquid_cache` |
| `.../rust/src/liquid_cache.rs` | the hook: no-op when off; when on, delegates to `opensearch-liquid-cache` to wrap eligible scans |

5 files changed, +95 / -3.

### Check List
- [x] Default build compiles with the feature off (no behavior change, no new dependency).
- [x] Functionality verified with the feature on (cache engages on eligible indexed scans) — via the integration PR, which supplies the crate.
- [ ] API changes companion PR raised (n/a).
- [ ] Public documentation issue/PR created (n/a — sandbox).

> Note: PRs target `main`, so until the parent merges the GitHub diff for the downstream PRs includes their parent commits. Review/merge in stack order: this PR → #22569 → #22595.
