### PR TITLE
Bound regexp determinize work limit and simple_query_string nesting depth

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -377,6 +377,22 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
      * Protects against too-difficult regular expression queries.
      */
     public QueryStringQueryBuilder maxDeterminizedStates(int maxDeterminizedStates) {
+        if (maxDeterminizedStates < 0) {
+            throw new IllegalArgumentException(
+                "[" + NAME + "] max_determinized_states cannot be negative but was [" + maxDeterminizedStates + "]"
+            );
+        }
+        if (maxDeterminizedStates > RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT) {
+            throw new IllegalArgumentException(
+                "["
+                    + NAME
+                    + "] max_determinized_states cannot exceed ["
+                    + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT
+                    + "] but was ["
+                    + maxDeterminizedStates
+                    + "]"
+            );
+        }
         this.maxDeterminizedStates = maxDeterminizedStates;
         return this;
     }

--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -209,7 +209,10 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         lenient = in.readOptionalBoolean();
         timeZone = in.readOptionalZoneId();
         escape = in.readBoolean();
-        maxDeterminizedStates = in.readVInt();
+        // Route through the setter so the CVE-2026-63136 bound is enforced on the transport
+        // deserialization path too, not just REST/XContent. Protects a patched data node from an
+        // unbounded value sent by an unpatched coordinating node in a mixed-version cluster.
+        maxDeterminizedStates(in.readVInt());
         autoGenerateSynonymsPhraseQuery = in.readBoolean();
         fuzzyTranspositions = in.readBoolean();
     }

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -68,6 +68,15 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
 
     public static final int DEFAULT_FLAGS_VALUE = RegexpFlag.ALL.value();
     public static final int DEFAULT_DETERMINIZE_WORK_LIMIT = Operations.DEFAULT_DETERMINIZE_WORK_LIMIT;
+    /**
+     * Upper bound for {@code max_determinized_states}. The determinize work limit exists to cap the
+     * amount of work Lucene performs while determinizing a regexp automaton; allowing an arbitrarily
+     * large value (e.g. {@link Integer#MAX_VALUE}) effectively disables that safeguard and lets a
+     * crafted pattern exhaust the heap before Lucene ever throws {@code TooComplexToDeterminizeException}.
+     * This ceiling (100x the default) still permits legitimately complex expressions while keeping the
+     * safeguard effective. See CVE-2026-63136.
+     */
+    public static final int MAX_DETERMINIZE_WORK_LIMIT = 1_000_000;
     public static final boolean DEFAULT_CASE_INSENSITIVITY = false;
 
     private static final ParseField FLAGS_VALUE_FIELD = new ParseField("flags_value");
@@ -180,6 +189,20 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
      * Sets the regexp maxDeterminizedStates.
      */
     public RegexpQueryBuilder maxDeterminizedStates(int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("[" + NAME + "] max_determinized_states cannot be negative but was [" + value + "]");
+        }
+        if (value > MAX_DETERMINIZE_WORK_LIMIT) {
+            throw new IllegalArgumentException(
+                "["
+                    + NAME
+                    + "] max_determinized_states cannot exceed ["
+                    + MAX_DETERMINIZE_WORK_LIMIT
+                    + "] but was ["
+                    + value
+                    + "]"
+            );
+        }
         this.maxDeterminizedStates = value;
         return this;
     }

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -122,7 +122,10 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         fieldName = in.readString();
         value = in.readString();
         syntaxFlagsValue = in.readVInt();
