### PR TITLE
Exempt server-injected preferences from strict weighted routing check…

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -265,19 +265,28 @@ public class OperationRouting {
         for (IndexShardRoutingTable shard : shards) {
 
             IndexMetadata indexMetadataForShard = indexMetadata(clusterState, shard.shardId.getIndex().getName());
-            if (indexMetadataForShard.isRemoteSnapshot() && (preference == null || preference.isEmpty())) {
-                preference = Preference.PRIMARY.type();
+            // Server-injected preferences are scoped per index: compute the effective preference for each shard
+            // instead of mutating the caller-supplied preference, so that a preference injected for one index
+            // (e.g. a remote snapshot or writable warm index) does not leak into other indices of the same
+            // multi-index search request.
+            String effectivePreference = preference;
+            boolean serverInjectedPreference = false;
+            if (indexMetadataForShard.isRemoteSnapshot() && (effectivePreference == null || effectivePreference.isEmpty())) {
+                effectivePreference = Preference.PRIMARY.type();
+                serverInjectedPreference = true;
             }
 
             if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)
                 && indexMetadataForShard.getSettings().getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false)
-                && (preference == null || preference.isEmpty())) {
-                preference = Preference.PRIMARY_FIRST.type();
+                && (effectivePreference == null || effectivePreference.isEmpty())) {
+                effectivePreference = Preference.PRIMARY_FIRST.type();
+                serverInjectedPreference = true;
             }
 
