### PR TITLE
Use dynamic max clause count for field expansion limit

### DIFF
--- a/server/src/main/java/org/opensearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/opensearch/index/search/QueryParserHelper.java
@@ -52,6 +52,16 @@ import java.util.Set;
  * @opensearch.internal
  */
 public final class QueryParserHelper {
+
+    private static SearchService searchService;
+
+    public static void setSearchService(SearchService service) {
+        if (searchService != null) {
+            return; // already initialized
+        }
+        searchService = service;
+    }
+
     private QueryParserHelper() {}
 
     /**
@@ -180,7 +190,7 @@ public final class QueryParserHelper {
     }
 
     static void checkForTooManyFields(int numberOfFields, QueryShardContext context, @Nullable String inputPattern) {
-        int limit = SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.get(context.getIndexSettings().getSettings());
+        int limit = searchService.getFieldExpansionLimit();
         if (numberOfFields > limit) {
             StringBuilder errorMsg = new StringBuilder("field expansion ");
             if (inputPattern != null) {

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -159,6 +159,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.threadpool.ThreadPool.Names;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.wlm.WorkloadGroupService;
+import org.opensearch.index.search.QueryParserHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -515,6 +516,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private final Executor indexSearcherExecutor;
     private final TaskResourceTrackingService taskResourceTrackingService;
 
+    private volatile int fieldExpansionLimit;
+
+    public int getFieldExpansionLimit() {
+        return fieldExpansionLimit;
+    }
+
     private final List<SearchPlugin.ProfileMetricsProvider> pluginProfilers;
 
     public SearchService(
@@ -583,7 +590,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         clusterService.getClusterSettings().addSettingsUpdateConsumer(LOW_LEVEL_CANCELLATION_SETTING, this::setLowLevelCancellation);
 
         IndexSearcher.setMaxClauseCount(INDICES_MAX_CLAUSE_COUNT_SETTING.get(settings));
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(INDICES_MAX_CLAUSE_COUNT_SETTING, IndexSearcher::setMaxClauseCount);
+        this.fieldExpansionLimit = INDICES_MAX_CLAUSE_COUNT_SETTING.get(clusterService.getSettings());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(INDICES_MAX_CLAUSE_COUNT_SETTING, value -> {
+            IndexSearcher.setMaxClauseCount(value);
+            this.fieldExpansionLimit = value;
+            });
 
         QueryStringQueryParser.setMaxQueryStringLength(SEARCH_MAX_QUERY_STRING_LENGTH.get(settings));
         clusterService.getClusterSettings()
@@ -599,6 +611,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         clusterService.getClusterSettings().addSettingsUpdateConsumer(CLUSTER_ALLOW_DERIVED_FIELD_SETTING, this::setAllowDerivedField);
 
         this.concurrentSearchDeciderFactories = concurrentSearchDeciderFactories;
+
+        QueryParserHelper.setSearchService(this);
 
         this.pluginProfilers = pluginProfilers;
 


### PR DESCRIPTION
## Description

This change makes `QueryParserHelper` use the current value of
`indices.query.bool.max_clause_count` when validating field expansion.

Previously, `checkForTooManyFields()` retrieved the limit from
`context.getIndexSettings().getSettings()`. However,
`indices.query.bool.max_clause_count` is a cluster setting and is not
part of the index settings, so this is not the correct source for the
current value.

To address this, `SearchService` now caches the current value of the
cluster setting and updates it through the existing settings update
consumer. `QueryParserHelper` retrieves the limit from `SearchService`
instead of reading it from `IndexSettings`.

## Changes

- Added a cached `fieldExpansionLimit` to `SearchService`.
- Updated the cached value whenever
  `indices.query.bool.max_clause_count` changes.
- Initialized `QueryParserHelper` with a `SearchService` instance.
- Updated field expansion validation to use the cached limit.

## Motivation

This ensures that field expansion validation always uses the current
value of `indices.query.bool.max_clause_count`, including after dynamic
cluster setting updates.

## Related Issues

N/A

## Check List

- [ ] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.