### PR TITLE
dsl-query-executor: route _search through DslCalciteGrammar with codec fallback

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -80,6 +80,10 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(DslQueryExecutorSettings.CALCITE_ENABLED);
+        return List.of(
+            DslQueryExecutorSettings.CALCITE_ENABLED,
+            DslQueryExecutorSettings.CALCITE_QUERY_ENABLED,
+            DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -63,9 +63,6 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        // Grammar owns its own long-lived registries — a few kilobytes for the lifetime of
-        // the node. The per-request SearchSourceConverter still builds its own copies; the
-        // duplication is intentional (see plugin-startup notes) and negligible under GC.
         DslCalciteGrammar grammar = new DslCalciteGrammar(QueryRegistryFactory.create(), AggregationRegistryFactory.create());
         this.searchActionFilter = new SearchActionFilter((NodeClient) client, clusterService, grammar);
         return Collections.emptyList();

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -12,12 +12,16 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.dsl.action.DslExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
 import org.opensearch.dsl.action.TransportDslExecuteAction;
+import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
+import org.opensearch.dsl.query.QueryRegistryFactory;
+import org.opensearch.dsl.router.DslCalciteGrammar;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugins.ActionPlugin;
@@ -59,7 +63,11 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        this.searchActionFilter = new SearchActionFilter((NodeClient) client);
+        // Grammar owns its own long-lived registries — a few kilobytes for the lifetime of
+        // the node. The per-request SearchSourceConverter still builds its own copies; the
+        // duplication is intentional (see plugin-startup notes) and negligible under GC.
+        DslCalciteGrammar grammar = new DslCalciteGrammar(QueryRegistryFactory.create(), AggregationRegistryFactory.create());
+        this.searchActionFilter = new SearchActionFilter((NodeClient) client, clusterService, grammar);
         return Collections.emptyList();
     }
 
