### PR TITLE
Make indices.queries.cache.size a dynamic setting

### DIFF
--- a/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
@@ -79,7 +79,8 @@ public class IndicesQueryCache implements QueryCache, Closeable {
     public static final Setting<ByteSizeValue> INDICES_CACHE_QUERY_SIZE_SETTING = Setting.memorySizeSetting(
         "indices.queries.cache.size",
         "10%",
-        Property.NodeScope
+        Property.NodeScope,
+        Property.Dynamic
     );
     // mostly a way to prevent queries from being the main source of memory usage
     // of the cache
@@ -123,10 +124,12 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         Property.Dynamic
     );
 
-    private final LRUQueryCache cache;
+    private final int count;
+    private final boolean cacheAllSegments;
+    // Replaced (not mutated) when the size setting is updated dynamically, see setMaxSizeInBytes.
+    private volatile OpenSearchLRUQueryCache cache;
     private final ShardCoreKeyMap shardKeyMap = new ShardCoreKeyMap();
     private final Map<ShardId, Stats> shardStats = new ConcurrentHashMap<>();
-    private volatile long sharedRamBytesUsed;
 
     // This is a hack for the fact that the close listener for the
     // ShardCoreKeyMap will be called before onDocIdSetEviction
@@ -140,24 +143,35 @@ public class IndicesQueryCache implements QueryCache, Closeable {
 
     public IndicesQueryCache(Settings settings, ClusterSettings clusterSettings) {
         final ByteSizeValue size = INDICES_CACHE_QUERY_SIZE_SETTING.get(settings);
-        final int count = INDICES_CACHE_QUERY_COUNT_SETTING.get(settings);
+        this.count = INDICES_CACHE_QUERY_COUNT_SETTING.get(settings);
+        this.cacheAllSegments = INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.get(settings);
         float skipCacheFactor = INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.get(settings);
         logger.debug("using [node] query cache with size [{}] max filter count [{}] skipCacheFactor [{}]", size, count, skipCacheFactor);
-        if (INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.get(settings)) {
-            cache = new OpenSearchLRUQueryCache(count, size.getBytes(), context -> true, 1f);
-        } else {
-            cache = new OpenSearchLRUQueryCache(count, size.getBytes());
-            cache.setSkipCacheFactor(skipCacheFactor);
-            if (clusterSettings != null) {
+        cache = createCache(size.getBytes(), skipCacheFactor);
+        if (clusterSettings != null) {
+            if (cacheAllSegments == false) {
                 clusterSettings.addSettingsUpdateConsumer(INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR, this::setSkipCacheFactor);
-            } else {
-                logger.warn("clusterSettings is null, so {} is not dynamic", INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.getKey());
             }
+            clusterSettings.addSettingsUpdateConsumer(INDICES_CACHE_QUERY_SIZE_SETTING, this::setMaxSizeInBytes);
+        } else {
+            logger.warn(
+                "clusterSettings is null, so {} and {} are not dynamic",
+                INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.getKey(),
+                INDICES_CACHE_QUERY_SIZE_SETTING.getKey()
+            );
         }
-        sharedRamBytesUsed = 0;
     }
 
-    public void setSkipCacheFactor(float skipCacheFactor) {
+    private OpenSearchLRUQueryCache createCache(long sizeInBytes, float skipCacheFactor) {
+        if (cacheAllSegments) {
+            return new OpenSearchLRUQueryCache(count, sizeInBytes, context -> true, 1f);
+        }
+        final OpenSearchLRUQueryCache newCache = new OpenSearchLRUQueryCache(count, sizeInBytes);
+        newCache.setSkipCacheFactor(skipCacheFactor);
+        return newCache;
+    }
+
+    public synchronized void setSkipCacheFactor(float skipCacheFactor) {
         logger.debug(
             "set cluster settings {} {} -> {}",
             INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.getKey(),
@@ -165,6 +179,32 @@ public class IndicesQueryCache implements QueryCache, Closeable {
             skipCacheFactor
         );
         cache.setSkipCacheFactor(skipCacheFactor);
+    }
+
+    /**
+     * Lucene's {@link LRUQueryCache} does not allow its memory limit to change after construction,
+     * so a size update replaces the cache with a new instance of the new size. The old instance is
+     * drained through {@link LRUQueryCache#clearCoreCacheKey(Object)} so that every entry it held
+     * is accounted out of the per-shard stats through the usual eviction callbacks. In-flight
+     * queries that obtained a cached weight before the swap may still insert entries into the old
+     * instance; those entries are evicted (with the same stats accounting) when their segment
+     * closes, exactly like entries the old instance held at swap time.
+     */
+    private synchronized void setMaxSizeInBytes(ByteSizeValue size) {
+        final OpenSearchLRUQueryCache oldCache = cache;
+        logger.info("set cluster settings {} -> [{}], rebuilding query cache", INDICES_CACHE_QUERY_SIZE_SETTING.getKey(), size);
+        cache = createCache(size.getBytes(), oldCache.getSkipCacheFactor());
+        for (Object coreKey : stats2.keySet().toArray()) {
+            oldCache.clearCoreCacheKey(coreKey);
+        }
+        // Release the queries (not doc id sets) still retained by the old instance. onClear on a
+        // retired instance only resets its own query memory accounting, not the shared shard stats.
+        oldCache.clear();
+    }
+
+    // Visible for testing
+    float getSkipCacheFactor() {
+        return cache.getSkipCacheFactor();
     }
 
     /** Get usage statistics for the given shard. */
@@ -182,6 +222,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
 
         // We also have some shared ram usage that we try to distribute to
         // proportionally to their number of cache entries of each shard
+        final long sharedRamBytesUsed = cache.queryRamBytesUsed;
         if (stats.isEmpty()) {
             shardStats.add(
                 new QueryCacheStats.Builder().ramBytesUsed(sharedRamBytesUsed).hitCount(0).missCount(0).cacheCount(0).cacheSize(0).build()
@@ -356,6 +397,11 @@ public class IndicesQueryCache implements QueryCache, Closeable {
 
     private class OpenSearchLRUQueryCache extends LRUQueryCache {
 
+        // Memory used by the queries (not doc id sets) retained by this instance. Kept per
+        // instance rather than on IndicesQueryCache so that draining a replaced instance after a
+        // dynamic size update cannot corrupt the accounting of its replacement.
+        volatile long queryRamBytesUsed;
+
         OpenSearchLRUQueryCache(int maxSize, long maxRamBytesUsed, Predicate<LeafReaderContext> leavesToCache, float skipFactor) {
             super(maxSize, maxRamBytesUsed, leavesToCache, skipFactor);
         }
@@ -387,25 +433,31 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         @Override
         protected void onClear() {
             super.onClear();
-            for (Stats stats : shardStats.values()) {
-                // don't throw away hit/miss
-                stats.cacheSize = 0;
-                stats.ramBytesUsed = 0;
+            queryRamBytesUsed = 0;
+            // Only a clear of the active instance resets the shared per-shard stats. A replaced
+            // instance being drained after a dynamic size update has already been accounted out
+            // entry by entry through onDocIdSetEviction, and the active instance's entries must
+            // stay counted.
+            if (IndicesQueryCache.this.cache == this) {
+                for (Stats stats : shardStats.values()) {
+                    // don't throw away hit/miss
+                    stats.cacheSize = 0;
+                    stats.ramBytesUsed = 0;
+                }
+                stats2.clear();
             }
-            stats2.clear();
-            sharedRamBytesUsed = 0;
         }
 
         @Override
         protected void onQueryCache(Query filter, long ramBytesUsed) {
             super.onQueryCache(filter, ramBytesUsed);
-            sharedRamBytesUsed += ramBytesUsed;
+            queryRamBytesUsed += ramBytesUsed;
         }
 
         @Override
         protected void onQueryEviction(Query filter, long ramBytesUsed) {
             super.onQueryEviction(filter, ramBytesUsed);
-            sharedRamBytesUsed -= ramBytesUsed;
+            queryRamBytesUsed -= ramBytesUsed;
         }
 
         @Override
@@ -437,6 +489,13 @@ public class IndicesQueryCache implements QueryCache, Closeable {
                 // we only evict when nothing is cached anymore on the segment
                 // instead of relying on close listeners
                 final StatsAndCount statsAndCount = stats2.get(readerCoreKey);
+                if (statsAndCount == null) {
+                    // A replaced instance can evict entries that were inserted into it after it
+                    // was drained (by queries in flight during a dynamic size update) and whose
+                    // stats were since reset by a clear of the active instance.
+                    assert this != IndicesQueryCache.this.cache;
+                    return;
+                }
                 final Stats shardStats = statsAndCount.stats;
                 shardStats.cacheSize -= numEntries;
                 shardStats.ramBytesUsed -= sumRamBytesUsed;

--- a/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
@@ -582,6 +582,105 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         cache.close(); // this triggers some assertions
     }
 
+    public void testDynamicallyChangeCacheSize() throws IOException {
+        Directory dir1 = newDirectory();
+        IndexWriter w1 = new IndexWriter(dir1, newIndexWriterConfig());
+        w1.addDocument(new Document());
+        DirectoryReader r1 = DirectoryReader.open(w1);
+        w1.close();
+        ShardId shard1 = new ShardId("index", "_na_", 0);
+        r1 = OpenSearchDirectoryReader.wrap(r1, shard1);
+        IndexSearcher s1 = new IndexSearcher(r1);
+        s1.setQueryCachingPolicy(alwaysCachePolicy());
+
+        Directory dir2 = newDirectory();
+        IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig());
+        w2.addDocument(new Document());
+        DirectoryReader r2 = DirectoryReader.open(w2);
+        w2.close();
+        ShardId shard2 = new ShardId("index", "_na_", 1);
+        r2 = OpenSearchDirectoryReader.wrap(r2, shard2);
+        IndexSearcher s2 = new IndexSearcher(r2);
+        s2.setQueryCachingPolicy(alwaysCachePolicy());
+
+        Settings settings = Settings.builder()
+            .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
+            .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+            .put(IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING.getKey(), "10mb")
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        IndicesQueryCache cache = new IndicesQueryCache(settings, clusterSettings);
+        s1.setQueryCache(cache);
+        s2.setQueryCache(cache);
+
+        for (int i = 0; i < 5; ++i) {
+            assertEquals(1, s1.count(new DummyQuery(i)));
+            assertEquals(1, s2.count(new DummyQuery(i)));
+        }
+
+        QueryCacheStats stats1 = cache.getStats(shard1);
+        assertEquals(5L, stats1.getCacheSize());
+        assertEquals(5L, stats1.getCacheCount());
+        assertTrue(stats1.getMemorySizeInBytes() > 0L);
+        final long missCount1 = stats1.getMissCount();
+
+        QueryCacheStats stats2 = cache.getStats(shard2);
+        assertEquals(5L, stats2.getCacheSize());
+        assertEquals(5L, stats2.getCacheCount());
+        assertTrue(stats2.getMemorySizeInBytes() > 0L);
+
+        // Shrinking the cache replaces and drains the old instance: per-shard entry and memory
+        // stats must be accounted down to zero while cumulative counters are preserved
+        clusterSettings.applySettings(Settings.builder().put(IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING.getKey(), "1mb").build());
+
+        stats1 = cache.getStats(shard1);
+        assertEquals(0L, stats1.getCacheSize());
+        assertEquals(5L, stats1.getCacheCount());
+        assertEquals(missCount1, stats1.getMissCount());
+        assertEquals(0L, stats1.getMemorySizeInBytes());
+
+        stats2 = cache.getStats(shard2);
+        assertEquals(0L, stats2.getCacheSize());
+        assertEquals(5L, stats2.getCacheCount());
+        assertEquals(0L, stats2.getMemorySizeInBytes());
+
+        // caching keeps working against the new instance
+        for (int i = 0; i < 5; ++i) {
+            assertEquals(1, s1.count(new DummyQuery(i)));
+        }
+
+        stats1 = cache.getStats(shard1);
+        assertEquals(5L, stats1.getCacheSize());
+        assertEquals(10L, stats1.getCacheCount());
+        assertTrue(stats1.getMemorySizeInBytes() > 0L);
+
+        IOUtils.close(r1, dir1, r2, dir2);
+        cache.onClose(shard1);
+        cache.onClose(shard2);
+        cache.close(); // this triggers some assertions
+    }
+
+    public void testSkipCacheFactorSurvivesSizeUpdate() {
+        Settings settings = Settings.EMPTY;
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        IndicesQueryCache cache = new IndicesQueryCache(settings, clusterSettings);
+
+        clusterSettings.applySettings(
+            Settings.builder().put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.getKey(), 42f).build()
+        );
+        assertEquals(42f, cache.getSkipCacheFactor(), 0f);
+
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(IndicesQueryCache.INDICES_QUERIES_CACHE_SKIP_CACHE_FACTOR.getKey(), 42f)
+                .put(IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING.getKey(), "1mb")
+                .build()
+        );
+        assertEquals(42f, cache.getSkipCacheFactor(), 0f);
+
+        cache.close();
+    }
+
     public void testCostlyMinFrequencyToCache() throws IOException {
         Settings settings = Settings.builder().build();
         OpenseachUsageTrackingQueryCachingPolicy queryCachingPolicy = new OpenseachUsageTrackingQueryCachingPolicy(


### PR DESCRIPTION
### Description
`indices.queries.cache.size` is a node-scope static setting today, so the only way to change the node query cache's memory budget is a rolling restart with an updated `opensearch.yml` — and on managed platforms that don't expose this key, it cannot be changed at all. The sibling admission settings (`skip_cache_factor`, `min_frequency`, `costly_min_frequency`) became dynamic in #18351, but the size cap itself did not, because Lucene's `LRUQueryCache` takes `maxRamBytesUsed` as a constructor argument with no setter.

This change makes the setting dynamic by replacing the `LRUQueryCache` instance on update:

- On a size update, a new cache instance is built with the new size (preserving the current `skipCacheFactor`) and swapped in; new queries cache into it immediately.
- The old instance is drained through `clearCoreCacheKey`, so every entry it held is accounted out of the per-shard stats through the ordinary eviction callbacks — `_nodes/stats` counters stay exact, and cumulative hit/miss/cacheCount are preserved.
- The shared query memory accounting (`sharedRamBytesUsed`) moves onto each cache instance, so `clear()` on a retired instance resets only its own accounting; the shared per-shard stats are reset only when the active instance is cleared.
- Queries in flight during the swap may still insert into the retired instance; those entries are evicted (through the same accounting callbacks) when their segment closes, the same way entries are reclaimed today.

A size update rebuilds the cache, so resident entries are dropped and re-admitted by traffic. That is the intended behavior for an operator shrinking the cache to relieve heap pressure, and matches the semantics of a restart with a new size today.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. *(N/A — no API surface change.)*
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. *(The settings docs list `indices.queries.cache.size` as static; I'll open a documentation-website issue once the approach here is confirmed.)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).