### PR TITLE
[BUG] Reject explicitly set empty index.store.type (GH#22550)

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1402,6 +1402,15 @@ public class MetadataCreateIndexService {
     }
 
     public static void validateStoreTypeSettings(Settings settings) {
+        // Reject explicitly set empty store type (GH#22550)
+        if (IndexModule.INDEX_STORE_TYPE_SETTING.exists(settings)) {
+            String storeType = IndexModule.INDEX_STORE_TYPE_SETTING.get(settings);
+            if (storeType.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Failed to parse value for setting [" + IndexModule.INDEX_STORE_TYPE_SETTING.getKey() + "] must not be empty"
+                );
+            }
+        }
         // deprecate simplefs store type:
         if (IndexModule.Type.SIMPLEFS.match(IndexModule.INDEX_STORE_TYPE_SETTING.get(settings))) {
             DEPRECATION_LOGGER.deprecate(


### PR DESCRIPTION
### Description

Fixes #22550 — Creating an index with `index.store.type` explicitly set to an empty string is accepted, but the primary shard subsequently fails to initialize and the index remains red.

### Root Cause

The `INDEX_STORE_TYPE_SETTING` definition in `IndexModule.java` has no validation for the store type value, and the `validateStoreTypeSettings` method in `MetadataCreateIndexService.java` only checks for deprecated `simplefs` type.

### Fix

Add validation in `validateStoreTypeSettings` to reject an explicitly set empty store type before the index metadata is committed. The empty string default is preserved for backward compatibility (when the setting is not specified, the default store type is used).

### Related Issues

- #22550