@@ -71,5 +79,10 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<ActionFilter> getActionFilters() {
         return searchActionFilter != null ? List.of(searchActionFilter) : List.of();
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(DslQueryExecutorSettings.CALCITE_ENABLED);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
@@ -29,5 +29,31 @@ public final class DslQueryExecutorSettings {
         Setting.Property.Dynamic
     );
 
+    /**
+     * Per-category switch for routing search/hits (and count) requests to Calcite (default
+     * {@code true}). When {@code false}, requests that return hits or are non-aggregation
+     * searches go through the codec path, even while {@link #CALCITE_AGGREGATION_ENABLED} stays
+     * on. Subordinate to {@link #CALCITE_ENABLED}. Dynamic and node-scoped.
+     */
+    public static final Setting<Boolean> CALCITE_QUERY_ENABLED = Setting.boolSetting(
+        "dsl.query_executor.calcite.query.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Per-category switch for routing aggregation requests to Calcite (default {@code true}).
+     * When {@code false}, any request that carries aggregations goes through the codec path,
+     * even while {@link #CALCITE_QUERY_ENABLED} stays on. Subordinate to {@link #CALCITE_ENABLED}.
+     * Dynamic and node-scoped.
+     */
+    public static final Setting<Boolean> CALCITE_AGGREGATION_ENABLED = Setting.boolSetting(
+        "dsl.query_executor.calcite.aggregation.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     private DslQueryExecutorSettings() {}
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl;
+
+import org.opensearch.common.settings.Setting;
+
+/**
+ * Cluster-scoped settings owned by the DSL query executor plugin. Registered via
+ * {@link DslQueryExecutorPlugin#getSettings()}.
+ */
+public final class DslQueryExecutorSettings {
+
+    /**
+     * Master switch for Calcite-path routing. Defaults to {@code true} — the plugin routes
+     * {@code _search} through the grammar, with codec fallback on grammar rejection or
+     * conversion failure. Set to {@code false} to force every request through the codec
+     * path unchanged (operational escape hatch: mitigations, benchmarking, incident
+     * response).
+     *
+     * <p>Node-scoped + dynamic → cluster-wide, updatable via {@code PUT _cluster/settings}
+     * (use {@code persistent} to survive a full cluster restart).
+     */
+    public static final Setting<Boolean> CALCITE_ENABLED = Setting.boolSetting(
+        "dsl.query_executor.calcite.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    private DslQueryExecutorSettings() {}
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
@@ -16,12 +16,7 @@ import org.opensearch.common.settings.Setting;
  */
 public final class DslQueryExecutorSettings {
 
-    /**
-     * Master switch for Calcite-path routing (default {@code true}). When {@code false}, every
-     * {@code _search} is sent through the codec path unchanged.
-     *
-     * <p>Dynamic and node-scoped, so it can be updated cluster-wide via {@code PUT _cluster/settings}.
-     */
+    /** Master switch for Calcite routing (default true); {@code false} sends every {@code _search} to codec. */
     public static final Setting<Boolean> CALCITE_ENABLED = Setting.boolSetting(
         "dsl.query_executor.calcite.enabled",
         true,
@@ -29,12 +24,7 @@ public final class DslQueryExecutorSettings {
         Setting.Property.Dynamic
     );
 
-    /**
-     * Per-category switch for routing search/hits (and count) requests to Calcite (default
-     * {@code true}). When {@code false}, requests that return hits or are non-aggregation
-     * searches go through the codec path, even while {@link #CALCITE_AGGREGATION_ENABLED} stays
-     * on. Subordinate to {@link #CALCITE_ENABLED}. Dynamic and node-scoped.
-     */
+    /** Routes hits/search (and count) requests to Calcite (default true); {@code false} sends them to codec. */
     public static final Setting<Boolean> CALCITE_QUERY_ENABLED = Setting.boolSetting(
         "dsl.query_executor.calcite.query.enabled",
         true,
@@ -42,12 +32,7 @@ public final class DslQueryExecutorSettings {
         Setting.Property.Dynamic
     );
 
-    /**
-     * Per-category switch for routing aggregation requests to Calcite (default {@code true}).
-     * When {@code false}, any request that carries aggregations goes through the codec path,
-     * even while {@link #CALCITE_QUERY_ENABLED} stays on. Subordinate to {@link #CALCITE_ENABLED}.
-     * Dynamic and node-scoped.
-     */
+    /** Routes aggregation requests to Calcite (default true); {@code false} sends them to codec. */
     public static final Setting<Boolean> CALCITE_AGGREGATION_ENABLED = Setting.boolSetting(
         "dsl.query_executor.calcite.aggregation.enabled",
         true,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorSettings.java
@@ -17,14 +17,10 @@ import org.opensearch.common.settings.Setting;
 public final class DslQueryExecutorSettings {
 
     /**
-     * Master switch for Calcite-path routing. Defaults to {@code true} — the plugin routes
-     * {@code _search} through the grammar, with codec fallback on grammar rejection or
-     * conversion failure. Set to {@code false} to force every request through the codec
-     * path unchanged (operational escape hatch: mitigations, benchmarking, incident
-     * response).
+     * Master switch for Calcite-path routing (default {@code true}). When {@code false}, every
+     * {@code _search} is sent through the codec path unchanged.
      *
-     * <p>Node-scoped + dynamic → cluster-wide, updatable via {@code PUT _cluster/settings}
-     * (use {@code persistent} to survive a full cluster restart).
+     * <p>Dynamic and node-scoped, so it can be updated cluster-wide via {@code PUT _cluster/settings}.
      */
     public static final Setting<Boolean> CALCITE_ENABLED = Setting.boolSetting(
         "dsl.query_executor.calcite.enabled",

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -104,7 +104,7 @@ public class SearchActionFilter implements ActionFilter {
         RouteDecision decision = grammar.validate(searchRequest.source());
 
         if (!decision.supported()) {
-            logger.debug("Grammar rejected _search, falling back to codec: {}", decision.unsupportedFeatures());
+            logger.debug("Grammar rejected _search, falling back to codec: {}", decision.rejectionReasons());
             chain.proceed(task, action, request, listener);
             return;
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -35,24 +35,16 @@ import java.util.IdentityHashMap;
 import java.util.Set;
 
 /**
- * Intercepts {@code _search} requests and, when Calcite routing is enabled, decides between
- * the Calcite path and the codec path.
+ * Intercepts {@code _search} and routes it to the Calcite path or the codec path.
  *
- * <p>Layer 1: {@link DslQueryExecutorSettings#CALCITE_ENABLED} — defaults to {@code true};
- * setting it to {@code false} forces every request through the codec path unchanged. The
- * per-category switches {@link DslQueryExecutorSettings#CALCITE_QUERY_ENABLED} and
- * {@link DslQueryExecutorSettings#CALCITE_AGGREGATION_ENABLED} additionally route just the
- * hits/search or aggregation category to codec while leaving the other on Calcite.
+ * <p>Master switch {@link DslQueryExecutorSettings#CALCITE_ENABLED} (default true) sends everything
+ * to codec when off; {@link DslQueryExecutorSettings#CALCITE_QUERY_ENABLED} and
+ * {@link DslQueryExecutorSettings#CALCITE_AGGREGATION_ENABLED} independently send just the
+ * hits/search or aggregation category to codec.
  *
- * <p>Layer 2 (only when the request's category is still on Calcite):
- * <ul>
- *   <li>{@link DslCalciteGrammar#validate} classifies the request. Grammar-rejected requests
- *       fall back to the codec path.</li>
- *   <li>Grammar-accepted requests are dispatched to {@link DslExecuteAction}. A
- *       {@link ConversionException} during execution triggers codec fallback (schema-side
- *       checks the grammar can't run may still fail at conversion time). Non-conversion
- *       errors surface to the caller unchanged.</li>
- * </ul>
+ * <p>Otherwise {@link DslCalciteGrammar#validate} decides: rejected requests fall back to codec;
+ * accepted ones go to {@link DslExecuteAction}, and a {@link ConversionException} there (a
+ * schema-dependent check the grammar cannot run) also falls back. Other errors surface to the caller.
  */
 public class SearchActionFilter implements ActionFilter {
 
@@ -64,11 +56,8 @@ public class SearchActionFilter implements ActionFilter {
     private final NodeClient client;
     private final DslCalciteGrammar grammar;
     /**
-     * Routing switches, kept in sync with their settings via cluster-settings update consumers so
-     * a {@code PUT _cluster/settings} change propagates without any per-request settings lookup.
-     * {@code calciteEnabled} is the master; {@code queryEnabledOnCalcite}/{@code aggregationEnabledOnCalcite} gate
-     * the hits/search and aggregation categories. {@code volatile} because updates land on the
-     * cluster-state-applier thread while reads happen on transport/search threads.
+     * Routing switches, kept live via cluster-settings update consumers (no per-request lookup).
+     * {@code volatile}: updates land on the cluster-state-applier thread, reads on transport threads.
      */
     private volatile boolean calciteEnabled;
     private volatile boolean queryEnabledOnCalcite;
@@ -135,9 +124,6 @@ public class SearchActionFilter implements ActionFilter {
             return;
         }
 
-        // Explicit listener, not ActionListener.wrap: wrap routes an exception thrown while
-        // delivering the success response into onFailure, double-completing the caller's listener.
-        // Forwarding onResponse directly means only a genuine Calcite failure reaches onFailure.
         ActionListener<SearchResponse> calciteListener = new ActionListener<>() {
             @Override
             public void onResponse(SearchResponse response) {
@@ -169,14 +155,6 @@ public class SearchActionFilter implements ActionFilter {
         return (usesAggs && aggregationEnabledOnCalcite == false) || (usesQuery && queryEnabledOnCalcite == false);
     }
 
-    /**
-     * Only fall back on failures that mean "Calcite can't handle this request" — grammar
-     * gaps or schema mismatches the grammar can't see. Runtime engine errors, timeouts,
-     * and other operational failures must surface to the caller so they can be diagnosed.
-     *
-     * <p>Uses an identity-based seen set to defend against pathological self-referential
-     * or cyclic exception chains (e.g. legacy code that calls {@code initCause(this)}).
-     */
     private static boolean isFallbackable(Throwable e) {
         Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Throwable t = e; t != null && seen.add(t); t = t.getCause()) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -36,8 +36,7 @@ import java.util.Set;
  * the Calcite path and the codec path.
  *
  * <p>Layer 1: {@link DslQueryExecutorSettings#CALCITE_ENABLED} — defaults to {@code true};
- * setting it to {@code false} forces every request through the codec path unchanged
- * (operational escape hatch).
+ * setting it to {@code false} forces every request through the codec path unchanged.
  *
  * <p>Layer 2 (only when the setting is on):
  * <ul>
@@ -109,17 +108,25 @@ public class SearchActionFilter implements ActionFilter {
             return;
         }
 
-        ActionListener<SearchResponse> calciteListener = ActionListener.wrap(
-            (SearchResponse resp) -> ((ActionListener<SearchResponse>) listener).onResponse(resp),
-            error -> {
-                if (isFallbackable(error)) {
-                    logger.debug("Calcite path threw ConversionException, falling back to codec", error);
-                    chain.proceed(task, action, request, listener);
-                } else {
-                    listener.onFailure(error);
-                }
+        // Explicit listener, not ActionListener.wrap: wrap routes an exception thrown while
+        // delivering the success response into onFailure, double-completing the caller's listener.
+        // Forwarding onResponse directly means only a genuine Calcite failure reaches onFailure.
+        ActionListener<SearchResponse> calciteListener = new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse response) {
+                ((ActionListener<SearchResponse>) listener).onResponse(response);
             }
-        );
+
+            @Override
+            public void onFailure(Exception error) {
+                if (isFallbackable(error) == false) {
+                    listener.onFailure(error);
+                    return;
+                }
+                logger.debug("Calcite path threw ConversionException, falling back to codec", error);
+                chain.proceed(task, action, request, listener);
+            }
+        };
         client.execute(DslExecuteAction.INSTANCE, searchRequest, calciteListener);
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -18,12 +18,15 @@ import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.dsl.DslQueryExecutorSettings;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.router.DslCalciteGrammar;
 import org.opensearch.dsl.router.RouteDecision;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -36,9 +39,12 @@ import java.util.Set;
  * the Calcite path and the codec path.
  *
  * <p>Layer 1: {@link DslQueryExecutorSettings#CALCITE_ENABLED} — defaults to {@code true};
- * setting it to {@code false} forces every request through the codec path unchanged.
+ * setting it to {@code false} forces every request through the codec path unchanged. The
+ * per-category switches {@link DslQueryExecutorSettings#CALCITE_QUERY_ENABLED} and
+ * {@link DslQueryExecutorSettings#CALCITE_AGGREGATION_ENABLED} additionally route just the
+ * hits/search or aggregation category to codec while leaving the other on Calcite.
  *
- * <p>Layer 2 (only when the setting is on):
+ * <p>Layer 2 (only when the request's category is still on Calcite):
  * <ul>
  *   <li>{@link DslCalciteGrammar#validate} classifies the request. Grammar-rejected requests
  *       fall back to the codec path.</li>
@@ -58,24 +64,36 @@ public class SearchActionFilter implements ActionFilter {
     private final NodeClient client;
     private final DslCalciteGrammar grammar;
     /**
-     * Kept in sync with {@link DslQueryExecutorSettings#CALCITE_ENABLED} via a
-     * cluster-settings update consumer, so a {@code PUT _cluster/settings} change propagates
-     * without any per-request settings lookup. {@code volatile} because updates land on the
+     * Routing switches, kept in sync with their settings via cluster-settings update consumers so
+     * a {@code PUT _cluster/settings} change propagates without any per-request settings lookup.
+     * {@code calciteEnabled} is the master; {@code queryEnabledOnCalcite}/{@code aggregationEnabledOnCalcite} gate
+     * the hits/search and aggregation categories. {@code volatile} because updates land on the
      * cluster-state-applier thread while reads happen on transport/search threads.
      */
     private volatile boolean calciteEnabled;
+    private volatile boolean queryEnabledOnCalcite;
+    private volatile boolean aggregationEnabledOnCalcite;
 
     /**
      * @param client node client for dispatching to {@link DslExecuteAction}
-     * @param clusterService source of the dynamic {@code CALCITE_ENABLED} setting value
+     * @param clusterService source of the dynamic routing settings
      * @param grammar route-decision oracle
      */
     public SearchActionFilter(NodeClient client, ClusterService clusterService, DslCalciteGrammar grammar) {
         this.client = client;
         this.grammar = grammar;
-        this.calciteEnabled = DslQueryExecutorSettings.CALCITE_ENABLED.get(clusterService.getSettings());
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(DslQueryExecutorSettings.CALCITE_ENABLED, v -> this.calciteEnabled = v);
+
+        Settings settings = clusterService.getSettings();
+        ClusterSettings clusterSettings = clusterService.getClusterSettings();
+        this.calciteEnabled = DslQueryExecutorSettings.CALCITE_ENABLED.get(settings);
+        this.queryEnabledOnCalcite = DslQueryExecutorSettings.CALCITE_QUERY_ENABLED.get(settings);
+        this.aggregationEnabledOnCalcite = DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(DslQueryExecutorSettings.CALCITE_ENABLED, v -> this.calciteEnabled = v);
+        clusterSettings.addSettingsUpdateConsumer(DslQueryExecutorSettings.CALCITE_QUERY_ENABLED, v -> this.queryEnabledOnCalcite = v);
+        clusterSettings.addSettingsUpdateConsumer(
+            DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED,
+            v -> this.aggregationEnabledOnCalcite = v
+        );
     }
 
     @Override
@@ -100,7 +118,16 @@ public class SearchActionFilter implements ActionFilter {
         }
 
         SearchRequest searchRequest = (SearchRequest) request;
-        RouteDecision decision = grammar.validate(searchRequest.source());
+        SearchSourceBuilder source = searchRequest.source();
+
+        // Per-category operational gate: even when the grammar could handle the request, route it
+        // to codec if it exercises a capability whose toggle is off.
+        if (isDisabledCapability(source)) {
+            chain.proceed(task, action, request, listener);
+            return;
+        }
+
+        RouteDecision decision = grammar.validate(source);
 
         if (!decision.supported()) {
             logger.debug("Grammar rejected _search, falling back to codec: {}", decision.rejectionReasons());
@@ -128,6 +155,18 @@ public class SearchActionFilter implements ActionFilter {
             }
         };
         client.execute(DslExecuteAction.INSTANCE, searchRequest, calciteListener);
+    }
+
+    /**
+     * True if the request exercises a capability whose per-category toggle is off — routed to
+     * codec even if the grammar could handle it. {@code usesAggs} = the request carries
+     * aggregations; {@code usesQuery} = it returns hits or is a non-aggregation request (plain
+     * search / count). A mixed request needs both toggles on.
+     */
+    private boolean isDisabledCapability(SearchSourceBuilder source) {
+        boolean usesAggs = source != null && source.aggregations() != null;
+        boolean usesQuery = usesAggs == false || source.size() != 0;
+        return (usesAggs && aggregationEnabledOnCalcite == false) || (usesQuery && queryEnabledOnCalcite == false);
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.dsl.action;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
@@ -15,29 +17,66 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.dsl.DslQueryExecutorSettings;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.router.DslCalciteGrammar;
+import org.opensearch.dsl.router.RouteDecision;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.client.node.NodeClient;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
 /**
- * Intercepts all {@code _search} requests and dispatches them to {@link DslExecuteAction}
- * for execution through the Calcite pipeline. Non-search actions pass through unchanged.
+ * Intercepts {@code _search} requests and, when Calcite routing is enabled, decides between
+ * the Calcite path and the codec path.
+ *
+ * <p>Layer 1: {@link DslQueryExecutorSettings#CALCITE_ENABLED} — defaults to {@code true};
+ * setting it to {@code false} forces every request through the codec path unchanged
+ * (operational escape hatch).
+ *
+ * <p>Layer 2 (only when the setting is on):
+ * <ul>
+ *   <li>{@link DslCalciteGrammar#validate} classifies the request. Grammar-rejected requests
+ *       fall back to the codec path.</li>
+ *   <li>Grammar-accepted requests are dispatched to {@link DslExecuteAction}. A
+ *       {@link ConversionException} during execution triggers codec fallback (schema-side
+ *       checks the grammar can't run may still fail at conversion time). Non-conversion
+ *       errors surface to the caller unchanged.</li>
+ * </ul>
  */
 public class SearchActionFilter implements ActionFilter {
+
+    private static final Logger logger = LogManager.getLogger(SearchActionFilter.class);
 
     /** Runs after the Security plugin's authorization filter (order 0). */
     static final int FILTER_ORDER = 1;
 
     private final NodeClient client;
+    private final DslCalciteGrammar grammar;
+    /**
+     * Kept in sync with {@link DslQueryExecutorSettings#CALCITE_ENABLED} via a
+     * cluster-settings update consumer, so a {@code PUT _cluster/settings} change propagates
+     * without any per-request settings lookup. {@code volatile} because updates land on the
+     * cluster-state-applier thread while reads happen on transport/search threads.
+     */
+    private volatile boolean calciteEnabled;
 
     /**
-     * Creates a filter that dispatches intercepted searches via the given client.
-     *
      * @param client node client for dispatching to {@link DslExecuteAction}
+     * @param clusterService source of the dynamic {@code CALCITE_ENABLED} setting value
+     * @param grammar route-decision oracle
      */
-    public SearchActionFilter(NodeClient client) {
+    public SearchActionFilter(NodeClient client, ClusterService clusterService, DslCalciteGrammar grammar) {
         this.client = client;
+        this.grammar = grammar;
+        this.calciteEnabled = DslQueryExecutorSettings.CALCITE_ENABLED.get(clusterService.getSettings());
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(DslQueryExecutorSettings.CALCITE_ENABLED, v -> this.calciteEnabled = v);
     }
 
     @Override
@@ -56,12 +95,47 @@ public class SearchActionFilter implements ActionFilter {
         ActionFilterChain<Request, Response> chain
     ) {
         // TODO: add support for other search-related APIs (_msearch, _count, _search_shards, etc.).
-        // Consider two categories: APIs that execute search vs APIs that only explain/validate.
-        if (SearchAction.NAME.equals(action)) {
-            SearchRequest searchRequest = (SearchRequest) request;
-            client.execute(DslExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
-        } else {
+        if (!calciteEnabled || !SearchAction.NAME.equals(action)) {
             chain.proceed(task, action, request, listener);
+            return;
         }
+
+        SearchRequest searchRequest = (SearchRequest) request;
+        RouteDecision decision = grammar.validate(searchRequest.source());
+
+        if (!decision.supported()) {
+            logger.debug("Grammar rejected _search, falling back to codec: {}", decision.unsupportedFeatures());
+            chain.proceed(task, action, request, listener);
+            return;
+        }
+
+        ActionListener<SearchResponse> calciteListener = ActionListener.wrap(
+            (SearchResponse resp) -> ((ActionListener<SearchResponse>) listener).onResponse(resp),
+            error -> {
+                if (isFallbackable(error)) {
+                    logger.debug("Calcite path threw ConversionException, falling back to codec", error);
+                    chain.proceed(task, action, request, listener);
+                } else {
+                    listener.onFailure(error);
+                }
+            }
+        );
+        client.execute(DslExecuteAction.INSTANCE, searchRequest, calciteListener);
+    }
+
+    /**
+     * Only fall back on failures that mean "Calcite can't handle this request" — grammar
+     * gaps or schema mismatches the grammar can't see. Runtime engine errors, timeouts,
+     * and other operational failures must surface to the caller so they can be diagnosed.
+     *
+     * <p>Uses an identity-based seen set to defend against pathological self-referential
+     * or cyclic exception chains (e.g. legacy code that calls {@code initCause(this)}).
+     */
+    private static boolean isFallbackable(Throwable e) {
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Throwable t = e; t != null && seen.add(t); t = t.getCause()) {
+            if (t instanceof ConversionException) return true;
+        }
+        return false;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistry.java
@@ -36,13 +36,7 @@ public class AggregationRegistry {
         translators.put(translator.getAggregationType(), translator);
     }
 
-    /**
-     * Returns {@code true} when a translator is registered for the given aggregation type. Used
-     * by routing (grammar) to decide whether a request can be sent to the Calcite path before
-     * any conversion work is attempted.
-     *
-     * @param type the concrete {@link AggregationBuilder} class
-     */
+    /** True if a translator is registered for the given aggregation type. */
     public boolean hasTranslator(Class<? extends AggregationBuilder> type) {
         return translators.containsKey(type);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistry.java
@@ -37,6 +37,17 @@ public class AggregationRegistry {
     }
 
     /**
+     * Returns {@code true} when a translator is registered for the given aggregation type. Used
+     * by routing (grammar) to decide whether a request can be sent to the Calcite path before
+     * any conversion work is attempted.
+     *
+     * @param type the concrete {@link AggregationBuilder} class
+     */
+    public boolean hasTranslator(Class<? extends AggregationBuilder> type) {
+        return translators.containsKey(type);
+    }
+
+    /**
      * Returns the translator for the given class, or null.
      * Caller checks {@code instanceof MetricTranslator} or {@code instanceof BucketTranslator}.
      *

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -15,14 +15,19 @@ import org.opensearch.dsl.aggregation.metric.MinMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.SumMetricTranslator;
 
 /**
- * Creates an {@link AggregationRegistry} populated with all supported translators.
+ * Returns the process-wide {@link AggregationRegistry} populated with all supported
+ * metric and bucket translators. Registrations are effectively immutable after class
+ * init, and the registry is safe to share across threads (concurrent reads, no writes
+ * at steady state).
  */
 public class AggregationRegistryFactory {
 
+    /** Built once at class init and cached forever. */
+    private static final AggregationRegistry INSTANCE = build();
+
     private AggregationRegistryFactory() {}
 
-    /** Creates a registry with all supported metric and bucket translators. */
-    public static AggregationRegistry create() {
+    private static AggregationRegistry build() {
         AggregationRegistry registry = new AggregationRegistry();
         registry.register(new AvgMetricTranslator());
         registry.register(new SumMetricTranslator());
@@ -31,5 +36,10 @@ public class AggregationRegistryFactory {
         registry.register(new TermsBucketTranslator());
         // TODO: add other aggregation translators
         return registry;
+    }
+
+    /** Returns the shared registry. All callers see the same instance. */
+    public static AggregationRegistry create() {
+        return INSTANCE;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
-import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.search.aggregations.AggregationBuilder;
 
 import java.util.Map;
@@ -24,17 +24,14 @@ public interface AggregationTranslator<T extends AggregationBuilder> {
     Class<T> getAggregationType();
 
     /**
-     * Rejects requests carrying parameters this translator does not implement. Called once per
-     * aggregation, before any plan is built.
-     *
-     * <p>An unimplemented parameter must be rejected rather than ignored: ignoring it returns
-     * a well-formed response whose numbers differ from classic search. A translator that
-     * honors every parameter of its aggregation type provides an empty implementation.
+     * Validates the aggregation's request shape, rejecting parameters this translator does not
+     * implement — ignoring one would return a response whose numbers differ from classic search.
+     * Called once per aggregation, before any plan is built.
      *
      * @param agg the aggregation builder to validate
-     * @throws ConversionException if the aggregation carries an unsupported parameter
+     * @return the validation result; {@link ValidationResult#accepted()} when every parameter is supported
      */
-    void validate(T agg) throws ConversionException;
+    ValidationResult validate(T agg);
 
     /**
      * Returns the user-supplied {@code meta} map from the request, or null when absent so the

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -14,6 +14,7 @@ import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
 import org.opensearch.dsl.aggregation.bucket.SizedBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.MetricTranslator;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.search.aggregations.AggregationBuilder;
 
 import java.util.ArrayList;
@@ -88,7 +89,10 @@ public class AggregationTreeWalker {
                 throw new ConversionException("No translator registered for aggregation type: " + aggBuilder.getClass().getSimpleName());
             }
             // Reject unsupported parameters before any plan state accumulates.
-            ((AggregationTranslator<AggregationBuilder>) type).validate(aggBuilder);
+            ValidationResult validationResult = ((AggregationTranslator<AggregationBuilder>) type).validate(aggBuilder);
+            if (validationResult.isAccepted() == false) {
+                throw new ConversionException(validationResult.message());
+            }
             if (type instanceof BucketTranslator) {
                 handleBucket((BucketTranslator<AggregationBuilder>) type, aggBuilder, currentPath, plans, rowType);
             } else if (type instanceof MetricTranslator) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -10,7 +10,7 @@ package org.opensearch.dsl.aggregation.bucket;
 
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
-import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -80,19 +80,22 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
      * bucket set or key rendering relative to classic search if ignored.
      */
     @Override
-    public void validate(TermsAggregationBuilder agg) throws ConversionException {
+    public ValidationResult validate(TermsAggregationBuilder agg) {
         if (agg.includeExclude() != null) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                "terms.include_exclude",
                 "[include]/[exclude] on terms aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
             );
         }
         if (agg.script() != null) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                "terms.script",
                 "[script] on terms aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
             );
         }
         if (agg.minDocCount() == 0) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                "terms.min_doc_count",
                 "[min_doc_count: 0] on terms aggregation ["
                     + agg.getName()
                     + "] is not supported by the DSL execution path — zero-count buckets require enumerating the index term "
@@ -103,7 +106,8 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
         if (fieldType != null
             && (DateFieldMapper.CONTENT_TYPE.equals(fieldType.typeName())
                 || DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(fieldType.typeName()))) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                "terms.date_field",
                 "terms aggregation ["
                     + agg.getName()
                     + "] on date field ["
@@ -111,6 +115,7 @@ public class TermsBucketTranslator implements SizedBucketTranslator<TermsAggrega
                     + "] is not supported by the DSL execution path — date bucket keys cannot yet be rendered with mapping formats"
             );
         }
+        return ValidationResult.accepted();
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 
 import java.util.Collections;
@@ -35,17 +36,20 @@ public abstract class AbstractMetricTranslator<T extends ValuesSourceAggregation
      * when either parameter is present.
      */
     @Override
-    public void validate(T agg) throws ConversionException {
+    public ValidationResult validate(T agg) {
         if (agg.missing() != null) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                agg.getType() + ".missing",
                 "[missing] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
             );
         }
         if (agg.script() != null) {
-            throw new ConversionException(
+            return ValidationResult.rejected(
+                agg.getType() + ".script",
                 "[script] on metric aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
             );
         }
+        return ValidationResult.accepted();
     }
 
     /** Returns the SQL aggregate function (e.g., AVG, SUM, MIN, MAX). */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -124,12 +124,17 @@ public class SearchSourceConverter {
     /**
      * Converts DSL for the given index into query plans.
      *
-     * @param searchSource the DSL query
+     * @param searchSource the DSL query; a {@code null} source (bodyless {@code _search}) is
+     *        treated as an empty match_all request
      * @param indexName target index
      * @return one or more query plans
      * @throws ConversionException if DSL conversion fails
      */
     public QueryPlans convert(SearchSourceBuilder searchSource, String indexName) throws ConversionException {
+        if (searchSource == null) {
+            searchSource = new SearchSourceBuilder();
+        }
+
         RelOptTable table = catalogReader.getTable(List.of(indexName));
         if (table == null) {
             throw new IllegalArgumentException("Index not found in schema: " + indexName);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -27,15 +27,25 @@ public class ExistsQueryTranslator implements QueryTranslator {
     }
 
     @Override
-    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+    public ValidationResult validate(QueryBuilder query) {
         ExistsQueryBuilder existsQuery = (ExistsQueryBuilder) query;
-        String fieldName = existsQuery.fieldName();
-        float boost = existsQuery.boost();
 
-        if (boost != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("boost is unsupported for Exists query type");
+        if (existsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return ValidationResult.rejected("exists.boost", "boost is unsupported for Exists query type");
         }
 
+        return ValidationResult.accepted();
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        ExistsQueryBuilder existsQuery = (ExistsQueryBuilder) query;
+        ValidationResult validationResult = validate(existsQuery);
+        if (!validationResult.isAccepted()) {
+            throw new ConversionException(validationResult.message());
+        }
+
+        String fieldName = existsQuery.fieldName();
         RexNode fieldRef = ctx.makeFieldRef(fieldName);
         return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
@@ -28,6 +28,12 @@ public class MatchAllQueryTranslator implements QueryTranslator {
         return MatchAllQueryBuilder.class;
     }
 
+    /** Accepts every match_all query: {@link #convert} rejects no parameter, so routing mirrors conversion. */
+    @Override
+    public ValidationResult validate(QueryBuilder query) {
+        return ValidationResult.accepted();
+    }
+
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) {
         return ctx.getRexBuilder().makeLiteral(true);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
@@ -37,15 +37,9 @@ public class QueryRegistry {
         translators.put(translator.getQueryType(), translator);
     }
 
-    /**
-     * Returns {@code true} when a translator is registered for the given query type. Used by
-     * routing (grammar) to decide whether a request can be sent to the Calcite path before any
-     * conversion work is attempted.
-     *
-     * @param type the concrete {@link QueryBuilder} class
-     */
-    public boolean hasTranslator(Class<? extends QueryBuilder> type) {
-        return translators.containsKey(type);
+    /** Returns the registered translator for the given query type, or null. */
+    public QueryTranslator get(Class<? extends QueryBuilder> type) {
+        return translators.get(type);
     }
 
     /**
@@ -59,7 +53,7 @@ public class QueryRegistry {
      * @throws ConversionException if a registered translator fails
      */
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
-        QueryTranslator translator = translators.get(query.getClass());
+        QueryTranslator translator = get(query.getClass());
         if (translator != null) {
             return translator.convert(query, ctx);
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
@@ -38,6 +38,17 @@ public class QueryRegistry {
     }
 
     /**
+     * Returns {@code true} when a translator is registered for the given query type. Used by
+     * routing (grammar) to decide whether a request can be sent to the Calcite path before any
+     * conversion work is attempted.
+     *
+     * @param type the concrete {@link QueryBuilder} class
+     */
+    public boolean hasTranslator(Class<? extends QueryBuilder> type) {
+        return translators.containsKey(type);
+    }
+
+    /**
      * Converts a query using the registered translator for its type.
      * If no translator is registered, wraps the query in an {@link UnresolvedQueryCall}
      * for the analytics engine's optimizer to resolve or reject.

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -9,14 +9,21 @@
 package org.opensearch.dsl.query;
 
 /**
- * Creates a {@link QueryRegistry} populated with all supported query translators.
+ * Returns the process-wide {@link QueryRegistry} populated with all supported query
+ * translators. Registrations are effectively immutable after class init, and the registry
+ * is safe to share across threads (concurrent reads, no writes at steady state).
  */
 public class QueryRegistryFactory {
 
+    /**
+     * Built once at class init. The registry is populated in a private helper (not inline
+     * so we can keep the {@code register(...)} calls readable) and cached forever.
+     */
+    private static final QueryRegistry INSTANCE = build();
+
     private QueryRegistryFactory() {}
 
-    /** Creates a registry with all supported query translators. */
-    public static QueryRegistry create() {
+    private static QueryRegistry build() {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new TermsQueryTranslator());
@@ -24,5 +31,10 @@ public class QueryRegistryFactory {
         registry.register(new ExistsQueryTranslator());
         // TODO: add other query translators
         return registry;
+    }
+
+    /** Returns the shared registry. All callers see the same instance. */
+    public static QueryRegistry create() {
+        return INSTANCE;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -21,11 +21,17 @@ public class QueryRegistryFactory {
      * Built once at class init. The registry is populated in a private helper (not inline
      * so we can keep the {@code register(...)} calls readable) and cached forever.
      */
-    private static final QueryRegistry INSTANCE = build();
+    private static final QueryRegistry INSTANCE = newInstance();
 
     private QueryRegistryFactory() {}
 
-    private static QueryRegistry build() {
+    /**
+     * Returns a fresh registry populated with all supported translators. Production code should
+     * use {@link #create()} (the shared, effectively-immutable singleton); callers that need to
+     * register additional translators — e.g. tests — must use this so they never mutate the
+     * shared instance.
+     */
+    public static QueryRegistry newInstance() {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new TermsQueryTranslator());

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -11,14 +11,21 @@ package org.opensearch.dsl.query;
 import org.opensearch.dsl.query.range.RangeQueryTranslator;
 
 /**
- * Creates a {@link QueryRegistry} populated with all supported query translators.
+ * Returns the process-wide {@link QueryRegistry} populated with all supported query
+ * translators. Registrations are effectively immutable after class init, and the registry
+ * is safe to share across threads (concurrent reads, no writes at steady state).
  */
 public class QueryRegistryFactory {
 
+    /**
+     * Built once at class init. The registry is populated in a private helper (not inline
+     * so we can keep the {@code register(...)} calls readable) and cached forever.
+     */
+    private static final QueryRegistry INSTANCE = build();
+
     private QueryRegistryFactory() {}
 
-    /** Creates a registry with all supported query translators. */
-    public static QueryRegistry create() {
+    private static QueryRegistry build() {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new TermsQueryTranslator());
@@ -27,5 +34,10 @@ public class QueryRegistryFactory {
         registry.register(new RangeQueryTranslator());
         // TODO: add other query translators
         return registry;
+    }
+
+    /** Returns the shared registry. All callers see the same instance. */
+    public static QueryRegistry create() {
+        return INSTANCE;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -11,26 +11,17 @@ package org.opensearch.dsl.query;
 import org.opensearch.dsl.query.range.RangeQueryTranslator;
 
 /**
- * Returns the process-wide {@link QueryRegistry} populated with all supported query
- * translators. Registrations are effectively immutable after class init, and the registry
- * is safe to share across threads (concurrent reads, no writes at steady state).
+ * Creates a {@link QueryRegistry} populated with all supported query translators.
  */
 public class QueryRegistryFactory {
 
-    /**
-     * Built once at class init. The registry is populated in a private helper (not inline
-     * so we can keep the {@code register(...)} calls readable) and cached forever.
-     */
+    /** Shared, immutable-after-init registry returned by {@link #create()}. */
     private static final QueryRegistry INSTANCE = newInstance();
 
     private QueryRegistryFactory() {}
 
-    /**
-     * Returns a fresh registry populated with all supported translators. Production code should
-     * use {@link #create()} (the shared, effectively-immutable singleton); callers that need to
-     * register additional translators — e.g. tests — must use this so they never mutate the
-     * shared instance.
-     */
+    /** A fresh {@link QueryRegistry} with all supported translators. */
+    // VisibleForTesting - tests use this to register extra translators without mutating the shared instance.
     public static QueryRegistry newInstance() {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
@@ -23,11 +23,8 @@ public interface QueryTranslator {
     Class<? extends QueryBuilder> getQueryType();
 
     /**
-     * Validates the query builder's request shape before routing/conversion.
-     *
-     * <p>Reject-unless-supported: the default <em>rejects</em>, so a translator whose type may run on
-     * the Calcite path must override this to accept (and to reject any parameter it cannot honor).
-     * Schema-dependent checks stay in {@link #convert(QueryBuilder, ConversionContext)}.
+     * Validates the query's parameters before routing. Defaults to reject (reject-unless-supported):
+     * a supported type must override this to accept. Schema-dependent checks stay in {@link #convert}.
      *
      * @param query the query builder to validate
      * @return the validation result; rejected by default

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
@@ -25,14 +25,18 @@ public interface QueryTranslator {
     /**
      * Validates the query builder's request shape before routing/conversion.
      *
-     * <p>Schema-dependent checks should remain in {@link #convert(QueryBuilder, ConversionContext)},
-     * since the routing layer does not have schema context.
+     * <p>Reject-unless-supported: the default <em>rejects</em>, so a translator whose type may run on
+     * the Calcite path must override this to accept (and to reject any parameter it cannot honor).
+     * Schema-dependent checks stay in {@link #convert(QueryBuilder, ConversionContext)}.
      *
      * @param query the query builder to validate
-     * @return the validation result
+     * @return the validation result; rejected by default
      */
     default ValidationResult validate(QueryBuilder query) {
-        return ValidationResult.accepted();
+        return ValidationResult.rejected(
+            query.getName() + ".unvalidated",
+            query.getName() + " query has no validate() override; its parameters are not vetted for the Calcite path"
+        );
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
@@ -23,6 +23,19 @@ public interface QueryTranslator {
     Class<? extends QueryBuilder> getQueryType();
 
     /**
+     * Validates the query builder's request shape before routing/conversion.
+     *
+     * <p>Schema-dependent checks should remain in {@link #convert(QueryBuilder, ConversionContext)},
+     * since the routing layer does not have schema context.
+     *
+     * @param query the query builder to validate
+     * @return the validation result
+     */
+    default ValidationResult validate(QueryBuilder query) {
+        return ValidationResult.accepted();
+    }
+
+    /**
      * Converts the query to a Calcite RexNode filter expression.
      *
      * @param query the query builder to convert

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
@@ -39,6 +39,12 @@ public class TermQueryTranslator implements QueryTranslator {
         return TermQueryBuilder.class;
     }
 
+    /** Accepts every term query: {@link #convert} rejects no parameter, so routing mirrors conversion. */
+    @Override
+    public ValidationResult validate(QueryBuilder query) {
+        return ValidationResult.accepted();
+    }
+
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         TermQueryBuilder termQuery = (TermQueryBuilder) query;

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -30,29 +30,44 @@ public class TermsQueryTranslator implements QueryTranslator {
     }
 
     @Override
-    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
-
+    public ValidationResult validate(QueryBuilder query) {
         TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
 
         if (termsQuery.termsLookup() != null) {
-            throw new ConversionException("Terms query does not support terms lookup");
+            return ValidationResult.rejected("terms.terms_lookup", "Terms query does not support terms lookup");
         }
         if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Terms query does not support non-default boost");
+            return ValidationResult.rejected("terms.boost", "Terms query does not support non-default boost");
         }
         if (termsQuery.queryName() != null) {
-            throw new ConversionException("Terms query does not support _name");
+            return ValidationResult.rejected("terms.name", "Terms query does not support _name");
         }
         if (termsQuery.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
-            throw new ConversionException("Terms query does not support non-default value_type");
+            return ValidationResult.rejected(
+                "terms.value_type:" + termsQuery.valueType(),
+                "Terms query does not support non-default value_type"
+            );
+        }
+
+        List<?> values = termsQuery.values();
+        if (values == null || values.isEmpty()) {
+            return ValidationResult.rejected("terms.no_values", "Terms query must have values");
+        }
+
+        return ValidationResult.accepted();
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+
+        TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
+        ValidationResult validationResult = validate(termsQuery);
+        if (!validationResult.isAccepted()) {
+            throw new ConversionException(validationResult.message());
         }
 
         String fieldName = termsQuery.fieldName();
         List<?> values = termsQuery.values();
-
-        if (values == null || values.isEmpty()) {
-            throw new ConversionException("Terms query must have values");
-        }
 
         RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
         if (field == null) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -11,6 +11,7 @@ package org.opensearch.dsl.query;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
+import org.opensearch.core.ParseField;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.AbstractQueryBuilder;
@@ -31,6 +32,9 @@ public class TermsQueryTranslator implements QueryTranslator {
 
     private static final TranslatorMapperRegistry REGISTRY = TranslatorMapperRegistry.INSTANCE;
 
+    /** Reason-code prefix, derived from the query name so it tracks {@link TermsQueryBuilder#NAME}. */
+    private static final String REASON_PREFIX = TermsQueryBuilder.NAME + ".";
+
     @Override
     public Class<? extends QueryBuilder> getQueryType() {
         return TermsQueryBuilder.class;
@@ -41,27 +45,35 @@ public class TermsQueryTranslator implements QueryTranslator {
         TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
 
         if (termsQuery.termsLookup() != null) {
-            return ValidationResult.rejected("terms.terms_lookup", "Terms query does not support terms lookup");
+            return ValidationResult.rejected(reasonCode(TermsQueryBuilder.TERMS_LOOKUP_FIELD), "Terms query does not support terms lookup");
         }
         if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return ValidationResult.rejected("terms.boost", "Terms query does not support non-default boost");
+            return ValidationResult.rejected(
+                reasonCode(AbstractQueryBuilder.BOOST_FIELD),
+                "Terms query does not support non-default boost"
+            );
         }
         if (termsQuery.queryName() != null) {
-            return ValidationResult.rejected("terms.name", "Terms query does not support _name");
+            return ValidationResult.rejected(reasonCode(AbstractQueryBuilder.NAME_FIELD), "Terms query does not support _name");
         }
         if (termsQuery.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
             return ValidationResult.rejected(
-                "terms.value_type:" + termsQuery.valueType(),
+                reasonCode(TermsQueryBuilder.VALUE_TYPE_FIELD) + ":" + termsQuery.valueType(),
                 "Terms query does not support non-default value_type"
             );
         }
 
         List<?> values = termsQuery.values();
         if (values == null || values.isEmpty()) {
-            return ValidationResult.rejected("terms.no_values", "Terms query must have values");
+            return ValidationResult.rejected(REASON_PREFIX + "no_values", "Terms query must have values");
         }
 
         return ValidationResult.accepted();
+    }
+
+    /** Builds a stable reason code {@code terms.<field>} from a query-parameter {@link ParseField}. */
+    private static String reasonCode(ParseField field) {
+        return REASON_PREFIX + field.getPreferredName();
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -37,29 +37,44 @@ public class TermsQueryTranslator implements QueryTranslator {
     }
 
     @Override
-    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
-
+    public ValidationResult validate(QueryBuilder query) {
         TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
 
         if (termsQuery.termsLookup() != null) {
-            throw new ConversionException("Terms query does not support terms lookup");
+            return ValidationResult.rejected("terms.terms_lookup", "Terms query does not support terms lookup");
         }
         if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Terms query does not support non-default boost");
+            return ValidationResult.rejected("terms.boost", "Terms query does not support non-default boost");
         }
         if (termsQuery.queryName() != null) {
-            throw new ConversionException("Terms query does not support _name");
+            return ValidationResult.rejected("terms.name", "Terms query does not support _name");
         }
         if (termsQuery.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
-            throw new ConversionException("Terms query does not support non-default value_type");
+            return ValidationResult.rejected(
+                "terms.value_type:" + termsQuery.valueType(),
+                "Terms query does not support non-default value_type"
+            );
+        }
+
+        List<?> values = termsQuery.values();
+        if (values == null || values.isEmpty()) {
+            return ValidationResult.rejected("terms.no_values", "Terms query must have values");
+        }
+
+        return ValidationResult.accepted();
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+
+        TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
+        ValidationResult validationResult = validate(termsQuery);
+        if (!validationResult.isAccepted()) {
+            throw new ConversionException(validationResult.message());
         }
 
         String fieldName = termsQuery.fieldName();
         List<?> values = termsQuery.values();
-
-        if (values == null || values.isEmpty()) {
-            throw new ConversionException("Terms query must have values");
-        }
 
         RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
         if (field == null) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ValidationResult.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ValidationResult.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+/**
+ * Result of validating a query builder's request shape before conversion.
+ *
+ * <p>{@code reasonCode} is used by routing/grammar for stable observability, while
+ * {@code message} is used when conversion needs to surface a human-readable error.
+ */
+public record ValidationResult(String reasonCode, String message) {
+
+    private static final ValidationResult ACCEPTED = new ValidationResult(null, null);
+
+    /** Returns the shared successful validation result. */
+    public static ValidationResult accepted() {
+        return ACCEPTED;
+    }
+
+    /** Returns a rejected validation result carrying both machine and human-readable forms. */
+    public static ValidationResult rejected(String reasonCode, String message) {
+        return new ValidationResult(reasonCode, message);
+    }
+
+    /** Returns {@code true} when validation passed. */
+    public boolean isAccepted() {
+        return reasonCode == null;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -8,23 +8,31 @@
 
 package org.opensearch.dsl.router;
 
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryTranslator;
 import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.aggregations.PipelineAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -33,8 +41,8 @@ import java.util.stream.Stream;
  *
  * <p>Strategy: registry-lookup is the safe list. Any query/aggregation whose class has a
  * translator registered is accepted structurally; per-parameter restrictions are layered on
- * top only where the translator has known request-shape limitations. Compound queries
- * ({@code bool}, {@code constant_score}) are transparent — recursed into, never looked up.
+ * top only where the translator has known request-shape limitations. The {@code bool} compound
+ * query is transparent — recursed into, never looked up.
  *
  * <p>Reject reasons are returned as short reason codes (e.g. {@code "query:function_score"},
  * {@code "range.relation:DISJOINT"}, {@code "pipeline_agg:cumulative_sum"}) for observability
@@ -47,9 +55,11 @@ import java.util.stream.Stream;
  *       trees are blanket-rejected for now and stay on the codec path until their Calcite /
  *       DataFusion performance is validated. Per-parameter checks per aggregation type are
  *       TODO and tracked inside {@code visitAggregation}.</li>
- *   <li>Top-level checks (size, sort, highlight, post_filter, etc.) are TODO — the response
- *       builder's hits are still stubbed, so top-level gating will be added when
- *       {@code buildHits} lands.</li>
+ *   <li>Top-level fields are reject-unless-supported: a field is supported only if we have a
+ *       handler for it. For now only {@code query} and {@code aggregations} have handlers, so a
+ *       request that sets any other top-level field ({@code size}, {@code sort}, {@code _source},
+ *       {@code highlight}, {@code post_filter}, …) is rejected and falls back to codec. Handlers
+ *       for the remaining supported fields are added incrementally.</li>
  * </ul>
  */
 public class DslCalciteGrammar {
@@ -62,16 +72,45 @@ public class DslCalciteGrammar {
      *
      * <p>Consulted before the leaf/registry path in {@link #visitQuery}, so a compound query
      * can never be mistaken for a leaf and have its children skipped.
+     *
+     * <p>Only {@code bool} is recursed today. Other compound queries ({@code constant_score},
+     * {@code dis_max}, {@code function_score}, {@code boosting}, {@code hybrid}) carry scoring
+     * semantics the DataFusion path does not support, so they have no entry here and fall back to
+     * codec.
      */
     private static final Map<Class<? extends QueryBuilder>, Function<QueryBuilder, Stream<QueryBuilder>>> COMPOUND_CHILDREN = Map.of(
         BoolQueryBuilder.class,
         q -> {
             BoolQueryBuilder b = (BoolQueryBuilder) q;
             return Stream.of(b.must(), b.filter(), b.should(), b.mustNot()).flatMap(List::stream);
-        },
-        ConstantScoreQueryBuilder.class,
-        q -> Stream.of(((ConstantScoreQueryBuilder) q).innerQuery())
+        }
     );
+
+    /**
+     * Validates the contents of one top-level field. Returns {@code true} if supported; otherwise
+     * adds a reason code to {@code issues} and returns {@code false}.
+     */
+    @FunctionalInterface
+    private interface TopLevelFieldHandler {
+        boolean isSupported(SearchSourceBuilder source, List<String> issues);
+    }
+
+    /**
+     * Handler for fields the converter supports in full — every value is honored, so there is
+     * nothing to validate (e.g. {@code size}, {@code _source}).
+     */
+    private static final TopLevelFieldHandler ALWAYS_SUPPORTED = (source, issues) -> true;
+
+    /**
+     * Handlers for the top-level {@link SearchSourceBuilder} fields we support, keyed by field
+     * name. A field with no handler here is rejected (routed to codec) — reject-unless-supported;
+     * a field with a handler is accepted only if the handler validates its contents. Contents are
+     * validated for {@code query} and {@code aggregations}; {@code size}, {@code from},
+     * {@code _source} and {@code track_total_hits} are supported in full. {@code sort} has no
+     * handler yet, so it still routes to codec until {@code visitSort} lands. Populated in the
+     * constructor because the query/aggregation handlers call instance methods.
+     */
+    private final Map<String, TopLevelFieldHandler> topLevelHandlers;
 
     private final QueryRegistry queryRegistry;
     private final AggregationRegistry aggRegistry;
@@ -83,6 +122,18 @@ public class DslCalciteGrammar {
     public DslCalciteGrammar(QueryRegistry queryRegistry, AggregationRegistry aggRegistry) {
         this.queryRegistry = queryRegistry;
         this.aggRegistry = aggRegistry;
+
+        Map<String, TopLevelFieldHandler> handlers = new HashMap<>();
+        handlers.put(SearchSourceBuilder.QUERY_FIELD.getPreferredName(), (source, issues) -> visitQuery(source.query(), issues));
+        handlers.put(
+            SearchSourceBuilder.AGGREGATIONS_FIELD.getPreferredName(),
+            (source, issues) -> visitAggregationTree(source.aggregations(), issues)
+        );
+        handlers.put(SearchSourceBuilder.SIZE_FIELD.getPreferredName(), ALWAYS_SUPPORTED);
+        handlers.put(SearchSourceBuilder.FROM_FIELD.getPreferredName(), ALWAYS_SUPPORTED);
+        handlers.put(SearchSourceBuilder._SOURCE_FIELD.getPreferredName(), ALWAYS_SUPPORTED);
+        handlers.put(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), ALWAYS_SUPPORTED);
+        this.topLevelHandlers = Map.copyOf(handlers);
     }
 
     /**
@@ -100,16 +151,35 @@ public class DslCalciteGrammar {
         }
 
         List<String> issues = new ArrayList<>();
-
-        if (source.query() != null && !visitQuery(source.query(), issues)) {
-            return RouteDecision.rejected(issues);
+        for (String field : topLevelFields(source)) {
+            TopLevelFieldHandler handler = topLevelHandlers.get(field);
+            if (handler == null) {
+                return RouteDecision.rejected(List.of("source." + field));
+            }
+            if (handler.isSupported(source, issues) == false) {
+                return RouteDecision.rejected(issues);
+            }
         }
 
-        if (source.aggregations() != null && !visitAggregationTree(source.aggregations(), issues)) {
-            return RouteDecision.rejected(issues);
-        }
-
+        // Reached when every field the request set had a passing handler, or the request set no
+        // fields at all (empty {} — the loop never ran). Both accept. (A null source is handled
+        // by the early return above.)
         return RouteDecision.accepted();
+    }
+
+    /**
+     * The top-level field names the request actually set. There is no getter that enumerates set
+     * fields, so the source is serialized ({@link SearchSourceBuilder#toXContent} emits only set
+     * fields) and its JSON keys are read — this sees every field, including ones added to
+     * OpenSearch later. Ordered, so a query failure is reported before an aggregation failure.
+     */
+    private static Set<String> topLevelFields(SearchSourceBuilder source) {
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            return XContentHelper.convertToMap(BytesReference.bytes(builder), true).v2().keySet();
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read search source top-level fields", e);
+        }
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -23,6 +23,9 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -51,6 +54,25 @@ import java.util.stream.Stream;
  */
 public class DslCalciteGrammar {
 
+    /**
+     * Compound (container) queries are transparent: structurally supported, but only if every
+     * child query is supported. Each entry declares how to extract that type's child clauses,
+     * so recursion follows the query tree rather than a hardcoded switch — adding a container
+     * type is a single entry here, and validation of its children comes for free.
+     *
+     * <p>Consulted before the leaf/registry path in {@link #visitQuery}, so a compound query
+     * can never be mistaken for a leaf and have its children skipped.
+     */
+    private static final Map<Class<? extends QueryBuilder>, Function<QueryBuilder, Stream<QueryBuilder>>> COMPOUND_CHILDREN = Map.of(
+        BoolQueryBuilder.class,
+        q -> {
+            BoolQueryBuilder b = (BoolQueryBuilder) q;
+            return Stream.of(b.must(), b.filter(), b.should(), b.mustNot()).flatMap(List::stream);
+        },
+        ConstantScoreQueryBuilder.class,
+        q -> Stream.of(((ConstantScoreQueryBuilder) q).innerQuery())
+    );
+
     private final QueryRegistry queryRegistry;
     private final AggregationRegistry aggRegistry;
 
@@ -68,15 +90,13 @@ public class DslCalciteGrammar {
      * failing section: top-level issues skip the query walk, query issues skip the aggregation
      * walk.
      *
-     * @param source the request body; a {@code null} source is rejected up front
-     *        ({@link org.opensearch.dsl.converter.SearchSourceConverter} would NPE)
+     * @param source the request body; a {@code null} source (bodyless {@code _search}) is
+     *        accepted as an implicit match_all — {@link org.opensearch.dsl.converter.SearchSourceConverter}
+     *        normalizes it to an empty source
      */
     public RouteDecision validate(SearchSourceBuilder source) {
         if (source == null) {
-            // SearchSourceConverter dereferences source.size()/source.aggregations() with
-            // no null guard — a null source would NPE the Calcite path. Semantically the
-            // request is a match_all, but that has to be expressed with an actual body.
-            return RouteDecision.rejected(List.of("source:null"));
+            return RouteDecision.accepted();
         }
 
         List<String> issues = new ArrayList<>();
@@ -92,19 +112,28 @@ public class DslCalciteGrammar {
         return RouteDecision.accepted();
     }
 
+    /**
+     * Visits a single query node. Compound queries (see {@link #COMPOUND_CHILDREN}) are
+     * transparent — recursed into and supported only if every child is supported. Every other
+     * query type is treated as a leaf and resolved against the translator registry. Driving the
+     * recursion off {@code COMPOUND_CHILDREN} rather than a hardcoded switch means a nested
+     * unsupported leaf inside any container type is always found, never silently accepted.
+     */
     private boolean visitQuery(QueryBuilder q, List<String> issues) {
-        // Compound queries are transparent to the registry — recurse into children.
-        switch (q) {
-            case BoolQueryBuilder b -> {
-                return visitBool(b, issues);
-            }
-            case ConstantScoreQueryBuilder csq -> {
-                return visitQuery(csq.innerQuery(), issues);
-            }
-            default -> {
-            }
+        Function<QueryBuilder, Stream<QueryBuilder>> childrenOf = COMPOUND_CHILDREN.get(q.getClass());
+        if (childrenOf != null) {
+            return childrenOf.apply(q).filter(Objects::nonNull).allMatch(child -> visitQuery(child, issues));
         }
+        return visitLeaf(q, issues);
+    }
 
+    /**
+     * Resolves a leaf (non-compound) query against the registry: rejects with a
+     * {@code query:<name>} reason when no translator is registered, otherwise delegates
+     * request-shape validation to that translator so routing and conversion share one source
+     * of truth.
+     */
+    private boolean visitLeaf(QueryBuilder q, List<String> issues) {
         QueryTranslator translator = queryRegistry.get(q.getClass());
         if (translator == null) {
             return reject("query:" + q.getName(), issues);
@@ -116,14 +145,6 @@ public class DslCalciteGrammar {
         }
 
         return true;
-    }
-
-    /**
-     * Recurses into every clause of a {@code bool} query. {@code allMatch} short-circuits on
-     * the first failing child so the reject reason reflects the exact node that broke.
-     */
-    private boolean visitBool(BoolQueryBuilder b, List<String> issues) {
-        return Stream.of(b.must(), b.filter(), b.should(), b.mustNot()).flatMap(List::stream).allMatch(inner -> visitQuery(inner, issues));
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -10,15 +10,11 @@ package org.opensearch.dsl.router;
 
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.query.QueryRegistry;
-import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.dsl.query.QueryTranslator;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
-import org.opensearch.index.query.ExistsQueryBuilder;
-import org.opensearch.index.query.PrefixQueryBuilder;
-import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.RangeQueryBuilder;
-import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.aggregations.PipelineAggregationBuilder;
@@ -43,9 +39,11 @@ import java.util.stream.Stream;
  *
  * <p>v1 scope:
  * <ul>
- *   <li>Query walker with per-parameter checks mirroring each registered query translator.</li>
- *   <li>Aggregation walker with registry check + pipeline-agg rejection; per-parameter checks
- *       per aggregation type are TODO and tracked inside {@code visitAggregation}.</li>
+ *   <li>Query walker with translator-backed leaf validation.</li>
+ *   <li>Aggregation walker with registry check + pipeline-agg rejection. Nested aggregation
+ *       trees are blanket-rejected for now and stay on the codec path until their Calcite /
+ *       DataFusion performance is validated. Per-parameter checks per aggregation type are
+ *       TODO and tracked inside {@code visitAggregation}.</li>
  *   <li>Top-level checks (size, sort, highlight, post_filter, etc.) are TODO — the response
  *       builder's hits are still stubbed, so top-level gating will be added when
  *       {@code buildHits} lands.</li>
@@ -107,67 +105,16 @@ public class DslCalciteGrammar {
             }
         }
 
-        if (!queryRegistry.hasTranslator(q.getClass())) {
+        QueryTranslator translator = queryRegistry.get(q.getClass());
+        if (translator == null) {
             return reject("query:" + q.getName(), issues);
         }
 
-        // Per-parameter restrictions for registered types. Types not listed have
-        // translators that accept anything the class carries — the default arm passes
-        // them through structurally. Examples:
-        //   - TermQueryTranslator: reads only fieldName/value, raises no rejects.
-        //   - MatchAllQueryTranslator: reads nothing, always returns TRUE. Note that a
-        //     null source.query() is treated by the converter as an implicit match_all
-        //     (no filter) and is also accepted — but a null source itself is rejected
-        //     up front (see validate()).
-        return switch (q) {
-            case RangeQueryBuilder r -> visitRangeQuery(r, issues);
-            case TermsQueryBuilder t -> visitTermsQuery(t, issues);
-            case ExistsQueryBuilder e -> visitExistsQuery(e, issues);
-            case PrefixQueryBuilder p -> visitPrefixQuery(p, issues);
-            case WildcardQueryBuilder w -> visitWildcardQuery(w, issues);
-            default -> true;
-        };
-    }
+        ValidationResult validationResult = translator.validate(q);
+        if (!validationResult.isAccepted()) {
+            return reject(validationResult.reasonCode(), issues);
+        }
 
-    /**
-     * Per-parameter checks for {@code wildcard} query, mirroring
-     * {@code WildcardQueryTranslator}'s rejects. Same shape as {@code prefix}:
-     * {@code case_insensitive} is consumed, {@code boost}/{@code rewrite} rejected.
-     */
-    private boolean visitWildcardQuery(WildcardQueryBuilder w, List<String> issues) {
-        if (w.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return reject(WildcardQueryBuilder.NAME + ".boost", issues);
-        }
-        if (w.rewrite() != null) {
-            return reject(WildcardQueryBuilder.NAME + ".rewrite", issues);
-        }
-        return true;
-    }
-
-    /**
-     * Per-parameter checks for {@code prefix} query, mirroring {@code PrefixQueryTranslator}'s
-     * rejects. {@code case_insensitive} is consumed by the translator (folds to LOWER) and
-     * intentionally not rejected here.
-     */
-    private boolean visitPrefixQuery(PrefixQueryBuilder p, List<String> issues) {
-        if (p.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return reject(PrefixQueryBuilder.NAME + ".boost", issues);
-        }
-        if (p.rewrite() != null) {
-            return reject(PrefixQueryBuilder.NAME + ".rewrite", issues);
-        }
-        return true;
-    }
-
-    /**
-     * Per-parameter checks for {@code exists} query, mirroring {@code ExistsQueryTranslator}'s
-     * rejects. Only {@code boost} is checked — the translator silently ignores other params
-     * (including {@code _name}), matching the translator literally.
-     */
-    private boolean visitExistsQuery(ExistsQueryBuilder e, List<String> issues) {
-        if (e.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return reject(ExistsQueryBuilder.NAME + ".boost", issues);
-        }
         return true;
     }
 
@@ -176,54 +123,7 @@ public class DslCalciteGrammar {
      * the first failing child so the reject reason reflects the exact node that broke.
      */
     private boolean visitBool(BoolQueryBuilder b, List<String> issues) {
-        return Stream.of(b.must(), b.filter(), b.should(), b.mustNot())
-            .flatMap(List::stream)
-            .allMatch(inner -> visitQuery(inner, issues));
-    }
-
-    /**
-     * Per-parameter checks for {@code terms} query, mirroring {@code TermsQueryTranslator}'s
-     * rejects. Field-existence and value-type-compatibility stay with the translator.
-     */
-    private boolean visitTermsQuery(TermsQueryBuilder t, List<String> issues) {
-        if (t.termsLookup() != null) {
-            return reject(TermsQueryBuilder.NAME + ".terms_lookup", issues);
-        }
-        if (t.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return reject(TermsQueryBuilder.NAME + ".boost", issues);
-        }
-        if (t.queryName() != null) {
-            return reject(TermsQueryBuilder.NAME + ".name", issues);
-        }
-        if (t.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
-            return reject(TermsQueryBuilder.NAME + ".value_type:" + t.valueType(), issues);
-        }
-        if (t.values() == null || t.values().isEmpty()) {
-            return reject(TermsQueryBuilder.NAME + ".no_values", issues);
-        }
-        return true;
-    }
-
-    /**
-     * Per-parameter checks for {@code range} query, mirroring {@code RangeQueryTranslator}'s
-     * rejects. Field-existence, binary-field guards, and date_nanos-precision checks stay
-     * with the translator (schema context is not available here).
-     *
-     * <p>The translator also rejects {@code relation=DISJOINT}, but that path is
-     * unreachable: {@link RangeQueryBuilder#relation(String)} rejects {@code DISJOINT} at
-     * construction time, so no such request can ever reach the grammar.
-     */
-    private boolean visitRangeQuery(RangeQueryBuilder r, List<String> issues) {
-        if (r.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            return reject(RangeQueryBuilder.NAME + ".boost", issues);
-        }
-        if (r.queryName() != null) {
-            return reject(RangeQueryBuilder.NAME + ".name", issues);
-        }
-        if (r.from() == null && r.to() == null) {
-            return reject(RangeQueryBuilder.NAME + ".no_bounds", issues);
-        }
-        return true;
+        return Stream.of(b.must(), b.filter(), b.should(), b.mustNot()).flatMap(List::stream).allMatch(inner -> visitQuery(inner, issues));
     }
 
     /**
@@ -262,14 +162,17 @@ public class DslCalciteGrammar {
             return reject("agg:" + agg.getType(), issues);
         }
 
+        if (agg.getSubAggregations() != null && agg.getSubAggregations().isEmpty() == false) {
+            return reject("agg.nested", issues);
+        }
+
         // TODO: per-parameter checks per aggregation type. To be filled in as each
         // aggregation translator (avg/sum/min/max/value_count/stats/extended_stats/terms/...)
         // is reviewed for the exact params it consumes vs silently ignores. Same pattern as
         // the query-side switch above — mirror the translator's rejects here to route to
         // codec early instead of failing at conversion time.
 
-        return visitPipelineAggregations(agg.getPipelineAggregations(), issues)
-            && visitAggregations(agg.getSubAggregations(), issues);
+        return visitPipelineAggregations(agg.getPipelineAggregations(), issues);
     }
 
     private static boolean reject(String reason, List<String> issues) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -1,0 +1,279 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.router;
+
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.query.QueryRegistry;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregatorFactories;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Decides whether a {@link SearchSourceBuilder} can be handled by the Calcite path.
+ *
+ * <p>Strategy: registry-lookup is the safe list. Any query/aggregation whose class has a
+ * translator registered is accepted structurally; per-parameter restrictions are layered on
+ * top only where the translator has known request-shape limitations. Compound queries
+ * ({@code bool}, {@code constant_score}) are transparent — recursed into, never looked up.
+ *
+ * <p>Reject reasons are returned as short reason codes (e.g. {@code "query:function_score"},
+ * {@code "range.relation:DISJOINT"}, {@code "pipeline_agg:cumulative_sum"}) for observability
+ * without leaking user data.
+ *
+ * <p>v1 scope:
+ * <ul>
+ *   <li>Query walker with per-parameter checks mirroring each registered query translator.</li>
+ *   <li>Aggregation walker with registry check + pipeline-agg rejection; per-parameter checks
+ *       per aggregation type are TODO and tracked inside {@code visitAggregation}.</li>
+ *   <li>Top-level checks (size, sort, highlight, post_filter, etc.) are TODO — the response
+ *       builder's hits are still stubbed, so top-level gating will be added when
+ *       {@code buildHits} lands.</li>
+ * </ul>
+ */
+public class DslCalciteGrammar {
+
+    private final QueryRegistry queryRegistry;
+    private final AggregationRegistry aggRegistry;
+
+    /**
+     * @param queryRegistry the registry consulted for query-leaf safe list
+     * @param aggRegistry the registry consulted for aggregation safe list
+     */
+    public DslCalciteGrammar(QueryRegistry queryRegistry, AggregationRegistry aggRegistry) {
+        this.queryRegistry = queryRegistry;
+        this.aggRegistry = aggRegistry;
+    }
+
+    /**
+     * Validates a search source, returning a routing decision. Short-circuits at the first
+     * failing section: top-level issues skip the query walk, query issues skip the aggregation
+     * walk.
+     *
+     * @param source the request body; a {@code null} source is rejected up front
+     *        ({@link org.opensearch.dsl.converter.SearchSourceConverter} would NPE)
+     */
+    public RouteDecision validate(SearchSourceBuilder source) {
+        if (source == null) {
+            // SearchSourceConverter dereferences source.size()/source.aggregations() with
+            // no null guard — a null source would NPE the Calcite path. Semantically the
+            // request is a match_all, but that has to be expressed with an actual body.
+            return RouteDecision.rejected(List.of("source:null"));
+        }
+
+        List<String> issues = new ArrayList<>();
+
+        if (source.query() != null && !visitQuery(source.query(), issues)) {
+            return RouteDecision.rejected(issues);
+        }
+
+        if (source.aggregations() != null && !visitAggregationTree(source.aggregations(), issues)) {
+            return RouteDecision.rejected(issues);
+        }
+
+        return RouteDecision.accepted();
+    }
+
+    private boolean visitQuery(QueryBuilder q, List<String> issues) {
+        // Compound queries are transparent to the registry — recurse into children.
+        switch (q) {
+            case BoolQueryBuilder b -> {
+                return visitBool(b, issues);
+            }
+            case ConstantScoreQueryBuilder csq -> {
+                return visitQuery(csq.innerQuery(), issues);
+            }
+            default -> {
+            }
+        }
+
+        if (!queryRegistry.hasTranslator(q.getClass())) {
+            return reject("query:" + q.getName(), issues);
+        }
+
+        // Per-parameter restrictions for registered types. Types not listed have
+        // translators that accept anything the class carries — the default arm passes
+        // them through structurally. Examples:
+        //   - TermQueryTranslator: reads only fieldName/value, raises no rejects.
+        //   - MatchAllQueryTranslator: reads nothing, always returns TRUE. Note that a
+        //     null source.query() is treated by the converter as an implicit match_all
+        //     (no filter) and is also accepted — but a null source itself is rejected
+        //     up front (see validate()).
+        return switch (q) {
+            case RangeQueryBuilder r -> visitRangeQuery(r, issues);
+            case TermsQueryBuilder t -> visitTermsQuery(t, issues);
+            case ExistsQueryBuilder e -> visitExistsQuery(e, issues);
+            case PrefixQueryBuilder p -> visitPrefixQuery(p, issues);
+            case WildcardQueryBuilder w -> visitWildcardQuery(w, issues);
+            default -> true;
+        };
+    }
+
+    /**
+     * Per-parameter checks for {@code wildcard} query, mirroring
+     * {@code WildcardQueryTranslator}'s rejects. Same shape as {@code prefix}:
+     * {@code case_insensitive} is consumed, {@code boost}/{@code rewrite} rejected.
+     */
+    private boolean visitWildcardQuery(WildcardQueryBuilder w, List<String> issues) {
+        if (w.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return reject(WildcardQueryBuilder.NAME + ".boost", issues);
+        }
+        if (w.rewrite() != null) {
+            return reject(WildcardQueryBuilder.NAME + ".rewrite", issues);
+        }
+        return true;
+    }
+
+    /**
+     * Per-parameter checks for {@code prefix} query, mirroring {@code PrefixQueryTranslator}'s
+     * rejects. {@code case_insensitive} is consumed by the translator (folds to LOWER) and
+     * intentionally not rejected here.
+     */
+    private boolean visitPrefixQuery(PrefixQueryBuilder p, List<String> issues) {
+        if (p.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return reject(PrefixQueryBuilder.NAME + ".boost", issues);
+        }
+        if (p.rewrite() != null) {
+            return reject(PrefixQueryBuilder.NAME + ".rewrite", issues);
+        }
+        return true;
+    }
+
+    /**
+     * Per-parameter checks for {@code exists} query, mirroring {@code ExistsQueryTranslator}'s
+     * rejects. Only {@code boost} is checked — the translator silently ignores other params
+     * (including {@code _name}), matching the translator literally.
+     */
+    private boolean visitExistsQuery(ExistsQueryBuilder e, List<String> issues) {
+        if (e.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return reject(ExistsQueryBuilder.NAME + ".boost", issues);
+        }
+        return true;
+    }
+
+    /**
+     * Recurses into every clause of a {@code bool} query. {@code allMatch} short-circuits on
+     * the first failing child so the reject reason reflects the exact node that broke.
+     */
+    private boolean visitBool(BoolQueryBuilder b, List<String> issues) {
+        return Stream.of(b.must(), b.filter(), b.should(), b.mustNot())
+            .flatMap(List::stream)
+            .allMatch(inner -> visitQuery(inner, issues));
+    }
+
+    /**
+     * Per-parameter checks for {@code terms} query, mirroring {@code TermsQueryTranslator}'s
+     * rejects. Field-existence and value-type-compatibility stay with the translator.
+     */
+    private boolean visitTermsQuery(TermsQueryBuilder t, List<String> issues) {
+        if (t.termsLookup() != null) {
+            return reject(TermsQueryBuilder.NAME + ".terms_lookup", issues);
+        }
+        if (t.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return reject(TermsQueryBuilder.NAME + ".boost", issues);
+        }
+        if (t.queryName() != null) {
+            return reject(TermsQueryBuilder.NAME + ".name", issues);
+        }
+        if (t.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
+            return reject(TermsQueryBuilder.NAME + ".value_type:" + t.valueType(), issues);
+        }
+        if (t.values() == null || t.values().isEmpty()) {
+            return reject(TermsQueryBuilder.NAME + ".no_values", issues);
+        }
+        return true;
+    }
+
+    /**
+     * Per-parameter checks for {@code range} query, mirroring {@code RangeQueryTranslator}'s
+     * rejects. Field-existence, binary-field guards, and date_nanos-precision checks stay
+     * with the translator (schema context is not available here).
+     *
+     * <p>The translator also rejects {@code relation=DISJOINT}, but that path is
+     * unreachable: {@link RangeQueryBuilder#relation(String)} rejects {@code DISJOINT} at
+     * construction time, so no such request can ever reach the grammar.
+     */
+    private boolean visitRangeQuery(RangeQueryBuilder r, List<String> issues) {
+        if (r.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            return reject(RangeQueryBuilder.NAME + ".boost", issues);
+        }
+        if (r.queryName() != null) {
+            return reject(RangeQueryBuilder.NAME + ".name", issues);
+        }
+        if (r.from() == null && r.to() == null) {
+            return reject(RangeQueryBuilder.NAME + ".no_bounds", issues);
+        }
+        return true;
+    }
+
+    /**
+     * Entry point for the aggregation section: rejects top-level pipeline aggregations, then
+     * walks each top-level regular aggregation.
+     */
+    private boolean visitAggregationTree(AggregatorFactories.Builder aggs, List<String> issues) {
+        return visitPipelineAggregations(aggs.getPipelineAggregatorFactories(), issues)
+            && visitAggregations(aggs.getAggregatorFactories(), issues);
+    }
+
+    /** Collection-level driver: short-circuits at the first failing aggregation. */
+    private boolean visitAggregations(Collection<AggregationBuilder> aggs, List<String> issues) {
+        return aggs == null || aggs.stream().allMatch(agg -> visitAggregation(agg, issues));
+    }
+
+    /**
+     * Pipeline aggregations have no Calcite equivalent — any presence is a hard reject.
+     * Called from both the top-level tree walk and the per-node recursion, since pipelines
+     * can appear as siblings of any level's regular aggregations.
+     *
+     * <p>TODO: when a {@code PipelineAggregationRegistry} (or equivalent) is introduced,
+     * replace the blanket reject with a registry check + per-type per-parameter switch,
+     * mirroring the query and normal-aggregation paths.
+     */
+    private boolean visitPipelineAggregations(Collection<PipelineAggregationBuilder> pipelines, List<String> issues) {
+        if (pipelines == null || pipelines.isEmpty()) {
+            return true;
+        }
+
+        return reject("pipeline_agg:" + pipelines.iterator().next().getName(), issues);
+    }
+
+    private boolean visitAggregation(AggregationBuilder agg, List<String> issues) {
+        if (!aggRegistry.hasTranslator(agg.getClass())) {
+            return reject("agg:" + agg.getType(), issues);
+        }
+
+        // TODO: per-parameter checks per aggregation type. To be filled in as each
+        // aggregation translator (avg/sum/min/max/value_count/stats/extended_stats/terms/...)
+        // is reviewed for the exact params it consumes vs silently ignores. Same pattern as
+        // the query-side switch above — mirror the translator's rejects here to route to
+        // codec early instead of failing at conversion time.
+
+        return visitPipelineAggregations(agg.getPipelineAggregations(), issues)
+            && visitAggregations(agg.getSubAggregations(), issues);
+    }
+
+    private static boolean reject(String reason, List<String> issues) {
+        issues.add(reason);
+        return false;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -11,13 +11,13 @@ package org.opensearch.dsl.router;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.query.QueryRegistry;
-import org.opensearch.dsl.query.QueryTranslator;
 import org.opensearch.dsl.query.ValidationResult;
-import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregatorFactories;
@@ -31,60 +31,22 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
- * Decides whether a {@link SearchSourceBuilder} can be handled by the Calcite path.
+ * Decides whether a {@link SearchSourceBuilder} can run on the Calcite path.
  *
- * <p>Strategy: registry-lookup is the safe list. Any query/aggregation whose class has a
- * translator registered is accepted structurally; per-parameter restrictions are layered on
- * top only where the translator has known request-shape limitations. The {@code bool} compound
- * query is transparent — recursed into, never looked up.
+ * <p>Reject-unless-supported: a request is accepted only if every top-level field has a handler and
+ * every query and aggregation type has a translator that accepts its parameters — otherwise it
+ * routes to codec. Parameter validation is delegated to the translators, so routing and conversion
+ * agree. Query-tree recursion is driven by {@link QueryBuilder#visit}, so a nested query in any
+ * container type is always reached without a hand-maintained list; nested aggregation trees are
+ * blanket-rejected for now, pending performance validation.
  *
- * <p>Reject reasons are returned as short reason codes (e.g. {@code "query:function_score"},
- * {@code "range.relation:DISJOINT"}, {@code "pipeline_agg:cumulative_sum"}) for observability
- * without leaking user data.
- *
- * <p>v1 scope:
- * <ul>
- *   <li>Query walker with translator-backed leaf validation.</li>
- *   <li>Aggregation walker with registry check + pipeline-agg rejection. Nested aggregation
- *       trees are blanket-rejected for now and stay on the codec path until their Calcite /
- *       DataFusion performance is validated. Per-parameter checks per aggregation type are
- *       TODO and tracked inside {@code visitAggregation}.</li>
- *   <li>Top-level fields are reject-unless-supported: a field is supported only if we have a
- *       handler for it. For now only {@code query} and {@code aggregations} have handlers, so a
- *       request that sets any other top-level field ({@code size}, {@code sort}, {@code _source},
- *       {@code highlight}, {@code post_filter}, …) is rejected and falls back to codec. Handlers
- *       for the remaining supported fields are added incrementally.</li>
- * </ul>
+ * <p>Reject reasons are short codes (e.g. {@code "query:function_score"}, {@code "terms.min_doc_count"})
+ * for observability without leaking user data.
  */
 public class DslCalciteGrammar {
-
-    /**
-     * Compound (container) queries are transparent: structurally supported, but only if every
-     * child query is supported. Each entry declares how to extract that type's child clauses,
-     * so recursion follows the query tree rather than a hardcoded switch — adding a container
-     * type is a single entry here, and validation of its children comes for free.
-     *
-     * <p>Consulted before the leaf/registry path in {@link #visitQuery}, so a compound query
-     * can never be mistaken for a leaf and have its children skipped.
-     *
-     * <p>Only {@code bool} is recursed today. Other compound queries ({@code constant_score},
-     * {@code dis_max}, {@code function_score}, {@code boosting}, {@code hybrid}) carry scoring
-     * semantics the DataFusion path does not support, so they have no entry here and fall back to
-     * codec.
-     */
-    private static final Map<Class<? extends QueryBuilder>, Function<QueryBuilder, Stream<QueryBuilder>>> COMPOUND_CHILDREN = Map.of(
-        BoolQueryBuilder.class,
-        q -> {
-            BoolQueryBuilder b = (BoolQueryBuilder) q;
-            return Stream.of(b.must(), b.filter(), b.should(), b.mustNot()).flatMap(List::stream);
-        }
-    );
 
     /**
      * Validates the contents of one top-level field. Returns {@code true} if supported; otherwise
@@ -102,13 +64,9 @@ public class DslCalciteGrammar {
     private static final TopLevelFieldHandler ALWAYS_SUPPORTED = (source, issues) -> true;
 
     /**
-     * Handlers for the top-level {@link SearchSourceBuilder} fields we support, keyed by field
-     * name. A field with no handler here is rejected (routed to codec) — reject-unless-supported;
-     * a field with a handler is accepted only if the handler validates its contents. Contents are
-     * validated for {@code query} and {@code aggregations}; {@code size}, {@code from},
-     * {@code _source} and {@code track_total_hits} are supported in full. {@code sort} has no
-     * handler yet, so it still routes to codec until {@code visitSort} lands. Populated in the
-     * constructor because the query/aggregation handlers call instance methods.
+     * Supported top-level fields keyed by name: a field with no handler is rejected (routed to
+     * codec), one with a handler is accepted only if the handler validates its contents. Populated
+     * in the constructor because the query/aggregation handlers call instance methods.
      */
     private final Map<String, TopLevelFieldHandler> topLevelHandlers;
 
@@ -137,12 +95,11 @@ public class DslCalciteGrammar {
     }
 
     /**
-     * Validates a search source, returning a routing decision. Short-circuits at the first
-     * failing section: top-level issues skip the query walk, query issues skip the aggregation
-     * walk.
+     * Validates a search source, returning a routing decision; short-circuits at the first failing
+     * field.
      *
-     * @param source the request body; a {@code null} source (bodyless {@code _search}) is
-     *        accepted as an implicit match_all — {@link org.opensearch.dsl.converter.SearchSourceConverter}
+     * @param source the request body; a {@code null} source (bodyless {@code _search}) is accepted
+     *        as an implicit match_all — {@link org.opensearch.dsl.converter.SearchSourceConverter}
      *        normalizes it to an empty source
      */
     public RouteDecision validate(SearchSourceBuilder source) {
@@ -161,9 +118,8 @@ public class DslCalciteGrammar {
             }
         }
 
-        // Reached when every field the request set had a passing handler, or the request set no
-        // fields at all (empty {} — the loop never ran). Both accept. (A null source is handled
-        // by the early return above.)
+        // Reached when every field the request set had a passing handler, or it set no fields at all
+        // (empty {} — the loop never ran). Both accept; a null source already returned early above.
         return RouteDecision.accepted();
     }
 
@@ -176,45 +132,20 @@ public class DslCalciteGrammar {
     private static Set<String> topLevelFields(SearchSourceBuilder source) {
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             source.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            return XContentHelper.convertToMap(BytesReference.bytes(builder), true).v2().keySet();
+            return XContentHelper.convertToMap(BytesReference.bytes(builder), true, MediaTypeRegistry.JSON).v2().keySet();
         } catch (IOException e) {
             throw new UncheckedIOException("failed to read search source top-level fields", e);
         }
     }
 
     /**
-     * Visits a single query node. Compound queries (see {@link #COMPOUND_CHILDREN}) are
-     * transparent — recursed into and supported only if every child is supported. Every other
-     * query type is treated as a leaf and resolved against the translator registry. Driving the
-     * recursion off {@code COMPOUND_CHILDREN} rather than a hardcoded switch means a nested
-     * unsupported leaf inside any container type is always found, never silently accepted.
+     * Validates the query tree via {@link QueryBuilder#visit}, which reaches every node;
+     * {@link ValidatingQueryVisitor} checks each one (translator lookup + parameter validation).
      */
-    private boolean visitQuery(QueryBuilder q, List<String> issues) {
-        Function<QueryBuilder, Stream<QueryBuilder>> childrenOf = COMPOUND_CHILDREN.get(q.getClass());
-        if (childrenOf != null) {
-            return childrenOf.apply(q).filter(Objects::nonNull).allMatch(child -> visitQuery(child, issues));
-        }
-        return visitLeaf(q, issues);
-    }
-
-    /**
-     * Resolves a leaf (non-compound) query against the registry: rejects with a
-     * {@code query:<name>} reason when no translator is registered, otherwise delegates
-     * request-shape validation to that translator so routing and conversion share one source
-     * of truth.
-     */
-    private boolean visitLeaf(QueryBuilder q, List<String> issues) {
-        QueryTranslator translator = queryRegistry.get(q.getClass());
-        if (translator == null) {
-            return reject("query:" + q.getName(), issues);
-        }
-
-        ValidationResult validationResult = translator.validate(q);
-        if (!validationResult.isAccepted()) {
-            return reject(validationResult.reasonCode(), issues);
-        }
-
-        return true;
+    private boolean visitQuery(QueryBuilder root, List<String> issues) {
+        ValidatingQueryVisitor visitor = new ValidatingQueryVisitor(queryRegistry, issues);
+        root.visit(visitor);
+        return visitor.failed() == false;
     }
 
     /**
@@ -232,13 +163,11 @@ public class DslCalciteGrammar {
     }
 
     /**
-     * Pipeline aggregations have no Calcite equivalent — any presence is a hard reject.
-     * Called from both the top-level tree walk and the per-node recursion, since pipelines
-     * can appear as siblings of any level's regular aggregations.
+     * Pipeline aggregations have no Calcite equivalent — any presence is a hard reject. Called at
+     * each level, since pipelines can be siblings of regular aggregations.
      *
-     * <p>TODO: when a {@code PipelineAggregationRegistry} (or equivalent) is introduced,
-     * replace the blanket reject with a registry check + per-type per-parameter switch,
-     * mirroring the query and normal-aggregation paths.
+     * <p>TODO: replace the blanket reject with a registry + per-type validation once pipeline aggs
+     * are supported.
      */
     private boolean visitPipelineAggregations(Collection<PipelineAggregationBuilder> pipelines, List<String> issues) {
         if (pipelines == null || pipelines.isEmpty()) {
@@ -248,8 +177,10 @@ public class DslCalciteGrammar {
         return reject("pipeline_agg:" + pipelines.iterator().next().getName(), issues);
     }
 
+    @SuppressWarnings("unchecked")
     private boolean visitAggregation(AggregationBuilder agg, List<String> issues) {
-        if (!aggRegistry.hasTranslator(agg.getClass())) {
+        AggregationTranslator<?> translator = aggRegistry.get(agg.getClass());
+        if (translator == null) {
             return reject("agg:" + agg.getType(), issues);
         }
 
@@ -257,11 +188,13 @@ public class DslCalciteGrammar {
             return reject("agg.nested", issues);
         }
 
-        // TODO: per-parameter checks per aggregation type. To be filled in as each
-        // aggregation translator (avg/sum/min/max/value_count/stats/extended_stats/terms/...)
-        // is reviewed for the exact params it consumes vs silently ignores. Same pattern as
-        // the query-side switch above — mirror the translator's rejects here to route to
-        // codec early instead of failing at conversion time.
+        // Delegate to the same validate() the converter uses, so routing and conversion agree.
+        // Schema-dependent checks (e.g. terms on a date field) need a MapperService the routing
+        // layer lacks, so they no-op here and stay enforced in convert().
+        ValidationResult validationResult = ((AggregationTranslator<AggregationBuilder>) translator).validate(agg);
+        if (validationResult.isAccepted() == false) {
+            return reject(validationResult.reasonCode(), issues);
+        }
 
         return visitPipelineAggregations(agg.getPipelineAggregations(), issues);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/DslCalciteGrammar.java
@@ -34,40 +34,24 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Decides whether a {@link SearchSourceBuilder} can run on the Calcite path.
+ * Decides whether a {@link SearchSourceBuilder} can run on the Calcite path (else codec).
  *
- * <p>Reject-unless-supported: a request is accepted only if every top-level field has a handler and
- * every query and aggregation type has a translator that accepts its parameters — otherwise it
- * routes to codec. Parameter validation is delegated to the translators, so routing and conversion
- * agree. Query-tree recursion is driven by {@link QueryBuilder#visit}, so a nested query in any
- * container type is always reached without a hand-maintained list; nested aggregation trees are
- * blanket-rejected for now, pending performance validation.
- *
- * <p>Reject reasons are short codes (e.g. {@code "query:function_score"}, {@code "terms.min_doc_count"})
- * for observability without leaking user data.
+ * <p>Reject-unless-supported: accepted only if every top-level field, query type and aggregation
+ * type is affirmatively supported — parameter validation is delegated to the translators. Query-tree
+ * recursion uses {@link QueryBuilder#visit}; nested aggregation trees are rejected for now.
  */
 public class DslCalciteGrammar {
 
-    /**
-     * Validates the contents of one top-level field. Returns {@code true} if supported; otherwise
-     * adds a reason code to {@code issues} and returns {@code false}.
-     */
+    /** Validates one top-level field: {@code true} if supported, else adds a reason to {@code issues}. */
     @FunctionalInterface
     private interface TopLevelFieldHandler {
         boolean isSupported(SearchSourceBuilder source, List<String> issues);
     }
 
-    /**
-     * Handler for fields the converter supports in full — every value is honored, so there is
-     * nothing to validate (e.g. {@code size}, {@code _source}).
-     */
+    /** Handler for fields honored in full — nothing to validate (e.g. {@code size}, {@code _source}). */
     private static final TopLevelFieldHandler ALWAYS_SUPPORTED = (source, issues) -> true;
 
-    /**
-     * Supported top-level fields keyed by name: a field with no handler is rejected (routed to
-     * codec), one with a handler is accepted only if the handler validates its contents. Populated
-     * in the constructor because the query/aggregation handlers call instance methods.
-     */
+    /** Supported top-level fields keyed by name; a field with no handler is rejected. */
     private final Map<String, TopLevelFieldHandler> topLevelHandlers;
 
     private final QueryRegistry queryRegistry;
@@ -95,12 +79,10 @@ public class DslCalciteGrammar {
     }
 
     /**
-     * Validates a search source, returning a routing decision; short-circuits at the first failing
-     * field.
+     * Validates a search source, short-circuiting at the first failing field.
      *
      * @param source the request body; a {@code null} source (bodyless {@code _search}) is accepted
-     *        as an implicit match_all — {@link org.opensearch.dsl.converter.SearchSourceConverter}
-     *        normalizes it to an empty source
+     *        as an implicit match_all
      */
     public RouteDecision validate(SearchSourceBuilder source) {
         if (source == null) {
@@ -124,10 +106,8 @@ public class DslCalciteGrammar {
     }
 
     /**
-     * The top-level field names the request actually set. There is no getter that enumerates set
-     * fields, so the source is serialized ({@link SearchSourceBuilder#toXContent} emits only set
-     * fields) and its JSON keys are read — this sees every field, including ones added to
-     * OpenSearch later. Ordered, so a query failure is reported before an aggregation failure.
+     * The top-level field names the request set. No getter enumerates them, so the source is
+     * serialized and its JSON keys read — ordered, so a query failure is reported before an agg one.
      */
     private static Set<String> topLevelFields(SearchSourceBuilder source) {
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
@@ -148,10 +128,7 @@ public class DslCalciteGrammar {
         return visitor.failed() == false;
     }
 
-    /**
-     * Entry point for the aggregation section: rejects top-level pipeline aggregations, then
-     * walks each top-level regular aggregation.
-     */
+    /** Walks the aggregation tree: rejects top-level pipeline aggs, then each regular aggregation. */
     private boolean visitAggregationTree(AggregatorFactories.Builder aggs, List<String> issues) {
         return visitPipelineAggregations(aggs.getPipelineAggregatorFactories(), issues)
             && visitAggregations(aggs.getAggregatorFactories(), issues);
@@ -162,13 +139,7 @@ public class DslCalciteGrammar {
         return aggs == null || aggs.stream().allMatch(agg -> visitAggregation(agg, issues));
     }
 
-    /**
-     * Pipeline aggregations have no Calcite equivalent — any presence is a hard reject. Called at
-     * each level, since pipelines can be siblings of regular aggregations.
-     *
-     * <p>TODO: replace the blanket reject with a registry + per-type validation once pipeline aggs
-     * are supported.
-     */
+    /** Pipeline aggregations have no Calcite equivalent — always rejected. Called at each level. */
     private boolean visitPipelineAggregations(Collection<PipelineAggregationBuilder> pipelines, List<String> issues) {
         if (pipelines == null || pipelines.isEmpty()) {
             return true;
@@ -188,9 +159,8 @@ public class DslCalciteGrammar {
             return reject("agg.nested", issues);
         }
 
-        // Delegate to the same validate() the converter uses, so routing and conversion agree.
-        // Schema-dependent checks (e.g. terms on a date field) need a MapperService the routing
-        // layer lacks, so they no-op here and stay enforced in convert().
+        // Same validate() the converter uses. Schema-dependent checks (e.g. terms on a date field)
+        // need a MapperService the routing layer lacks, so they no-op here and stay in convert().
         ValidationResult validationResult = ((AggregationTranslator<AggregationBuilder>) translator).validate(agg);
         if (validationResult.isAccepted() == false) {
             return reject(validationResult.reasonCode(), issues);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
@@ -12,32 +12,16 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Result of a {@link DslCalciteGrammar#validate} pass over a {@code SearchSourceBuilder}.
- *
- * <p>A request is {@link #supported()} when the grammar accepts every node in the DSL tree.
- * Otherwise {@link #rejectionReasons()} enumerates the reason codes that caused rejection
- * (e.g. {@code "script"}, {@code "range.time_zone"}).
- *
- * <p>Callers use this record to route the request:
- * <pre>{@code
- * RouteDecision decision = grammar.validate(source);
- * if (decision.supported()) {
- *     // Calcite path
- * } else {
- *     // codec path; log decision.rejectionReasons() for observability
- * }
- * }</pre>
+ * Result of {@link DslCalciteGrammar#validate}: {@link #supported()} when the grammar accepts the
+ * whole DSL tree, else {@link #rejectionReasons()} carries the reason codes (e.g.
+ * {@code "query:match"}, {@code "terms.boost"}) and the caller routes to codec.
  */
 public record RouteDecision(boolean supported, List<String> rejectionReasons) {
 
-    /** Cached instance for the common "everything is fine" result. */
+    /** Cached "supported" result. */
     private static final RouteDecision SUPPORTED = new RouteDecision(true, Collections.emptyList());
 
-    /**
-     * Returns the singleton supported decision. Named {@code accepted} rather than
-     * {@code supported} to avoid colliding with the record's own {@code supported()}
-     * accessor (Java rejects a static factory with the same signature as an accessor).
-     */
+    /** The shared supported decision (named {@code accepted} to avoid clashing with the {@code supported()} accessor). */
     public static RouteDecision accepted() {
         return SUPPORTED;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
@@ -15,7 +15,7 @@ import java.util.List;
  * Result of a {@link DslCalciteGrammar#validate} pass over a {@code SearchSourceBuilder}.
  *
  * <p>A request is {@link #supported()} when the grammar accepts every node in the DSL tree.
- * Otherwise {@link #unsupportedFeatures()} enumerates the reason codes that caused rejection
+ * Otherwise {@link #rejectionReasons()} enumerates the reason codes that caused rejection
  * (e.g. {@code "script"}, {@code "range.time_zone"}).
  *
  * <p>Callers use this record to route the request:
@@ -24,11 +24,11 @@ import java.util.List;
  * if (decision.supported()) {
  *     // Calcite path
  * } else {
- *     // codec path; log decision.unsupportedFeatures() for observability
+ *     // codec path; log decision.rejectionReasons() for observability
  * }
  * }</pre>
  */
-public record RouteDecision(boolean supported, List<String> unsupportedFeatures) {
+public record RouteDecision(boolean supported, List<String> rejectionReasons) {
 
     /** Cached instance for the common "everything is fine" result. */
     private static final RouteDecision SUPPORTED = new RouteDecision(true, Collections.emptyList());
@@ -45,9 +45,9 @@ public record RouteDecision(boolean supported, List<String> unsupportedFeatures)
     /**
      * Constructs a rejection with the given reason codes.
      *
-     * @param features the reason codes accumulated during the walk
+     * @param rejectionReasons the reason codes accumulated during the walk
      */
-    public static RouteDecision rejected(List<String> features) {
-        return new RouteDecision(false, List.copyOf(features));
+    public static RouteDecision rejected(List<String> rejectionReasons) {
+        return new RouteDecision(false, List.copyOf(rejectionReasons));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/RouteDecision.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.router;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of a {@link DslCalciteGrammar#validate} pass over a {@code SearchSourceBuilder}.
+ *
+ * <p>A request is {@link #supported()} when the grammar accepts every node in the DSL tree.
+ * Otherwise {@link #unsupportedFeatures()} enumerates the reason codes that caused rejection
+ * (e.g. {@code "script"}, {@code "range.time_zone"}).
+ *
+ * <p>Callers use this record to route the request:
+ * <pre>{@code
+ * RouteDecision decision = grammar.validate(source);
+ * if (decision.supported()) {
+ *     // Calcite path
+ * } else {
+ *     // codec path; log decision.unsupportedFeatures() for observability
+ * }
+ * }</pre>
+ */
+public record RouteDecision(boolean supported, List<String> unsupportedFeatures) {
+
+    /** Cached instance for the common "everything is fine" result. */
+    private static final RouteDecision SUPPORTED = new RouteDecision(true, Collections.emptyList());
+
+    /**
+     * Returns the singleton supported decision. Named {@code accepted} rather than
+     * {@code supported} to avoid colliding with the record's own {@code supported()}
+     * accessor (Java rejects a static factory with the same signature as an accessor).
+     */
+    public static RouteDecision accepted() {
+        return SUPPORTED;
+    }
+
+    /**
+     * Constructs a rejection with the given reason codes.
+     *
+     * @param features the reason codes accumulated during the walk
+     */
+    public static RouteDecision rejected(List<String> features) {
+        return new RouteDecision(false, List.copyOf(features));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/ValidatingQueryVisitor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/ValidatingQueryVisitor.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.router;
+
+import org.apache.lucene.search.BooleanClause;
+import org.opensearch.dsl.query.QueryRegistry;
+import org.opensearch.dsl.query.QueryTranslator;
+import org.opensearch.dsl.query.ValidationResult;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+
+import java.util.List;
+
+/**
+ * Validates every query node the {@link QueryBuilder#visit} walk reaches: the node's type must have
+ * a registered translator (else rejected), which then validates that node's own parameters — child
+ * recursion is {@code visit}'s job. {@link #getChildVisitor} returns {@code this}, so one instance
+ * validates the whole tree with shared {@code failed}/{@code issues} state.
+ *
+ * <p>First failing node wins: once a reason is recorded, later {@link #accept} calls no-op (the walk
+ * cannot be stopped mid-traversal).
+ */
+final class ValidatingQueryVisitor implements QueryBuilderVisitor {
+
+    private final QueryRegistry queryRegistry;
+    private final List<String> issues;
+    private boolean failed = false;
+
+    ValidatingQueryVisitor(QueryRegistry queryRegistry, List<String> issues) {
+        this.queryRegistry = queryRegistry;
+        this.issues = issues;
+    }
+
+    /** @return true if any visited node was unsupported. */
+    boolean failed() {
+        return failed;
+    }
+
+    @Override
+    public void accept(QueryBuilder query) {
+        if (failed) {
+            return;
+        }
+        QueryTranslator translator = queryRegistry.get(query.getClass());
+        if (translator == null) {
+            reject("query:" + query.getName());
+            return;
+        }
+        ValidationResult validationResult = translator.validate(query);
+        if (validationResult.isAccepted() == false) {
+            reject(validationResult.reasonCode());
+        }
+    }
+
+    @Override
+    public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+        return this;
+    }
+
+    private void reject(String reason) {
+        issues.add(reason);
+        failed = true;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/ValidatingQueryVisitor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/ValidatingQueryVisitor.java
@@ -18,13 +18,9 @@ import org.opensearch.index.query.QueryBuilderVisitor;
 import java.util.List;
 
 /**
- * Validates every query node the {@link QueryBuilder#visit} walk reaches: the node's type must have
- * a registered translator (else rejected), which then validates that node's own parameters — child
- * recursion is {@code visit}'s job. {@link #getChildVisitor} returns {@code this}, so one instance
- * validates the whole tree with shared {@code failed}/{@code issues} state.
- *
- * <p>First failing node wins: once a reason is recorded, later {@link #accept} calls no-op (the walk
- * cannot be stopped mid-traversal).
+ * Validates each query node the {@link QueryBuilder#visit} walk reaches: the node's type must have a
+ * translator (else rejected), which validates that node's own parameters. {@link #getChildVisitor}
+ * returns {@code this}, so one instance validates the whole tree; the first failing node wins.
  */
 final class ValidatingQueryVisitor implements QueryBuilderVisitor {
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/package-info.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/router/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Routing gate that classifies incoming {@code _search} DSL between the Calcite path and the codec fallback. */
+package org.opensearch.dsl.router;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
@@ -9,6 +9,9 @@
 package org.opensearch.dsl;
 
 import org.opensearch.action.support.ActionFilter;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.dsl.action.DslExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
 import org.opensearch.dsl.action.TransportDslExecuteAction;
@@ -17,8 +20,10 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
 
@@ -37,7 +42,16 @@ public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
     }
 
     public void testGetActionFiltersAfterCreateComponents() {
-        plugin.createComponents(mock(NodeClient.class), null, null, null, null, null, null, null, null, null, null);
+        // SearchActionFilter subscribes to CALCITE_ENABLED via ClusterService — a real (but
+        // minimal) ClusterSettings is needed so addSettingsUpdateConsumer() has somewhere to
+        // register. Other createComponents params remain null: none of them are dereferenced.
+        Settings settings = Settings.EMPTY;
+        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        plugin.createComponents(mock(NodeClient.class), clusterService, null, null, null, null, null, null, null, null, null);
 
         List<ActionFilter> filters = plugin.getActionFilters();
         assertEquals(1, filters.size());

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
@@ -42,11 +42,18 @@ public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
     }
 
     public void testGetActionFiltersAfterCreateComponents() {
-        // SearchActionFilter subscribes to CALCITE_ENABLED via ClusterService — a real (but
+        // SearchActionFilter subscribes to the routing settings via ClusterService — a real (but
         // minimal) ClusterSettings is needed so addSettingsUpdateConsumer() has somewhere to
         // register. Other createComponents params remain null: none of them are dereferenced.
         Settings settings = Settings.EMPTY;
-        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(
+                DslQueryExecutorSettings.CALCITE_ENABLED,
+                DslQueryExecutorSettings.CALCITE_QUERY_ENABLED,
+                DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED
+            )
+        );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(settings);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -8,24 +8,38 @@
 
 package org.opensearch.dsl.action;
 
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.dsl.DslQueryExecutorSettings;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.router.DslCalciteGrammar;
+import org.opensearch.dsl.router.RouteDecision;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class SearchActionFilterTests extends OpenSearchTestCase {
@@ -35,29 +49,147 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
     private final ActionListener<ActionResponse> listener = mock(ActionListener.class);
     private final ActionFilterChain<ActionRequest, ActionResponse> chain = mock(ActionFilterChain.class);
     private final ActionRequestMetadata<ActionRequest, ActionResponse> metadata = mock(ActionRequestMetadata.class);
-    private final SearchActionFilter filter = new SearchActionFilter(client);
+    private final DslCalciteGrammar grammar = mock(DslCalciteGrammar.class);
+
+    private SearchActionFilter buildFilter(boolean calciteEnabled) {
+        Settings settings = Settings.builder()
+            .put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), calciteEnabled)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        return new SearchActionFilter(client, clusterService, grammar);
+    }
 
     public void testOrderRunsAfterSecurityFilter() {
+        SearchActionFilter filter = buildFilter(true);
         assertEquals(SearchActionFilter.FILTER_ORDER, filter.order());
     }
 
-    public void testPassesThroughNonSearchAction() {
+    // ---- Layer 1: master switch ----
+
+    public void testCalciteDisabledSendsSearchToCodec() {
+        SearchActionFilter filter = buildFilter(false);
+        SearchRequest request = new SearchRequest("test-index");
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(client, never()).execute(any(), any(), any());
+        verify(grammar, never()).validate(any());
+    }
+
+    public void testCalciteEnabledButNonSearchActionPassesThrough() {
+        SearchActionFilter filter = buildFilter(true);
         BulkRequest request = new BulkRequest();
 
         filter.apply(task, BulkAction.NAME, request, metadata, listener, chain);
 
         verify(chain).proceed(task, BulkAction.NAME, request, listener);
         verify(client, never()).execute(any(), any(), any());
+        verify(grammar, never()).validate(any());
     }
 
-    // TODO: add tests to verify reroute only happens when the target index has the setting enabled
+    // ---- Layer 2: grammar decision ----
 
-    public void testReroutesSearchAction() {
-        SearchRequest request = new SearchRequest("test-index");
+    public void testGrammarRejectFallsBackToCodec() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.rejected(List.of("query:match")));
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(grammar).validate(request.source());
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(client, never()).execute(any(), any(), any());
+    }
+
+    public void testGrammarAcceptDispatchesToCalcite() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
 
         filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
 
         verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), any());
         verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    // ---- Layer 2 fallback: ConversionException triggers codec ----
+
+    public void testConversionExceptionInCalciteFallsBackToCodec() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        // Grab the wrapped listener passed to client.execute and simulate a ConversionException.
+        ArgumentCaptor<ActionListener<SearchResponse>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), captor.capture());
+
+        captor.getValue().onFailure(new ConversionException("field 'x' not in schema"));
+
+        // Fallback = chain.proceed with the original listener.
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testWrappedConversionExceptionAlsoTriggersFallback() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        ArgumentCaptor<ActionListener<SearchResponse>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), captor.capture());
+
+        // Simulate an OS-side wrapper around the real cause.
+        Exception wrapped = new RuntimeException("engine failed", new ConversionException("nested cause"));
+        captor.getValue().onFailure(wrapped);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+    }
+
+    public void testNonConversionExceptionSurfacesToCaller() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        ArgumentCaptor<ActionListener<SearchResponse>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), captor.capture());
+
+        RuntimeException engineErr = new RuntimeException("engine timeout");
+        captor.getValue().onFailure(engineErr);
+
+        // No fallback for runtime errors — the caller sees the failure.
+        verify(listener).onFailure(engineErr);
+        verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    // ---- dynamic setting update ----
+
+    public void testDynamicDisableStopsInterception() {
+        Settings initial = Settings.builder().put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), true).build();
+        ClusterSettings clusterSettings = new ClusterSettings(initial, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(initial);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        SearchActionFilter filter = new SearchActionFilter(client, clusterService, grammar);
+
+        // Push a dynamic update: calcite off.
+        Settings updated = Settings.builder().put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), false).build();
+        clusterSettings.applySettings(updated);
+
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(client, never()).execute(any(), any(), any());
+        verify(grammar, never()).validate(any());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -25,6 +25,8 @@ import org.opensearch.dsl.DslQueryExecutorSettings;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.router.DslCalciteGrammar;
 import org.opensearch.dsl.router.RouteDecision;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
@@ -54,8 +56,23 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
     private final DslCalciteGrammar grammar = mock(DslCalciteGrammar.class);
 
     private SearchActionFilter buildFilter(boolean calciteEnabled) {
-        Settings settings = Settings.builder().put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), calciteEnabled).build();
-        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        return buildFilter(calciteEnabled, true, true);
+    }
+
+    private SearchActionFilter buildFilter(boolean calciteEnabled, boolean queryEnabled, boolean aggregationEnabled) {
+        Settings settings = Settings.builder()
+            .put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), calciteEnabled)
+            .put(DslQueryExecutorSettings.CALCITE_QUERY_ENABLED.getKey(), queryEnabled)
+            .put(DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED.getKey(), aggregationEnabled)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(
+                DslQueryExecutorSettings.CALCITE_ENABLED,
+                DslQueryExecutorSettings.CALCITE_QUERY_ENABLED,
+                DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED
+            )
+        );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(settings);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -89,6 +106,47 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
         verify(chain).proceed(task, BulkAction.NAME, request, listener);
         verify(client, never()).execute(any(), any(), any());
         verify(grammar, never()).validate(any());
+    }
+
+    // ---- Layer 1b: per-category toggles ----
+
+    public void testAggregationDisabledSendsAggRequestToCodec() {
+        SearchActionFilter filter = buildFilter(true, true, false); // aggregation off
+        SearchRequest request = new SearchRequest("test-index").source(
+            new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("avg_price").field("price"))
+        );
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(grammar, never()).validate(any());
+        verify(client, never()).execute(any(), any(), any());
+    }
+
+    public void testQueryDisabledSendsHitsRequestToCodec() {
+        SearchActionFilter filter = buildFilter(true, false, true); // query/hits off
+        SearchRequest request = new SearchRequest("test-index").source(
+            new SearchSourceBuilder().query(QueryBuilders.termQuery("brand", "Acme"))
+        );
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(grammar, never()).validate(any());
+    }
+
+    public void testAggregationDisabledStillRoutesHitsRequest() {
+        SearchActionFilter filter = buildFilter(true, true, false); // aggregation off, query on
+        SearchRequest request = new SearchRequest("test-index").source(
+            new SearchSourceBuilder().query(QueryBuilders.termQuery("brand", "Acme"))
+        );
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        // A hits request is unaffected by the aggregation toggle — grammar consulted, dispatched to Calcite.
+        verify(grammar).validate(request.source());
+        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), any());
     }
 
     // ---- Layer 2: grammar decision ----
@@ -199,7 +257,14 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
 
     public void testDynamicDisableStopsInterception() {
         Settings initial = Settings.builder().put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), true).build();
-        ClusterSettings clusterSettings = new ClusterSettings(initial, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
+        ClusterSettings clusterSettings = new ClusterSettings(
+            initial,
+            Set.of(
+                DslQueryExecutorSettings.CALCITE_ENABLED,
+                DslQueryExecutorSettings.CALCITE_QUERY_ENABLED,
+                DslQueryExecutorSettings.CALCITE_AGGREGATION_ENABLED
+            )
+        );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(initial);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.dsl.action;
 
-import org.mockito.ArgumentCaptor;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequest;
@@ -34,6 +33,8 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.util.List;
 import java.util.Set;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -52,9 +53,7 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
     private final DslCalciteGrammar grammar = mock(DslCalciteGrammar.class);
 
     private SearchActionFilter buildFilter(boolean calciteEnabled) {
-        Settings settings = Settings.builder()
-            .put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), calciteEnabled)
-            .build();
+        Settings settings = Settings.builder().put(DslQueryExecutorSettings.CALCITE_ENABLED.getKey(), calciteEnabled).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(DslQueryExecutorSettings.CALCITE_ENABLED));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(settings);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -37,6 +37,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -167,6 +168,30 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
 
         // No fallback for runtime errors — the caller sees the failure.
         verify(listener).onFailure(engineErr);
+        verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    public void testSuccessDeliveryFailureDoesNotDoubleComplete() {
+        SearchActionFilter filter = buildFilter(true);
+        SearchRequest request = new SearchRequest("test-index").source(new SearchSourceBuilder());
+        when(grammar.validate(any())).thenReturn(RouteDecision.accepted());
+
+        // Delivering the successful response to the caller throws (e.g. channel closed).
+        RuntimeException deliveryError = new RuntimeException("channel closed");
+        doThrow(deliveryError).when(listener).onResponse(any());
+
+        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        ArgumentCaptor<ActionListener<SearchResponse>> captor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), captor.capture());
+
+        // Calcite succeeded; the delivery hiccup must propagate as-is, NOT be turned into a second
+        // completion of the caller's listener (onFailure) or a codec fallback.
+        SearchResponse resp = mock(SearchResponse.class);
+        expectThrows(RuntimeException.class, () -> captor.getValue().onResponse(resp));
+
+        verify(listener).onResponse(resp);
+        verify(listener, never()).onFailure(any());
         verify(chain, never()).proceed(any(), any(), any(), any());
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
-import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.DateFieldMapper;
@@ -17,11 +17,13 @@ import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -318,9 +320,11 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
     public void testValidateRejectsDateField() {
         TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created");
 
-        ConversionException e = expectThrows(ConversionException.class, () -> translator.validate(dateAgg));
+        ValidationResult result = translator.validate(dateAgg);
 
-        assertTrue(e.getMessage().contains("date field [created]"));
+        assertFalse(result.isAccepted());
+        assertEquals("terms.date_field", result.reasonCode());
+        assertTrue(result.message().contains("date field [created]"));
     }
 
     public void testValidateRejectsDateNanosField() {
@@ -332,20 +336,49 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
 
         TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created_nanos");
 
-        ConversionException e = expectThrows(ConversionException.class, () -> nanosTranslator.validate(dateAgg));
+        ValidationResult result = nanosTranslator.validate(dateAgg);
 
-        assertTrue(e.getMessage().contains("date field [created_nanos]"));
+        assertFalse(result.isAccepted());
+        assertTrue(result.message().contains("date field [created_nanos]"));
     }
 
     /** Mapping-dependent validation is skipped when no MapperService is supplied (conversion-only use). */
-    public void testValidateSkipsMappingChecksWithoutMapperService() throws Exception {
+    public void testValidateSkipsMappingChecksWithoutMapperService() {
         TermsAggregationBuilder dateAgg = new TermsAggregationBuilder("by_day").field("created");
 
-        unmappedTranslator.validate(dateAgg); // must not throw
+        assertTrue(unmappedTranslator.validate(dateAgg).isAccepted()); // no MapperService → date check skipped
     }
 
-    public void testValidateAcceptsNonDateMappedField() throws Exception {
-        translator.validate(brandAgg); // must not throw
+    public void testValidateAcceptsNonDateMappedField() {
+        assertTrue(translator.validate(brandAgg).isAccepted());
+    }
+
+    public void testValidateRejectsIncludeExclude() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").field("brand");
+        agg.includeExclude(new IncludeExclude("Brand.*", null));
+
+        ValidationResult result = translator.validate(agg);
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.include_exclude", result.reasonCode());
+    }
+
+    public void testValidateRejectsScript() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").script(new Script("doc['brand'].value"));
+
+        ValidationResult result = translator.validate(agg);
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.script", result.reasonCode());
+    }
+
+    public void testValidateRejectsMinDocCountZero() {
+        TermsAggregationBuilder agg = new TermsAggregationBuilder("by_brand").field("brand").minDocCount(0);
+
+        ValidationResult result = translator.validate(agg);
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.min_doc_count", result.reasonCode());
     }
 
     // ---- Pushdown mode: totals-derived sum_other_doc_count ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
@@ -13,6 +13,8 @@ import org.apache.calcite.sql.SqlKind;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.query.ValidationResult;
+import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
@@ -90,5 +92,25 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
     public void testNullMetadataStaysNull() {
         assertNull(new AvgMetricTranslator().toInternalAggregation("a", 1.0, null).getMetadata());
         assertNull(new MaxMetricTranslator().toInternalAggregation("mx", null, null).getMetadata());
+    }
+
+    // ---- validate(): metric parameter gating ----
+
+    public void testValidateAcceptsPlainMetric() {
+        assertTrue(new AvgMetricTranslator().validate(new AvgAggregationBuilder("avg_price").field("price")).isAccepted());
+    }
+
+    public void testValidateRejectsMissing() {
+        ValidationResult result = new AvgMetricTranslator().validate(new AvgAggregationBuilder("avg_price").field("price").missing(0));
+        assertFalse(result.isAccepted());
+        assertEquals("avg.missing", result.reasonCode());
+    }
+
+    public void testValidateRejectsScript() {
+        ValidationResult result = new AvgMetricTranslator().validate(
+            new AvgAggregationBuilder("avg_price").script(new Script("doc['price'].value"))
+        );
+        assertFalse(result.isAccepted());
+        assertEquals("avg.script", result.reasonCode());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -78,6 +78,17 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         assertTrue(plan.relNode() instanceof LogicalTableScan);
     }
 
+    public void testNullSourceProducesHitsPlan() throws ConversionException {
+        // A bodyless _search (null source) is normalized to an empty match_all and plans
+        // exactly like new SearchSourceBuilder() — a HITS scan plus the COUNT plan for hits.total.
+        QueryPlans plans = converter.convert(null, "test-index");
+
+        assertEquals(2, plans.getAll().size());
+        assertTrue(plans.has(QueryPlans.Type.HITS));
+        assertTrue(plans.has(QueryPlans.Type.COUNT));
+        assertTrue(plans.get(QueryPlans.Type.HITS).get(0).relNode() instanceof LogicalTableScan);
+    }
+
     public void testConvertResolvesFieldNames() throws ConversionException {
         QueryPlans plans = converter.convert(new SearchSourceBuilder(), "test-index");
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
@@ -51,6 +51,22 @@ public class ExistsQueryTranslatorTests extends OpenSearchTestCase {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
     }
 
+    public void testValidateRejectsBoost() {
+        ValidationResult result = translator.validate(QueryBuilders.existsQuery("name").boost(2.0f));
+
+        assertFalse(result.isAccepted());
+        assertEquals("exists.boost", result.reasonCode());
+        assertEquals("boost is unsupported for Exists query type", result.message());
+    }
+
+    public void testValidateAcceptsSupportedExistsQuery() {
+        ValidationResult result = translator.validate(QueryBuilders.existsQuery("name"));
+
+        assertTrue(result.isAccepted());
+        assertNull(result.reasonCode());
+        assertNull(result.message());
+    }
+
     public void testReportsCorrectQueryType() {
         assertEquals(ExistsQueryBuilder.class, translator.getQueryType());
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
@@ -32,4 +32,9 @@ public class MatchAllQueryTranslatorTests extends OpenSearchTestCase {
         MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
         assertEquals(MatchAllQueryBuilder.class, translator.getQueryType());
     }
+
+    public void testValidateAcceptsMatchAll() {
+        // match_all's validate() is a blanket accept: convert() rejects no parameter.
+        assertTrue(new MatchAllQueryTranslator().validate(QueryBuilders.matchAllQuery()).isAccepted());
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
@@ -25,6 +25,12 @@ public class TermQueryTranslatorTests extends OpenSearchTestCase {
     private final TermQueryTranslator translator = new TermQueryTranslator();
     private final ConversionContext ctx = TestUtils.createContext();
 
+    public void testValidateAcceptsAnyTermQuery() {
+        // term's validate() is a blanket accept: convert() rejects no parameter, so routing mirrors it.
+        assertTrue(translator.validate(QueryBuilders.termQuery("name", "laptop")).isAccepted());
+        assertTrue(translator.validate(QueryBuilders.termQuery("name", "laptop").boost(2.0f)).isAccepted());
+    }
+
     public void testConvertsTermQueryToEquals() throws ConversionException {
         RexNode result = translator.convert(QueryBuilders.termQuery("name", "laptop"), ctx);
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -105,7 +105,7 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"));
 
         assertFalse(result.isAccepted());
-        assertEquals("terms.name", result.reasonCode());
+        assertEquals("terms._name", result.reasonCode());
         assertEquals("Terms query does not support _name", result.message());
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -86,6 +86,14 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
     }
 
+    public void testValidateRejectsBoost() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop").boost(2.0f));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.boost", result.reasonCode());
+        assertEquals("Terms query does not support non-default boost", result.message());
+    }
+
     public void testThrowsForQueryName() {
         expectThrows(
             ConversionException.class,
@@ -93,9 +101,26 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         );
     }
 
+    public void testValidateRejectsQueryName() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.name", result.reasonCode());
+        assertEquals("Terms query does not support _name", result.message());
+    }
+
     public void testThrowsForTermsLookup() {
         TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsLookupQuery("name", termsLookup), ctx));
+    }
+
+    public void testValidateRejectsTermsLookup() {
+        TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
+        ValidationResult result = translator.validate(QueryBuilders.termsLookupQuery("name", termsLookup));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.terms_lookup", result.reasonCode());
+        assertEquals("Terms query does not support terms lookup", result.message());
     }
 
     public void testThrowsForValueType() {
@@ -103,6 +128,32 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
             ConversionException.class,
             () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").valueType(TermsQueryBuilder.ValueType.BITMAP), ctx)
         );
+    }
+
+    public void testValidateRejectsValueType() {
+        ValidationResult result = translator.validate(
+            QueryBuilders.termsQuery("name", "laptop").valueType(TermsQueryBuilder.ValueType.BITMAP)
+        );
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.value_type:BITMAP", result.reasonCode());
+        assertEquals("Terms query does not support non-default value_type", result.message());
+    }
+
+    public void testValidateRejectsEmptyValues() {
+        ValidationResult result = translator.validate(new TermsQueryBuilder("name", java.util.List.of()));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.no_values", result.reasonCode());
+        assertEquals("Terms query must have values", result.message());
+    }
+
+    public void testValidateAcceptsSupportedTermsQuery() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop"));
+
+        assertTrue(result.isAccepted());
+        assertNull(result.reasonCode());
+        assertNull(result.message());
     }
 
     public void testReportsCorrectQueryType() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -85,6 +85,14 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
     }
 
+    public void testValidateRejectsBoost() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop").boost(2.0f));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.boost", result.reasonCode());
+        assertEquals("Terms query does not support non-default boost", result.message());
+    }
+
     public void testThrowsForQueryName() {
         expectThrows(
             ConversionException.class,
@@ -92,9 +100,26 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         );
     }
 
+    public void testValidateRejectsQueryName() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.name", result.reasonCode());
+        assertEquals("Terms query does not support _name", result.message());
+    }
+
     public void testThrowsForTermsLookup() {
         TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsLookupQuery("name", termsLookup), ctx));
+    }
+
+    public void testValidateRejectsTermsLookup() {
+        TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
+        ValidationResult result = translator.validate(QueryBuilders.termsLookupQuery("name", termsLookup));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.terms_lookup", result.reasonCode());
+        assertEquals("Terms query does not support terms lookup", result.message());
     }
 
     public void testThrowsForValueType() {
@@ -102,6 +127,32 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
             ConversionException.class,
             () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").valueType(TermsQueryBuilder.ValueType.BITMAP), ctx)
         );
+    }
+
+    public void testValidateRejectsValueType() {
+        ValidationResult result = translator.validate(
+            QueryBuilders.termsQuery("name", "laptop").valueType(TermsQueryBuilder.ValueType.BITMAP)
+        );
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.value_type:BITMAP", result.reasonCode());
+        assertEquals("Terms query does not support non-default value_type", result.message());
+    }
+
+    public void testValidateRejectsEmptyValues() {
+        ValidationResult result = translator.validate(new TermsQueryBuilder("name", java.util.List.of()));
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.no_values", result.reasonCode());
+        assertEquals("Terms query must have values", result.message());
+    }
+
+    public void testValidateAcceptsSupportedTermsQuery() {
+        ValidationResult result = translator.validate(QueryBuilders.termsQuery("name", "laptop"));
+
+        assertTrue(result.isAccepted());
+        assertNull(result.reasonCode());
+        assertNull(result.message());
     }
 
     public void testReportsCorrectQueryType() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ValidationResultTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ValidationResultTests.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ValidationResultTests extends OpenSearchTestCase {
+
+    public void testAcceptedFactoryProducesAcceptedResult() {
+        ValidationResult result = ValidationResult.accepted();
+
+        assertTrue(result.isAccepted());
+        assertNull(result.reasonCode());
+        assertNull(result.message());
+    }
+
+    public void testRejectedFactoryCarriesReasonCodeAndMessage() {
+        ValidationResult result = ValidationResult.rejected("terms.boost", "Terms query does not support non-default boost");
+
+        assertFalse(result.isAccepted());
+        assertEquals("terms.boost", result.reasonCode());
+        assertEquals("Terms query does not support non-default boost", result.message());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
@@ -17,6 +17,7 @@ import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.dsl.query.QueryTranslator;
 import org.opensearch.dsl.query.ValidationResult;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
@@ -34,7 +35,9 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     private final DslCalciteGrammar grammar = new DslCalciteGrammar(QueryRegistryFactory.create(), aggRegistry);
 
     private DslCalciteGrammar grammarWith(QueryTranslator... extraTranslators) {
-        QueryRegistry registry = QueryRegistryFactory.create();
+        // Fresh registry (not the shared create() singleton) so registering extra translators
+        // here never mutates process-wide state seen by other callers/tests.
+        QueryRegistry registry = QueryRegistryFactory.newInstance();
         for (QueryTranslator translator : extraTranslators) {
             registry.register(translator);
         }
@@ -76,11 +79,10 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
 
     // ---- source-level ----
 
-    public void testNullSourceRejected() {
-        RouteDecision decision = grammar.validate(null);
-        assertFalse(decision.supported());
-        assertEquals(1, decision.rejectionReasons().size());
-        assertEquals("source:null", decision.rejectionReasons().get(0));
+    public void testNullSourceSupported() {
+        // A bodyless _search is an implicit match_all — accepted and handled by Calcite,
+        // consistent with an empty "{}" body (see testEmptySourceSupported).
+        assertTrue(grammar.validate(null).supported());
     }
 
     public void testEmptySourceSupported() {
@@ -129,6 +131,28 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         assertFalse(grammar.validate(bad).supported());
     }
 
+    public void testDeeplyNestedUnsupportedLeafRejected() {
+        // constant_score -> bool -> match: the unregistered "match" leaf sits two containers
+        // deep and must still be found and rejected (structural recursion, not a hardcoded switch).
+        BoolQueryBuilder inner = QueryBuilders.boolQuery();
+        inner.must(QueryBuilders.termQuery("brand", "Acme"));
+        inner.should(QueryBuilders.matchQuery("desc", "fast"));
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.constantScoreQuery(inner));
+        RouteDecision decision = grammar.validate(source);
+        assertFalse(decision.supported());
+        assertEquals("query:match", decision.rejectionReasons().get(0));
+    }
+
+    public void testDeeplyNestedSupportedTreeAccepted() {
+        // constant_score -> bool with only registered leaves at depth is accepted.
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.constantScoreQuery(
+                QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price"))
+            )
+        );
+        assertTrue(grammar.validate(source).supported());
+    }
+
     // ---- translator-backed leaf validation ----
 
     public void testRangeSupported() {
@@ -163,7 +187,7 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").queryName("labelled");
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertEquals("terms.name", d.rejectionReasons().get(0));
+        assertEquals("terms._name", d.rejectionReasons().get(0));
     }
 
     public void testTermsRejectsEmptyValues() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
@@ -119,36 +119,34 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
-    public void testConstantScoreRecurses() {
-        SearchSourceBuilder ok = new SearchSourceBuilder().query(
+    public void testConstantScoreRejected() {
+        // constant_score has no handler (scoring not supported on the RelNode path) → codec,
+        // regardless of whether its inner query would be supported.
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
             QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("brand", "Acme"))
         );
-        assertTrue(grammar.validate(ok).supported());
-
-        SearchSourceBuilder bad = new SearchSourceBuilder().query(
-            QueryBuilders.constantScoreQuery(QueryBuilders.matchQuery("desc", "fast"))
-        );
-        assertFalse(grammar.validate(bad).supported());
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("query:constant_score", d.rejectionReasons().get(0));
     }
 
     public void testDeeplyNestedUnsupportedLeafRejected() {
-        // constant_score -> bool -> match: the unregistered "match" leaf sits two containers
-        // deep and must still be found and rejected (structural recursion, not a hardcoded switch).
+        // bool -> bool -> match: the unregistered "match" leaf sits two bool levels deep and must
+        // still be found and rejected (structural recursion, not a hardcoded switch).
         BoolQueryBuilder inner = QueryBuilders.boolQuery();
         inner.must(QueryBuilders.termQuery("brand", "Acme"));
         inner.should(QueryBuilders.matchQuery("desc", "fast"));
-        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.constantScoreQuery(inner));
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(inner));
         RouteDecision decision = grammar.validate(source);
         assertFalse(decision.supported());
         assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
     public void testDeeplyNestedSupportedTreeAccepted() {
-        // constant_score -> bool with only registered leaves at depth is accepted.
+        // bool -> bool with only registered leaves at depth is accepted.
         SearchSourceBuilder source = new SearchSourceBuilder().query(
-            QueryBuilders.constantScoreQuery(
-                QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price"))
-            )
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price")))
         );
         assertTrue(grammar.validate(source).supported());
     }
@@ -286,6 +284,28 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
         assertEquals("agg.nested", d.rejectionReasons().get(0));
+    }
+
+    // ---- top-level field gating ----
+
+    public void testSupportedScalarTopLevelFieldsAccepted() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(10).from(5).trackTotalHits(true);
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testUnsupportedTopLevelFieldRejected() {
+        // post_filter has no handler yet → reject-unless-supported routes it to codec.
+        SearchSourceBuilder source = new SearchSourceBuilder().postFilter(QueryBuilders.termQuery("brand", "Acme"));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("source.post_filter", d.rejectionReasons().get(0));
+    }
+
+    public void testSortRejectedUntilSupported() {
+        // sort has no handler yet (visitSort pending) → routed to codec.
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().sort("price"));
+        assertFalse(d.supported());
+        assertEquals("source.sort", d.rejectionReasons().get(0));
     }
 
     // ---- short-circuit ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
@@ -8,17 +8,19 @@
 
 package org.opensearch.dsl.router;
 
-import org.mockito.Mockito;
+import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
-import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.dsl.query.QueryTranslator;
+import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
-import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -31,18 +33,45 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     /** Grammar with only the translators actually registered on this branch. */
     private final DslCalciteGrammar grammar = new DslCalciteGrammar(QueryRegistryFactory.create(), aggRegistry);
 
-    /**
-     * Grammar with extra query types treated as if their translators were registered.
-     * Used to exercise per-parameter checks for range/prefix/wildcard whose translators
-     * live behind pending PRs (#22525, #22526).
-     */
-    @SafeVarargs
-    private DslCalciteGrammar grammarWith(Class<? extends QueryBuilder>... registeredExtras) {
-        QueryRegistry spy = Mockito.spy(QueryRegistryFactory.create());
-        for (Class<? extends QueryBuilder> c : registeredExtras) {
-            Mockito.doReturn(true).when(spy).hasTranslator(c);
+    private DslCalciteGrammar grammarWith(QueryTranslator... extraTranslators) {
+        QueryRegistry registry = QueryRegistryFactory.create();
+        for (QueryTranslator translator : extraTranslators) {
+            registry.register(translator);
         }
-        return new DslCalciteGrammar(spy, aggRegistry);
+        return new DslCalciteGrammar(registry, aggRegistry);
+    }
+
+    private QueryTranslator acceptingTranslatorFor(Class<? extends QueryBuilder> queryType) {
+        return new QueryTranslator() {
+            @Override
+            public Class<? extends QueryBuilder> getQueryType() {
+                return queryType;
+            }
+
+            @Override
+            public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+                throw new UnsupportedOperationException("Grammar test helper");
+            }
+        };
+    }
+
+    private QueryTranslator rejectingTranslatorFor(Class<? extends QueryBuilder> queryType, String reasonCode) {
+        return new QueryTranslator() {
+            @Override
+            public Class<? extends QueryBuilder> getQueryType() {
+                return queryType;
+            }
+
+            @Override
+            public ValidationResult validate(QueryBuilder query) {
+                return ValidationResult.rejected(reasonCode, "test rejection");
+            }
+
+            @Override
+            public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+                throw new UnsupportedOperationException("Grammar test helper");
+            }
+        };
     }
 
     // ---- source-level ----
@@ -50,8 +79,8 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     public void testNullSourceRejected() {
         RouteDecision decision = grammar.validate(null);
         assertFalse(decision.supported());
-        assertEquals(1, decision.unsupportedFeatures().size());
-        assertEquals("source:null", decision.unsupportedFeatures().get(0));
+        assertEquals(1, decision.rejectionReasons().size());
+        assertEquals("source:null", decision.rejectionReasons().get(0));
     }
 
     public void testEmptySourceSupported() {
@@ -69,27 +98,23 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchQuery("name", "laptop"));
         RouteDecision decision = grammar.validate(source);
         assertFalse(decision.supported());
-        assertEquals("query:match", decision.unsupportedFeatures().get(0));
+        assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
     public void testBoolRecursesIntoRegisteredChildren() {
         SearchSourceBuilder source = new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.termQuery("brand", "Acme"))
-                .filter(QueryBuilders.existsQuery("price"))
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price"))
         );
         assertTrue(grammar.validate(source).supported());
     }
 
     public void testBoolRejectsIfAnyChildRejected() {
         SearchSourceBuilder source = new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.termQuery("brand", "Acme"))
-                .must(QueryBuilders.matchQuery("desc", "fast")) // unregistered
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).must(QueryBuilders.matchQuery("desc", "fast")) // unregistered
         );
         RouteDecision decision = grammar.validate(source);
         assertFalse(decision.supported());
-        assertEquals("query:match", decision.unsupportedFeatures().get(0));
+        assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
     public void testConstantScoreRecurses() {
@@ -104,54 +129,21 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         assertFalse(grammar.validate(bad).supported());
     }
 
-    // ---- range per-param (uses a spy since translator isn't merged yet) ----
+    // ---- translator-backed leaf validation ----
 
     public void testRangeSupported() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        DslCalciteGrammar g = grammarWith(acceptingTranslatorFor(RangeQueryBuilder.class));
         SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100).lt(500));
         assertTrue(g.validate(source).supported());
     }
 
-    public void testRangeRejectsBoost() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+    public void testRangeUsesTranslatorValidationReason() {
+        DslCalciteGrammar g = grammarWith(rejectingTranslatorFor(RangeQueryBuilder.class, "range.boost"));
         RangeQueryBuilder q = QueryBuilders.rangeQuery("price").gt(100).boost(2.0f);
         RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
         assertFalse(decision.supported());
-        assertEquals("range.boost", decision.unsupportedFeatures().get(0));
+        assertEquals("range.boost", decision.rejectionReasons().get(0));
     }
-
-    public void testRangeRejectsName() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
-        RangeQueryBuilder q = QueryBuilders.rangeQuery("price").gt(100).queryName("my_range");
-        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
-        assertFalse(decision.supported());
-        assertEquals("range.name", decision.unsupportedFeatures().get(0));
-    }
-
-    public void testRangeRejectsNoBounds() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
-        RangeQueryBuilder q = QueryBuilders.rangeQuery("price");
-        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
-        assertFalse(decision.supported());
-        assertEquals("range.no_bounds", decision.unsupportedFeatures().get(0));
-    }
-
-    /** Covers the {@code from != null, to == null} branch of the compound bounds check. */
-    public void testRangeWithOnlyLowerBoundSupported() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
-        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100))).supported());
-    }
-
-    /** Covers the {@code from == null, to != null} branch of the compound bounds check. */
-    public void testRangeWithOnlyUpperBoundSupported() {
-        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
-        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").lt(500))).supported());
-    }
-
-    // Note: DISJOINT is rejected by RangeQueryBuilder.relation() at construction time
-    // (see isRelationAllowed) — INTERSECTS/CONTAINS/WITHIN are the only reachable values,
-    // and all three are accepted by the translator. So the grammar has nothing to check
-    // for range.relation, and no test can produce a builder carrying DISJOINT.
 
     // ---- terms query per-param ----
 
@@ -164,38 +156,35 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").boost(2.0f);
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertEquals("terms.boost", d.unsupportedFeatures().get(0));
+        assertEquals("terms.boost", d.rejectionReasons().get(0));
     }
 
     public void testTermsRejectsName() {
         TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").queryName("labelled");
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertEquals("terms.name", d.unsupportedFeatures().get(0));
+        assertEquals("terms.name", d.rejectionReasons().get(0));
     }
 
     public void testTermsRejectsEmptyValues() {
         TermsQueryBuilder q = QueryBuilders.termsQuery("brand", new String[0]);
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertEquals("terms.no_values", d.unsupportedFeatures().get(0));
+        assertEquals("terms.no_values", d.rejectionReasons().get(0));
     }
 
     public void testTermsRejectsTermsLookup() {
-        TermsQueryBuilder q = new TermsQueryBuilder(
-            "brand",
-            new org.opensearch.indices.TermsLookup("lookup_idx", "1", "brands")
-        );
+        TermsQueryBuilder q = new TermsQueryBuilder("brand", new org.opensearch.indices.TermsLookup("lookup_idx", "1", "brands"));
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertEquals("terms.terms_lookup", d.unsupportedFeatures().get(0));
+        assertEquals("terms.terms_lookup", d.rejectionReasons().get(0));
     }
 
     public void testTermsRejectsNonDefaultValueType() {
         TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").valueType(TermsQueryBuilder.ValueType.BITMAP);
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
         assertFalse(d.supported());
-        assertTrue(d.unsupportedFeatures().get(0).startsWith("terms.value_type:"));
+        assertTrue(d.rejectionReasons().get(0).startsWith("terms.value_type:"));
     }
 
     // ---- exists per-param ----
@@ -208,66 +197,18 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     public void testExistsRejectsBoost() {
         RouteDecision d = grammar.validate(new SearchSourceBuilder().query(QueryBuilders.existsQuery("price").boost(3.0f)));
         assertFalse(d.supported());
-        assertEquals("exists.boost", d.unsupportedFeatures().get(0));
-    }
-
-    // ---- prefix per-param (spy) ----
-
-    public void testPrefixSupported() {
-        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
-        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap"))).supported());
-    }
-
-    public void testPrefixCaseInsensitiveSupported() {
-        // Consumed by translator (folds to LOWER), not rejected.
-        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
-        assertTrue(
-            g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").caseInsensitive(true))).supported()
-        );
-    }
-
-    public void testPrefixRejectsBoost() {
-        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
-        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").boost(2.0f)));
-        assertFalse(d.supported());
-        assertEquals("prefix.boost", d.unsupportedFeatures().get(0));
-    }
-
-    public void testPrefixRejectsRewrite() {
-        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
-        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score")));
-        assertFalse(d.supported());
-        assertEquals("prefix.rewrite", d.unsupportedFeatures().get(0));
-    }
-
-    // ---- wildcard per-param (spy) ----
-
-    public void testWildcardSupported() {
-        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
-        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*"))).supported());
-    }
-
-    public void testWildcardRejectsBoost() {
-        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
-        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*").boost(2.0f)));
-        assertFalse(d.supported());
-        assertEquals("wildcard.boost", d.unsupportedFeatures().get(0));
-    }
-
-    public void testWildcardRejectsRewrite() {
-        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
-        RouteDecision d = g.validate(
-            new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"))
-        );
-        assertFalse(d.supported());
-        assertEquals("wildcard.rewrite", d.unsupportedFeatures().get(0));
+        assertEquals("exists.boost", d.rejectionReasons().get(0));
     }
 
     // ---- aggregation walker ----
 
     public void testRegisteredAggSupported() {
-        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
-            .aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testTopLevelBucketAggSupported() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.terms("by_brand").field("brand"));
         assertTrue(grammar.validate(source).supported());
     }
 
@@ -276,18 +217,27 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
             .aggregation(AggregationBuilders.cardinality("card_brand").field("brand"));
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
-        assertEquals("agg:cardinality", d.unsupportedFeatures().get(0));
+        assertEquals("agg:cardinality", d.rejectionReasons().get(0));
     }
 
-    public void testNestedSubAggWalked() {
+    public void testNestedAggTreeRejected() {
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(
-                AggregationBuilders.terms("by_brand").field("brand")
-                    .subAggregation(AggregationBuilders.cardinality("card").field("sku")) // unregistered
+                AggregationBuilders.terms("by_brand").field("brand").subAggregation(AggregationBuilders.cardinality("card").field("sku")) // unregistered
             );
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
-        assertEquals("agg:cardinality", d.unsupportedFeatures().get(0));
+        assertEquals("agg.nested", d.rejectionReasons().get(0));
+    }
+
+    public void testNestedAggTreeRejectedEvenWhenAllAggTypesAreRegistered() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand").field("brand").subAggregation(AggregationBuilders.sum("sales").field("price"))
+            );
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("agg.nested", d.rejectionReasons().get(0));
     }
 
     // ---- pipeline agg ----
@@ -298,19 +248,20 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
             .aggregation(PipelineAggregatorBuilders.maxBucket("max_bucket", "by_brand>_count"));
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
-        assertTrue(d.unsupportedFeatures().get(0).startsWith("pipeline_agg:"));
+        assertTrue(d.rejectionReasons().get(0).startsWith("pipeline_agg:"));
     }
 
-    public void testNestedPipelineAggRejected() {
+    public void testNestedPipelineAggTreeRejectedBeforePipelineValidation() {
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(
-                AggregationBuilders.terms("by_brand").field("brand")
+                AggregationBuilders.terms("by_brand")
+                    .field("brand")
                     .subAggregation(AggregationBuilders.sum("sales").field("price"))
                     .subAggregation(PipelineAggregatorBuilders.cumulativeSum("cum", "sales"))
             );
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
-        assertTrue(d.unsupportedFeatures().get(0).startsWith("pipeline_agg:"));
+        assertEquals("agg.nested", d.rejectionReasons().get(0));
     }
 
     // ---- short-circuit ----
@@ -322,7 +273,7 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
             .aggregation(AggregationBuilders.cardinality("card").field("sku"));
         RouteDecision d = grammar.validate(source);
         assertFalse(d.supported());
-        assertEquals(1, d.unsupportedFeatures().size());
-        assertEquals("query:match", d.unsupportedFeatures().get(0));
+        assertEquals(1, d.rejectionReasons().size());
+        assertEquals("query:match", d.rejectionReasons().get(0));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
@@ -1,0 +1,328 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.router;
+
+import org.mockito.Mockito;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
+import org.opensearch.dsl.query.QueryRegistry;
+import org.opensearch.dsl.query.QueryRegistryFactory;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class DslCalciteGrammarTests extends OpenSearchTestCase {
+
+    private final AggregationRegistry aggRegistry = AggregationRegistryFactory.create();
+
+    /** Grammar with only the translators actually registered on this branch. */
+    private final DslCalciteGrammar grammar = new DslCalciteGrammar(QueryRegistryFactory.create(), aggRegistry);
+
+    /**
+     * Grammar with extra query types treated as if their translators were registered.
+     * Used to exercise per-parameter checks for range/prefix/wildcard whose translators
+     * live behind pending PRs (#22525, #22526).
+     */
+    @SafeVarargs
+    private DslCalciteGrammar grammarWith(Class<? extends QueryBuilder>... registeredExtras) {
+        QueryRegistry spy = Mockito.spy(QueryRegistryFactory.create());
+        for (Class<? extends QueryBuilder> c : registeredExtras) {
+            Mockito.doReturn(true).when(spy).hasTranslator(c);
+        }
+        return new DslCalciteGrammar(spy, aggRegistry);
+    }
+
+    // ---- source-level ----
+
+    public void testNullSourceRejected() {
+        RouteDecision decision = grammar.validate(null);
+        assertFalse(decision.supported());
+        assertEquals(1, decision.unsupportedFeatures().size());
+        assertEquals("source:null", decision.unsupportedFeatures().get(0));
+    }
+
+    public void testEmptySourceSupported() {
+        assertTrue(grammar.validate(new SearchSourceBuilder()).supported());
+    }
+
+    // ---- query walker: registry gate ----
+
+    public void testRegisteredLeafQuerySupported() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.termQuery("name", "laptop"));
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testUnregisteredLeafQueryRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchQuery("name", "laptop"));
+        RouteDecision decision = grammar.validate(source);
+        assertFalse(decision.supported());
+        assertEquals("query:match", decision.unsupportedFeatures().get(0));
+    }
+
+    public void testBoolRecursesIntoRegisteredChildren() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("brand", "Acme"))
+                .filter(QueryBuilders.existsQuery("price"))
+        );
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testBoolRejectsIfAnyChildRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("brand", "Acme"))
+                .must(QueryBuilders.matchQuery("desc", "fast")) // unregistered
+        );
+        RouteDecision decision = grammar.validate(source);
+        assertFalse(decision.supported());
+        assertEquals("query:match", decision.unsupportedFeatures().get(0));
+    }
+
+    public void testConstantScoreRecurses() {
+        SearchSourceBuilder ok = new SearchSourceBuilder().query(
+            QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("brand", "Acme"))
+        );
+        assertTrue(grammar.validate(ok).supported());
+
+        SearchSourceBuilder bad = new SearchSourceBuilder().query(
+            QueryBuilders.constantScoreQuery(QueryBuilders.matchQuery("desc", "fast"))
+        );
+        assertFalse(grammar.validate(bad).supported());
+    }
+
+    // ---- range per-param (uses a spy since translator isn't merged yet) ----
+
+    public void testRangeSupported() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100).lt(500));
+        assertTrue(g.validate(source).supported());
+    }
+
+    public void testRangeRejectsBoost() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        RangeQueryBuilder q = QueryBuilders.rangeQuery("price").gt(100).boost(2.0f);
+        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
+        assertFalse(decision.supported());
+        assertEquals("range.boost", decision.unsupportedFeatures().get(0));
+    }
+
+    public void testRangeRejectsName() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        RangeQueryBuilder q = QueryBuilders.rangeQuery("price").gt(100).queryName("my_range");
+        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
+        assertFalse(decision.supported());
+        assertEquals("range.name", decision.unsupportedFeatures().get(0));
+    }
+
+    public void testRangeRejectsNoBounds() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        RangeQueryBuilder q = QueryBuilders.rangeQuery("price");
+        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
+        assertFalse(decision.supported());
+        assertEquals("range.no_bounds", decision.unsupportedFeatures().get(0));
+    }
+
+    /** Covers the {@code from != null, to == null} branch of the compound bounds check. */
+    public void testRangeWithOnlyLowerBoundSupported() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100))).supported());
+    }
+
+    /** Covers the {@code from == null, to != null} branch of the compound bounds check. */
+    public void testRangeWithOnlyUpperBoundSupported() {
+        DslCalciteGrammar g = grammarWith(RangeQueryBuilder.class);
+        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").lt(500))).supported());
+    }
+
+    // Note: DISJOINT is rejected by RangeQueryBuilder.relation() at construction time
+    // (see isRelationAllowed) — INTERSECTS/CONTAINS/WITHIN are the only reachable values,
+    // and all three are accepted by the translator. So the grammar has nothing to check
+    // for range.relation, and no test can produce a builder carrying DISJOINT.
+
+    // ---- terms query per-param ----
+
+    public void testTermsQuerySupported() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.termsQuery("brand", "Acme", "Bravo"));
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testTermsRejectsBoost() {
+        TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").boost(2.0f);
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
+        assertFalse(d.supported());
+        assertEquals("terms.boost", d.unsupportedFeatures().get(0));
+    }
+
+    public void testTermsRejectsName() {
+        TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").queryName("labelled");
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
+        assertFalse(d.supported());
+        assertEquals("terms.name", d.unsupportedFeatures().get(0));
+    }
+
+    public void testTermsRejectsEmptyValues() {
+        TermsQueryBuilder q = QueryBuilders.termsQuery("brand", new String[0]);
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
+        assertFalse(d.supported());
+        assertEquals("terms.no_values", d.unsupportedFeatures().get(0));
+    }
+
+    public void testTermsRejectsTermsLookup() {
+        TermsQueryBuilder q = new TermsQueryBuilder(
+            "brand",
+            new org.opensearch.indices.TermsLookup("lookup_idx", "1", "brands")
+        );
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
+        assertFalse(d.supported());
+        assertEquals("terms.terms_lookup", d.unsupportedFeatures().get(0));
+    }
+
+    public void testTermsRejectsNonDefaultValueType() {
+        TermsQueryBuilder q = QueryBuilders.termsQuery("brand", "Acme").valueType(TermsQueryBuilder.ValueType.BITMAP);
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(q));
+        assertFalse(d.supported());
+        assertTrue(d.unsupportedFeatures().get(0).startsWith("terms.value_type:"));
+    }
+
+    // ---- exists per-param ----
+
+    public void testExistsSupported() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.existsQuery("price"));
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testExistsRejectsBoost() {
+        RouteDecision d = grammar.validate(new SearchSourceBuilder().query(QueryBuilders.existsQuery("price").boost(3.0f)));
+        assertFalse(d.supported());
+        assertEquals("exists.boost", d.unsupportedFeatures().get(0));
+    }
+
+    // ---- prefix per-param (spy) ----
+
+    public void testPrefixSupported() {
+        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
+        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap"))).supported());
+    }
+
+    public void testPrefixCaseInsensitiveSupported() {
+        // Consumed by translator (folds to LOWER), not rejected.
+        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
+        assertTrue(
+            g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").caseInsensitive(true))).supported()
+        );
+    }
+
+    public void testPrefixRejectsBoost() {
+        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
+        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").boost(2.0f)));
+        assertFalse(d.supported());
+        assertEquals("prefix.boost", d.unsupportedFeatures().get(0));
+    }
+
+    public void testPrefixRejectsRewrite() {
+        DslCalciteGrammar g = grammarWith(PrefixQueryBuilder.class);
+        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.prefixQuery("name", "lap").rewrite("constant_score")));
+        assertFalse(d.supported());
+        assertEquals("prefix.rewrite", d.unsupportedFeatures().get(0));
+    }
+
+    // ---- wildcard per-param (spy) ----
+
+    public void testWildcardSupported() {
+        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
+        assertTrue(g.validate(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*"))).supported());
+    }
+
+    public void testWildcardRejectsBoost() {
+        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
+        RouteDecision d = g.validate(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*").boost(2.0f)));
+        assertFalse(d.supported());
+        assertEquals("wildcard.boost", d.unsupportedFeatures().get(0));
+    }
+
+    public void testWildcardRejectsRewrite() {
+        DslCalciteGrammar g = grammarWith(WildcardQueryBuilder.class);
+        RouteDecision d = g.validate(
+            new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*").rewrite("constant_score"))
+        );
+        assertFalse(d.supported());
+        assertEquals("wildcard.rewrite", d.unsupportedFeatures().get(0));
+    }
+
+    // ---- aggregation walker ----
+
+    public void testRegisteredAggSupported() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testUnregisteredAggRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.cardinality("card_brand").field("brand"));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("agg:cardinality", d.unsupportedFeatures().get(0));
+    }
+
+    public void testNestedSubAggWalked() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand").field("brand")
+                    .subAggregation(AggregationBuilders.cardinality("card").field("sku")) // unregistered
+            );
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("agg:cardinality", d.unsupportedFeatures().get(0));
+    }
+
+    // ---- pipeline agg ----
+
+    public void testTopLevelPipelineAggRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.terms("by_brand").field("brand"))
+            .aggregation(PipelineAggregatorBuilders.maxBucket("max_bucket", "by_brand>_count"));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertTrue(d.unsupportedFeatures().get(0).startsWith("pipeline_agg:"));
+    }
+
+    public void testNestedPipelineAggRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand").field("brand")
+                    .subAggregation(AggregationBuilders.sum("sales").field("price"))
+                    .subAggregation(PipelineAggregatorBuilders.cumulativeSum("cum", "sales"))
+            );
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertTrue(d.unsupportedFeatures().get(0).startsWith("pipeline_agg:"));
+    }
+
+    // ---- short-circuit ----
+
+    public void testQueryFailureShortCircuitsBeforeAggWalk() {
+        // Aggs contain an unregistered agg too, but the query fails first — we should
+        // only see the query reason.
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchQuery("desc", "fast"))
+            .aggregation(AggregationBuilders.cardinality("card").field("sku"));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals(1, d.unsupportedFeatures().size());
+        assertEquals("query:match", d.unsupportedFeatures().get(0));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/router/DslCalciteGrammarTests.java
@@ -20,7 +20,6 @@ import org.opensearch.dsl.query.ValidationResult;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
@@ -49,6 +48,11 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
             @Override
             public Class<? extends QueryBuilder> getQueryType() {
                 return queryType;
+            }
+
+            @Override
+            public ValidationResult validate(QueryBuilder query) {
+                return ValidationResult.accepted();
             }
 
             @Override
@@ -103,18 +107,26 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
         assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
-    public void testBoolRecursesIntoRegisteredChildren() {
+    public void testBoolRejectedWithoutTranslator() {
+        // Invariant: supported <=> has a translator. bool has none on this branch (pending its own
+        // BoolQueryTranslator), so a bool is rejected at its own node — before its children are seen.
         SearchSourceBuilder source = new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price"))
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme"))
         );
-        assertTrue(grammar.validate(source).supported());
+        RouteDecision decision = grammar.validate(source);
+        assertFalse(decision.supported());
+        assertEquals("query:bool", decision.rejectionReasons().get(0));
     }
 
-    public void testBoolRejectsIfAnyChildRejected() {
+    public void testWalkDescendsIntoCompoundChildren() {
+        // A stub stands in for a compound translator (bool gets a real one in #22604): once the
+        // compound node is accepted, QueryBuilder#visit descends and the unsupported "match" child is
+        // found and rejected. Asserting a rejection proves the descent without implying bool is routable.
+        DslCalciteGrammar g = grammarWith(acceptingTranslatorFor(BoolQueryBuilder.class));
         SearchSourceBuilder source = new SearchSourceBuilder().query(
             QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).must(QueryBuilders.matchQuery("desc", "fast")) // unregistered
         );
-        RouteDecision decision = grammar.validate(source);
+        RouteDecision decision = g.validate(source);
         assertFalse(decision.supported());
         assertEquals("query:match", decision.rejectionReasons().get(0));
     }
@@ -131,40 +143,39 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     }
 
     public void testDeeplyNestedUnsupportedLeafRejected() {
-        // bool -> bool -> match: the unregistered "match" leaf sits two bool levels deep and must
-        // still be found and rejected (structural recursion, not a hardcoded switch).
+        // bool -> bool -> match: with a stub bool translator so the walk descends, the unregistered
+        // "match" leaf two bool levels deep is still found and rejected (QueryBuilder#visit descends).
+        DslCalciteGrammar g = grammarWith(acceptingTranslatorFor(BoolQueryBuilder.class));
         BoolQueryBuilder inner = QueryBuilders.boolQuery();
         inner.must(QueryBuilders.termQuery("brand", "Acme"));
         inner.should(QueryBuilders.matchQuery("desc", "fast"));
         SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(inner));
-        RouteDecision decision = grammar.validate(source);
+        RouteDecision decision = g.validate(source);
         assertFalse(decision.supported());
         assertEquals("query:match", decision.rejectionReasons().get(0));
     }
 
-    public void testDeeplyNestedSupportedTreeAccepted() {
-        // bool -> bool with only registered leaves at depth is accepted.
-        SearchSourceBuilder source = new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).filter(QueryBuilders.existsQuery("price")))
-        );
-        assertTrue(grammar.validate(source).supported());
-    }
+    // ---- reject-unless-validated ----
 
-    // ---- translator-backed leaf validation ----
-
-    public void testRangeSupported() {
-        DslCalciteGrammar g = grammarWith(acceptingTranslatorFor(RangeQueryBuilder.class));
-        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100).lt(500));
-        assertTrue(g.validate(source).supported());
-    }
-
-    public void testRangeUsesTranslatorValidationReason() {
-        DslCalciteGrammar g = grammarWith(rejectingTranslatorFor(RangeQueryBuilder.class, "range.boost"));
-        RangeQueryBuilder q = QueryBuilders.rangeQuery("price").gt(100).boost(2.0f);
-        RouteDecision decision = g.validate(new SearchSourceBuilder().query(q));
+    public void testRangeRejectedUntilItValidates() {
+        // Reject-unless-supported: RangeQueryTranslator has no validate() override yet, so the
+        // reject-by-default contract routes range to codec until range validation is implemented.
+        RouteDecision decision = grammar.validate(new SearchSourceBuilder().query(QueryBuilders.rangeQuery("price").gt(100)));
         assertFalse(decision.supported());
-        assertEquals("range.boost", decision.rejectionReasons().get(0));
+        assertEquals("range.unvalidated", decision.rejectionReasons().get(0));
+    }
+
+    public void testCompoundTranslatorParamRejectionHonored() {
+        // A compound's own translator.validate() runs on the node before the walk descends; when it
+        // rejects, first-failing-node-wins surfaces the compound's reason, not a child's. (Stub stands
+        // in for a compound translator such as bool's, arriving in #22604.)
+        DslCalciteGrammar g = grammarWith(rejectingTranslatorFor(BoolQueryBuilder.class, "bool.minimum_should_match"));
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("brand", "Acme")).minimumShouldMatch(1)
+        );
+        RouteDecision decision = g.validate(source);
+        assertFalse(decision.supported());
+        assertEquals("bool.minimum_should_match", decision.rejectionReasons().get(0));
     }
 
     // ---- terms query per-param ----
@@ -232,6 +243,26 @@ public class DslCalciteGrammarTests extends OpenSearchTestCase {
     public void testTopLevelBucketAggSupported() {
         SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.terms("by_brand").field("brand"));
         assertTrue(grammar.validate(source).supported());
+    }
+
+    public void testMetricAggUnsupportedParamRejected() {
+        // 'missing' is unsupported on metric aggs; the grammar runs the same validate() the converter
+        // does and rejects up front (to codec) with the translator's per-parameter reason code.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.avg("avg_price").field("price").missing(0));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("avg.missing", d.rejectionReasons().get(0));
+    }
+
+    public void testBucketAggUnsupportedParamRejected() {
+        // min_doc_count:0 is unsupported on terms (zero-count buckets need the term dictionary);
+        // rejected up front to codec with the translator's reason code.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.terms("by_brand").field("brand").minDocCount(0));
+        RouteDecision d = grammar.validate(source);
+        assertFalse(d.supported());
+        assertEquals("terms.min_doc_count", d.rejectionReasons().get(0));
     }
 
     public void testUnregisteredAggRejected() {

--- a/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
@@ -95,7 +95,8 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> i
     private final TermsLookup termsLookup;
     private final Supplier<List<?>> supplier;
 
-    private static final ParseField VALUE_TYPE_FIELD = new ParseField("value_type");
+    public static final ParseField VALUE_TYPE_FIELD = new ParseField("value_type");
+    public static final ParseField TERMS_LOOKUP_FIELD = new ParseField("terms_lookup");
     private ValueType valueType = ValueType.DEFAULT;
 
     /**


### PR DESCRIPTION
### Description

Introduces a request-level routing gate between the DSL request and the Calcite execution path in the `dsl-query-executor` sandbox plugin.

Today the plugin's `SearchActionFilter` unconditionally intercepts every `_search` request and dispatches it to `DslExecuteAction`. This change adds two layers of gating so requests the Calcite path can't handle, or should not handle yet, fall back to the codec path transparently.

**Design**

*Layer 1 — master switch (`dsl.query_executor.calcite.enabled`, dynamic, default `true`)*: cluster-scoped setting; when `false`, every request passes through to the codec path unchanged. Serves as an operational escape hatch — a persistent `PUT _cluster/settings` update flips routing without redeploy.

*Layer 2 — request-shape whitelist (`DslCalciteGrammar`)*: walks the `SearchSourceBuilder` and classifies it.

- **Query routing** — compound queries like `bool` and `constant_score` are transparent to the registry; the walker recurses into their children. For query leaves, grammar checks whether a translator is registered. If not, it rejects with a short reason code such as `query:match`. If a translator exists, grammar delegates request-shape validation to that translator via `validate(...)`, so routing and conversion share the same validation ownership and do not drift.
- **Current query-side validation coverage** — this branch validates request-shape restrictions for the currently registered translators such as `terms` (`terms.terms_lookup`, `terms.boost`, `terms.name`, `terms.value_type:*`, `terms.no_values`) and `exists` (`exists.boost`).
- **Aggregation routing** — grammar checks aggregation translator registration, rejects all pipeline aggregations (`pipeline_agg:*`), and currently applies a blanket fallback for nested aggregation trees via `agg.nested`. This keeps multi-level aggregation plans on the codec path until their Calcite/DataFusion performance is validated. Per-aggregation parameter validation remains follow-up work.

*Fallback — `ConversionException` at execution time*: schema-side checks the grammar cannot run (field existence, field-type constraints, and other conversion-time checks) may still fail during `SearchSourceConverter` conversion. `SearchActionFilter` wraps the `DslExecuteAction` listener; on any `ConversionException` (including wrapped causes, guarded by a seen-set traversal), the request retries via `chain.proceed(...)` to the codec path. Non-conversion errors (engine timeouts, runtime failures) surface to the caller so they can be diagnosed.

**Behavior matrix**

| Setting | Grammar | Calcite exec | Result |
|---|---|---|---|
| off | — | — | codec |
| on | reject | — | codec |
| on | accept | `ConversionException` | codec |
| on | accept | success | Calcite response |
| on | accept | other error | surfaced to caller |

**Routing flow**

High-level flow: setting gate -> grammar gate -> Calcite execution -> codec fallback only on `ConversionException`.

```mermaid
sequenceDiagram
    participant Client
    participant SAF as SearchActionFilter
    participant Grammar as DslCalciteGrammar
    participant Calcite as DslExecuteAction
    participant Codec as Default _search path

    Client->>SAF: _search request

    alt calcite setting disabled
        SAF->>Codec: chain.proceed(...)
        Codec-->>Client: response
    else calcite setting enabled
        SAF->>Grammar: validate(source)

        alt grammar rejected
            Grammar-->>SAF: rejected(reason)
            SAF->>Codec: chain.proceed(...)
            Codec-->>Client: response
        else grammar accepted
            Grammar-->>SAF: accepted
            SAF->>Calcite: execute(request)

            alt success
                Calcite-->>Client: Calcite response
            else ConversionException
                Calcite-->>SAF: ConversionException
                SAF->>Codec: chain.proceed(...)
                Codec-->>Client: response
            else other error
                Calcite-->>Client: failure
            end
        end
    end
```

**Additional cleanup**

- Registry factories (`QueryRegistryFactory`, `AggregationRegistryFactory`) now return process-wide singletons, so the grammar and the per-request `SearchSourceConverter` share one populated registry instead of allocating separate translator instances.


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