-            if (preference == null || preference.isEmpty()) {
+            if (effectivePreference == null || effectivePreference.isEmpty()) {
                 if (indexMetadataForShard.getNumberOfSearchOnlyReplicas() > 0 && isStrictSearchOnlyShardRouting) {
-                    preference = Preference.SEARCH_REPLICA.type();
+                    effectivePreference = Preference.SEARCH_REPLICA.type();
+                    serverInjectedPreference = true;
                 }
             }
 
@@ -285,10 +294,11 @@ public class OperationRouting {
                 shard,
                 clusterState.nodes().getLocalNodeId(),
                 clusterState.nodes(),
-                preference,
+                effectivePreference,
                 collectorService,
                 nodeCounts,
-                clusterState.metadata().weightedRoutingMetadata()
+                clusterState.metadata().weightedRoutingMetadata(),
+                serverInjectedPreference
             );
             if (iterator != null) {
                 shardIterators.computeIfAbsent(iterator.shardId().getIndex(), k -> new ArrayList<>()).add(iterator);
@@ -363,6 +373,28 @@ public class OperationRouting {
         @Nullable Map<String, Long> nodeCounts,
         @Nullable WeightedRoutingMetadata weightedRoutingMetadata
     ) {
+        return preferenceActiveShardIterator(
+            indexShard,
+            localNodeId,
+            nodes,
+            preference,
+            collectorService,
+            nodeCounts,
+            weightedRoutingMetadata,
+            false
+        );
+    }
+
+    private ShardIterator preferenceActiveShardIterator(
+        IndexShardRoutingTable indexShard,
+        String localNodeId,
+        DiscoveryNodes nodes,
+        @Nullable String preference,
+        @Nullable ResponseCollectorService collectorService,
+        @Nullable Map<String, Long> nodeCounts,
+        @Nullable WeightedRoutingMetadata weightedRoutingMetadata,
+        boolean serverInjectedPreference
+    ) {
         if (preference == null || preference.isEmpty()) {
             return shardRoutings(indexShard, nodes, collectorService, nodeCounts, weightedRoutingMetadata);
         }
@@ -399,7 +431,7 @@ public class OperationRouting {
                 }
             }
             preferenceType = Preference.parse(preference);
-            checkPreferenceBasedRoutingAllowed(preferenceType, weightedRoutingMetadata);
+            checkPreferenceBasedRoutingAllowed(preferenceType, weightedRoutingMetadata, serverInjectedPreference);
             switch (preferenceType) {
                 case PREFER_NODES:
                     final Set<String> nodesIds = Arrays.stream(preference.substring(Preference.PREFER_NODES.type().length() + 1).split(","))
@@ -565,12 +597,22 @@ public class OperationRouting {
         return indexMetadata.getSplitShardsMetadata().getShardIdOfHash(rootShardId, hash, includeInProgressChild);
     }
 
-    private void checkPreferenceBasedRoutingAllowed(Preference preference, @Nullable WeightedRoutingMetadata weightedRoutingMetadata) {
-        if (WeightedRoutingUtils.shouldPerformStrictWeightedRouting(
-            isStrictWeightedShardRouting,
-            ignoreWeightedRouting,
-            weightedRoutingMetadata
-        ) && WEIGHTED_ROUTING_RESTRICTED_PREFERENCES.contains(preference)) {
+    // package-private for testing
+    void checkPreferenceBasedRoutingAllowed(
+        Preference preference,
+        @Nullable WeightedRoutingMetadata weightedRoutingMetadata,
+        boolean serverInjectedPreference
+    ) {
+        // Preferences injected by the server for specific index types (e.g. remote snapshot or writable warm
+        // indices) are the engine's own routing decision and are exempt from this check, which exists to stop
+        // caller-supplied preferences from bypassing weighted shard routing.
+        if (serverInjectedPreference == false
+            && WeightedRoutingUtils.shouldPerformStrictWeightedRouting(
+                isStrictWeightedShardRouting,
+                ignoreWeightedRouting,
+                weightedRoutingMetadata
+            )
+            && WEIGHTED_ROUTING_RESTRICTED_PREFERENCES.contains(preference)) {
             throw new PreferenceBasedSearchNotAllowedException(
                 "Preference type based routing not allowed with strict weighted shard routing enabled"
             );

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -1119,6 +1119,141 @@ public class OperationRoutingTests extends OpenSearchTestCase {
         }
     }
 
+    public void testServerInjectedPreferenceDoesNotLeakAcrossIndices() throws Exception {
+        final int numIndices = 4;
+        final int numShards = 3;
+        final int numReplicas = 2;
+        final String[] indexNames = new String[numIndices];
+        for (int i = 0; i < numIndices; i++) {
+            indexNames[i] = "test" + i;
+        }
+        // The first index is a remote snapshot index, for which the server injects the _primary preference
+        final String remoteSnapshotIndex = indexNames[0];
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            OperationRouting opRouting = new OperationRouting(
+                Settings.EMPTY,
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+
+            ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(indexNames, numShards, numReplicas);
+            threadPool = new TestThreadPool("testServerInjectedPreferenceDoesNotLeakAcrossIndices");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            IndexMetadata remoteSnapshotIndexMetadata = IndexMetadata.builder(remoteSnapshotIndex)
+                .settings(
+                    Settings.builder()
+                        .put(state.metadata().index(remoteSnapshotIndex).getSettings())
+                        .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.REMOTE_SNAPSHOT.getSettingsKey())
+                        .build()
+                )
+                .build();
+            Metadata.Builder metadataBuilder = Metadata.builder(state.metadata())
+                .put(remoteSnapshotIndexMetadata, false)
+                .generateClusterUuidIfNeeded();
+            state = ClusterState.builder(state).metadata(metadataBuilder.build()).build();
+
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, null);
+            assertThat("One group per index shard", groupIterator.size(), equalTo(numIndices * numShards));
+
+            for (ShardIterator shardIterator : groupIterator) {
+                if (remoteSnapshotIndex.equals(shardIterator.shardId().getIndexName())) {
+                    // Server-injected _primary preference applies to the remote snapshot index
+                    assertThat("Only the primary should be returned for the remote snapshot index", shardIterator.size(), equalTo(1));
+                    assertTrue("Returned shard should be the primary", shardIterator.nextOrNull().primary());
+                } else {
+                    // The injected preference must not leak into the other indices of the same request:
+                    // they should route across all active shard copies
+                    assertThat("All shard copies should be returned for a regular index", shardIterator.size(), equalTo(1 + numReplicas));
+                }
+            }
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
+    public void testStrictWeightedRoutingExemptsOnlyServerInjectedPreferences() {
+        OperationRouting opRouting = new OperationRouting(
+            Settings.builder().put(OperationRouting.STRICT_WEIGHTED_SHARD_ROUTING_ENABLED.getKey(), true).build(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        WeightedRouting weightedRouting = new WeightedRouting("zone", Map.of("a", 1.0, "b", 1.0, "c", 0.0));
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting, 0);
+
+        // A caller-supplied restricted preference must be rejected under strict weighted routing
+        expectThrows(
+            PreferenceBasedSearchNotAllowedException.class,
+            () -> opRouting.checkPreferenceBasedRoutingAllowed(Preference.PREFER_NODES, weightedRoutingMetadata, false)
+        );
+
+        // The same preference must be allowed when it was injected by the server itself
+        opRouting.checkPreferenceBasedRoutingAllowed(Preference.PREFER_NODES, weightedRoutingMetadata, true);
+    }
+
+    @LockFeatureFlag(WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)
+    @SuppressForbidden(reason = "feature flag overrides")
+    public void testWarmIndexSearchNotBlockedByStrictWeightedRouting() throws Exception {
+        final int numShards = 2;
+        final int numReplicas = 2;
+        final String[] indexNames = { "test0", "test1" };
+        // The first index is a writable warm index, for which the server injects the _primary_first preference
+        final String warmIndex = indexNames[0];
+        ClusterService clusterService = null;
+        ThreadPool threadPool = null;
+
+        try {
+            ClusterState state = clusterStateForWeightedRouting(indexNames, numShards, numReplicas);
+
+            Settings setting = Settings.builder()
+                .put("cluster.routing.allocation.awareness.attributes", "zone")
+                .put(OperationRouting.STRICT_WEIGHTED_SHARD_ROUTING_ENABLED.getKey(), true)
+                .build();
+
+            threadPool = new TestThreadPool("testWarmIndexSearchNotBlockedByStrictWeightedRouting");
+            clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+            OperationRouting opRouting = new OperationRouting(
+                setting,
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            );
+
+            IndexMetadata warmIndexMetadata = IndexMetadata.builder(warmIndex)
+                .settings(
+                    Settings.builder()
+                        .put(state.metadata().index(warmIndex).getSettings())
+                        .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+                        .build()
+                )
+                .build();
+            Metadata.Builder metadataBuilder = Metadata.builder(state.metadata())
+                .put(warmIndexMetadata, false)
+                .generateClusterUuidIfNeeded();
+            state = ClusterState.builder(state).metadata(metadataBuilder.build()).build();
+
+            // Weighted shard routing is active with a zero-weight zone (e.g. Multi-AZ with Standby)
+            Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
+            state = setWeightedRoutingWeights(state, weights);
+            ClusterServiceUtils.setState(clusterService, ClusterState.builder(state));
+
+            // A search with no caller-supplied preference must not be rejected by the strict weighted
+            // routing preference check, even though the server injects _primary_first for the warm index
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, null);
+            assertThat("One group per index shard", groupIterator.size(), equalTo(indexNames.length * numShards));
+
+            for (ShardIterator shardIterator : groupIterator) {
+                if (warmIndex.equals(shardIterator.shardId().getIndexName())) {
+                    assertTrue("Primary should be returned first for the warm index", shardIterator.nextOrNull().primary());
+                }
+            }
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
     public void testSearchReplicaDefaultRouting() throws Exception {
         final int numShards = 1;
         final int numReplicas = 2;


### PR DESCRIPTION
 ### Description
  
  `OperationRouting#searchShards` injects a search preference server-side for certain index types when the
  caller supplies none: `_primary` for remote snapshot indices and `_primary_first` for writable warm
  indices (behind `WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG`). This causes two problems:
  
  **Problem 1 — injected preference leaks across indices.** The injected preference is assigned to the
  caller-supplied preference variable inside the per-shard loop, so in a multi-index search it leaks into
  every index processed afterwards. A search spanning a remote snapshot (or warm) index and regular indices
  silently routes the regular indices with `_primary`/`_primary_first` as well, defeating replica
  load-balancing and zone-aware routing for those indices. Since `computeTargetedShards` returns a
  `HashSet`, which index "wins" is iteration-order dependent, making routing non-deterministic.
  
  **Problem 2 — the server rejects its own routing decision.** `checkPreferenceBasedRoutingAllowed` cannot
  distinguish the engine's own injected preference from a caller-supplied one. When a restricted preference
  is injected while strict weighted shard routing is active (`WeightedRoutingMetadata` present and
  `cluster.routing.weighted.strict=true`), the server rejects its own routing decision with
  `PreferenceBasedSearchNotAllowedException` (HTTP 403) and the search fails even though the caller never
  set a preference. Distributions that restrict `PRIMARY_FIRST` hit this on every warm-index search on
  weighted-routing clusters.
  
  ### Solution
  
  - Compute an effective preference per shard instead of mutating the request-level preference, so
  server-injected preferences are scoped to the index they were injected for (fixes Problem 1).
  - Track whether the preference was server-injected and skip the strict weighted routing restriction check
  for server-injected preferences (fixes Problem 2). The check exists to stop callers from bypassing
  weighted shard routing; it should not apply to the engine's own routing decisions. All three server
  injections (`_primary` for remote snapshot, `_primary_first` for writable warm, `_search_replica` for
  search-only replicas) are treated uniformly.
  - Caller-supplied preferences are unaffected: they keep `serverInjectedPreference = false` and hit the
  restriction check exactly as before.
  
  ### Testing
  
  - `testServerInjectedPreferenceDoesNotLeakAcrossIndices` — reproduces Problem 1; fails on `main` without
  this fix (`AssertionError: All shard copies should be returned for a regular index`), passes with it.
  - `testStrictWeightedRoutingExemptsOnlyServerInjectedPreferences` — pins both sides of the exemption
  directly: a caller-supplied restricted preference still throws
  `PreferenceBasedSearchNotAllowedException`; the same preference passes when server-injected.
  - `testWarmIndexSearchNotBlockedByStrictWeightedRouting` — end-to-end: warm index + zero-weight zone +
  `cluster.routing.weighted.strict=true` + no caller preference succeeds.
  - All existing `OperationRoutingTests` and `SearchWeightedRoutingIT` pass; `:server:precommit` passes.
  
  Note: the earlier gradle-check failure was `Netty4HttpRequestSizeLimitIT.testLimitsInFlightRequests`, a
  known flaky test (#18875) unrelated to this change.
  
  ### Related Issues
  
  Flaky test seen in CI on this PR: #18875 (unrelated to this change).
  
  ### Check List
  - [x] Functionality includes testing.
  - [ ] API changes companion pull request
  [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md
  ), if applicable.
  - [ ] Public documentation issue/PR
  [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0
  license.
  For more information on following Developer Certificate of Origin and signing off your commits, please
  check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-o
  f-origin).