-        maxDeterminizedStates = in.readVInt();
+        // Route through the setter so the CVE-2026-63136 bound is enforced on the transport
+        // deserialization path too, not just REST/XContent. Protects a patched data node from an
+        // unbounded value sent by an unpatched coordinating node in a mixed-version cluster.
+        maxDeterminizedStates(in.readVInt());
         rewrite = in.readOptionalString();
         caseInsensitive = in.readBoolean();
     }

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -197,13 +197,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         }
         if (value > MAX_DETERMINIZE_WORK_LIMIT) {
             throw new IllegalArgumentException(
-                "["
-                    + NAME
-                    + "] max_determinized_states cannot exceed ["
-                    + MAX_DETERMINIZE_WORK_LIMIT
-                    + "] but was ["
-                    + value
-                    + "]"
+                "[" + NAME + "] max_determinized_states cannot exceed [" + MAX_DETERMINIZE_WORK_LIMIT + "] but was [" + value + "]"
             );
         }
         this.maxDeterminizedStates = value;

--- a/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
@@ -82,9 +82,7 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
      * (default 1000, aligned with the recursion depth limits in {@code StreamInput} /
      * {@code XContentConstraints}) so operators can tune it for unusual workloads without a code change.
      */
-    static final int MAX_NESTING_DEPTH = Integer.parseInt(
-        System.getProperty("opensearch.query.simple_query_string.max_depth", "1000")
-    );
+    static final int MAX_NESTING_DEPTH = Integer.parseInt(System.getProperty("opensearch.query.simple_query_string.max_depth", "1000"));
 
     private final Settings settings;
     private QueryShardContext context;

--- a/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
@@ -77,8 +77,14 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
      * deeply nested unescaped parentheses drives one JVM stack frame per level and overflows the
      * stack ({@code StackOverflowError}) before any query is built. Capping the depth and failing
      * with a catchable exception keeps the recursion bounded. See CVE-2026-63144.
+     * <p>
+     * Configurable via the {@code opensearch.query.simple_query_string.max_depth} system property
+     * (default 1000, aligned with the recursion depth limits in {@code StreamInput} /
+     * {@code XContentConstraints}) so operators can tune it for unusual workloads without a code change.
      */
-    static final int MAX_NESTING_DEPTH = 1000;
+    static final int MAX_NESTING_DEPTH = Integer.parseInt(
+        System.getProperty("opensearch.query.simple_query_string.max_depth", "1000")
+    );
 
     private final Settings settings;
     private QueryShardContext context;

