### PR TITLE
Fix cancellation issue for QTF

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSinkContext.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ExchangeSinkContext.java
@@ -23,10 +23,11 @@ import java.util.List;
  * <ul>
  *   <li>{@code queryId} / {@code stageId} — correlation ids for backend logs
  *       and metrics.</li>
- *   <li>{@code taskId} — the parent {@code AnalyticsQueryTask} id. Backends
- *       forward this to the native runtime as the query-tracking context id so
- *       one cancellation call from Java cascades to every native query scope
- *       (shard scans + coord reduce) registered under the same task.</li>
+ *   <li>{@code taskId} — the parent {@code AnalyticsQueryTask}'s {@code nativeTaskId}:
+ *       a JVM-unique id minted by {@link NativeTaskIdManager} (NOT {@code Task#getId()},
+ *       which is only unique per node). Backends forward this to the native runtime as
+ *       the query-tracking context id so one cancellation call from Java cascades to
+ *       every native query scope registered under the same id.</li>
  *   <li>{@code fragmentBytes} — backend-specific serialized plan (e.g.
  *       Substrait) the backend will execute over the fed batches.</li>
  *   <li>{@code allocator} — the parent buffer allocator the backend should

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/NativeTaskIdManager.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/NativeTaskIdManager.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Manages JVM-unique native task ids, analogous to how TaskManager mints per-node task ids.
+ *
+ * <p>The native engine keeps one process-wide registry keyed by context id, but
+ * {@code Task} ids are only unique per node. Nodes sharing a JVM (internal test
+ * clusters) therefore collide when task ids are used directly: one node's
+ * cancellation reaches another node's live query. Callers registering a native
+ * context MUST key it with {@link #next()} and route cancellation through the
+ * same minted id; {@code 0} remains the "tracking disabled" sentinel.
+ *
+ * @opensearch.internal
+ */
+public final class NativeTaskIdManager {
+
+    private static final AtomicLong COUNTER = new AtomicLong();
+
+    private NativeTaskIdManager() {}
+
+    /** Returns the next JVM-unique, non-zero context id. */
+    public static long next() {
+        return COUNTER.incrementAndGet();
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1368,16 +1368,22 @@ pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError>
     // cancel then can't interrupt an in-flight drain (the ~5s LM stall).
     let token = handle._query_tracking_context.cancellation_token();
 
-    // Fetch the next batch (cancellation-aware)
-    let result = cancellation::cancellable_or(token.as_ref(), None, async {
-        handle
-            .stream
-            .try_next()
-            .await
-            .map_err(|e: DataFusionError| e)
-    })
+    // Fetch the next batch (cancellation-aware). Query cancellation is an abort,
+    // not normal end-of-stream: callers must receive an error rather than the
+    // same zero sentinel used for EOF.
+    let result = cancellation::cancellable(
+        token.as_ref(),
+        handle._query_tracking_context.context_id(),
+        async {
+            handle
+                .stream
+                .try_next()
+                .await
+                .map_err(|e: DataFusionError| e)
+        },
+    )
     .await
-    .map_err(|e| DataFusionError::Execution(e))?;
+    .map_err(DataFusionError::Execution)?;
 
     match result {
         Some(batch) => {
@@ -2139,6 +2145,13 @@ pub unsafe fn sender_send(
 /// # Safety
 /// `sender_ptr` must be 0 or a valid pointer returned by
 /// `register_partition_stream`.
+pub unsafe fn sender_terminate_early(sender_ptr: i64) {
+    if sender_ptr != 0 {
+        let sender = &*(sender_ptr as *const PartitionStreamSender);
+        sender.terminate_early();
+    }
+}
+
 pub unsafe fn sender_close(sender_ptr: i64) {
     if sender_ptr != 0 {
         let _ = Box::from_raw(sender_ptr as *mut PartitionStreamSender);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1361,7 +1361,12 @@ pub unsafe fn stream_get_schema(stream_ptr: i64) -> Result<i64, DataFusionError>
 /// on the same stream.
 pub async unsafe fn stream_next(stream_ptr: i64) -> Result<i64, DataFusionError> {
     let handle = &mut *(stream_ptr as *mut QueryStreamHandle);
-    let token = query_tracker::get_cancellation_token(handle._query_tracking_context.context_id());
+    // Use the handle's OWN token, not a registry lookup by context_id. The
+    // registry entry can be removed by a sibling stream's Drop (same id) while
+    // this stream is mid-flight; a `None` token here silently degrades
+    // `cancellable_or` to a bare uncancellable await — the reduce sink's
+    // cancel then can't interrupt an in-flight drain (the ~5s LM stall).
+    let token = handle._query_tracking_context.cancellation_token();
 
     // Fetch the next batch (cancellation-aware)
     let result = cancellation::cancellable_or(token.as_ref(), None, async {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -769,6 +769,11 @@ fn send_outcome_to_code(outcome: crate::partition_stream::SendOutcome) -> i64 {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn df_sender_terminate_early(sender_ptr: i64) {
+    api::sender_terminate_early(sender_ptr);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn df_sender_close(sender_ptr: i64) {
     api::sender_close(sender_ptr);
 }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
@@ -43,6 +43,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{stream, Stream};
+use parking_lot::Mutex as ChannelMutex;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
@@ -57,7 +58,7 @@ const CHANNEL_CAPACITY: usize = 4;
 /// receiver side.
 pub struct PartitionStreamSender {
     tx: mpsc::Sender<Result<RecordBatch, DataFusionError>>,
-    receiver: Weak<Mutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
+    receiver: Weak<ChannelMutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
     schema: SchemaRef,
 }
 
@@ -86,10 +87,7 @@ impl PartitionStreamSender {
     /// borrow, unlike dropping the sender itself.
     pub fn terminate_early(&self) {
         if let Some(receiver) = self.receiver.upgrade() {
-            receiver
-                .lock()
-                .expect("partition receiver mutex poisoned")
-                .close();
+            receiver.lock().close();
         }
     }
 
@@ -129,7 +127,7 @@ impl fmt::Debug for PartitionStreamSender {
 /// directly. Typically handed to [`SingleReceiverPartition`] and registered on
 /// a `SessionContext` as a `StreamingTable`.
 pub struct PartitionStreamReceiver {
-    rx: Arc<Mutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
+    rx: Arc<ChannelMutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
     schema: SchemaRef,
 }
 
@@ -145,10 +143,7 @@ impl Stream for PartitionStreamReceiver {
     type Item = Result<RecordBatch, DataFusionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.rx
-            .lock()
-            .expect("partition receiver mutex poisoned")
-            .poll_recv(cx)
+        self.rx.lock().poll_recv(cx)
     }
 }
 
@@ -166,7 +161,7 @@ impl RecordBatchStream for PartitionStreamReceiver {
 /// buffered batches are drained, which DataFusion interprets as end-of-input.
 pub fn channel(schema: SchemaRef) -> (PartitionStreamSender, PartitionStreamReceiver) {
     let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-    let receiver = Arc::new(Mutex::new(rx));
+    let receiver = Arc::new(ChannelMutex::new(rx));
     let sender = PartitionStreamSender {
         tx,
         receiver: Arc::downgrade(&receiver),
@@ -365,6 +360,18 @@ mod tests {
             blocked.join().unwrap(),
             SendOutcome::ReceiverDropped
         ));
+    }
+
+    #[test]
+    fn early_termination_after_receiver_drop_is_noop() {
+        let schema = test_schema();
+        let (sender, receiver) = channel(Arc::clone(&schema));
+        drop(receiver);
+
+        // The weak receiver-control handle no longer upgrades; this must not panic
+        // and later sends must still report the dropped receiver.
+        sender.terminate_early();
+        assert!(sender.tx.try_send(Ok(test_batch(&schema, &[1]))).is_err());
     }
 
     #[tokio::test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/partition_stream.rs
@@ -32,7 +32,7 @@
 
 use std::fmt;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll};
 
 use datafusion::arrow::datatypes::SchemaRef;
@@ -57,13 +57,15 @@ const CHANNEL_CAPACITY: usize = 4;
 /// receiver side.
 pub struct PartitionStreamSender {
     tx: mpsc::Sender<Result<RecordBatch, DataFusionError>>,
+    receiver: Weak<Mutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
     schema: SchemaRef,
 }
 
 /// Outcome of a blocking send. `ReceiverDropped` is the benign terminal case — the
-/// DataFusion consumer finished (e.g. a `LimitExec` satisfied its fetch) and dropped the
-/// receiver. Surfaced as a distinct variant so the FFM layer can signal it without the Java
-/// side substring-matching an error message.
+/// DataFusion consumer finished (e.g. a `LimitExec` satisfied its fetch), or an
+/// early-termination request closed this partition's receiver. Surfaced as a distinct
+/// variant so the FFM layer can signal it without the Java side substring-matching an
+/// error message.
 #[must_use]
 pub enum SendOutcome {
     Sent,
@@ -76,6 +78,21 @@ impl PartitionStreamSender {
         &self.schema
     }
 
+    /// Gracefully terminates this input partition without cancelling the query.
+    ///
+    /// Closing the receiver rejects any blocked or future sends while preserving
+    /// already buffered batches for the DataFusion consumer to drain before EOF.
+    /// This is safe to call while [`Self::send_blocking`] holds an immutable sender
+    /// borrow, unlike dropping the sender itself.
+    pub fn terminate_early(&self) {
+        if let Some(receiver) = self.receiver.upgrade() {
+            receiver
+                .lock()
+                .expect("partition receiver mutex poisoned")
+                .close();
+        }
+    }
+
     /// Push a batch into the channel from a synchronous (non-async) context.
     ///
     /// The provided `handle` is used to drive the async send — typically the
@@ -84,8 +101,8 @@ impl PartitionStreamSender {
     /// thread to be a Tokio worker.
     ///
     /// Blocks while the channel is full (natural backpressure). Returns
-    /// [`SendOutcome::ReceiverDropped`] only if the receiver has been dropped —
-    /// the sole failure mode of `mpsc::Sender::send`.
+    /// [`SendOutcome::ReceiverDropped`] only if the receiver has been dropped or
+    /// closed for early termination — the sole failure mode of `mpsc::Sender::send`.
     pub fn send_blocking(
         &self,
         batch: Result<RecordBatch, DataFusionError>,
@@ -112,7 +129,7 @@ impl fmt::Debug for PartitionStreamSender {
 /// directly. Typically handed to [`SingleReceiverPartition`] and registered on
 /// a `SessionContext` as a `StreamingTable`.
 pub struct PartitionStreamReceiver {
-    rx: mpsc::Receiver<Result<RecordBatch, DataFusionError>>,
+    rx: Arc<Mutex<mpsc::Receiver<Result<RecordBatch, DataFusionError>>>>,
     schema: SchemaRef,
 }
 
@@ -127,8 +144,11 @@ impl fmt::Debug for PartitionStreamReceiver {
 impl Stream for PartitionStreamReceiver {
     type Item = Result<RecordBatch, DataFusionError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.rx.poll_recv(cx)
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx
+            .lock()
+            .expect("partition receiver mutex poisoned")
+            .poll_recv(cx)
     }
 }
 
@@ -146,11 +166,16 @@ impl RecordBatchStream for PartitionStreamReceiver {
 /// buffered batches are drained, which DataFusion interprets as end-of-input.
 pub fn channel(schema: SchemaRef) -> (PartitionStreamSender, PartitionStreamReceiver) {
     let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let receiver = Arc::new(Mutex::new(rx));
     let sender = PartitionStreamSender {
         tx,
+        receiver: Arc::downgrade(&receiver),
         schema: Arc::clone(&schema),
     };
-    let receiver = PartitionStreamReceiver { rx, schema };
+    let receiver = PartitionStreamReceiver {
+        rx: receiver,
+        schema,
+    };
     (sender, receiver)
 }
 
@@ -297,6 +322,49 @@ mod tests {
         .join()
         .unwrap();
         assert!(matches!(outcome, SendOutcome::ReceiverDropped));
+    }
+
+    #[tokio::test]
+    async fn early_termination_drains_buffered_batches_then_eof() {
+        let schema = test_schema();
+        let (sender, mut receiver) = channel(Arc::clone(&schema));
+
+        sender.tx.try_send(Ok(test_batch(&schema, &[1]))).unwrap();
+        sender.tx.try_send(Ok(test_batch(&schema, &[2]))).unwrap();
+        sender.terminate_early();
+
+        assert!(sender.tx.try_send(Ok(test_batch(&schema, &[3]))).is_err());
+        assert_eq!(receiver.next().await.unwrap().unwrap().num_rows(), 1);
+        assert_eq!(receiver.next().await.unwrap().unwrap().num_rows(), 1);
+        assert!(receiver.next().await.is_none());
+    }
+
+    #[test]
+    fn early_termination_unblocks_full_channel_sender() {
+        let rt = tokio::runtime::Runtime::new().expect("runtime builds");
+        let handle = rt.handle().clone();
+        let schema = test_schema();
+        let (sender, _receiver) = channel(Arc::clone(&schema));
+        let sender = Arc::new(sender);
+
+        for value in 0..CHANNEL_CAPACITY {
+            sender
+                .tx
+                .try_send(Ok(test_batch(&schema, &[value as i64])))
+                .unwrap();
+        }
+
+        let blocked_sender = Arc::clone(&sender);
+        let blocked_schema = Arc::clone(&schema);
+        let blocked = std::thread::spawn(move || {
+            blocked_sender.send_blocking(Ok(test_batch(&blocked_schema, &[99])), &handle)
+        });
+
+        sender.terminate_early();
+        assert!(matches!(
+            blocked.join().unwrap(),
+            SendOutcome::ReceiverDropped
+        ));
     }
 
     #[tokio::test]

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -327,33 +327,33 @@ pub fn snapshot_top_n_by_current(out: &mut [WireQueryMetric]) -> usize {
 
     for entry in QUERY_REGISTRY.iter() {
         for tracker in entry.value() {
-        let bytes_raw = tracker.memory_pool.current_bytes();
-        let completed = tracker.is_completed();
-        if sample_logged < 5 {
-            sample_logged += 1;
-        }
-        if completed {
-            continue;
-        }
-        let bytes = usize_to_i64_saturating(bytes_raw);
-        if bytes == 0 {
-            continue;
-        }
-        if heap.len() < n {
-            heap.push(Reverse(HeapEntry {
-                bytes,
-                tracker: Arc::clone(tracker),
-            }));
-        } else if let Some(Reverse(min)) = heap.peek() {
-            // Strictly greater: equal-byte ties keep the first-seen entry.
-            if bytes > min.bytes {
-                heap.pop();
+            let bytes_raw = tracker.memory_pool.current_bytes();
+            let completed = tracker.is_completed();
+            if sample_logged < 5 {
+                sample_logged += 1;
+            }
+            if completed {
+                continue;
+            }
+            let bytes = usize_to_i64_saturating(bytes_raw);
+            if bytes == 0 {
+                continue;
+            }
+            if heap.len() < n {
                 heap.push(Reverse(HeapEntry {
                     bytes,
                     tracker: Arc::clone(tracker),
                 }));
+            } else if let Some(Reverse(min)) = heap.peek() {
+                // Strictly greater: equal-byte ties keep the first-seen entry.
+                if bytes > min.bytes {
+                    heap.pop();
+                    heap.push(Reverse(HeapEntry {
+                        bytes,
+                        tracker: Arc::clone(tracker),
+                    }));
+                }
             }
-        }
         }
     }
 
@@ -444,9 +444,11 @@ pub fn cancel_query(context_id: i64) {
 ///
 /// No-op if no runtime handle is registered or the query is unknown.
 pub fn flush_cpu_runtime(context_id: i64) {
-    let rt_handle = QUERY_REGISTRY
-        .get(&context_id)
-        .and_then(|trackers| trackers.last().and_then(|t| t.cpu_runtime_handle.get().cloned()));
+    let rt_handle = QUERY_REGISTRY.get(&context_id).and_then(|trackers| {
+        trackers
+            .last()
+            .and_then(|t| t.cpu_runtime_handle.get().cloned())
+    });
 
     if let Some(handle) = rt_handle {
         flush_cpu_runtime_with_handle(&handle, context_id);
@@ -484,9 +486,11 @@ pub fn flush_cpu_runtime_with_handle(handle: &tokio::runtime::Handle, context_id
 /// `stream_close` to grab the handle before the tracker is dropped (which
 /// removes it from the registry).
 pub fn take_cpu_runtime_handle(context_id: i64) -> Option<tokio::runtime::Handle> {
-    QUERY_REGISTRY
-        .get(&context_id)
-        .and_then(|trackers| trackers.last().and_then(|t| t.cpu_runtime_handle.get().cloned()))
+    QUERY_REGISTRY.get(&context_id).and_then(|trackers| {
+        trackers
+            .last()
+            .and_then(|t| t.cpu_runtime_handle.get().cloned())
+    })
 }
 
 /// Clone a cancellation token for the given context_id, if registered.
@@ -688,8 +692,7 @@ impl Drop for QueryTrackingContext {
                 let now_empty = entry.is_empty();
                 drop(entry);
                 if now_empty {
-                    QUERY_REGISTRY
-                        .remove_if(&tracker.context_id, |_, v| v.is_empty());
+                    QUERY_REGISTRY.remove_if(&tracker.context_id, |_, v| v.is_empty());
                 }
             }
 
@@ -877,9 +880,19 @@ mod tests {
         let ctx_id = 50_002;
         let _ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
 
-        let t1 = QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap().wall_secs();
+        let t1 = QUERY_REGISTRY
+            .get(&ctx_id)
+            .unwrap()
+            .last()
+            .unwrap()
+            .wall_secs();
         thread::sleep(Duration::from_millis(50));
-        let t2 = QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap().wall_secs();
+        let t2 = QUERY_REGISTRY
+            .get(&ctx_id)
+            .unwrap()
+            .last()
+            .unwrap()
+            .wall_secs();
         assert!(t2 - t1 >= 0.04);
 
         drop(_ctx);

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_tracker.rs
@@ -211,7 +211,19 @@ impl QueryTracker {
 // Global registry
 // ---------------------------------------------------------------------------
 
-static QUERY_REGISTRY: Lazy<DashMap<i64, Arc<QueryTracker>>> = Lazy::new(DashMap::new);
+/// Registry of live query trackers, keyed by context_id.
+///
+/// The value is a Vec because ONE context_id can have MULTIPLE live native
+/// streams: a query with a late-materialization stage opens two coordinator
+/// reduce sinks (stage 1 and stage 3), and both call
+/// `executeLocalPlan(..., ctx.taskId())` with the same query-level task id.
+/// The previous `DashMap<i64, Arc<QueryTracker>>` silently overwrote the
+/// first tracker on the second insert, and `Drop` removed the key
+/// unconditionally — so the first stream to close deleted the entry for its
+/// still-running sibling. `cancel_query` then found nothing, an in-flight
+/// `stream_next` could not be interrupted, and the reduce sink's
+/// `reduceDone.await(5s)` latch expired on every LM query (~5s stall).
+static QUERY_REGISTRY: Lazy<DashMap<i64, Vec<Arc<QueryTracker>>>> = Lazy::new(DashMap::new);
 
 // ---------------------------------------------------------------------------
 // Registry snapshot — top-N FFM export
@@ -314,7 +326,7 @@ pub fn snapshot_top_n_by_current(out: &mut [WireQueryMetric]) -> usize {
     let mut sample_logged = 0usize;
 
     for entry in QUERY_REGISTRY.iter() {
-        let tracker = entry.value();
+        for tracker in entry.value() {
         let bytes_raw = tracker.memory_pool.current_bytes();
         let completed = tracker.is_completed();
         if sample_logged < 5 {
@@ -341,6 +353,7 @@ pub fn snapshot_top_n_by_current(out: &mut [WireQueryMetric]) -> usize {
                     tracker: Arc::clone(tracker),
                 }));
             }
+        }
         }
     }
 
@@ -382,12 +395,38 @@ const FLUSH_WORKER_COUNT: usize = 4;
 /// [`flush_cpu_runtime`] after `stream_close` to ensure deferred drops are
 /// processed and GroupValues buffers are freed.
 pub fn cancel_query(context_id: i64) {
-    if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
+    // Snapshot the trackers under the entry lock, then cancel outside it —
+    // `token.cancel()` can wake tasks whose teardown re-enters the registry
+    // (Drop → get_mut on the same shard) and would deadlock under DashMap's
+    // shard lock.
+    let trackers: Vec<Arc<QueryTracker>> = match QUERY_REGISTRY.get(&context_id) {
+        Some(entry) => entry.iter().map(Arc::clone).collect(),
+        None => Vec::new(),
+    };
+    if trackers.is_empty() {
+        // A cancel for an id that was never registered (or already finished)
+        // does nothing. Silent no-ops here hid a real bug (the ~5s LM stall):
+        // log the miss and the live ids so any recurrence is visible.
+        let live: Vec<i64> = QUERY_REGISTRY.iter().map(|e| *e.key()).collect();
+        native_bridge_common::log_debug!(
+            "cancel_query: NO REGISTRY ENTRY for context_id={context_id} (no-op). live ids={live:?}"
+        );
+        return;
+    }
+    native_bridge_common::log_debug!(
+        "cancel_query: cancelling context_id={context_id} ({} tracker(s))",
+        trackers.len()
+    );
+    // 0 is the "not cancelled" sentinel in cancelled_at_nanos. The FIRST deref
+    // of PROCESS_START in a process creates the Instant and measures elapsed
+    // on it immediately, which can legitimately be 0ns — clamp to 1 so a real
+    // cancellation is never mistaken for "not cancelled".
+    let nanos = (PROCESS_START.elapsed().as_nanos() as u64).max(1);
+    for tracker in trackers {
         tracker.cancellation_token.cancel();
         if let Some(handle) = tracker.abort_handle.get() {
             handle.abort();
         }
-        let nanos = PROCESS_START.elapsed().as_nanos() as u64;
         tracker
             .cancelled_at_nanos
             .compare_exchange(0, nanos, Ordering::Release, Ordering::Relaxed)
@@ -407,7 +446,7 @@ pub fn cancel_query(context_id: i64) {
 pub fn flush_cpu_runtime(context_id: i64) {
     let rt_handle = QUERY_REGISTRY
         .get(&context_id)
-        .and_then(|tracker| tracker.cpu_runtime_handle.get().cloned());
+        .and_then(|trackers| trackers.last().and_then(|t| t.cpu_runtime_handle.get().cloned()));
 
     if let Some(handle) = rt_handle {
         flush_cpu_runtime_with_handle(&handle, context_id);
@@ -447,28 +486,41 @@ pub fn flush_cpu_runtime_with_handle(handle: &tokio::runtime::Handle, context_id
 pub fn take_cpu_runtime_handle(context_id: i64) -> Option<tokio::runtime::Handle> {
     QUERY_REGISTRY
         .get(&context_id)
-        .and_then(|tracker| tracker.cpu_runtime_handle.get().cloned())
+        .and_then(|trackers| trackers.last().and_then(|t| t.cpu_runtime_handle.get().cloned()))
 }
 
-/// Clone the cancellation token for the given context_id, if registered.
+/// Clone a cancellation token for the given context_id, if registered.
+///
+/// With multiple streams under one id this returns the MOST RECENTLY
+/// registered tracker's token — callers that own a `QueryTrackingContext`
+/// should prefer its own token (see `QueryTrackingContext::cancellation_token`)
+/// over this registry lookup, which can go stale mid-stream.
 pub fn get_cancellation_token(context_id: i64) -> Option<CancellationToken> {
     QUERY_REGISTRY
         .get(&context_id)
-        .map(|t| t.cancellation_token.clone())
+        .and_then(|trackers| trackers.last().map(|t| t.cancellation_token.clone()))
 }
 
 /// Store the CPU task's AbortHandle for the given context_id.
+///
+/// Targets the most recently registered tracker for the id — matching the
+/// call pattern where a stream registers its context then immediately
+/// attaches its handles.
 pub fn set_abort_handle(context_id: i64, handle: AbortHandle) {
-    if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
-        tracker.abort_handle.set(handle).ok();
+    if let Some(trackers) = QUERY_REGISTRY.get(&context_id) {
+        if let Some(tracker) = trackers.last() {
+            tracker.abort_handle.set(handle).ok();
+        }
     }
 }
 
 /// Store the CPU runtime handle for the given context_id so that
 /// `cancel_query` can flush deferred drops on that runtime.
 pub fn set_cpu_runtime_handle(context_id: i64, handle: tokio::runtime::Handle) {
-    if let Some(tracker) = QUERY_REGISTRY.get(&context_id) {
-        tracker.cpu_runtime_handle.set(handle).ok();
+    if let Some(trackers) = QUERY_REGISTRY.get(&context_id) {
+        if let Some(tracker) = trackers.last() {
+            tracker.cpu_runtime_handle.set(handle).ok();
+        }
     }
 }
 
@@ -482,12 +534,13 @@ pub fn count_cancelled_running(threshold: Duration) -> (i64, i64) {
     let threshold_nanos = threshold.as_nanos() as u64;
     let now_nanos = PROCESS_START.elapsed().as_nanos() as u64;
     for entry in QUERY_REGISTRY.iter() {
-        let tracker = entry.value();
-        let cancelled_nanos = tracker.cancelled_at_nanos.load(Ordering::Acquire);
-        if cancelled_nanos > 0 && (now_nanos - cancelled_nanos) >= threshold_nanos {
-            match tracker.query_type {
-                QueryType::Shard => shard_count += 1,
-                QueryType::Coordinator => coordinator_count += 1,
+        for tracker in entry.value() {
+            let cancelled_nanos = tracker.cancelled_at_nanos.load(Ordering::Acquire);
+            if cancelled_nanos > 0 && (now_nanos - cancelled_nanos) >= threshold_nanos {
+                match tracker.query_type {
+                    QueryType::Shard => shard_count += 1,
+                    QueryType::Coordinator => coordinator_count += 1,
+                }
             }
         }
     }
@@ -535,7 +588,13 @@ impl QueryTrackingContext {
             completed: AtomicBool::new(false),
             wall_nanos: std::sync::atomic::AtomicU64::new(0),
         });
-        QUERY_REGISTRY.insert(context_id, Arc::clone(&tracker));
+        // Append, don't insert: a second stream registering under the same
+        // context_id (LM queries have two reduce sinks) must not orphan the
+        // first stream's tracker.
+        QUERY_REGISTRY
+            .entry(context_id)
+            .or_default()
+            .push(Arc::clone(&tracker));
         Self {
             tracker: Some(tracker),
             phantom_reservation: None,
@@ -592,6 +651,16 @@ impl QueryTrackingContext {
     pub fn context_id(&self) -> i64 {
         self.tracker.as_ref().map_or(0, |t| t.context_id)
     }
+
+    /// This context's OWN cancellation token, or `None` if tracking is
+    /// disabled. Prefer this over `get_cancellation_token(context_id)` when a
+    /// `QueryTrackingContext` is at hand: the registry lookup targets the most
+    /// recently registered tracker for the id (which may be a sibling stream)
+    /// and returns `None` once the entry is gone — silently making the
+    /// caller's await uncancellable.
+    pub fn cancellation_token(&self) -> Option<CancellationToken> {
+        self.tracker.as_ref().map(|t| t.cancellation_token.clone())
+    }
 }
 
 impl Drop for QueryTrackingContext {
@@ -610,7 +679,19 @@ impl Drop for QueryTrackingContext {
             // query is never simultaneously visible in both the registry scan
             // (current) and the total counter — preventing double-counting in
             // snapshot_cancellation_stats.
-            QUERY_REGISTRY.remove(&tracker.context_id);
+            //
+            // Remove ONLY this context's own tracker (ptr_eq), never the whole
+            // key blindly: sibling streams under the same context_id may still
+            // be live. Drop the key when the Vec empties.
+            if let Some(mut entry) = QUERY_REGISTRY.get_mut(&tracker.context_id) {
+                entry.retain(|t| !Arc::ptr_eq(t, tracker));
+                let now_empty = entry.is_empty();
+                drop(entry);
+                if now_empty {
+                    QUERY_REGISTRY
+                        .remove_if(&tracker.context_id, |_, v| v.is_empty());
+                }
+            }
 
             // If this query was cancelled and ran past the threshold, bump the total counter.
             let cancelled_nanos = tracker.cancelled_at_nanos.load(Ordering::Acquire);
@@ -741,15 +822,64 @@ mod tests {
         assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
     }
 
+    /// Regression test for the ~5s late-materialization stall: an LM query
+    /// registers TWO reduce streams under the SAME context_id (stage-1 and
+    /// stage-3 sinks both pass ctx.taskId()). The old `DashMap<i64, Arc<_>>`
+    /// registry overwrote the first tracker at insert and removed the whole
+    /// key at first Drop — so `cancel_query` on the shared id found nothing
+    /// and the surviving stream could never be interrupted.
+    #[test]
+    fn test_sibling_stream_drop_does_not_orphan_survivor() {
+        let global = make_global_pool(10_000);
+        let ctx_id = 50_042;
+        let first = QueryTrackingContext::new(ctx_id, Arc::clone(&global), QueryType::Coordinator);
+        let second = QueryTrackingContext::new(ctx_id, global, QueryType::Coordinator);
+
+        // Both trackers visible under the shared id.
+        assert_eq!(QUERY_REGISTRY.get(&ctx_id).unwrap().len(), 2);
+
+        // First stream closes (stage-1 drains to EOF and drops) …
+        drop(first);
+
+        // … the survivor MUST still be registered and cancellable.
+        assert_eq!(QUERY_REGISTRY.get(&ctx_id).unwrap().len(), 1);
+        let survivor_token = second.cancellation_token().unwrap();
+        assert!(!survivor_token.is_cancelled());
+        cancel_query(ctx_id);
+        assert!(survivor_token.is_cancelled());
+
+        drop(second);
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
+    }
+
+    /// cancel_query on a shared id must cancel EVERY live tracker, not just one.
+    #[test]
+    fn test_cancel_query_cancels_all_siblings() {
+        let global = make_global_pool(10_000);
+        let ctx_id = 50_043;
+        let a = QueryTrackingContext::new(ctx_id, Arc::clone(&global), QueryType::Coordinator);
+        let b = QueryTrackingContext::new(ctx_id, global, QueryType::Coordinator);
+
+        let tok_a = a.cancellation_token().unwrap();
+        let tok_b = b.cancellation_token().unwrap();
+        cancel_query(ctx_id);
+        assert!(tok_a.is_cancelled());
+        assert!(tok_b.is_cancelled());
+
+        drop(a);
+        drop(b);
+        assert!(!QUERY_REGISTRY.contains_key(&ctx_id));
+    }
+
     #[test]
     fn test_wall_secs_ticks_while_running() {
         let global = make_global_pool(10_000);
         let ctx_id = 50_002;
         let _ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
 
-        let t1 = QUERY_REGISTRY.get(&ctx_id).unwrap().wall_secs();
+        let t1 = QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap().wall_secs();
         thread::sleep(Duration::from_millis(50));
-        let t2 = QUERY_REGISTRY.get(&ctx_id).unwrap().wall_secs();
+        let t2 = QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap().wall_secs();
         assert!(t2 - t1 >= 0.04);
 
         drop(_ctx);
@@ -879,7 +1009,7 @@ mod tests {
         let ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
 
         // Not cancelled yet
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
+        let tracker = Arc::clone(QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap());
         assert!(tracker.cancelled_at_nanos.load(Ordering::Relaxed) == 0);
 
         // Cancel
@@ -901,6 +1031,8 @@ mod tests {
         let first = QUERY_REGISTRY
             .get(&ctx_id)
             .unwrap()
+            .last()
+            .unwrap()
             .cancelled_at_nanos
             .load(Ordering::Relaxed);
 
@@ -908,6 +1040,8 @@ mod tests {
         cancel_query(ctx_id);
         let second = QUERY_REGISTRY
             .get(&ctx_id)
+            .unwrap()
+            .last()
             .unwrap()
             .cancelled_at_nanos
             .load(Ordering::Relaxed);
@@ -924,7 +1058,7 @@ mod tests {
         let ctx = QueryTrackingContext::new(ctx_id, global, QueryType::Shard);
 
         // Not cancelled — cancelled_at_nanos should be 0
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
+        let tracker = Arc::clone(QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap());
         assert_eq!(tracker.cancelled_at_nanos.load(Ordering::Relaxed), 0);
         drop(tracker);
 
@@ -932,7 +1066,7 @@ mod tests {
         cancel_query(ctx_id);
 
         // Now cancelled_at_nanos should be > 0
-        let tracker = QUERY_REGISTRY.get(&ctx_id).unwrap();
+        let tracker = Arc::clone(QUERY_REGISTRY.get(&ctx_id).unwrap().last().unwrap());
         assert!(tracker.cancelled_at_nanos.load(Ordering::Relaxed) > 0);
         drop(tracker);
 
@@ -956,12 +1090,12 @@ mod tests {
         cancel_query(coord_id);
 
         // Verify each query is registered, cancelled, and has correct type
-        let shard_tracker = QUERY_REGISTRY.get(&shard_id).unwrap();
+        let shard_tracker = Arc::clone(QUERY_REGISTRY.get(&shard_id).unwrap().last().unwrap());
         assert!(shard_tracker.cancelled_at_nanos.load(Ordering::Relaxed) > 0);
         assert_eq!(shard_tracker.query_type, QueryType::Shard);
         drop(shard_tracker);
 
-        let coord_tracker = QUERY_REGISTRY.get(&coord_id).unwrap();
+        let coord_tracker = Arc::clone(QUERY_REGISTRY.get(&coord_id).unwrap().last().unwrap());
         assert!(coord_tracker.cancelled_at_nanos.load(Ordering::Relaxed) > 0);
         assert_eq!(coord_tracker.query_type, QueryType::Coordinator);
         drop(coord_tracker);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.backend.EngineResultStream;
+import org.opensearch.analytics.exec.task.AnalyticsShardTask;
 import org.opensearch.analytics.spi.AbstractNameMappingAdapter;
 import org.opensearch.analytics.spi.AggregateCapability;
 import org.opensearch.analytics.spi.AggregateFunction;
@@ -901,7 +902,13 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
             if (dfReader == null) {
                 throw new IllegalStateException("No DatafusionReader available in the acquired reader");
             }
-            DatafusionContext context = new DatafusionContext(ctx.getTask(), dfReader, dataFusionService.getNativeRuntime());
+            // Fail fast if the scan context ever carries a non-analytics task: the context id
+            // and cancellation wiring both hang off AnalyticsShardTask#getNativeTaskId().
+            DatafusionContext context = new DatafusionContext(
+                (AnalyticsShardTask) ctx.getTask(),
+                dfReader,
+                dataFusionService.getNativeRuntime()
+            );
             if (backendContext != null) {
                 DataFusionSessionState sessionState = (DataFusionSessionState) backendContext;
                 context.setSessionContextHandle(sessionState.sessionContextHandle());

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionContext.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionContext.java
@@ -8,13 +8,12 @@
 
 package org.opensearch.be.datafusion;
 
+import org.opensearch.analytics.exec.task.AnalyticsShardTask;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 import org.opensearch.be.datafusion.nativelib.SessionContextHandle;
 import org.opensearch.be.datafusion.nativelib.StreamHandle;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.search.SearchExecutionContext;
-import org.opensearch.tasks.CancellableTask;
-import org.opensearch.tasks.Task;
 
 import java.io.IOException;
 
@@ -33,7 +32,7 @@ public class DatafusionContext implements SearchExecutionContext<DatafusionSearc
     private final NativeRuntimeHandle nativeRuntime;
     private DatafusionQuery datafusionQuery;
     private StreamHandle streamHandle;
-    private Task task;
+    private final AnalyticsShardTask task;
     private SessionContextHandle sessionContextHandle;
 
     /**
@@ -42,7 +41,7 @@ public class DatafusionContext implements SearchExecutionContext<DatafusionSearc
      * @param reader the DataFusion reader providing index data
      * @param nativeRuntime handle to the native DataFusion runtime
      */
-    public DatafusionContext(Task task, DatafusionReader reader, NativeRuntimeHandle nativeRuntime) {
+    public DatafusionContext(AnalyticsShardTask task, DatafusionReader reader, NativeRuntimeHandle nativeRuntime) {
         this.task = task;
         this.engineSearcher = new DatafusionSearcher(reader.getReaderHandle());
         this.nativeRuntime = nativeRuntime;
@@ -78,7 +77,7 @@ public class DatafusionContext implements SearchExecutionContext<DatafusionSearc
 
     /** Returns true if the underlying task has been cancelled. */
     public boolean isCancelled() {
-        return task instanceof CancellableTask ct && ct.isCancelled();
+        return task != null && task.isCancelled();
     }
 
     /** Returns the context ID for this query, or 0 if not set. */
@@ -131,7 +130,7 @@ public class DatafusionContext implements SearchExecutionContext<DatafusionSearc
     }
 
     @Override
-    public Task task() {
+    public AnalyticsShardTask task() {
         return task;
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
@@ -76,6 +76,29 @@ public final class DatafusionPartitionSender extends NativeHandle {
         }
     }
 
+    /**
+     * Non-blocking close attempt, for signalling end-of-input from a thread that must
+     * not park. Returns {@code true} if the sender was closed (or already closed);
+     * {@code false} if the write lock could not be acquired immediately — i.e. a feeder
+     * is currently parked inside {@link #send} holding the read lock, and blocking here
+     * would deadlock (see DatafusionReduceSinkTests
+     * #testCloseWhileFeederParkedOnFullChannelDoesNotDeadlock). Callers that get
+     * {@code false} must unblock the producer by other means (e.g. cancel, which drops
+     * the native receiver and pops the parked send with {@code ReceiverDropped}).
+     */
+    public boolean tryClose() {
+        if (!lifecycle.writeLock().tryLock()) {
+            return false;
+        }
+        try {
+            super.close();
+            logger.debug("[sender] closed ptr={} (tryClose)", ptr);
+            return true;
+        } finally {
+            lifecycle.writeLock().unlock();
+        }
+    }
+
     @Override
     protected void doClose() {
         NativeBridge.senderClose(ptr);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
@@ -38,18 +38,28 @@ public final class DatafusionPartitionSender extends NativeHandle {
      */
     private volatile boolean receiverDropped;
 
+    /**
+     * Set when the owning reduce sink has finished accepting input. A send that is already in
+     * progress completes or is released by native early termination, then closes this handle after
+     * it relinquishes the read lock.
+     */
+    private volatile boolean closeRequested;
+
     public DatafusionPartitionSender(long senderPtr) {
         super(senderPtr);
     }
 
     /**
      * Sends one exported batch. Returns {@code 0} on a normal send or
-     * {@link NativeBridge#SENDER_SEND_RECEIVER_DROPPED} if the consumer already dropped the
-     * receiver (benign — the caller should discard the batch and stop feeding).
+     * {@link NativeBridge#SENDER_SEND_RECEIVER_DROPPED} if the consumer already dropped or
+     * gracefully terminated the receiver.
      */
     public long send(long arrayAddr, long schemaAddr) {
         lifecycle.readLock().lock();
         try {
+            if (closeRequested) {
+                throw new IllegalStateException("sender close requested");
+            }
             long rc = NativeBridge.senderSend(getPointer(), arrayAddr, schemaAddr);
             if (rc == NativeBridge.SENDER_SEND_RECEIVER_DROPPED) {
                 receiverDropped = true;
@@ -57,6 +67,7 @@ public final class DatafusionPartitionSender extends NativeHandle {
             return rc;
         } finally {
             lifecycle.readLock().unlock();
+            closeAfterInFlightSend();
         }
     }
 
@@ -67,36 +78,64 @@ public final class DatafusionPartitionSender extends NativeHandle {
 
     @Override
     public void close() {
+        closeRequested = true;
         lifecycle.writeLock().lock();
         try {
-            super.close();
-            logger.debug("[sender] closed ptr={}", ptr);
+            closeUnderWriteLock("close");
         } finally {
             lifecycle.writeLock().unlock();
         }
     }
 
     /**
-     * Non-blocking close attempt, for signalling end-of-input from a thread that must
-     * not park. Returns {@code true} if the sender was closed (or already closed);
-     * {@code false} if the write lock could not be acquired immediately — i.e. a feeder
-     * is currently parked inside {@link #send} holding the read lock, and blocking here
-     * would deadlock (see DatafusionReduceSinkTests
-     * #testCloseWhileFeederParkedOnFullChannelDoesNotDeadlock). Callers that get
-     * {@code false} must unblock the producer by other means (e.g. cancel, which drops
-     * the native receiver and pops the parked send with {@code ReceiverDropped}).
+     * Signals normal end-of-input for this partition without cancelling the whole query.
+     *
+     * <p>If no send is active, this drops the native sender immediately and its receiver drains
+     * buffered batches before EOF. If a feeder holds the read lock inside a blocking native send,
+     * the native receiver is closed instead: that unblocks the send with
+     * {@link NativeBridge#SENDER_SEND_RECEIVER_DROPPED}; the feeder then performs the deferred
+     * native-sender close after releasing its read lock.
      */
-    public boolean tryClose() {
-        if (!lifecycle.writeLock().tryLock()) {
-            return false;
+    public void requestEarlyTermination() {
+        closeRequested = true;
+        if (lifecycle.writeLock().tryLock()) {
+            try {
+                closeUnderWriteLock("early termination");
+            } finally {
+                lifecycle.writeLock().unlock();
+            }
+            return;
         }
+
+        // An active send has an immutable native borrow. Hold a shared Java read lock while
+        // signalling its receiver so no concurrent close can reclaim that borrowed sender.
+        lifecycle.readLock().lock();
         try {
-            super.close();
-            logger.debug("[sender] closed ptr={} (tryClose)", ptr);
-            return true;
+            try {
+                NativeBridge.senderTerminateEarly(getPointer());
+            } catch (IllegalStateException ignored) {
+                // The in-flight send completed and performed the deferred close first.
+            }
+        } finally {
+            lifecycle.readLock().unlock();
+        }
+    }
+
+    private void closeAfterInFlightSend() {
+        if (closeRequested == false) {
+            return;
+        }
+        lifecycle.writeLock().lock();
+        try {
+            closeUnderWriteLock("deferred close");
         } finally {
             lifecycle.writeLock().unlock();
         }
+    }
+
+    private void closeUnderWriteLock(String reason) {
+        super.close();
+        logger.debug("[sender] closed ptr={} ({})", ptr, reason);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionSender.java
@@ -76,6 +76,11 @@ public final class DatafusionPartitionSender extends NativeHandle {
         return receiverDropped;
     }
 
+    /** True once {@link #close()} or {@link #requestEarlyTermination()} has been invoked. */
+    public boolean isCloseRequested() {
+        return closeRequested;
+    }
+
     @Override
     public void close() {
         closeRequested = true;

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -379,27 +379,16 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
             // keys with fetched columns returned 0 rows when this branch cancelled).
             // fireCancelQuery remains the mechanism for genuine aborts via cancel().
             //
-            // MUST be tryClose, not close(): a feeder thread parked inside send()
-            // (bounded channel full) holds the sender READ lock; a blocking close()
-            // here would wait forever on the WRITE lock — the exact deadlock covered
-            // by testCloseWhileFeederParkedOnFullChannelDoesNotDeadlock. When
-            // tryClose fails, cancel instead: cancel drops the native receiver,
-            // which pops the parked send with ReceiverDropped, releasing the lock.
-            boolean allClosed = true;
+            // Signal EOF for every input without cancelling the query. A sender with no active
+            // feed closes immediately; a sender parked on a full channel closes its receiver
+            // first, which unblocks the feed and defers native-sender reclamation until its read
+            // lock is released. This preserves buffered input for the reducer to drain.
             for (DatafusionPartitionSender sender : sendersByChildStageId.values()) {
                 try {
-                    allClosed &= sender.tryClose();
+                    sender.requestEarlyTermination();
                 } catch (Exception e) {
-                    logger.warn("[reduce-sink] error closing input sender for EOF: taskId={}", ctx.taskId(), e);
+                    logger.warn("[reduce-sink] error signalling input EOF: taskId={}", ctx.taskId(), e);
                 }
-            }
-            if (allClosed == false) {
-                // A producer is parked mid-send: rows are still streaming in, so this
-                // close is racing a live producer (not the clean drained-early case).
-                // Cancel is the only lock-free way to unblock it; dropped rows are
-                // acceptable here because the consumer already stopped listening.
-                logger.debug("[reduce-sink] input sender busy at close; cancelling to unblock: taskId={}", ctx.taskId());
-                fireCancelQuery();
             }
             try {
                 if (!reduceDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -363,26 +363,12 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
     protected Exception closeImpl() {
         SinkState before = state.compareAndExchange(SinkState.READY, SinkState.DONE);
         if (before == SinkState.REDUCING) {
-            // Drain in flight. Close the input senders FIRST: dropping a sender closes
-            // its mpsc channel, which the native plan's streaming input reads as
-            // end-of-input. Pipeline-breaking operators above it (SortExec/TopK) cannot
-            // emit until they see EOF, so without this the drain blocks in streamNext
-            // waiting for output that structurally cannot exist yet, while we block
-            // here waiting for the drain — a cycle only the await timeout used to
-            // break (observed as a constant ~5s stall on every LM query, with the
-            // WARN below firing each time).
-            //
-            // EOF (not cancelQuery) is the correct unblocking mechanism on this path:
-            // close() here means "no more input is coming", not "abort". Cancelling
-            // instead aborts the TopK before it emits and the drain returns the
-            // cancellation sentinel with ZERO rows (verified: projections mixing sort
-            // keys with fetched columns returned 0 rows when this branch cancelled).
-            // fireCancelQuery remains the mechanism for genuine aborts via cancel().
-            //
-            // Signal EOF for every input without cancelling the query. A sender with no active
-            // feed closes immediately; a sender parked on a full channel closes its receiver
-            // first, which unblocks the feed and defers native-sender reclamation until its read
-            // lock is released. This preserves buffered input for the reducer to drain.
+            // Drain in flight: signal per-partition EOF, never cancel. Pipeline breakers
+            // (SortExec/TopK) emit only after end-of-input, so closing the inputs lets the
+            // drain finish naturally with all accepted rows; cancelling here aborted the
+            // plan pre-emit (~5s stall, zero-row results). A sender with a feed in flight
+            // closes its receiver instead — the woken feeder runs the deferred native
+            // close after releasing its read lock. Genuine aborts still use cancel().
             for (DatafusionPartitionSender sender : sendersByChildStageId.values()) {
                 try {
                     sender.requestEarlyTermination();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -251,14 +251,16 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
                 }
                 feedCount.incrementAndGet();
             } catch (IllegalStateException e) {
-                // Sender close raced our send — getPointer() threw BEFORE the native call,
-                // so Rust never took ownership and the FFI structs' release callbacks are
-                // still set. Invoke them explicitly to free the exported buffers back to the
-                // Java allocator. (ArrowArray.close / ArrowSchema.close in the finally below
-                // frees the wrapper but does NOT invoke the C release callback.)
+                // Sender close raced our send — thrown BEFORE the native call, so Rust
+                // never took ownership and the FFI structs' release callbacks are still
+                // set. Invoke them explicitly to free the exported buffers back to the
+                // Java allocator. (ArrowArray.close / ArrowSchema.close in the finally
+                // below frees the wrapper but does NOT invoke the C release callback.)
                 array.release();
                 arrowSchema.release();
-                if (closed) {
+                if (closed || sender.isCloseRequested()) {
+                    // Benign: the sink — or just this input (per-child EOF racing a live
+                    // producer) — stopped accepting batches. Discard, don't fail the stream.
                     logger.debug("[ReduceSink] send-after-close race caught, discarding batch");
                     return;
                 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -363,12 +363,57 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
     protected Exception closeImpl() {
         SinkState before = state.compareAndExchange(SinkState.READY, SinkState.DONE);
         if (before == SinkState.REDUCING) {
-            // Drain in flight — fire cancel so it unblocks, then wait for reduce's
-            // finally to complete teardown (releases Arrow batches from the allocator).
-            fireCancelQuery();
+            // Drain in flight. Close the input senders FIRST: dropping a sender closes
+            // its mpsc channel, which the native plan's streaming input reads as
+            // end-of-input. Pipeline-breaking operators above it (SortExec/TopK) cannot
+            // emit until they see EOF, so without this the drain blocks in streamNext
+            // waiting for output that structurally cannot exist yet, while we block
+            // here waiting for the drain — a cycle only the await timeout used to
+            // break (observed as a constant ~5s stall on every LM query, with the
+            // WARN below firing each time).
+            //
+            // EOF (not cancelQuery) is the correct unblocking mechanism on this path:
+            // close() here means "no more input is coming", not "abort". Cancelling
+            // instead aborts the TopK before it emits and the drain returns the
+            // cancellation sentinel with ZERO rows (verified: projections mixing sort
+            // keys with fetched columns returned 0 rows when this branch cancelled).
+            // fireCancelQuery remains the mechanism for genuine aborts via cancel().
+            //
+            // MUST be tryClose, not close(): a feeder thread parked inside send()
+            // (bounded channel full) holds the sender READ lock; a blocking close()
+            // here would wait forever on the WRITE lock — the exact deadlock covered
+            // by testCloseWhileFeederParkedOnFullChannelDoesNotDeadlock. When
+            // tryClose fails, cancel instead: cancel drops the native receiver,
+            // which pops the parked send with ReceiverDropped, releasing the lock.
+            boolean allClosed = true;
+            for (DatafusionPartitionSender sender : sendersByChildStageId.values()) {
+                try {
+                    allClosed &= sender.tryClose();
+                } catch (Exception e) {
+                    logger.warn("[reduce-sink] error closing input sender for EOF: taskId={}", ctx.taskId(), e);
+                }
+            }
+            if (allClosed == false) {
+                // A producer is parked mid-send: rows are still streaming in, so this
+                // close is racing a live producer (not the clean drained-early case).
+                // Cancel is the only lock-free way to unblock it; dropped rows are
+                // acceptable here because the consumer already stopped listening.
+                logger.debug("[reduce-sink] input sender busy at close; cancelling to unblock: taskId={}", ctx.taskId());
+                fireCancelQuery();
+            }
             try {
                 if (!reduceDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
-                    logger.warn("[reduce-sink] timed out waiting for reduce teardown: taskId={}", ctx.taskId());
+                    // EOF didn't unblock the drain (e.g. the native plan is stuck for
+                    // another reason). Fall back to a hard cancel so close() cannot
+                    // hang, then give teardown a short grace period.
+                    logger.warn(
+                        "[reduce-sink] reduce did not finish after input EOF; falling back to cancel: taskId={}",
+                        ctx.taskId()
+                    );
+                    fireCancelQuery();
+                    if (!reduceDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                        logger.warn("[reduce-sink] timed out waiting for reduce teardown: taskId={}", ctx.taskId());
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionReduceSink.java
@@ -406,10 +406,7 @@ public class DatafusionReduceSink extends AbstractDatafusionReduceSink implement
                     // EOF didn't unblock the drain (e.g. the native plan is stuck for
                     // another reason). Fall back to a hard cancel so close() cannot
                     // hang, then give teardown a short grace period.
-                    logger.warn(
-                        "[reduce-sink] reduce did not finish after input EOF; falling back to cancel: taskId={}",
-                        ctx.taskId()
-                    );
+                    logger.warn("[reduce-sink] reduce did not finish after input EOF; falling back to cancel: taskId={}", ctx.taskId());
                     fireCancelQuery();
                     if (!reduceDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
                         logger.warn("[reduce-sink] timed out waiting for reduce teardown: taskId={}", ctx.taskId());

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSearchExecEngine.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSearchExecEngine.java
@@ -38,7 +38,7 @@ public class DatafusionSearchExecEngine implements SearchExecEngine<ShardScanExe
     @Override
     public void prepare(ShardScanExecutionContext requestContext) {
         byte[] substraitBytes = requestContext.getFragmentBytes();
-        long contextId = datafusionContext.task() != null ? datafusionContext.task().getId() : 0L;
+        long contextId = datafusionContext.task() != null ? datafusionContext.task().getNativeTaskId() : 0L;
         datafusionContext.setDatafusionQuery(new DatafusionQuery(requestContext.getTableName(), substraitBytes, contextId));
     }
 
@@ -52,7 +52,7 @@ public class DatafusionSearchExecEngine implements SearchExecEngine<ShardScanExe
         // Register cancellation hook so HTTP disconnect / _tasks/_cancel / timeout
         // immediately fires the Rust CancellationToken.
         long contextId = datafusionContext.getContextId();
-        AnalyticsShardTask shardTask = datafusionContext.task() instanceof AnalyticsShardTask t ? t : null;
+        AnalyticsShardTask shardTask = datafusionContext.task();
         if (shardTask != null) {
             shardTask.setCancellationListener(() -> NativeBridge.cancelQuery(contextId));
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -119,6 +119,7 @@ public final class NativeBridge {
     private static final MethodHandle REGISTER_PARTITION_STREAM;
     private static final MethodHandle EXECUTE_LOCAL_PLAN;
     private static final MethodHandle SENDER_SEND;
+    private static final MethodHandle SENDER_TERMINATE_EARLY;
     private static final MethodHandle SENDER_CLOSE;
     private static final MethodHandle REGISTER_MEMTABLE;
     private static final MethodHandle CREATE_CUSTOM_CACHE_MANAGER;
@@ -359,6 +360,12 @@ public final class NativeBridge {
         SENDER_SEND = linker.downcallHandle(
             lib.find("df_sender_send").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+
+        // void df_sender_terminate_early(sender_ptr)
+        SENDER_TERMINATE_EARLY = linker.downcallHandle(
+            lib.find("df_sender_terminate_early").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
         );
 
         // void df_sender_close(sender_ptr)
@@ -1338,6 +1345,16 @@ public final class NativeBridge {
         try (var call = new NativeCall()) {
             return call.invoke(SENDER_SEND, senderPtr, arrayPtr, schemaPtr);
         }
+    }
+
+    /**
+     * Gracefully terminates one partition stream without cancelling the query. Any blocked sender
+     * is released, buffered batches remain available to the receiver, and the receiver observes
+     * EOF after it drains them.
+     */
+    public static void senderTerminateEarly(long senderPtr) {
+        NativeHandle.validatePointer(senderPtr, "sender");
+        NativeCall.invokeVoid(SENDER_TERMINATE_EARLY, senderPtr);
     }
 
     /** Closes the sender, signalling end-of-input. Tolerates a zero pointer. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionContextCancellationTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionContextCancellationTests.java
@@ -10,7 +10,6 @@ package org.opensearch.be.datafusion;
 
 import org.opensearch.analytics.exec.task.AnalyticsShardTask;
 import org.opensearch.core.tasks.TaskId;
-import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -24,7 +23,7 @@ public class DatafusionContextCancellationTests extends OpenSearchTestCase {
         return new AnalyticsShardTask(1L, "type", "action", "desc", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
     }
 
-    private DatafusionContext createContext(Task task) {
+    private DatafusionContext createContext(AnalyticsShardTask task) {
         DatafusionReader reader = mock(DatafusionReader.class);
         when(reader.getReaderHandle()).thenReturn(null);
         return new DatafusionContext(task, reader, null);
@@ -45,12 +44,6 @@ public class DatafusionContextCancellationTests extends OpenSearchTestCase {
 
     public void testIsCancelledReturnsFalseWhenTaskIsNull() {
         DatafusionContext ctx = createContext(null);
-        assertFalse(ctx.isCancelled());
-    }
-
-    public void testIsCancelledReturnsFalseWhenTaskIsNotCancellable() {
-        Task plainTask = new Task(1L, "type", "action", "desc", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
-        DatafusionContext ctx = createContext(plainTask);
         assertFalse(ctx.isCancelled());
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -151,6 +151,73 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     }
 
     /**
+     * Regression test for the late-materialization ~5s stall: {@code close()} arriving while
+     * {@code reduce()} is mid-drain (state=REDUCING) must (a) return promptly and (b) NOT lose
+     * rows the native plan has yet to emit.
+     *
+     * <p>The SUM plan is pipeline-breaking: the aggregate emits nothing until its input reaches
+     * end-of-input. Closing the sink from outside while the drain is parked used to fire
+     * {@code cancel_query} and wait on {@code reduceDone} for a hard-coded 5s — but the input
+     * senders were only closed AFTER that wait, so the aggregate could not emit, the drain could
+     * not finish, and every such close burned the full timeout (observed as a constant ~5s on
+     * every LM query, one WARN per query). Worse, once cancellation actually worked, the cancel
+     * aborted the aggregate BEFORE EOF and the result was 0 rows.
+     *
+     * <p>The fix closes the input senders first (tryClose → EOF → aggregate emits → drain ends
+     * naturally). This test feeds rows, calls {@code close()} WITHOUT signalling per-child EOF
+     * (simulating the Stitcher's early close), and asserts the SUM still arrives and close()
+     * returns in far less than the old 5s timeout.
+     */
+    public void testCloseWhileReducingSignalsEofAndPreservesRows() throws Exception {
+        NativeBridge.initTokioRuntimeManager(2);
+        Path spillDir = createTempDir("datafusion-spill");
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
+
+        try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
+            Schema inputSchema = new Schema(List.of(new Field("x", FieldType.nullable(new ArrowType.Int(64, true)), null)));
+            byte[] substrait = buildSumSubstraitBytes(DatafusionReduceSink.INPUT_ID);
+
+            CapturingSink downstream = new CapturingSink();
+            // Non-zero taskId so the cancel fallback path is wired if the test regresses.
+            ExchangeSinkContext ctx = new ExchangeSinkContext(
+                "q-close-eof",
+                0,
+                4242L,
+                substrait,
+                alloc,
+                List.of(new ExchangeSinkContext.ChildInput(0, buildPassthroughSubstraitBytes(DatafusionReduceSink.INPUT_ID))),
+                downstream
+            );
+
+            DatafusionReduceSink sink = new DatafusionReduceSink(ctx, runtimeHandle);
+            PlainActionFuture<Void> drainDone = PlainActionFuture.newFuture();
+            Thread.ofVirtual().start(() -> sink.reduce(drainDone));
+
+            sink.feed(makeBatch(alloc, inputSchema, new long[] { 1L, 2L, 3L }));
+            sink.feed(makeBatch(alloc, inputSchema, new long[] { 4L, 5L, 6L }));
+            // Give the drain time to actually park in stream_next waiting for more input,
+            // so close() observes state=REDUCING (the stalling branch).
+            Thread.sleep(200);
+
+            // Close WITHOUT sinkForChild(0).close() — this is the Stitcher-style early close.
+            long closeStartNanos = System.nanoTime();
+            sink.close();
+            long closeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - closeStartNanos);
+
+            drainDone.actionGet(10, TimeUnit.SECONDS);
+
+            assertEquals("EOF-on-close must let the aggregate emit: SUM(1..6)", 21L, downstream.total);
+            assertTrue("downstream should have received the aggregate row", downstream.totalRows >= 1);
+            // The old behavior burned the full 5s await; EOF-first should finish in millis.
+            // Generous bound to stay unflaky on slow CI hosts while still catching a 5s burn.
+            assertTrue("close() should not burn the teardown timeout, took " + closeMillis + "ms", closeMillis < 4000);
+        } finally {
+            runtimeHandle.close();
+        }
+    }
+
+    /**
      * Coordinator reduce running {@code SELECT x FROM "input-0" LIMIT 3} produces exactly the
      * limited output and tears down cleanly. Feeds far more rows than the limit through a real
      * native reduce; the {@code LimitExec} emits 3 rows and the drain ends.

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -453,37 +453,31 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             assertTrue("drain should produce a first batch", downstream.firstBatchLatch.await(10, TimeUnit.SECONDS));
             Thread.sleep(300);
 
-            // close() from this thread must not deadlock against the parked feeder. This is the
-            // crux of the regression: with the old teardown ordering close() would block forever
-            // on the sender write lock held by the parked feeder.
+            // Request graceful termination from another thread. It must close the partition
+            // receiver even while the feeder owns the sender read lock, releasing the feeder
+            // without globally cancelling the query.
             Thread closer = new Thread(sink::close, "deadlock-closer");
             closer.setDaemon(true);
             closer.start();
-            closer.join(15_000);
-            assertFalse("close() deadlocked against a feeder parked on the full channel", closer.isAlive());
-
-            // reduce() is in flight (state=REDUCING), so close() fires cancel and DEFERS teardown to
-            // reduce()'s finally — torndown is set only after the drain unwinds. Release the drain,
-            // wait for reduce to settle, then assert teardown ran exactly once.
-            downstream.release.countDown();
-            try {
-                reduceDone.actionGet(10, TimeUnit.SECONDS);
-            } catch (Exception expected) {
-                // reduce may complete or fail depending on cancel timing — either is fine here.
-            }
             feeder.join(10_000);
-            assertFalse("feeder thread should have unparked and exited", feeder.isAlive());
-            assertTrue("teardown must have run after reduce unwound", sink.torndown.get());
+            assertFalse("graceful termination must unpark the feeder", feeder.isAlive());
+
+            // Allow the drain to consume buffered batches and finish naturally, then close must
+            // return without using the timeout-and-cancel fallback.
+            downstream.release.countDown();
+            reduceDone.actionGet(10, TimeUnit.SECONDS);
+            closer.join(10_000);
+            assertFalse("close() deadlocked against a feeder parked on the full channel", closer.isAlive());
+            assertTrue("teardown must run after reduce unwound", sink.torndown.get());
         } finally {
             runtimeHandle.close();
         }
     }
 
     /**
-     * Cancel-before-first-batch: drain is parked in stream_next waiting for input.
-     * {@code close()} fires {@code cancel_query} on the registered taskId — the cancellation
-     * token wakes the {@code cancellable_or}'s select, drain returns sentinel, reduce()
-     * unwinds cleanly. No leak.
+     * Cancel-before-first-batch: drain is parked in stream_next waiting for input. Explicit
+     * {@code cancel()} must wake it and surface a failure; {@code close()} remains the separate
+     * graceful-EOF path. No leak.
      */
     public void testCancelBeforeFirstBatchUnwindsDrain() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
@@ -517,16 +511,13 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
             // "sink closed before reduce" instead of the cancel-during-drain path we want.
             assertTrue(reduceEntered.await(5, TimeUnit.SECONDS));
             Thread.sleep(50);
-            // Drain is parked waiting for first batch. Fire cancel via close().
-            // close() sees state=REDUCING, calls cancelQuery(4242L), returns immediately.
+            // Drain is parked waiting for first batch. Explicit cancellation must surface as a
+            // reduce failure; normal sink.close() is reserved for graceful EOF.
+            sink.cancel();
+            expectThrows(RuntimeException.class, () -> reduceDone.actionGet(5, TimeUnit.SECONDS));
             sink.close();
-            reduceDone.actionGet(5, TimeUnit.SECONDS);
 
             assertEquals("no rows should be delivered (cancel before any feed)", 0, downstream.totalRows);
-            // Regression: the cancel-during-REDUCING path used to leak outStream/session
-            // because close() set the base's `closed` flag, then reduce()'s finally called
-            // super.close() which short-circuited on that flag — closeImpl never ran a
-            // second time and teardown never happened. reduce() now calls closeImpl directly.
             assertTrue("teardown must run on the cancel-during-REDUCING path", sink.torndown.get());
         } finally {
             runtimeHandle.close();
@@ -534,8 +525,8 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     }
 
     /**
-     * Cancel-after-first-batch: drain has consumed at least one row, then {@code close()}
-     * fires {@code cancel_query}. The drain returns partial output and unwinds cleanly.
+     * Cancel-after-first-batch: drain has consumed at least one row, then explicit
+     * {@code cancel()} surfaces a failure while preserving output delivered before the abort.
      */
     public void testCancelAfterFirstBatchUnwindsDrain() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
@@ -565,8 +556,9 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
                 // Wait until the drain produced the first batch to downstream — proves
                 // we're past the empty-stream-park state and in the steady-pull state.
                 assertTrue("first batch did not reach downstream within 5s", downstream.firstBatchLatch.await(5, TimeUnit.SECONDS));
-                sink.close();  // cancel mid-stream
-                reduceDone.actionGet(5, TimeUnit.SECONDS);
+                sink.cancel();
+                expectThrows(RuntimeException.class, () -> reduceDone.actionGet(5, TimeUnit.SECONDS));
+                sink.close();
             } finally {
                 sink.close();  // idempotent
             }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchService.java
@@ -363,7 +363,13 @@ public class AnalyticsSearchService implements AutoCloseable {
                 rowIdVector.set(i, rowIds[i]);
             }
             rowIdVector.setValueCount(rowIds.length);
-            EngineResultStream stream = backend.fetchByRowIds(readerContext.getReader(), rowIdVector, columns, allocator, task.getId());
+            EngineResultStream stream = backend.fetchByRowIds(
+                readerContext.getReader(),
+                rowIdVector,
+                columns,
+                allocator,
+                task.getNativeTaskId()
+            );
             // FragmentResources keeps the rowIdVector alive until the stream drains — closing
             // it earlier would pull off-heap memory out from under the native FFM call.
             // Fetch is the terminal phase: no fetch follows, so close() frees the reader eagerly.
@@ -386,7 +392,7 @@ public class AnalyticsSearchService implements AutoCloseable {
         }
         // On cancel, release a fetch parked in the native pull via cooperative cancellation, not
         // stream.close() (which would race the in-flight native pull).
-        task.setCancellationListener(() -> backend.cancelByContext(task.getId()));
+        task.setCancellationListener(() -> backend.cancelByContext(task.getNativeTaskId()));
         try (FragmentResources ctx = resources) {
             Iterator<EngineResultBatch> it = ctx.stream().iterator();
             while (it.hasNext()) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/LateMaterializationStageExecution.java
@@ -32,6 +32,7 @@ import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.dag.ShardExecutionTarget;
 import org.opensearch.analytics.planner.dag.Stage;
 import org.opensearch.analytics.planner.rel.OpenSearchLateMaterialization;
+import org.opensearch.analytics.spi.CancellableExchangeSink;
 import org.opensearch.analytics.spi.DataConsumer;
 import org.opensearch.analytics.spi.ExchangeSink;
 import org.opensearch.cluster.service.ClusterService;
@@ -304,6 +305,12 @@ public final class LateMaterializationStageExecution extends AbstractStageExecut
         Stitcher s = this.stitcher;
         if (s != null) {
             s.close();
+        }
+        if ((terminal == State.CANCELLED || terminal == State.FAILED) && parentSink instanceof CancellableExchangeSink cancellable) {
+            // Fetch failure is terminal for the QTF query. The parent reduce stream may otherwise
+            // observe its inputs as ordinary EOF and complete the top-level PPL request before
+            // this asynchronous failure reaches the query listener.
+            cancellable.cancel();
         }
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/Stitcher.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.exec.VectorUtils;
 import org.opensearch.analytics.planner.rel.OpenSearchLateMaterialization;
+import org.opensearch.analytics.spi.CancellableExchangeSink;
 import org.opensearch.analytics.spi.ExchangeSink;
 
 import java.util.List;
@@ -206,6 +207,12 @@ public final class Stitcher {
                 }
                 logger.debug("[Stitcher] emitted rows={}", totalRows);
             } else {
+                // A fetch failure is not normal input completion. Abort a cancellable parent
+                // before closing it so its native stream reports an error instead of treating
+                // close as graceful EOF and completing the top-level query successfully.
+                if (parentSink instanceof CancellableExchangeSink cancellable) {
+                    cancellable.cancel();
+                }
                 try {
                     parentSink.close();
                 } catch (Exception ignore) {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/LocalComputeStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/LocalComputeStageExecutionFactory.java
@@ -46,7 +46,7 @@ public final class LocalComputeStageExecutionFactory implements StageExecutionFa
         ExchangeSinkContext context = new ExchangeSinkContext(
             config.queryId(),
             stage.getStageId(),
-            config.parentTask() != null ? config.parentTask().getId() : 0L,
+            config.parentTask() != null ? config.parentTask().getNativeTaskId() : 0L,
             chosenBytes(stage),
             config.bufferAllocator(),
             List.of(),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/coordinator/ReduceStageExecutionFactory.java
@@ -47,7 +47,7 @@ public final class ReduceStageExecutionFactory implements StageExecutionFactory 
         ExchangeSinkContext context = new ExchangeSinkContext(
             config.queryId(),
             stage.getStageId(),
-            config.parentTask() != null ? config.parentTask().getId() : 0L,
+            config.parentTask() != null ? config.parentTask().getNativeTaskId() : 0L,
             chosenBytes(stage),
             config.bufferAllocator(),
             buildChildInputs(stage),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsQueryTask.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsQueryTask.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.search.SearchTask;
+import org.opensearch.analytics.spi.NativeTaskIdManager;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.tasks.TaskId;
@@ -34,6 +35,12 @@ public class AnalyticsQueryTask extends SearchTask {
     private final String queryId;
     private final TimeValue cancelAfterTimeInterval;
     private final AtomicReference<Runnable> onCancelCallback = new AtomicReference<>();
+    /**
+     * JVM-unique id keying this query's native tracking contexts. {@link #getId()} must
+     * not be used for that: task ids are per-node counters and collide in the
+     * process-wide native registry when nodes share a JVM (internal test clusters).
+     */
+    private final long nativeTaskId = NativeTaskIdManager.next();
 
     public AnalyticsQueryTask(
         long id,
@@ -54,6 +61,11 @@ public class AnalyticsQueryTask extends SearchTask {
 
     public AnalyticsQueryTask(long id, String type, String action, String queryId, TaskId parentTaskId, Map<String, String> headers) {
         this(id, type, action, queryId, parentTaskId, headers, null);
+    }
+
+    /** JVM-unique id for this query's native tracking contexts (see field javadoc). */
+    public long getNativeTaskId() {
+        return nativeTaskId;
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsShardTask.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/task/AnalyticsShardTask.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics.exec.task;
 
 import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.analytics.spi.NativeTaskIdManager;
 import org.opensearch.core.tasks.TaskId;
 
 import java.util.Map;
@@ -31,6 +32,17 @@ import java.util.concurrent.atomic.AtomicReference;
 public class AnalyticsShardTask extends SearchShardTask {
 
     private final AtomicReference<Runnable> cancellationListener = new AtomicReference<>();
+    /**
+     * JVM-unique id keying this execution's native tracking context. {@link #getId()}
+     * must not be used for that: task ids are per-node counters and collide in the
+     * process-wide native registry when nodes share a JVM (internal test clusters).
+     */
+    private final long nativeTaskId = NativeTaskIdManager.next();
+
+    /** JVM-unique id for this execution's native tracking context (see field javadoc). */
+    public long getNativeTaskId() {
+        return nativeTaskId;
+    }
 
     public AnalyticsShardTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
         super(id, type, action, description, parentTaskId, headers);


### PR DESCRIPTION
### Description

Every PPL query whose plan includes a **late-materialization fetch phase** (any `... | sort <col> | head K | fields <non-sort-key-col>` shape) pays a **fixed ~5s** in the `LATE_MATERIALIZATION` stage — invariant to row count, column count, and bytes scanned — and logs one WARN per query:

```
[reduce-sink] timed out waiting for reduce teardown: taskId=...
```

Profile of an affected query (50 rows out of 749M docs; scan itself is 60–90ms):

| Stage | Type | Elapsed |
|---|---|---|
| 0 | SHARD_FRAGMENT | 78 ms |
| 1 | COORDINATOR_REDUCE | 79 ms |
| 2 | **LATE_MATERIALIZATION** | **5037 ms** |
| 3 | COORDINATOR_REDUCE | 5038 ms |

#### Root cause: a teardown cycle that only the 5s timeout could break

`DatafusionReduceSink.closeImpl` (REDUCING branch) fired `cancel_query` and then waited on `reduceDone.await(5, SECONDS)`. That wait sat inside a cycle:

1. `close()` waits on `reduceDone`,
2. `reduceDone.countDown()` runs only after the drain loop exits,
3. the drain is parked in `stream_next` waiting for a pipeline-breaking `SortExec/TopK` to emit,
4. the TopK cannot emit until its input reaches **end-of-input**,
5. the input senders were only closed **after** `close()` returned.

The cancel could not break the cycle either, because of two Rust-side defects:

- **Registry overwrite/orphan.** `QUERY_REGISTRY` was `DashMap<i64, Arc<QueryTracker>>` — one tracker per `context_id`. But a query with an LM stage opens **two** coordinator reduce sinks (both constructed at graph-**build** time, before any stage runs), and both register under the same `ctx.taskId()`. The second `insert` silently overwrote the first tracker, and the first stream to close removed the shared key in `Drop` — so `cancel_query` found **no entry** (silent no-op) while the sibling stream was still running. Verified live: `cancel_query: NO REGISTRY ENTRY for context_id=943 (no-op). live ids=[]` one line after `fireCancelQuery: taskId=943`.
- **Token lookup goes stale.** `stream_next` re-fetched its cancellation token from the registry on every call. Once the entry was gone, it got `None`, and the cancellation helper degrades to a bare, structurally **uncancellable** await.

jstack during the stall confirms it: the drain thread is RUNNABLE inside the FFM downcall with `cpu=0.43ms` — waiting, not working.

#### Why cancel-based teardown was also wrong (not just slow)

With the Rust fixes in place, cancellation actually works — and that exposed the deeper problem: **the close path was expressing "no more input is coming" using an abort mechanism, and the FFI boundary represented "cancelled" and "finished" identically** (`stream_next` returned `0` for both). Two sandbox CI regressions on this PR proved the consequences:

- `ReduceThreadPoolCleanupIT.testReducePoolReleasedAfterSuccessfulQuery` — a close racing a live producer fell back to query-wide cancel; the cancelled drain returned the EOF sentinel; a normal `stats sum(...)` completed **successfully with zero rows** (silent data loss).
- `AnalyticsQueryTaskCleanupIT.testQtfFetchCancelTearsDownAndCleansUp` — an injected fetch-phase failure cancelled the reduce streams, the cancellation surfaced as clean EOF, and the query returned a **successful** `PPLResponse` instead of the error.

Both tests pass at the merge-base and failed deterministically/intermittently on the initial version of this PR — the regressions were introduced here and are fixed here.

#### The fix

Three distinct teardown signals now exist, and each path uses the right one: **graceful per-partition EOF** (keeps data), **explicit cancellation** (surfaces as an error), and **normal EOF**.

**Rust — tracker registry (`query_tracker.rs`):**
- `QUERY_REGISTRY` becomes `DashMap<i64, Vec<Arc<QueryTracker>>>`: register appends; `Drop` removes only its own tracker (`Arc::ptr_eq` retain) and drops the key when empty; `cancel_query` snapshots outside the shard lock and cancels **every** tracker under the id, logging registry misses instead of silently no-oping.
- `stream_next` uses its handle's own token via new `QueryTrackingContext::cancellation_token()` — immune to registry churn.

**Rust — graceful per-partition termination (`partition_stream.rs`, `api.rs`, `ffm.rs`):**
- New `df_sender_terminate_early(sender_ptr)`: closes **only that partition's receiver** (`rx.close()`). Buffered batches remain poppable — the plan drains them and then sees genuine EOF, so pipeline breakers (TopK/Sort/Aggregate) still emit everything they accepted. A producer parked on the full channel wakes immediately with `ReceiverDropped`. The query's cancellation token is untouched, so sibling streams are unaffected.
- The sender reaches the receiver through a **`Weak`** control handle (`Arc<parking_lot::Mutex<Receiver>>` strong ref lives in the receiver): a consumer that legitimately drops its stream (`LimitExec` satisfied) still destroys the receiver and fails sends exactly as before. `parking_lot` keeps the per-batch `poll_next` lock at a single uncontended CAS.

**Rust — cancellation is an error, not EOF (`api.rs`):**
- `stream_next` now maps a fired cancellation token to `Err("Query <id> cancelled")` instead of the `0`/EOF sentinel. Java surfaces it as an exception → `listener.onFailure` → the stage transitions FAILED truthfully.

**Java — sink close semantics (`DatafusionReduceSink`, `DatafusionPartitionSender`):**
- `closeImpl`'s REDUCING branch calls new `requestEarlyTermination()` per input sender — never `cancel_query`. If no send is in flight, the native sender is closed immediately (plain EOF). If a feeder is parked inside a blocking native send (it holds the sender read lock; native `sender_send` holds a borrow of the boxed sender across an await, so reclaiming it would be a use-after-free, and blocking on the write lock would deadlock), the receiver is closed instead; the woken feeder then performs the **deferred native-sender close** itself after releasing its read lock. The old `tryClose()` and its cancel fallback are removed.
- The 5s `reduceDone.await` + cancel remains only as a last resort for a native plan that ignores EOF — no longer the normal path.

**Java — fetch-failure propagation (`Stitcher`, `LateMaterializationStageExecution`):**
- `Stitcher.finish()`'s failure branch now calls `parentSink.cancel()` **before** `parentSink.close()`. With close now graceful, the old close-only path let the post-LM reduce complete successfully before the failure reached the query listener. `LateMaterializationStageExecution.onTerminalTransition` also cancels the parent sink on FAILED/CANCELLED, covering terminations where `finish()` never runs (node lost mid-fetch, cancel before dispatch). Cancellation is idempotent, so the overlap is harmless.

#### Measured impact

On a 749M-doc, 5-shard composite (parquet-primary) index, `where <lead-sort-key>=<v> | sort - <second-key> | head 50 | fields <2 non-sort-key cols>`:

| | before | after |
|---|---|---|
| latency (warm) | **5.15 s** | **0.17–0.19 s** (~27×) |
| mixed sort-key+fetched projection | 50 rows (only because the timeout expired before EOF) | 50 rows, sha-identical output |
| teardown WARNs | 1 per query | 0 |
| cancelled/failed queries | could return success (possibly empty) | surface as errors |

`head K` variants, no-sort, and aggregation shapes all row-correct after the fix.

### Related Issues

Resolves #22688.
Related to the observability gap in #22601 (the LM stage emits no plan/metrics, which is why this required jstack + DEBUG logs to diagnose).

### Check List

- [x] Functionality includes testing.
  - Rust `query_tracker`: `test_sibling_stream_drop_does_not_orphan_survivor`, `test_cancel_query_cancels_all_siblings` (new); 23/23 pass.
  - Rust `partition_stream` (new): `early_termination_drains_buffered_batches_then_eof`, `early_termination_unblocks_full_channel_sender`, `early_termination_after_receiver_drop_is_noop`; 8/8 pass.
  - Java `DatafusionReduceSinkTests`: `testCloseWhileReducingSignalsEofAndPreservesRows` (new) — fails on the old code both ways (5s close stall pre-fix; 0 rows with cancel-based teardown). Cancel tests now use explicit `cancel()` + `expectThrows` (cancellation must surface as an error); the parked-feeder test requires natural completion without the timeout/cancel fallback. 12/12 pass.
  - Internal-cluster regressions (CI seed `B715F055FD80719C`): `AnalyticsQueryTaskCleanupIT.testQtfFetchCancelTearsDownAndCleansUp` and `ReduceThreadPoolCleanupIT.testReducePoolReleasedAfterSuccessfulQuery` pass; both full cleanup classes pass; both verified failing on the pre-fix commit and passing at merge-base.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
