### PR TITLE
Support per-action outbound buffer threshold for streaming transports

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightListeners.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightListeners.java
@@ -13,27 +13,18 @@ import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import io.grpc.stub.ServerCallStreamObserver;
 
 /**
- * Package-private bridge into Arrow Flight server listener internals, living in {@code org.apache.arrow.flight}
- * (alongside {@link OSFlightServer}) so it can reach members not exposed by Arrow's public API.
- *
- * <p>The gRPC per-stream backpressure watermark is set via {@link ServerCallStreamObserver#setOnReadyThreshold(int)},
- * but Arrow's {@link ServerStreamListener} does not surface that observer. The concrete server listener extends
- * {@link OutboundStreamListenerImpl}, whose {@code responseObserver} is {@code protected} and therefore accessible
- * from this package. This is ordinary package access, not reflection: a change to that field on an Arrow upgrade is
- * a compile error surfaced here, not a runtime surprise.
+ * Reaches the gRPC {@link ServerCallStreamObserver} behind an Arrow {@link ServerStreamListener}, which Arrow's
+ * public API does not expose. Lives in {@code org.apache.arrow.flight} to access the {@code protected}
+ * {@code responseObserver} field of {@link OutboundStreamListenerImpl} without reflection.
  */
 public final class OSFlightListeners {
 
     private OSFlightListeners() {}
 
     /**
-     * Applies a per-stream outbound buffer threshold to the given server listener, if it is backed by a gRPC
-     * {@link ServerCallStreamObserver}. gRPC allows the threshold to be re-set at any point during the call, so this
-     * may be called after the call has started. A listener not backed by such an observer (e.g. a test double) is a
-     * no-op.
-     *
-     * @param listener the Arrow server stream listener for the call
-     * @param bytes    the outbound buffered-bytes watermark at which {@code isReady()} flips false
+     * Sets the per-stream outbound buffer watermark (bytes at which {@code isReady()} flips false) on the
+     * listener's gRPC observer. May be called after the call has started. No-op if the listener is not backed
+     * by a {@link ServerCallStreamObserver}.
      */
     public static void setOnReadyThreshold(ServerStreamListener listener, int bytes) {
         if (listener instanceof OutboundStreamListenerImpl impl

--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightListeners.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightListeners.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.arrow.flight;
+
+import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+
+import io.grpc.stub.ServerCallStreamObserver;
+
+/**
+ * Package-private bridge into Arrow Flight server listener internals, living in {@code org.apache.arrow.flight}
+ * (alongside {@link OSFlightServer}) so it can reach members not exposed by Arrow's public API.
+ *
+ * <p>The gRPC per-stream backpressure watermark is set via {@link ServerCallStreamObserver#setOnReadyThreshold(int)},
+ * but Arrow's {@link ServerStreamListener} does not surface that observer. The concrete server listener extends
+ * {@link OutboundStreamListenerImpl}, whose {@code responseObserver} is {@code protected} and therefore accessible
+ * from this package. This is ordinary package access, not reflection: a change to that field on an Arrow upgrade is
+ * a compile error surfaced here, not a runtime surprise.
+ */
+public final class OSFlightListeners {
+
+    private OSFlightListeners() {}
+
+    /**
+     * Applies a per-stream outbound buffer threshold to the given server listener, if it is backed by a gRPC
+     * {@link ServerCallStreamObserver}. gRPC allows the threshold to be re-set at any point during the call, so this
+     * may be called after the call has started. A listener not backed by such an observer (e.g. a test double) is a
+     * no-op.
+     *
+     * @param listener the Arrow server stream listener for the call
+     * @param bytes    the outbound buffered-bytes watermark at which {@code isReady()} flips false
+     */
+    public static void setOnReadyThreshold(ServerStreamListener listener, int bytes) {
+        if (listener instanceof OutboundStreamListenerImpl impl
+            && impl.responseObserver instanceof ServerCallStreamObserver<?> observer) {
+            observer.setOnReadyThreshold(bytes);
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightMessageHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightMessageHandler.java
@@ -28,8 +28,8 @@ import org.opensearch.transport.TransportKeepAlive;
 
 class FlightMessageHandler extends NativeMessageHandler {
 
-    // The base class keeps its own private copy; retained here so createTcpTransportChannel can look up the
-    // per-action outbound buffer threshold to apply to the freshly created FlightServerChannel.
+    // Resolves the handler for an action to read its per-action outbound buffer threshold (the base class copy
+    // is private).
     private final Transport.RequestHandlers requestHandlers;
 
     public FlightMessageHandler(
@@ -88,8 +88,6 @@ class FlightMessageHandler extends NativeMessageHandler {
         Header header,
         Releasable breakerRelease
     ) {
-        // The action is known here, so apply any per-action outbound buffer threshold the handler declared to
-        // this stream's channel. Actions that declare none keep the transport-wide default (watermark untouched).
         if (channel instanceof FlightServerChannel flightServerChannel) {
             final RequestHandlerRegistry<?> reg = requestHandlers.getHandler(action);
             if (reg != null) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightMessageHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightMessageHandler.java
@@ -18,6 +18,7 @@ import org.opensearch.transport.Header;
 import org.opensearch.transport.NativeMessageHandler;
 import org.opensearch.transport.OutboundHandler;
 import org.opensearch.transport.ProtocolOutboundHandler;
+import org.opensearch.transport.RequestHandlerRegistry;
 import org.opensearch.transport.StatsTracker;
 import org.opensearch.transport.TcpChannel;
 import org.opensearch.transport.TcpTransportChannel;
@@ -26,6 +27,10 @@ import org.opensearch.transport.TransportHandshaker;
 import org.opensearch.transport.TransportKeepAlive;
 
 class FlightMessageHandler extends NativeMessageHandler {
+
+    // The base class keeps its own private copy; retained here so createTcpTransportChannel can look up the
+    // per-action outbound buffer threshold to apply to the freshly created FlightServerChannel.
+    private final Transport.RequestHandlers requestHandlers;
 
     public FlightMessageHandler(
         String nodeName,
@@ -57,6 +62,7 @@ class FlightMessageHandler extends NativeMessageHandler {
             tracer,
             keepAlive
         );
+        this.requestHandlers = requestHandlers;
     }
 
     @Override
@@ -82,6 +88,14 @@ class FlightMessageHandler extends NativeMessageHandler {
         Header header,
         Releasable breakerRelease
     ) {
+        // The action is known here, so apply any per-action outbound buffer threshold the handler declared to
+        // this stream's channel. Actions that declare none keep the transport-wide default (watermark untouched).
+        if (channel instanceof FlightServerChannel flightServerChannel) {
+            final RequestHandlerRegistry<?> reg = requestHandlers.getHandler(action);
+            if (reg != null) {
+                flightServerChannel.setOutboundBufferThreshold(reg.getOutboundBufferThresholdBytes());
+            }
+        }
         return new FlightTransportChannel(
             (FlightOutboundHandler) outboundHandler,
             channel,

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -12,6 +12,7 @@ import org.apache.arrow.flight.BackpressureStrategy;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.OSFlightListeners;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
@@ -41,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
 
 import static org.opensearch.arrow.flight.transport.FlightErrorMapper.mapFromCallStatus;
 
@@ -102,6 +104,11 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final AtomicInteger batchNumber = new AtomicInteger(0);
     private final CompositeBackpressureStrategy bp;
     private final long readyTimeoutMillis;
+    /**
+     * Applies a per-stream outbound buffer threshold (bytes) to the underlying gRPC call. Isolated behind this
+     * seam so the Arrow-observer access lives in one place and tests can inject a capturing consumer.
+     */
+    private final IntConsumer outboundThresholdSetter;
 
     /**
      * The reused stream root (native or byte-serialized). Confined to the flight-executor thread:
@@ -125,10 +132,34 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         ExecutorService executor,
         long readyTimeoutMillis
     ) {
+        // Production wiring: the threshold seam applies to the real Arrow-backed gRPC observer for this listener.
+        this(
+            serverStreamListener,
+            allocator,
+            middleware,
+            callTracker,
+            executor,
+            readyTimeoutMillis,
+            bytes -> OSFlightListeners.setOnReadyThreshold(serverStreamListener, bytes)
+        );
+    }
+
+    // Package-private constructor allowing a test to inject the outbound-threshold seam in place of the real
+    // Arrow-backed applier.
+    FlightServerChannel(
+        ServerStreamListener serverStreamListener,
+        BufferAllocator allocator,
+        ServerHeaderMiddleware middleware,
+        FlightCallTracker callTracker,
+        ExecutorService executor,
+        long readyTimeoutMillis,
+        IntConsumer outboundThresholdSetter
+    ) {
         this.correlationId = Long.parseLong(middleware.getCorrelationId());
         logger.debug("Creating FlightServerChannel for correlation ID: {}", correlationId);
         this.serverStreamListener = serverStreamListener;
         this.serverStreamListener.setUseZeroCopy(true);
+        this.outboundThresholdSetter = outboundThresholdSetter;
         this.allocator = allocator;
         this.middleware = middleware;
         this.callTracker = callTracker;
@@ -141,6 +172,20 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         // notifying parked threads so the cancelled state is visible on wake.
         this.bp = new CompositeBackpressureStrategy(this::onChannelCancelled);
         this.bp.register(serverStreamListener);
+    }
+
+    /**
+     * Sets this stream's outbound buffer threshold: the number of buffered outbound bytes at which gRPC's
+     * {@code isReady()} flips false so the producer parks. Overrides the transport-wide default for this stream
+     * only, letting a memory-sensitive action bound its per-stream footprint without affecting other streams.
+     * A non-positive value is ignored (the transport-wide default remains in effect).
+     *
+     * @param bytes the per-stream watermark in bytes; ignored if {@code <= 0}
+     */
+    public void setOutboundBufferThreshold(int bytes) {
+        if (bytes > 0) {
+            outboundThresholdSetter.accept(bytes);
+        }
     }
 
     /**

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -104,10 +104,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     private final AtomicInteger batchNumber = new AtomicInteger(0);
     private final CompositeBackpressureStrategy bp;
     private final long readyTimeoutMillis;
-    /**
-     * Applies a per-stream outbound buffer threshold (bytes) to the underlying gRPC call. Isolated behind this
-     * seam so the Arrow-observer access lives in one place and tests can inject a capturing consumer.
-     */
+    /** Applies the per-stream outbound buffer threshold (bytes) to the gRPC call. */
     private final IntConsumer outboundThresholdSetter;
 
     /**
@@ -132,7 +129,6 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         ExecutorService executor,
         long readyTimeoutMillis
     ) {
-        // Production wiring: the threshold seam applies to the real Arrow-backed gRPC observer for this listener.
         this(
             serverStreamListener,
             allocator,
@@ -144,8 +140,7 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
         );
     }
 
-    // Package-private constructor allowing a test to inject the outbound-threshold seam in place of the real
-    // Arrow-backed applier.
+    /** Visible for testing: injects the outbound-threshold applier in place of the gRPC-backed one. */
     FlightServerChannel(
         ServerStreamListener serverStreamListener,
         BufferAllocator allocator,
@@ -175,10 +170,9 @@ class FlightServerChannel implements TcpChannel, ArrowFlightChannel {
     }
 
     /**
-     * Sets this stream's outbound buffer threshold: the number of buffered outbound bytes at which gRPC's
-     * {@code isReady()} flips false so the producer parks. Overrides the transport-wide default for this stream
-     * only, letting a memory-sensitive action bound its per-stream footprint without affecting other streams.
-     * A non-positive value is ignored (the transport-wide default remains in effect).
+     * Sets this stream's outbound buffer watermark: the buffered-bytes count at which gRPC's {@code isReady()}
+     * flips false so the producer parks. Applies to this stream only. A non-positive value is ignored, leaving
+     * the transport-wide default in effect.
      *
      * @param bytes the per-stream watermark in bytes; ignored if {@code <= 0}
      */

--- a/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightListenersTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightListenersTests.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.apache.arrow.flight;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import io.grpc.stub.ServerCallStreamObserver;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Proves {@link OSFlightListeners#setOnReadyThreshold} actually reaches gRPC's per-stream watermark on a REAL
+ * Arrow server listener, not just the injected seam used by the {@code FlightServerChannel} unit tests.
+ *
+ * <p>Arrow's concrete server-side listener ({@code FlightService.GetListener}) extends
+ * {@link OutboundStreamListenerImpl} and holds the call's {@link ServerCallStreamObserver} in the {@code
+ * protected} {@code responseObserver} field. {@code GetListener} is not accessible from tests, so this uses a
+ * minimal listener with the identical shape — extends {@code OutboundStreamListenerImpl} (so the {@code
+ * responseObserver} the bridge reads is the real Arrow field) and implements {@code
+ * FlightProducer.ServerStreamListener}. The test asserts the threshold call lands on the observer, exercising
+ * the {@code instanceof OutboundStreamListenerImpl} cast and {@code responseObserver} access the production
+ * path depends on. If an Arrow upgrade changed the listener hierarchy or hid the observer, this fails instead
+ * of the threshold silently becoming a no-op.
+ */
+public class OSFlightListenersTests extends OpenSearchTestCase {
+
+    /**
+     * Same shape as Arrow's package-private {@code FlightService.GetListener}: a {@code ServerStreamListener}
+     * backed by {@link OutboundStreamListenerImpl}, so {@code responseObserver} is the genuine Arrow field the
+     * bridge reads. Only the members needed to instantiate are implemented.
+     */
+    private static final class TestServerStreamListener extends OutboundStreamListenerImpl implements FlightProducer.ServerStreamListener {
+        TestServerStreamListener(ServerCallStreamObserver<ArrowMessage> observer) {
+            super(null, observer);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public void setOnCancelHandler(Runnable handler) {}
+
+        @Override
+        protected void waitUntilStreamReady() {}
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSetOnReadyThresholdReachesServerCallObserver() {
+        ServerCallStreamObserver<ArrowMessage> observer = mock(ServerCallStreamObserver.class);
+        TestServerStreamListener listener = new TestServerStreamListener(observer);
+
+        OSFlightListeners.setOnReadyThreshold(listener, 512 * 1024);
+
+        verify(observer).setOnReadyThreshold(512 * 1024);
+    }
+
+    public void testSetOnReadyThresholdIgnoresListenerWithoutObserver() {
+        // A ServerStreamListener that is not an OutboundStreamListenerImpl (e.g. a test double) must be a
+        // safe no-op rather than throwing, so the stream simply keeps the transport-wide default watermark.
+        FlightProducer.ServerStreamListener notObserverBacked = mock(FlightProducer.ServerStreamListener.class);
+
+        OSFlightListeners.setOnReadyThreshold(notObserverBacked, 512 * 1024);
+        // No exception; nothing to apply.
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSetOnReadyThresholdAppliesExactValue() {
+        ServerCallStreamObserver<ArrowMessage> observer = mock(ServerCallStreamObserver.class);
+        TestServerStreamListener listener = new TestServerStreamListener(observer);
+
+        OSFlightListeners.setOnReadyThreshold(listener, 1);
+        OSFlightListeners.setOnReadyThreshold(listener, 64 * 1024 * 1024);
+
+        verify(observer).setOnReadyThreshold(1);
+        verify(observer).setOnReadyThreshold(64 * 1024 * 1024);
+        verify(observer, never()).setOnReadyThreshold(0);
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightListenersTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/apache/arrow/flight/OSFlightListenersTests.java
@@ -17,25 +17,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
- * Proves {@link OSFlightListeners#setOnReadyThreshold} actually reaches gRPC's per-stream watermark on a REAL
- * Arrow server listener, not just the injected seam used by the {@code FlightServerChannel} unit tests.
- *
- * <p>Arrow's concrete server-side listener ({@code FlightService.GetListener}) extends
- * {@link OutboundStreamListenerImpl} and holds the call's {@link ServerCallStreamObserver} in the {@code
- * protected} {@code responseObserver} field. {@code GetListener} is not accessible from tests, so this uses a
- * minimal listener with the identical shape — extends {@code OutboundStreamListenerImpl} (so the {@code
- * responseObserver} the bridge reads is the real Arrow field) and implements {@code
- * FlightProducer.ServerStreamListener}. The test asserts the threshold call lands on the observer, exercising
- * the {@code instanceof OutboundStreamListenerImpl} cast and {@code responseObserver} access the production
- * path depends on. If an Arrow upgrade changed the listener hierarchy or hid the observer, this fails instead
- * of the threshold silently becoming a no-op.
+ * Verifies {@link OSFlightListeners#setOnReadyThreshold} sets the watermark on the gRPC observer of a listener
+ * backed by {@link OutboundStreamListenerImpl} (as Arrow's server listener is), and is a no-op otherwise.
  */
 public class OSFlightListenersTests extends OpenSearchTestCase {
 
     /**
-     * Same shape as Arrow's package-private {@code FlightService.GetListener}: a {@code ServerStreamListener}
-     * backed by {@link OutboundStreamListenerImpl}, so {@code responseObserver} is the genuine Arrow field the
-     * bridge reads. Only the members needed to instantiate are implemented.
+     * A {@link OutboundStreamListenerImpl}-backed {@code ServerStreamListener}, matching the shape of Arrow's
+     * package-private server listener so {@code responseObserver} is the real Arrow field the bridge reads.
      */
     private static final class TestServerStreamListener extends OutboundStreamListenerImpl implements FlightProducer.ServerStreamListener {
         TestServerStreamListener(ServerCallStreamObserver<ArrowMessage> observer) {
@@ -65,12 +54,8 @@ public class OSFlightListenersTests extends OpenSearchTestCase {
     }
 
     public void testSetOnReadyThresholdIgnoresListenerWithoutObserver() {
-        // A ServerStreamListener that is not an OutboundStreamListenerImpl (e.g. a test double) must be a
-        // safe no-op rather than throwing, so the stream simply keeps the transport-wide default watermark.
         FlightProducer.ServerStreamListener notObserverBacked = mock(FlightProducer.ServerStreamListener.class);
-
         OSFlightListeners.setOnReadyThreshold(notObserverBacked, 512 * 1024);
-        // No exception; nothing to apply.
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightServerChannelTests.java
@@ -24,6 +24,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.RequestHandlerRegistry;
 import org.opensearch.transport.stream.StreamErrorCode;
 import org.opensearch.transport.stream.StreamException;
 
@@ -701,6 +702,22 @@ public class FlightServerChannelTests extends OpenSearchTestCase {
             verify(listener, never()).start(any());
             assertEquals("no queued source root may leak after cancel", 0, realAllocator.getAllocatedMemory());
         }
+    }
+
+    public void testSetOutboundBufferThresholdAppliesPositiveValue() {
+        AtomicInteger applied = new AtomicInteger(-1);
+        FlightServerChannel channel = new FlightServerChannel(listener, allocator, middleware, callTracker, executor, 5_000, applied::set);
+        channel.setOutboundBufferThreshold(512 * 1024);
+        assertEquals("the exact per-stream threshold must reach the applier", 512 * 1024, applied.get());
+    }
+
+    public void testSetOutboundBufferThresholdIgnoresNonPositiveValue() {
+        AtomicInteger applied = new AtomicInteger(-1);
+        FlightServerChannel channel = new FlightServerChannel(listener, allocator, middleware, callTracker, executor, 5_000, applied::set);
+        // Non-positive means "no per-action override" — the transport-wide default must be left untouched.
+        channel.setOutboundBufferThreshold(0);
+        channel.setOutboundBufferThreshold(RequestHandlerRegistry.OUTBOUND_BUFFER_THRESHOLD_UNSET);
+        assertEquals("a non-positive threshold must not invoke the applier", -1, applied.get());
     }
 
     private static VectorSchemaRoot newSingleIntRoot(BufferAllocator allocator, int value) {

--- a/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
@@ -53,6 +53,9 @@ import java.io.IOException;
 @PublicApi(since = "1.0.0")
 public final class RequestHandlerRegistry<Request extends TransportRequest> {
 
+    /** Sentinel for {@link #getOutboundBufferThresholdBytes()} meaning "no per-action override; use the transport default". */
+    public static final int OUTBOUND_BUFFER_THRESHOLD_UNSET = -1;
+
     private final String action;
     private final TransportRequestHandler<Request> handler;
     private final boolean forceExecution;
@@ -60,6 +63,7 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
     private final String executor;
     private final TaskManager taskManager;
     private final Writeable.Reader<Request> requestReader;
+    private final int outboundBufferThresholdBytes;
 
     public RequestHandlerRegistry(
         String action,
@@ -70,6 +74,19 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
         boolean forceExecution,
         boolean canTripCircuitBreaker
     ) {
+        this(action, requestReader, taskManager, handler, executor, forceExecution, canTripCircuitBreaker, OUTBOUND_BUFFER_THRESHOLD_UNSET);
+    }
+
+    public RequestHandlerRegistry(
+        String action,
+        Writeable.Reader<Request> requestReader,
+        TaskManager taskManager,
+        TransportRequestHandler<Request> handler,
+        String executor,
+        boolean forceExecution,
+        boolean canTripCircuitBreaker,
+        int outboundBufferThresholdBytes
+    ) {
         this.action = action;
         this.requestReader = requestReader;
         this.handler = handler;
@@ -77,6 +94,7 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
         this.canTripCircuitBreaker = canTripCircuitBreaker;
         this.executor = executor;
         this.taskManager = taskManager;
+        this.outboundBufferThresholdBytes = outboundBufferThresholdBytes;
     }
 
     public String getAction() {
@@ -129,6 +147,16 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
         return handler;
     }
 
+    /**
+     * The per-action outbound buffer threshold in bytes for streaming transports, or
+     * {@link #OUTBOUND_BUFFER_THRESHOLD_UNSET} when the action opts out and the transport-wide default applies.
+     * Streaming transports (e.g. Arrow Flight) may use this to size the per-stream backpressure watermark for
+     * this action's streams without affecting other actions sharing the transport.
+     */
+    public int getOutboundBufferThresholdBytes() {
+        return outboundBufferThresholdBytes;
+    }
+
     @Override
     public String toString() {
         return handler.toString();
@@ -145,7 +173,8 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
             handler,
             registry.executor,
             registry.forceExecution,
-            registry.canTripCircuitBreaker
+            registry.canTripCircuitBreaker,
+            registry.outboundBufferThresholdBytes
         );
     }
 }

--- a/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
@@ -149,9 +149,8 @@ public final class RequestHandlerRegistry<Request extends TransportRequest> {
 
     /**
      * The per-action outbound buffer threshold in bytes for streaming transports, or
-     * {@link #OUTBOUND_BUFFER_THRESHOLD_UNSET} when the action opts out and the transport-wide default applies.
-     * Streaming transports (e.g. Arrow Flight) may use this to size the per-stream backpressure watermark for
-     * this action's streams without affecting other actions sharing the transport.
+     * {@link #OUTBOUND_BUFFER_THRESHOLD_UNSET} when the transport-wide default applies. A streaming transport
+     * uses it to size this action's per-stream backpressure watermark.
      */
     public int getOutboundBufferThresholdBytes() {
         return outboundBufferThresholdBytes;

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1270,6 +1270,47 @@ public class TransportService extends AbstractLifecycleComponent
     }
 
     /**
+     * Registers a new streaming request handler that declares a per-action outbound buffer threshold.
+     *
+     * <p>Streaming transports (e.g. Arrow Flight) buffer outbound batches per stream and apply a backpressure
+     * watermark once a stream's buffered bytes cross a threshold. That watermark is otherwise a single
+     * transport-wide default shared by every action. This overload lets one action size its own per-stream
+     * watermark without changing the default for other actions sharing the transport, so a memory-sensitive
+     * streaming action can bound its per-stream footprint independently. Non-streaming transports ignore it.
+     *
+     * @param action                        The action the request handler is associated with
+     * @param executor                      The executor the request handling will be executed on
+     * @param forceExecution                Force execution on the executor queue and never reject it
+     * @param canTripCircuitBreaker         Check the request size and raise an exception in case the limit is breached.
+     * @param outboundBufferThresholdBytes  Per-action outbound buffer threshold in bytes for streaming transports
+     * @param requestReader                 The request class that will be used to construct new instances for streaming
+     * @param handler                       The handler itself that implements the request handling
+     */
+    public <Request extends TransportRequest> void registerRequestHandler(
+        String action,
+        String executor,
+        boolean forceExecution,
+        boolean canTripCircuitBreaker,
+        int outboundBufferThresholdBytes,
+        Writeable.Reader<Request> requestReader,
+        TransportRequestHandler<Request> handler
+    ) {
+        validateActionName(action);
+        handler = interceptor.interceptHandler(action, executor, forceExecution, handler);
+        RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
+            action,
+            requestReader,
+            taskManager,
+            handler,
+            executor,
+            forceExecution,
+            canTripCircuitBreaker,
+            outboundBufferThresholdBytes
+        );
+        transport.registerRequestHandler(reg);
+    }
+
+    /**
      * Registers a new request handler with admission control support
      *
      * @param action                The action the request handler is associated with

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1270,13 +1270,9 @@ public class TransportService extends AbstractLifecycleComponent
     }
 
     /**
-     * Registers a new streaming request handler that declares a per-action outbound buffer threshold.
-     *
-     * <p>Streaming transports (e.g. Arrow Flight) buffer outbound batches per stream and apply a backpressure
-     * watermark once a stream's buffered bytes cross a threshold. That watermark is otherwise a single
-     * transport-wide default shared by every action. This overload lets one action size its own per-stream
-     * watermark without changing the default for other actions sharing the transport, so a memory-sensitive
-     * streaming action can bound its per-stream footprint independently. Non-streaming transports ignore it.
+     * Registers a request handler that declares a per-action outbound buffer threshold. A streaming transport
+     * (e.g. Arrow Flight) applies it as this action's per-stream backpressure watermark instead of the
+     * transport-wide default; other actions are unaffected. Non-streaming transports ignore it.
      *
      * @param action                        The action the request handler is associated with
      * @param executor                      The executor the request handling will be executed on


### PR DESCRIPTION
### Description

Streaming transports (Arrow Flight) buffer outbound batches per stream and park the producer once a stream's buffered bytes cross a backpressure watermark (gRPC's `setOnReadyThreshold`). Today that watermark is a single transport-wide default (`arrow.flight.channel.outbound_buffer_threshold`) shared by every streaming action. An action cannot bound its own per-stream memory footprint without changing the watermark for **all** other actions sharing the transport.

This change adds an **optional per-action outbound buffer threshold**, declared at handler registration and applied to that action's streams only:

- `RequestHandlerRegistry` carries an `outboundBufferThresholdBytes` (defaulting to a sentinel `OUTBOUND_BUFFER_THRESHOLD_UNSET = -1` meaning "use the transport default"), threaded through a new `registerRequestHandler` overload on `TransportService`.
- `FlightMessageHandler.createTcpTransportChannel` resolves the handler for the action (already known at channel creation) and applies its declared threshold to the newly created `FlightServerChannel`. Actions that declare none keep the transport-wide default.
- `FlightServerChannel` exposes `setOutboundBufferThreshold(int)`. The gRPC-observer access is isolated behind a small seam (`OSFlightListeners`, placed in the `org.apache.arrow.flight` package so it can reach Arrow's `protected` response observer via ordinary package access — no reflection) and is injectable for unit testing.

A non-positive threshold is ignored, so non-streaming transports and non-opting actions are unaffected. **No existing default is changed** — this only adds the capability to override per action.

### Motivation

Memory-sensitive streaming actions (e.g. large fan-out of concurrent streams) need a small per-stream watermark to bound aggregate outbound memory, while other actions on the same shared Flight transport (e.g. streaming search) should keep their larger default for throughput. A single global setting cannot serve both; this lets each action size its own watermark.

### Check List
- [x] Functionality includes testing (`FlightServerChannelTests` covers the positive value reaching the applier and the non-positive no-op).
- [x] New/modified code follows the style guidelines (`./gradlew :plugins:arrow-flight-rpc:check` passes).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