--- a/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
@@ -71,6 +71,15 @@ import static org.opensearch.common.lucene.search.Queries.newUnmappedFieldQuery;
  */
 public class SimpleQueryStringQueryParser extends SimpleQueryParser {
 
+    /**
+     * Maximum nesting depth of parenthesized (precedence) groups that will be parsed. Lucene's
+     * {@link SimpleQueryParser} parses precedence groups recursively, so a query string containing
+     * deeply nested unescaped parentheses drives one JVM stack frame per level and overflows the
+     * stack ({@code StackOverflowError}) before any query is built. Capping the depth and failing
+     * with a catchable exception keeps the recursion bounded. See CVE-2026-63144.
+     */
+    static final int MAX_NESTING_DEPTH = 1000;
+
     private final Settings settings;
     private QueryShardContext context;
     private final MultiMatchQuery queryBuilder;
@@ -97,6 +106,58 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
         this.queryBuilder.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.NULL);
         if (analyzer != null) {
             this.queryBuilder.setAnalyzer(analyzer);
+        }
+    }
+
+    @Override
+    public Query parse(String queryText) {
+        checkNestingDepth(queryText);
+        return super.parse(queryText);
+    }
+
+    /**
+     * Rejects query strings whose parenthesized (precedence) groups nest deeper than
+     * {@link #MAX_NESTING_DEPTH}. This mirrors how Lucene's {@link SimpleQueryParser} tokenizes the
+     * input so the guard trips before the recursive parse can overflow the JVM stack: a parenthesis
+     * only opens/closes a group when the precedence flag is enabled and the character is neither
+     * escaped nor inside a quoted phrase. Fails with an {@link IllegalArgumentException} (translated
+     * to an HTTP 400) instead of an unrecoverable {@code StackOverflowError}. See CVE-2026-63144.
+     */
+    private void checkNestingDepth(String queryText) {
+        if (queryText == null || (flags & SimpleQueryParser.PRECEDENCE_OPERATORS) == 0) {
+            return;
+        }
+        final boolean escapeEnabled = (flags & SimpleQueryParser.ESCAPE_OPERATOR) != 0;
+        final boolean phraseEnabled = (flags & SimpleQueryParser.PHRASE_OPERATOR) != 0;
+        int depth = 0;
+        boolean inPhrase = false;
+        for (int i = 0; i < queryText.length(); i++) {
+            char c = queryText.charAt(i);
+            if (escapeEnabled && c == '\\') {
+                i++; // skip the escaped character
+                continue;
+            }
+            if (phraseEnabled && c == '"') {
+                inPhrase = !inPhrase;
+                continue;
+            }
+            if (inPhrase) {
+                continue;
+            }
+            if (c == '(') {
+                depth++;
+                if (depth > MAX_NESTING_DEPTH) {
+                    throw new IllegalArgumentException(
+                        "["
+                            + SimpleQueryStringBuilder.NAME
+                            + "] query text nests parentheses deeper than the limit of ["
+                            + MAX_NESTING_DEPTH
+                            + "]"
+                    );
+                }
+            } else if (c == ')' && depth > 0) {
+                depth--;
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -118,6 +119,49 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
 
         e = expectThrows(IllegalArgumentException.class, () -> new RegexpQueryBuilder("field", null));
         assertEquals("value cannot be null", e.getMessage());
+    }
+
+    public void testMaxDeterminizedStatesIsBounded() {
+        // Guards against CVE-2026-63136: an unbounded max_determinized_states disables Lucene's
+        // determinization safeguard and lets a crafted pattern exhaust the heap.
+        RegexpQueryBuilder query = new RegexpQueryBuilder("field", ".*a.{30}");
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> query.maxDeterminizedStates(Integer.MAX_VALUE)
+        );
+        assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> query.maxDeterminizedStates(RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + 1)
+        );
+        assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
+
+        e = expectThrows(IllegalArgumentException.class, () -> query.maxDeterminizedStates(-1));
+        assertThat(e.getMessage(), containsString("cannot be negative"));
+
+        // The ceiling itself and typical values remain accepted.
+        assertEquals(
+            RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT,
+            query.maxDeterminizedStates(RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT).maxDeterminizedStates()
+        );
+        assertEquals(20000, query.maxDeterminizedStates(20000).maxDeterminizedStates());
+    }
+
+    public void testMaxDeterminizedStatesFromJsonIsBounded() {
+        // The bound must also apply when the value arrives via the REST/XContent parse path.
+        String json = String.format(Locale.ROOT, """
+            {
+                "regexp" : {
+                    "field" : {
+                        "value" : ".*a.{30}",
+                        "max_determinized_states" : 2147483647
+                    }
+                }
+            }""");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
+        assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
     }
 
     public void testFromJson() throws IOException {

--- a/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
@@ -128,10 +128,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
         // determinization safeguard and lets a crafted pattern exhaust the heap.
         RegexpQueryBuilder query = new RegexpQueryBuilder("field", ".*a.{30}");
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> query.maxDeterminizedStates(Integer.MAX_VALUE)
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.maxDeterminizedStates(Integer.MAX_VALUE));
         assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
 
         e = expectThrows(

--- a/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
@@ -34,7 +34,9 @@ package org.opensearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -162,6 +164,27 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
             }""");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(json));
         assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
+    }
+
+    public void testMaxDeterminizedStatesFromStreamIsBounded() throws IOException {
+        // Guards against CVE-2026-63136 on the transport deserialization path: a patched data node
+        // must reject an out-of-bounds value serialized by an (unpatched) coordinating node instead
+        // of feeding it to Lucene. The setter bound cannot be reached by serializing a real builder
+        // (the setter itself blocks it), so we hand-craft the wire bytes with an oversized value.
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeFloat(AbstractQueryBuilder.DEFAULT_BOOST); // boost
+        out.writeOptionalString(null);                      // queryName
+        out.writeString("field");                           // fieldName
+        out.writeString(".*a.{30}");                        // value
+        out.writeVInt(RegexpQueryBuilder.DEFAULT_FLAGS_VALUE);
+        out.writeVInt(Integer.MAX_VALUE);                   // maxDeterminizedStates (malicious)
+        out.writeOptionalString(null);                      // rewrite
+        out.writeBoolean(false);                            // caseInsensitive
+
+        try (StreamInput in = out.bytes().streamInput()) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RegexpQueryBuilder(in));
+            assertThat(e.getMessage(), containsString("max_determinized_states cannot exceed"));
+        }
     }
 
     public void testFromJson() throws IOException {

--- a/server/src/test/java/org/opensearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/SimpleQueryStringBuilderTests.java
@@ -479,6 +479,28 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         assertEquals(expected, query);
     }
 
+    public void testDeeplyNestedParensAreRejected() throws IOException {
+        // Guards against CVE-2026-63144: deeply nested parentheses drive one recursion frame per
+        // level in Lucene's SimpleQueryParser and overflow the JVM stack. The query must instead
+        // fail with a catchable IllegalArgumentException (surfaced to clients as HTTP 400).
+        int depth = 200_000;
+        String nested = "(".repeat(depth) + "a" + ")".repeat(depth);
+        SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder(nested).field(TEXT_FIELD_NAME);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> qb.toQuery(createShardContext()));
+        assertThat(e.getMessage(), containsString("nests parentheses deeper than the limit"));
+
+        // Escaped parentheses and parentheses inside a quoted phrase do not count toward nesting
+        // depth, mirroring how Lucene tokenizes the input, so they must still parse successfully.
+        String escaped = "\\(".repeat(depth) + "a";
+        Query query = new SimpleQueryStringBuilder(escaped).field(TEXT_FIELD_NAME).toQuery(createShardContext());
+        assertNotNull(query);
+
+        // A modestly nested (well under the limit) query remains valid.
+        String shallow = "(".repeat(50) + "a" + ")".repeat(50);
+        query = new SimpleQueryStringBuilder(shallow).field(TEXT_FIELD_NAME).toQuery(createShardContext());
+        assertNotNull(query);
+    }
+
     public void testAnalyzeWildcard() throws IOException {
         SimpleQueryStringQueryParser.Settings settings = new SimpleQueryStringQueryParser.Settings();
         settings.analyzeWildcard(true);


### PR DESCRIPTION
Two low-privilege search-request DoS vectors:

- CVE-2026-63136 (regexp/query_string determinization OOM): max_determinized_states was read unbounded and passed to Lucene's RegexpQuery, so a request could set it to Integer.MAX_VALUE and disable Lucene's TooComplexToDeterminizeException safeguard. A pattern like .*a.{30} then determinizes toward ~2^30 states and exhausts the heap. Bound the value to MAX_DETERMINIZE_WORK_LIMIT (1,000,000, 100x the default) in the RegexpQueryBuilder and QueryStringQueryBuilder setters, covering the REST, transport, and programmatic paths, and reject negatives.

- CVE-2026-63144 (simple_query_string nested-paren StackOverflow): Lucene's SimpleQueryParser recurses one frame per '(' with no depth cap, so deeply nested parentheses overflow the JVM stack. Add a bounded pre-scan in SimpleQueryStringQueryParser.parse() that counts unescaped, non-phrase parenthesis nesting (mirroring Lucene's tokenizer) and rejects depth > MAX_NESTING_DEPTH (1000) with a catchable IllegalArgumentException (HTTP 400) before recursion begins.

Both now fail fast with a 4xx instead of crashing the node. Adds regression tests including the reported PoC payloads.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
