### PR TITLE
fix: Gate internal ignore settings on remote data attributes in restore

### DIFF
--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -246,6 +246,26 @@ public class RestoreService implements ClusterStateApplier {
         return USER_UNREMOVABLE_SETTINGS;
     }
 
+    /**
+     * Returns the internal index settings to be ignored (stripped) when restoring a snapshot
+     * onto a cluster that does not store index data remotely.
+     * <p>
+     * The remote data attribute check (segment/translog repositories) is used rather than the
+     * broader remote store attribute check, because clusters with only remote cluster state or
+     * routing table publication enabled do not store index data remotely and must still have
+     * {@code index.remote_store.*} settings stripped on restore.
+     *
+     * @param nodeSettings the node settings of the cluster performing the restore
+     * @return array of index setting patterns to ignore during restore
+     */
+    static String[] getIgnoreSettingsInternal(Settings nodeSettings) {
+        String[] indexSettingsToBeIgnored = new String[] {};
+        if (false == RemoteStoreNodeAttribute.isRemoteDataAttributePresent(nodeSettings)) {
+            indexSettingsToBeIgnored = ArrayUtils.concat(indexSettingsToBeIgnored, new String[] { REMOTE_STORE_INDEX_SETTINGS_REGEX });
+        }
+        return indexSettingsToBeIgnored;
+    }
+
     private final ClusterService clusterService;
 
     private final RepositoriesService repositoriesService;
@@ -762,16 +782,9 @@ public class RestoreService implements ClusterStateApplier {
                     }
 
                     private String[] getIgnoreSettingsInternal() {
-                        // for non-remote store enabled domain, we will remove all the remote store
-                        // related index settings present in the snapshot.
-                        String[] indexSettingsToBeIgnored = new String[] {};
-                        if (false == RemoteStoreNodeAttribute.isRemoteStoreAttributePresent(clusterService.getSettings())) {
-                            indexSettingsToBeIgnored = ArrayUtils.concat(
-                                indexSettingsToBeIgnored,
-                                new String[] { REMOTE_STORE_INDEX_SETTINGS_REGEX }
-                            );
-                        }
-                        return indexSettingsToBeIgnored;
+                        // for a domain that does not store index data remotely, we will remove all the
+                        // remote store related index settings present in the snapshot.
+                        return RestoreService.getIgnoreSettingsInternal(clusterService.getSettings());
                     }
 
                     private Settings getOverrideSettingsInternal() {

--- a/server/src/test/java/org/opensearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RestoreServiceTests.java
@@ -269,4 +269,33 @@ public class RestoreServiceTests extends OpenSearchTestCase {
         // User can filter non-protected settings
         assertFalse(filter.test("index.custom.setting"));
     }
+
+    // Tests for internal ignore settings gating on remote data attributes
+
+    public void testIgnoreSettingsInternalOnClusterWithoutRemoteAttributes() {
+        // A cluster with no remote store attributes must strip remote store index settings on restore
+        String[] ignoreSettings = RestoreService.getIgnoreSettingsInternal(Settings.EMPTY);
+        assertArrayEquals(new String[] { "index.remote_store.*" }, ignoreSettings);
+    }
+
+    public void testIgnoreSettingsInternalOnRemotePublicationOnlyCluster() {
+        // A cluster with only remote cluster state/routing table publication enabled does not
+        // store index data remotely, so remote store index settings must still be stripped
+        Settings nodeSettings = Settings.builder()
+            .put("node.attr.remote_publication.state.repository", "cluster-state-repo")
+            .put("node.attr.remote_publication.routing_table.repository", "routing-table-repo")
+            .build();
+        String[] ignoreSettings = RestoreService.getIgnoreSettingsInternal(nodeSettings);
+        assertArrayEquals(new String[] { "index.remote_store.*" }, ignoreSettings);
+    }
+
+    public void testIgnoreSettingsInternalOnRemoteDataCluster() {
+        // A cluster that stores index data remotely must preserve remote store index settings
+        Settings nodeSettings = Settings.builder()
+            .put("node.attr.remote_store.segment.repository", "segment-repo")
+            .put("node.attr.remote_store.translog.repository", "translog-repo")
+            .build();
+        String[] ignoreSettings = RestoreService.getIgnoreSettingsInternal(nodeSettings);
+        assertEquals(0, ignoreSettings.length);
+    }
 }


### PR DESCRIPTION
 ### Description
  
  Follow-up to #20494.
  
  The internal ignore settings (`index.remote_store.*`) are only applied during snapshot
  restore when the cluster is considered non-remote-store. This check used
  `isRemoteStoreAttributePresent()`, which also matches `remote_publication.*` node
  attributes. Clusters with only remote cluster state / routing table publication enabled
  do not store index data remotely, but were wrongly treated as remote store clusters —
  so stale `index.remote_store.*` settings from a snapshot (taken on a remote-store
  cluster) were never stripped on restore.
  
  Such stale settings later fail shard recovery on the restored index with
  `RepositoryMissingException` ("Repository should be created before creating index with
  remote_store enabled setting") when the referenced repositories do not exist, since
  `isRemoteTranslogStoreEnabled()` selects the remote translog factory based on
  repository-setting presence alone.
  
  Changes:
  - Gate the internal ignore settings on `isRemoteDataAttributePresent()`
    (segment/translog repository attributes) instead of `isRemoteStoreAttributePresent()`
  - Extract the logic into a static package-private method for testability, with unit
    tests covering plain, publication-only, and remote-data clusters
  

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
