### PR TITLE
Add per-slice and per-partition breakdowns to the query profiler

### DIFF
--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -83,6 +83,7 @@ import org.opensearch.search.fetch.FetchSearchResult;
 import org.opensearch.search.fetch.QueryFetchSearchResult;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.Timer;
+import org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown;
 import org.opensearch.search.profile.query.ProfileWeight;
 import org.opensearch.search.profile.query.QueryProfiler;
 import org.opensearch.search.profile.query.QueryTimingType;
@@ -348,82 +349,95 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             return;
         }
 
-        final LeafCollector leafCollector;
+        // Record the slice (collector) this thread is about to search so the query profiler can key
+        // leaf breakdowns per (slice, segment). Without this, an intra-segment split segment searched
+        // by two slices/threads would share one non-thread-safe Timer and produce corrupted timings.
+        final boolean profiling = weight instanceof ProfileWeight;
+        if (profiling) {
+            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(collector);
+        }
         try {
-            cancellable.checkCancelled();
-            if (weight instanceof ProfileWeight profileWeight) {
-                // For a whole-segment partition Lucene passes maxDocId == NO_MORE_DOCS (Integer.MAX_VALUE);
-                // resolve it to the segment's actual maxDoc so the profiled doc_range reflects the real
-                // segment size rather than the sentinel.
-                int resolvedMaxDocId = (maxDocId == DocIdSetIterator.NO_MORE_DOCS) ? ctx.reader().maxDoc() : maxDocId;
-                profileWeight.associateCollectorToLeaves(ctx, collector, minDocId, resolvedMaxDocId);
+            final LeafCollector leafCollector;
+            try {
+                cancellable.checkCancelled();
+                if (weight instanceof ProfileWeight profileWeight) {
+                    // For a whole-segment partition Lucene passes maxDocId == NO_MORE_DOCS (Integer.MAX_VALUE);
+                    // resolve it to the segment's actual maxDoc so the profiled doc_range reflects the real
+                    // segment size rather than the sentinel.
+                    int resolvedMaxDocId = (maxDocId == DocIdSetIterator.NO_MORE_DOCS) ? ctx.reader().maxDoc() : maxDocId;
+                    profileWeight.associateCollectorToLeaves(ctx, collector, minDocId, resolvedMaxDocId);
+                }
+                weight = wrapWeight(weight);
+                // See please https://github.com/apache/lucene/pull/964
+                collector.setWeight(weight);
+                leafCollector = collector.getLeafCollector(ctx);
+            } catch (CollectionTerminatedException e) {
+                // there is no doc of interest in this reader context
+                // continue with the following leaf
+                return;
+            } catch (QueryPhase.TimeExceededException e) {
+                searchContext.setSearchTimedOut(true);
+                return;
             }
-            weight = wrapWeight(weight);
-            // See please https://github.com/apache/lucene/pull/964
-            collector.setWeight(weight);
-            leafCollector = collector.getLeafCollector(ctx);
-        } catch (CollectionTerminatedException e) {
-            // there is no doc of interest in this reader context
-            // continue with the following leaf
-            return;
-        } catch (QueryPhase.TimeExceededException e) {
-            searchContext.setSearchTimedOut(true);
-            return;
-        }
-        // catch early terminated exception and rethrow?
-        Bits liveDocs = ctx.reader().getLiveDocs();
-        BitSet liveDocsBitSet = getSparseBitSetOrNull(liveDocs);
-        if (liveDocsBitSet == null) {
-            BulkScorer bulkScorer = weight.bulkScorer(ctx);
-            if (bulkScorer != null) {
-                try {
-                    bulkScorer.score(leafCollector, liveDocs, minDocId, maxDocId);
-                } catch (CollectionTerminatedException e) {
-                    // collection was terminated prematurely
-                    // continue with the following leaf
-                } catch (QueryPhase.TimeExceededException e) {
-                    searchContext.setSearchTimedOut(true);
-                    return;
+            // catch early terminated exception and rethrow?
+            Bits liveDocs = ctx.reader().getLiveDocs();
+            BitSet liveDocsBitSet = getSparseBitSetOrNull(liveDocs);
+            if (liveDocsBitSet == null) {
+                BulkScorer bulkScorer = weight.bulkScorer(ctx);
+                if (bulkScorer != null) {
+                    try {
+                        bulkScorer.score(leafCollector, liveDocs, minDocId, maxDocId);
+                    } catch (CollectionTerminatedException e) {
+                        // collection was terminated prematurely
+                        // continue with the following leaf
+                    } catch (QueryPhase.TimeExceededException e) {
+                        searchContext.setSearchTimedOut(true);
+                        return;
+                    }
+                }
+            } else {
+                // if the role query result set is sparse then we should use the SparseFixedBitSet for advancing:
+                Scorer scorer = weight.scorer(ctx);
+                if (scorer != null) {
+                    try {
+                        intersectScorerAndBitSet(
+                            scorer,
+                            liveDocsBitSet,
+                            leafCollector,
+                            minDocId,
+                            maxDocId,
+                            this.cancellable.isEnabled() ? cancellable::checkCancelled : () -> {}
+                        );
+                    } catch (CollectionTerminatedException e) {
+                        // collection was terminated prematurely
+                        // continue with the following leaf
+                    } catch (QueryPhase.TimeExceededException e) {
+                        searchContext.setSearchTimedOut(true);
+                        return;
+                    }
                 }
             }
-        } else {
-            // if the role query result set is sparse then we should use the SparseFixedBitSet for advancing:
-            Scorer scorer = weight.scorer(ctx);
-            if (scorer != null) {
-                try {
-                    intersectScorerAndBitSet(
-                        scorer,
-                        liveDocsBitSet,
-                        leafCollector,
-                        minDocId,
-                        maxDocId,
-                        this.cancellable.isEnabled() ? cancellable::checkCancelled : () -> {}
-                    );
-                } catch (CollectionTerminatedException e) {
-                    // collection was terminated prematurely
-                    // continue with the following leaf
-                } catch (QueryPhase.TimeExceededException e) {
-                    searchContext.setSearchTimedOut(true);
-                    return;
+
+            if (searchContext.isStreamSearch() && searchContext.getFlushMode() == FlushMode.PER_SEGMENT) {
+                logger.debug(
+                    "Stream intermediate aggregation for segment [{}], shard [{}]",
+                    ctx.ord,
+                    searchContext.shardTarget().getShardId().id()
+                );
+                List<InternalAggregation> internalAggregation = searchContext.bucketCollectorProcessor().buildAggBatch(collector);
+                if (!internalAggregation.isEmpty()) {
+                    sendBatch(internalAggregation);
                 }
             }
-        }
 
-        if (searchContext.isStreamSearch() && searchContext.getFlushMode() == FlushMode.PER_SEGMENT) {
-            logger.debug(
-                "Stream intermediate aggregation for segment [{}], shard [{}]",
-                ctx.ord,
-                searchContext.shardTarget().getShardId().id()
-            );
-            List<InternalAggregation> internalAggregation = searchContext.bucketCollectorProcessor().buildAggBatch(collector);
-            if (!internalAggregation.isEmpty()) {
-                sendBatch(internalAggregation);
+            // Note: this is called if collection ran successfully, including the above special cases of
+            // CollectionTerminatedException and TimeExceededException, but no other exception.
+            leafCollector.finish();
+        } finally {
+            if (profiling) {
+                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
             }
         }
-
-        // Note: this is called if collection ran successfully, including the above special cases of
-        // CollectionTerminatedException and TimeExceededException, but no other exception.
-        leafCollector.finish();
     }
 
     void sendBatch(List<InternalAggregation> batch) {

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -83,7 +83,6 @@ import org.opensearch.search.fetch.FetchSearchResult;
 import org.opensearch.search.fetch.QueryFetchSearchResult;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.Timer;
-import org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown;
 import org.opensearch.search.profile.query.ProfileWeight;
 import org.opensearch.search.profile.query.QueryProfiler;
 import org.opensearch.search.profile.query.QueryTimingType;
@@ -349,95 +348,82 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             return;
         }
 
-        // Record the slice (collector) this thread is about to search so the query profiler can key
-        // leaf breakdowns per (slice, segment). Without this, an intra-segment split segment searched
-        // by two slices/threads would share one non-thread-safe Timer and produce corrupted timings.
-        final boolean profiling = weight instanceof ProfileWeight;
-        if (profiling) {
-            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(collector);
-        }
+        final LeafCollector leafCollector;
         try {
-            final LeafCollector leafCollector;
-            try {
-                cancellable.checkCancelled();
-                if (weight instanceof ProfileWeight profileWeight) {
-                    // For a whole-segment partition Lucene passes maxDocId == NO_MORE_DOCS (Integer.MAX_VALUE);
-                    // resolve it to the segment's actual maxDoc so the profiled doc_range reflects the real
-                    // segment size rather than the sentinel.
-                    int resolvedMaxDocId = (maxDocId == DocIdSetIterator.NO_MORE_DOCS) ? ctx.reader().maxDoc() : maxDocId;
-                    profileWeight.associateCollectorToLeaves(ctx, collector, minDocId, resolvedMaxDocId);
-                }
-                weight = wrapWeight(weight);
-                // See please https://github.com/apache/lucene/pull/964
-                collector.setWeight(weight);
-                leafCollector = collector.getLeafCollector(ctx);
-            } catch (CollectionTerminatedException e) {
-                // there is no doc of interest in this reader context
-                // continue with the following leaf
-                return;
-            } catch (QueryPhase.TimeExceededException e) {
-                searchContext.setSearchTimedOut(true);
-                return;
+            cancellable.checkCancelled();
+            if (weight instanceof ProfileWeight profileWeight) {
+                // For a whole-segment partition Lucene passes maxDocId == NO_MORE_DOCS (Integer.MAX_VALUE);
+                // resolve it to the segment's actual maxDoc so the profiled doc_range reflects the real
+                // segment size rather than the sentinel.
+                int resolvedMaxDocId = (maxDocId == DocIdSetIterator.NO_MORE_DOCS) ? ctx.reader().maxDoc() : maxDocId;
+                profileWeight.associateCollectorToLeaves(ctx, collector, minDocId, resolvedMaxDocId);
             }
-            // catch early terminated exception and rethrow?
-            Bits liveDocs = ctx.reader().getLiveDocs();
-            BitSet liveDocsBitSet = getSparseBitSetOrNull(liveDocs);
-            if (liveDocsBitSet == null) {
-                BulkScorer bulkScorer = weight.bulkScorer(ctx);
-                if (bulkScorer != null) {
-                    try {
-                        bulkScorer.score(leafCollector, liveDocs, minDocId, maxDocId);
-                    } catch (CollectionTerminatedException e) {
-                        // collection was terminated prematurely
-                        // continue with the following leaf
-                    } catch (QueryPhase.TimeExceededException e) {
-                        searchContext.setSearchTimedOut(true);
-                        return;
-                    }
-                }
-            } else {
-                // if the role query result set is sparse then we should use the SparseFixedBitSet for advancing:
-                Scorer scorer = weight.scorer(ctx);
-                if (scorer != null) {
-                    try {
-                        intersectScorerAndBitSet(
-                            scorer,
-                            liveDocsBitSet,
-                            leafCollector,
-                            minDocId,
-                            maxDocId,
-                            this.cancellable.isEnabled() ? cancellable::checkCancelled : () -> {}
-                        );
-                    } catch (CollectionTerminatedException e) {
-                        // collection was terminated prematurely
-                        // continue with the following leaf
-                    } catch (QueryPhase.TimeExceededException e) {
-                        searchContext.setSearchTimedOut(true);
-                        return;
-                    }
+            weight = wrapWeight(weight);
+            // See please https://github.com/apache/lucene/pull/964
+            collector.setWeight(weight);
+            leafCollector = collector.getLeafCollector(ctx);
+        } catch (CollectionTerminatedException e) {
+            // there is no doc of interest in this reader context
+            // continue with the following leaf
+            return;
+        } catch (QueryPhase.TimeExceededException e) {
+            searchContext.setSearchTimedOut(true);
+            return;
+        }
+        // catch early terminated exception and rethrow?
+        Bits liveDocs = ctx.reader().getLiveDocs();
+        BitSet liveDocsBitSet = getSparseBitSetOrNull(liveDocs);
+        if (liveDocsBitSet == null) {
+            BulkScorer bulkScorer = weight.bulkScorer(ctx);
+            if (bulkScorer != null) {
+                try {
+                    bulkScorer.score(leafCollector, liveDocs, minDocId, maxDocId);
+                } catch (CollectionTerminatedException e) {
+                    // collection was terminated prematurely
+                    // continue with the following leaf
+                } catch (QueryPhase.TimeExceededException e) {
+                    searchContext.setSearchTimedOut(true);
+                    return;
                 }
             }
-
-            if (searchContext.isStreamSearch() && searchContext.getFlushMode() == FlushMode.PER_SEGMENT) {
-                logger.debug(
-                    "Stream intermediate aggregation for segment [{}], shard [{}]",
-                    ctx.ord,
-                    searchContext.shardTarget().getShardId().id()
-                );
-                List<InternalAggregation> internalAggregation = searchContext.bucketCollectorProcessor().buildAggBatch(collector);
-                if (!internalAggregation.isEmpty()) {
-                    sendBatch(internalAggregation);
+        } else {
+            // if the role query result set is sparse then we should use the SparseFixedBitSet for advancing:
+            Scorer scorer = weight.scorer(ctx);
+            if (scorer != null) {
+                try {
+                    intersectScorerAndBitSet(
+                        scorer,
+                        liveDocsBitSet,
+                        leafCollector,
+                        minDocId,
+                        maxDocId,
+                        this.cancellable.isEnabled() ? cancellable::checkCancelled : () -> {}
+                    );
+                } catch (CollectionTerminatedException e) {
+                    // collection was terminated prematurely
+                    // continue with the following leaf
+                } catch (QueryPhase.TimeExceededException e) {
+                    searchContext.setSearchTimedOut(true);
+                    return;
                 }
-            }
-
-            // Note: this is called if collection ran successfully, including the above special cases of
-            // CollectionTerminatedException and TimeExceededException, but no other exception.
-            leafCollector.finish();
-        } finally {
-            if (profiling) {
-                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
             }
         }
+
+        if (searchContext.isStreamSearch() && searchContext.getFlushMode() == FlushMode.PER_SEGMENT) {
+            logger.debug(
+                "Stream intermediate aggregation for segment [{}], shard [{}]",
+                ctx.ord,
+                searchContext.shardTarget().getShardId().id()
+            );
+            List<InternalAggregation> internalAggregation = searchContext.bucketCollectorProcessor().buildAggBatch(collector);
+            if (!internalAggregation.isEmpty()) {
+                sendBatch(internalAggregation);
+            }
+        }
+
+        // Note: this is called if collection ran successfully, including the above special cases of
+        // CollectionTerminatedException and TimeExceededException, but no other exception.
+        leafCollector.finish();
     }
 
     void sendBatch(List<InternalAggregation> batch) {

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -352,7 +352,11 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         try {
             cancellable.checkCancelled();
             if (weight instanceof ProfileWeight profileWeight) {
-                profileWeight.associateCollectorToLeaves(ctx, collector);
+                // For a whole-segment partition Lucene passes maxDocId == NO_MORE_DOCS (Integer.MAX_VALUE);
+                // resolve it to the segment's actual maxDoc so the profiled doc_range reflects the real
+                // segment size rather than the sentinel.
+                int resolvedMaxDocId = (maxDocId == DocIdSetIterator.NO_MORE_DOCS) ? ctx.reader().maxDoc() : maxDocId;
+                profileWeight.associateCollectorToLeaves(ctx, collector, minDocId, resolvedMaxDocId);
             }
             weight = wrapWeight(weight);
             // See please https://github.com/apache/lucene/pull/964

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -39,5 +39,15 @@ public abstract class ContextualProfileBreakdown extends AbstractProfileBreakdow
 
     public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {}
 
+    /**
+     * Associate a collector (slice) with a leaf it searched, along with the doc-id range
+     * {@code [minDocId, maxDocId)} it was searched over. Enables additive per-slice/per-partition
+     * profiling to report doc-ranges (including intra-segment partitions). Defaults to ignoring the
+     * range and delegating to {@link #associateCollectorToLeaves(Collector, LeafReaderContext)}.
+     */
+    public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf, int minDocId, int maxDocId) {
+        associateCollectorToLeaves(collector, leaf);
+    }
+
     public void associateCollectorsToLeaves(Map<Collector, List<LeafReaderContext>> collectorToLeaves) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
@@ -81,6 +81,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
     static final ParseField MAX_SLICE_NODE_TIME_RAW = new ParseField("max_slice_time_in_nanos");
     static final ParseField MIN_SLICE_NODE_TIME_RAW = new ParseField("min_slice_time_in_nanos");
     static final ParseField AVG_SLICE_NODE_TIME_RAW = new ParseField("avg_slice_time_in_nanos");
+    static final ParseField SLICES = new ParseField("slices");
     static final ParseField CHILDREN = new ParseField("children");
 
     private final String type;
@@ -91,6 +92,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
     private Long maxSliceNodeTime;
     private Long minSliceNodeTime;
     private Long avgSliceNodeTime;
+    private final List<SliceProfileResult> sliceProfileResults;
     private final List<ProfileResult> children;
 
     public ProfileResult(
@@ -101,7 +103,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         long nodeTime,
         List<ProfileResult> children
     ) {
-        this(type, description, breakdown, debug, nodeTime, children, null, null, null);
+        this(type, description, breakdown, debug, nodeTime, children, null, null, null, null);
     }
 
     public ProfileResult(
@@ -115,6 +117,21 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         Long minSliceNodeTime,
         Long avgSliceNodeTime
     ) {
+        this(type, description, breakdown, debug, nodeTime, children, maxSliceNodeTime, minSliceNodeTime, avgSliceNodeTime, null);
+    }
+
+    public ProfileResult(
+        String type,
+        String description,
+        Map<String, Long> breakdown,
+        Map<String, Object> debug,
+        long nodeTime,
+        List<ProfileResult> children,
+        Long maxSliceNodeTime,
+        Long minSliceNodeTime,
+        Long avgSliceNodeTime,
+        List<SliceProfileResult> sliceProfileResults
+    ) {
         this.type = type;
         this.description = description;
         this.breakdown = Objects.requireNonNull(breakdown, "required breakdown argument missing");
@@ -124,6 +141,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         this.maxSliceNodeTime = maxSliceNodeTime;
         this.minSliceNodeTime = minSliceNodeTime;
         this.avgSliceNodeTime = avgSliceNodeTime;
+        this.sliceProfileResults = sliceProfileResults == null ? List.of() : sliceProfileResults;
     }
 
     /**
@@ -145,6 +163,11 @@ public final class ProfileResult implements Writeable, ToXContentObject {
             this.minSliceNodeTime = null;
             this.avgSliceNodeTime = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            this.sliceProfileResults = in.readList(SliceProfileResult::new);
+        } else {
+            this.sliceProfileResults = List.of();
+        }
     }
 
     @Override
@@ -159,6 +182,9 @@ public final class ProfileResult implements Writeable, ToXContentObject {
             out.writeOptionalLong(maxSliceNodeTime);
             out.writeOptionalLong(minSliceNodeTime);
             out.writeOptionalLong(avgSliceNodeTime);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeList(sliceProfileResults);
         }
     }
 
@@ -212,6 +238,15 @@ public final class ProfileResult implements Writeable, ToXContentObject {
     }
 
     /**
+     * Returns the additive per-slice profiling results for this node, or an empty list if none were
+     * captured (e.g. non-concurrent execution or an older node). These are the raw per-slice detail
+     * behind the {@code max_/min_/avg_slice_time} aggregates.
+     */
+    public List<SliceProfileResult> getSliceProfileResults() {
+        return Collections.unmodifiableList(sliceProfileResults);
+    }
+
+    /**
      * Returns a list of all profiled children queries
      */
     public List<ProfileResult> getProfiledChildren() {
@@ -248,6 +283,14 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         createBreakdownView(builder);
         if (false == debug.isEmpty()) {
             builder.field(DEBUG.getPreferredName(), debug);
+        }
+
+        if (false == sliceProfileResults.isEmpty()) {
+            builder.startArray(SLICES.getPreferredName());
+            for (SliceProfileResult sliceProfileResult : sliceProfileResults) {
+                builder = sliceProfileResult.toXContent(builder, params);
+            }
+            builder.endArray();
         }
 
         if (false == children.isEmpty()) {
@@ -293,6 +336,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         parser.declareLong(optionalConstructorArg(), MAX_SLICE_NODE_TIME_RAW);
         parser.declareLong(optionalConstructorArg(), MIN_SLICE_NODE_TIME_RAW);
         parser.declareLong(optionalConstructorArg(), AVG_SLICE_NODE_TIME_RAW);
+        parser.declareObjectArray(optionalConstructorArg(), (p, c) -> SliceProfileResult.fromXContent(p), SLICES);
         PARSER = parser.build();
     }
 

--- a/server/src/main/java/org/opensearch/search/profile/SliceProfileResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/SliceProfileResult.java
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ConstructingObjectParser;
+import org.opensearch.core.xcontent.InstantiatingObjectParser;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Profiling result for a single slice (the unit of parallelism in concurrent search). Holds the
+ * timing breakdown attributed to that slice alone, the slice's node time, and the
+ * {@link PartitionInfo partitions} (segment ordinal plus doc-id range) the slice searched.
+ *
+ * <p>This mirrors the per-slice / per-partition structure of Lucene's sandbox query profiler
+ * ({@code SliceProfilerResult} / {@code AggregatedQueryLeafProfilerResult}): a whole segment appears
+ * as a partition whose doc-id range spans the segment, while under intra-segment search a segment is
+ * split into partitions each covering a doc-id sub-range (and the same segment ordinal may then
+ * appear across multiple slices).
+ *
+ * <p>Emitted additively, alongside the existing {@code max_/min_/avg_} slice aggregates on
+ * {@link ProfileResult}: the per-slice breakdowns are the raw detail from which those aggregates are
+ * derived, exposed so consumers can inspect individual slices (e.g. to spot skew).
+ *
+ * @opensearch.api
+ */
+@PublicApi(since = "3.8.0")
+public class SliceProfileResult implements Writeable, ToXContentObject {
+
+    static final ParseField SLICE_ID = new ParseField("slice_id");
+    static final ParseField SLICE_TIME = new ParseField("slice_time");
+    static final ParseField SLICE_TIME_RAW = new ParseField("slice_time_in_nanos");
+    static final ParseField PARTITIONS = new ParseField("partitions");
+    static final ParseField BREAKDOWN = new ParseField("breakdown");
+
+    /**
+     * Identity of a leaf partition searched within a slice: the segment ordinal and the doc-id range
+     * {@code [minDocId, maxDocId)}. A whole-segment partition uses {@code minDocId == 0} and
+     * {@code maxDocId == Integer.MAX_VALUE} (the "entire segment" sentinel used by Lucene's
+     * {@code LeafReaderContextPartition}).
+     */
+    @PublicApi(since = "3.8.0")
+    public static class PartitionInfo implements Writeable, ToXContentObject {
+        static final ParseField SEGMENT_ORD = new ParseField("segment_ord");
+        static final ParseField DOC_RANGE = new ParseField("doc_range");
+
+        private final int segmentOrd;
+        private final int minDocId;
+        private final int maxDocId;
+
+        public PartitionInfo(int segmentOrd, int minDocId, int maxDocId) {
+            this.segmentOrd = segmentOrd;
+            this.minDocId = minDocId;
+            this.maxDocId = maxDocId;
+        }
+
+        public PartitionInfo(StreamInput in) throws IOException {
+            this.segmentOrd = in.readVInt();
+            this.minDocId = in.readInt();
+            this.maxDocId = in.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(segmentOrd);
+            out.writeInt(minDocId);
+            out.writeInt(maxDocId);
+        }
+
+        public int getSegmentOrd() {
+            return segmentOrd;
+        }
+
+        public int getMinDocId() {
+            return minDocId;
+        }
+
+        public int getMaxDocId() {
+            return maxDocId;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(SEGMENT_ORD.getPreferredName(), segmentOrd);
+            builder.array(DOC_RANGE.getPreferredName(), minDocId, maxDocId);
+            return builder.endObject();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static final ConstructingObjectParser<PartitionInfo, Void> PARSER = new ConstructingObjectParser<>(
+            "partition_info",
+            true,
+            args -> {
+                final List<Integer> docRange = (List<Integer>) args[1];
+                return new PartitionInfo((int) args[0], docRange.get(0), docRange.get(1));
+            }
+        );
+        static {
+            PARSER.declareInt(constructorArg(), SEGMENT_ORD);
+            PARSER.declareIntArray(constructorArg(), DOC_RANGE);
+        }
+
+        public static PartitionInfo fromXContent(XContentParser p) throws IOException {
+            return PARSER.parse(p, null);
+        }
+    }
+
+    private final int sliceId;
+    private final long sliceNodeTime;
+    private final List<PartitionInfo> partitions;
+    private final Map<String, Long> breakdown;
+
+    public SliceProfileResult(int sliceId, long sliceNodeTime, List<PartitionInfo> partitions, Map<String, Long> breakdown) {
+        this.sliceId = sliceId;
+        this.sliceNodeTime = sliceNodeTime;
+        this.partitions = Collections.unmodifiableList(Objects.requireNonNull(partitions));
+        this.breakdown = Collections.unmodifiableMap(Objects.requireNonNull(breakdown));
+    }
+
+    public SliceProfileResult(StreamInput in) throws IOException {
+        this.sliceId = in.readVInt();
+        this.sliceNodeTime = in.readLong();
+        this.partitions = in.readList(PartitionInfo::new);
+        this.breakdown = in.readMap(StreamInput::readString, StreamInput::readLong);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(sliceId);
+        out.writeLong(sliceNodeTime);
+        out.writeList(partitions);
+        out.writeMap(breakdown, StreamOutput::writeString, StreamOutput::writeLong);
+    }
+
+    /** Stable identifier of this slice within the query node. */
+    public int getSliceId() {
+        return sliceId;
+    }
+
+    /** Wall-clock span of this slice for this query node, in nanoseconds. */
+    public long getSliceNodeTime() {
+        return sliceNodeTime;
+    }
+
+    /** The partitions (segment ordinal + doc-id range) searched within this slice. */
+    public List<PartitionInfo> getPartitions() {
+        return partitions;
+    }
+
+    /** The timing breakdown attributed to this slice. */
+    public Map<String, Long> getBreakdown() {
+        return breakdown;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(SLICE_ID.getPreferredName(), sliceId);
+        if (builder.humanReadable()) {
+            builder.field(SLICE_TIME.getPreferredName(), new TimeValue(sliceNodeTime, TimeUnit.NANOSECONDS).toString());
+        }
+        builder.field(SLICE_TIME_RAW.getPreferredName(), sliceNodeTime);
+        builder.startArray(PARTITIONS.getPreferredName());
+        for (PartitionInfo partition : partitions) {
+            partition.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.field(BREAKDOWN.getPreferredName(), breakdown);
+        return builder.endObject();
+    }
+
+    private static final InstantiatingObjectParser<SliceProfileResult, Void> PARSER;
+    static {
+        InstantiatingObjectParser.Builder<SliceProfileResult, Void> parser = InstantiatingObjectParser.builder(
+            "slice_profile_result",
+            true,
+            SliceProfileResult.class
+        );
+        parser.declareInt(constructorArg(), SLICE_ID);
+        parser.declareLong(constructorArg(), SLICE_TIME_RAW);
+        parser.declareObjectArray(constructorArg(), (p, c) -> PartitionInfo.fromXContent(p), PARTITIONS);
+        parser.declareObject(constructorArg(), (p, c) -> {
+            final Map<String, Object> raw = p.map();
+            final Map<String, Long> breakdown = new HashMap<>(raw.size());
+            for (Map.Entry<String, Object> entry : raw.entrySet()) {
+                breakdown.put(entry.getKey(), ((Number) entry.getValue()).longValue());
+            }
+            return breakdown;
+        }, BREAKDOWN);
+        PARSER = parser.build();
+    }
+
+    public static SliceProfileResult fromXContent(XContentParser p) throws IOException {
+        return PARSER.parse(p, null);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -50,8 +50,20 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     private long minSliceNodeTime = Long.MAX_VALUE;
     private long avgSliceNodeTime = 0L;
 
-    // keep track of all breakdown timings per segment. package-private for testing
+    // keep track of all breakdown timings per (slice, segment). package-private for testing.
+    // Under intra-segment search a single segment (LeafReaderContext) is split into partitions that
+    // run on different slices/threads. Keying only by the segment would make those partitions share
+    // one breakdown — and therefore one non-thread-safe Timer — so concurrent start()/stop() calls
+    // would race and corrupt the timing. Qualifying the key by the current slice (collector) gives
+    // each partition of a split segment its own breakdown/Timer. See #sliceLeafContextKey.
     private final Map<Object, AbstractProfileBreakdown> contexts = new ConcurrentHashMap<>();
+
+    // The slice (collector) currently being searched by the executing thread, set at the searchLeaf
+    // seam (see ContextIndexSearcher#searchLeaf) where the slice identity is in scope. Used to
+    // qualify per-leaf breakdown keys. Static so it is visible to every query node's breakdown in the
+    // tree: child query breakdowns never observe searchLeaf directly, but their context() runs on the
+    // same thread within the parent's searchLeaf, so they read the same value.
+    private static final ThreadLocal<Collector> currentSliceCollector = new ThreadLocal<>();
 
     // represents slice to leaves mapping as for each slice a unique collector instance is created
     private final Map<Collector, List<LeafReaderContext>> sliceCollectorsToLeaves = new ConcurrentHashMap<>();
@@ -84,14 +96,47 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
     @Override
     public AbstractProfileBreakdown context(Object context) {
+        // Qualify the per-leaf breakdown with the slice currently being searched, so that intra-segment
+        // partitions of the same segment (which run on different slices/threads) get separate
+        // breakdowns instead of racing on one shared, non-thread-safe Timer.
+        final Object key = contextKey(currentSliceCollector.get(), context);
         // See please https://bugs.openjdk.java.net/browse/JDK-8161372
-        final AbstractProfileBreakdown profile = contexts.get(context);
+        final AbstractProfileBreakdown profile = contexts.get(key);
 
         if (profile != null) {
             return profile;
         }
 
-        return contexts.computeIfAbsent(context, ctx -> new QueryProfileBreakdown(metricSuppliers));
+        return contexts.computeIfAbsent(key, ctx -> new QueryProfileBreakdown(metricSuppliers));
+    }
+
+    /**
+     * Builds the key under which a leaf's breakdown is stored. When a slice (collector) is in scope
+     * (the normal concurrent-search case), the key is qualified by it so that partitions of one
+     * segment searched by different slices do not collide. When no slice is in scope (e.g. the
+     * rewritten-query-per-leaf path, or unit tests exercising a single leaf), the leaf is used
+     * directly, preserving the original behavior.
+     */
+    static Object contextKey(Collector sliceCollector, Object leaf) {
+        return (sliceCollector == null) ? leaf : new SliceLeafKey(sliceCollector, leaf);
+    }
+
+    /** Composite key pairing the searching slice (collector) with the segment (leaf) it searched. */
+    private record SliceLeafKey(Collector sliceCollector, Object leaf) {
+    }
+
+    /**
+     * Records the slice (collector) the current thread is about to search, so that leaf breakdowns
+     * created during this partition's search are keyed to it. Called at the searchLeaf seam, paired
+     * with {@link #clearCurrentSliceCollector()} in a finally block.
+     */
+    public static void setCurrentSliceCollector(Collector sliceCollector) {
+        currentSliceCollector.set(sliceCollector);
+    }
+
+    /** Clears the current thread's slice collector once its searchLeaf call completes. */
+    public static void clearCurrentSliceCollector() {
+        currentSliceCollector.remove();
     }
 
     @Override
@@ -206,7 +251,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                 final String timingTypeSliceEndTimeKey = timingType + SLICE_END_TIME_SUFFIX;
 
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
-                    if (!contexts.containsKey(sliceLeaf)) {
+                    // Breakdowns are keyed by (slice, leaf); reconstruct the same key used at search time.
+                    final Object sliceLeafKey = contextKey(sliceCollector, sliceLeaf);
+                    if (!contexts.containsKey(sliceLeafKey)) {
                         // In case like early termination, the sliceCollectorToLeave association will be added for a
                         // leaf, but the leaf level breakdown will not be created in the contexts map.
                         // This is because before updating the contexts map, the query hits earlyTerminationException.
@@ -219,7 +266,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                         // for second clause weight.
                         continue;
                     }
-                    final Map<String, Long> currentSliceLeafBreakdownMap = contexts.get(sliceLeaf).toBreakdownMap();
+                    final Map<String, Long> currentSliceLeafBreakdownMap = contexts.get(sliceLeafKey).toBreakdownMap();
                     // get the count for current leaf timing type
                     final long sliceLeafTimingTypeCount = currentSliceLeafBreakdownMap.get(timingTypeCountKey);
                     currentSliceBreakdown.compute(
@@ -279,10 +326,11 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
             for (String metric : nonTimingMetrics) {
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
-                    if (!contexts.containsKey(sliceLeaf)) {
+                    final Object sliceLeafKey = contextKey(sliceCollector, sliceLeaf);
+                    if (!contexts.containsKey(sliceLeafKey)) {
                         continue;
                     }
-                    final Map<String, Long> currentSliceLeafBreakdownMap = contexts.get(sliceLeaf).toBreakdownMap();
+                    final Map<String, Long> currentSliceLeafBreakdownMap = contexts.get(sliceLeafKey).toBreakdownMap();
                     final long sliceLeafMetricValue = currentSliceLeafBreakdownMap.get(metric);
                     currentSliceBreakdown.compute(
                         metric,
@@ -324,10 +372,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
             for (LeafReaderContext sliceLeaf : slice.getValue()) {
                 // Fall back to the whole segment (0 .. segment maxDoc) when no explicit doc-range was
                 // recorded, using the real segment size rather than a sentinel so doc_range is meaningful.
-                final int[] docRange = leafRangesForSlice.getOrDefault(
-                    sliceLeaf,
-                    new int[] { 0, sliceLeaf.reader().maxDoc() }
-                );
+                final int[] docRange = leafRangesForSlice.getOrDefault(sliceLeaf, new int[] { 0, sliceLeaf.reader().maxDoc() });
                 slicePartitions.add(new SliceProfileResult.PartitionInfo(sliceLeaf.ord, docRange[0], docRange[1]));
             }
             sliceProfileResults.add(
@@ -335,12 +380,31 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                     sliceProfileResults.size(),
                     currentSliceNodeTime,
                     slicePartitions,
-                    new TreeMap<>(currentSliceBreakdown)
+                    cleanSliceBreakdown(currentSliceBreakdown)
                 )
             );
         }
         avgSliceNodeTime = totalSliceNodeTime / sliceCollectorsToLeaves.size();
         return sliceLevelBreakdowns;
+    }
+
+    /**
+     * Returns a copy of a slice breakdown containing only user-facing timing and count entries. The
+     * {@code *_slice_start_time}/{@code *_slice_end_time} keys are raw {@code System.nanoTime()}
+     * timestamps used internally to derive per-timing-type durations; the query-level breakdown
+     * strips them before output, so the additive per-slice breakdown does the same to stay consistent
+     * and avoid surfacing confusing intermediate timestamps.
+     */
+    private static Map<String, Long> cleanSliceBreakdown(Map<String, Long> sliceBreakdown) {
+        final Map<String, Long> cleaned = new TreeMap<>();
+        for (Map.Entry<String, Long> entry : sliceBreakdown.entrySet()) {
+            final String key = entry.getKey();
+            if (key.endsWith(SLICE_START_TIME_SUFFIX) || key.endsWith(SLICE_END_TIME_SUFFIX)) {
+                continue;
+            }
+            cleaned.put(key, entry.getValue());
+        }
+        return cleaned;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -62,10 +62,10 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     // represents slice to leaves mapping as for each slice a unique collector instance is created
     private final Map<Collector, List<LeafReaderContext>> sliceCollectorsToLeaves = new ConcurrentHashMap<>();
 
-    // The thread that searched each slice (collector), captured at associateCollectorToLeaves time
-    // (i.e. during that slice's searchLeaf, on the slice's thread). Lets the reduce reconstruct the
-    // (thread, leaf) breakdown key for each slice. One thread per slice, so this is 1:1.
-    private final Map<Collector, Thread> sliceCollectorThreads = new ConcurrentHashMap<>();
+    // The id of the thread that searched each slice (collector), captured at associateCollectorToLeaves
+    // time (i.e. during that slice's searchLeaf, on the slice's thread). Lets the reduce reconstruct
+    // the (threadId, leaf) breakdown key for each slice. One thread per slice, so this is 1:1.
+    private final Map<Collector, Long> sliceCollectorThreads = new ConcurrentHashMap<>();
 
     // Additive per-slice breakdowns captured during the eager reduce. These are the raw per-slice
     // detail from which max_/min_/avg_ are derived; retained (instead of discarded) so consumers can
@@ -103,7 +103,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         // runs one thread per slice, so keying by thread separates exactly the concurrent partitions
         // that would otherwise collide. The collector→thread mapping recorded in
         // associateCollectorToLeaves lets the reduce reconstruct this key.
-        final Object key = contextKey(Thread.currentThread(), context);
+        final Object key = contextKey(Thread.currentThread().threadId(), context);
         // See please https://bugs.openjdk.java.net/browse/JDK-8161372
         final AbstractProfileBreakdown profile = contexts.get(key);
 
@@ -115,16 +115,18 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     }
 
     /**
-     * Builds the key under which a leaf's breakdown is stored: the searching thread paired with the
-     * segment (leaf). When no thread is known (e.g. a reduce lookup for a collector whose thread was
-     * never recorded), the leaf is used directly, preserving the original single-key behavior.
+     * Builds the key under which a leaf's breakdown is stored: the searching thread's id paired with
+     * the segment (leaf). When no thread id is known (e.g. a reduce lookup for a collector whose
+     * thread was never recorded), the leaf is used directly, preserving the original single-key
+     * behavior. Keying by thread id mirrors how {@link ConcurrentQueryProfiler} already separates
+     * concurrent work.
      */
-    static Object contextKey(Thread thread, Object leaf) {
-        return (thread == null) ? leaf : new ThreadLeafKey(thread, leaf);
+    static Object contextKey(Long threadId, Object leaf) {
+        return (threadId == null) ? leaf : new ThreadLeafKey(threadId, leaf);
     }
 
-    /** Composite key pairing the searching thread with the segment (leaf) it searched. */
-    private record ThreadLeafKey(Thread thread, Object leaf) {
+    /** Composite key pairing the searching thread's id with the segment (leaf) it searched. */
+    private record ThreadLeafKey(long threadId, Object leaf) {
     }
 
     @Override
@@ -222,9 +224,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         final List<CapturedSlice> capturedSlices = new ArrayList<>(sliceCollectorsToLeaves.size());
         for (Map.Entry<Collector, List<LeafReaderContext>> slice : sliceCollectorsToLeaves.entrySet()) {
             final Collector sliceCollector = slice.getKey();
-            // The thread that searched this slice (recorded in associateCollectorToLeaves); used to
-            // reconstruct the (thread, leaf) breakdown key that context() stored under.
-            final Thread sliceThread = sliceCollectorThreads.get(sliceCollector);
+            // The id of the thread that searched this slice (recorded in associateCollectorToLeaves);
+            // used to reconstruct the (threadId, leaf) breakdown key that context() stored under.
+            final Long sliceThreadId = sliceCollectorThreads.get(sliceCollector);
             // initialize each slice level breakdown
             final Map<String, Long> currentSliceBreakdown = sliceLevelBreakdowns.computeIfAbsent(sliceCollector, k -> new HashMap<>());
             // max slice end time across all timing types
@@ -247,7 +249,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
                     // Breakdowns are keyed by (thread, leaf); reconstruct the same key using the thread
                     // that searched this slice (recorded in associateCollectorToLeaves).
-                    final Object sliceLeafKey = contextKey(sliceThread, sliceLeaf);
+                    final Object sliceLeafKey = contextKey(sliceThreadId, sliceLeaf);
                     if (!contexts.containsKey(sliceLeafKey)) {
                         // In case like early termination, the sliceCollectorToLeave association will be added for a
                         // leaf, but the leaf level breakdown will not be created in the contexts map.
@@ -321,7 +323,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
             for (String metric : nonTimingMetrics) {
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
-                    final Object sliceLeafKey = contextKey(sliceThread, sliceLeaf);
+                    final Object sliceLeafKey = contextKey(sliceThreadId, sliceLeaf);
                     if (!contexts.containsKey(sliceLeafKey)) {
                         continue;
                     }
@@ -591,7 +593,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         sliceCollectorsToLeaves.computeIfAbsent(collector, k -> new ArrayList<>()).add(leaf);
         // Record the thread searching this slice so the reduce can reconstruct the (thread, leaf)
         // breakdown key. Called on the slice's own search thread, before that slice scores its leaves.
-        sliceCollectorThreads.putIfAbsent(collector, Thread.currentThread());
+        sliceCollectorThreads.putIfAbsent(collector, Thread.currentThread().threadId());
     }
 
     @Override
@@ -634,12 +636,12 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
      * receive the searchLeaf association directly); without it a child's reduce cannot reconstruct the
      * (thread, leaf) key its breakdowns were stored under. Mirrors {@link #getSliceCollectorsToLeaves()}.
      */
-    Map<Collector, Thread> getSliceCollectorThreads() {
+    Map<Collector, Long> getSliceCollectorThreads() {
         return Collections.unmodifiableMap(sliceCollectorThreads);
     }
 
-    /** Copies parent collector→thread associations into this (child) breakdown. */
-    void associateSliceCollectorThreads(Map<Collector, Thread> collectorThreads) {
+    /** Copies parent collector→threadId associations into this (child) breakdown. */
+    void associateSliceCollectorThreads(Map<Collector, Long> collectorThreads) {
         sliceCollectorThreads.putAll(collectorThreads);
     }
 

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -20,6 +20,7 @@ import org.opensearch.search.profile.Timer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -50,23 +51,21 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     private long minSliceNodeTime = Long.MAX_VALUE;
     private long avgSliceNodeTime = 0L;
 
-    // keep track of all breakdown timings per (slice, segment). package-private for testing.
+    // keep track of all breakdown timings per (thread, segment). package-private for testing.
     // Under intra-segment search a single segment (LeafReaderContext) is split into partitions that
-    // run on different slices/threads. Keying only by the segment would make those partitions share
-    // one breakdown — and therefore one non-thread-safe Timer — so concurrent start()/stop() calls
-    // would race and corrupt the timing. Qualifying the key by the current slice (collector) gives
-    // each partition of a split segment its own breakdown/Timer. See #sliceLeafContextKey.
+    // run on different threads. Keying only by the segment would make those partitions share one
+    // breakdown — and therefore one non-thread-safe Timer — so concurrent start()/stop() calls would
+    // race and corrupt the timing. Qualifying the key by the searching thread gives each partition of
+    // a split segment its own breakdown/Timer. See #contextKey.
     private final Map<Object, AbstractProfileBreakdown> contexts = new ConcurrentHashMap<>();
-
-    // The slice (collector) currently being searched by the executing thread, set at the searchLeaf
-    // seam (see ContextIndexSearcher#searchLeaf) where the slice identity is in scope. Used to
-    // qualify per-leaf breakdown keys. Static so it is visible to every query node's breakdown in the
-    // tree: child query breakdowns never observe searchLeaf directly, but their context() runs on the
-    // same thread within the parent's searchLeaf, so they read the same value.
-    private static final ThreadLocal<Collector> currentSliceCollector = new ThreadLocal<>();
 
     // represents slice to leaves mapping as for each slice a unique collector instance is created
     private final Map<Collector, List<LeafReaderContext>> sliceCollectorsToLeaves = new ConcurrentHashMap<>();
+
+    // The thread that searched each slice (collector), captured at associateCollectorToLeaves time
+    // (i.e. during that slice's searchLeaf, on the slice's thread). Lets the reduce reconstruct the
+    // (thread, leaf) breakdown key for each slice. One thread per slice, so this is 1:1.
+    private final Map<Collector, Thread> sliceCollectorThreads = new ConcurrentHashMap<>();
 
     // Additive per-slice breakdowns captured during the eager reduce. These are the raw per-slice
     // detail from which max_/min_/avg_ are derived; retained (instead of discarded) so consumers can
@@ -96,10 +95,15 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
     @Override
     public AbstractProfileBreakdown context(Object context) {
-        // Qualify the per-leaf breakdown with the slice currently being searched, so that intra-segment
-        // partitions of the same segment (which run on different slices/threads) get separate
-        // breakdowns instead of racing on one shared, non-thread-safe Timer.
-        final Object key = contextKey(currentSliceCollector.get(), context);
+        // Qualify the per-leaf breakdown with the thread doing the search, so that intra-segment
+        // partitions of the same segment (which run on different threads) get separate breakdowns
+        // instead of racing on one shared, non-thread-safe Timer. The thread is the right
+        // discriminator here: it is available at scoring time for both parent and child query nodes
+        // (child breakdowns learn their collector only later, during tree assembly), and OpenSearch
+        // runs one thread per slice, so keying by thread separates exactly the concurrent partitions
+        // that would otherwise collide. The collector→thread mapping recorded in
+        // associateCollectorToLeaves lets the reduce reconstruct this key.
+        final Object key = contextKey(Thread.currentThread(), context);
         // See please https://bugs.openjdk.java.net/browse/JDK-8161372
         final AbstractProfileBreakdown profile = contexts.get(key);
 
@@ -111,32 +115,16 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     }
 
     /**
-     * Builds the key under which a leaf's breakdown is stored. When a slice (collector) is in scope
-     * (the normal concurrent-search case), the key is qualified by it so that partitions of one
-     * segment searched by different slices do not collide. When no slice is in scope (e.g. the
-     * rewritten-query-per-leaf path, or unit tests exercising a single leaf), the leaf is used
-     * directly, preserving the original behavior.
+     * Builds the key under which a leaf's breakdown is stored: the searching thread paired with the
+     * segment (leaf). When no thread is known (e.g. a reduce lookup for a collector whose thread was
+     * never recorded), the leaf is used directly, preserving the original single-key behavior.
      */
-    static Object contextKey(Collector sliceCollector, Object leaf) {
-        return (sliceCollector == null) ? leaf : new SliceLeafKey(sliceCollector, leaf);
+    static Object contextKey(Thread thread, Object leaf) {
+        return (thread == null) ? leaf : new ThreadLeafKey(thread, leaf);
     }
 
-    /** Composite key pairing the searching slice (collector) with the segment (leaf) it searched. */
-    private record SliceLeafKey(Collector sliceCollector, Object leaf) {
-    }
-
-    /**
-     * Records the slice (collector) the current thread is about to search, so that leaf breakdowns
-     * created during this partition's search are keyed to it. Called at the searchLeaf seam, paired
-     * with {@link #clearCurrentSliceCollector()} in a finally block.
-     */
-    public static void setCurrentSliceCollector(Collector sliceCollector) {
-        currentSliceCollector.set(sliceCollector);
-    }
-
-    /** Clears the current thread's slice collector once its searchLeaf call completes. */
-    public static void clearCurrentSliceCollector() {
-        currentSliceCollector.remove();
+    /** Composite key pairing the searching thread with the segment (leaf) it searched. */
+    private record ThreadLeafKey(Thread thread, Object leaf) {
     }
 
     @Override
@@ -229,8 +217,14 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         // Rebuild the per-slice results from scratch; toBreakdownMap() (hence this method) may be
         // invoked more than once for the same breakdown, and we must not accumulate duplicates.
         sliceProfileResults.clear();
+        // Collected during the (non-deterministically ordered) iteration below, then sorted so that
+        // slice_id can be assigned in a stable order.
+        final List<CapturedSlice> capturedSlices = new ArrayList<>(sliceCollectorsToLeaves.size());
         for (Map.Entry<Collector, List<LeafReaderContext>> slice : sliceCollectorsToLeaves.entrySet()) {
             final Collector sliceCollector = slice.getKey();
+            // The thread that searched this slice (recorded in associateCollectorToLeaves); used to
+            // reconstruct the (thread, leaf) breakdown key that context() stored under.
+            final Thread sliceThread = sliceCollectorThreads.get(sliceCollector);
             // initialize each slice level breakdown
             final Map<String, Long> currentSliceBreakdown = sliceLevelBreakdowns.computeIfAbsent(sliceCollector, k -> new HashMap<>());
             // max slice end time across all timing types
@@ -251,8 +245,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                 final String timingTypeSliceEndTimeKey = timingType + SLICE_END_TIME_SUFFIX;
 
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
-                    // Breakdowns are keyed by (slice, leaf); reconstruct the same key used at search time.
-                    final Object sliceLeafKey = contextKey(sliceCollector, sliceLeaf);
+                    // Breakdowns are keyed by (thread, leaf); reconstruct the same key using the thread
+                    // that searched this slice (recorded in associateCollectorToLeaves).
+                    final Object sliceLeafKey = contextKey(sliceThread, sliceLeaf);
                     if (!contexts.containsKey(sliceLeafKey)) {
                         // In case like early termination, the sliceCollectorToLeave association will be added for a
                         // leaf, but the leaf level breakdown will not be created in the contexts map.
@@ -326,7 +321,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
             for (String metric : nonTimingMetrics) {
                 for (LeafReaderContext sliceLeaf : slice.getValue()) {
-                    final Object sliceLeafKey = contextKey(sliceCollector, sliceLeaf);
+                    final Object sliceLeafKey = contextKey(sliceThread, sliceLeaf);
                     if (!contexts.containsKey(sliceLeafKey)) {
                         continue;
                     }
@@ -375,17 +370,49 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
                 final int[] docRange = leafRangesForSlice.getOrDefault(sliceLeaf, new int[] { 0, sliceLeaf.reader().maxDoc() });
                 slicePartitions.add(new SliceProfileResult.PartitionInfo(sliceLeaf.ord, docRange[0], docRange[1]));
             }
-            sliceProfileResults.add(
-                new SliceProfileResult(
-                    sliceProfileResults.size(),
-                    currentSliceNodeTime,
-                    slicePartitions,
-                    cleanSliceBreakdown(currentSliceBreakdown)
-                )
-            );
+            capturedSlices.add(new CapturedSlice(currentSliceNodeTime, slicePartitions, cleanSliceBreakdown(currentSliceBreakdown)));
         }
-        avgSliceNodeTime = totalSliceNodeTime / sliceCollectorsToLeaves.size();
+        // sliceCollectorsToLeaves is a ConcurrentHashMap, so the iteration order above is not
+        // deterministic. Sort the captured slices by their partitions (segment ordinal, then doc-id
+        // range) so that slice_id is a stable identifier for a given slice across invocations of this
+        // method (toBreakdownMap may call it more than once), rather than depending on map order.
+        capturedSlices.sort(CapturedSlice.BY_PARTITIONS);
+        for (int sliceId = 0; sliceId < capturedSlices.size(); sliceId++) {
+            final CapturedSlice captured = capturedSlices.get(sliceId);
+            sliceProfileResults.add(new SliceProfileResult(sliceId, captured.nodeTime, captured.partitions, captured.breakdown));
+        }
+        // Guard the average against an empty map. In the normal flow toBreakdownMap() returns early
+        // when sliceCollectorsToLeaves is empty, so this is defensive for direct callers/tests.
+        avgSliceNodeTime = sliceCollectorsToLeaves.isEmpty() ? 0L : totalSliceNodeTime / sliceCollectorsToLeaves.size();
         return sliceLevelBreakdowns;
+    }
+
+    /**
+     * A slice's captured profiling data, before a stable {@code slice_id} is assigned. Sorting these
+     * by their partitions makes the assigned id independent of {@link #sliceCollectorsToLeaves}
+     * iteration order.
+     */
+    private record CapturedSlice(long nodeTime, List<SliceProfileResult.PartitionInfo> partitions, Map<String, Long> breakdown) {
+        static final Comparator<CapturedSlice> BY_PARTITIONS = (a, b) -> {
+            final int n = Math.min(a.partitions.size(), b.partitions.size());
+            for (int i = 0; i < n; i++) {
+                final SliceProfileResult.PartitionInfo pa = a.partitions.get(i);
+                final SliceProfileResult.PartitionInfo pb = b.partitions.get(i);
+                int cmp = Integer.compare(pa.getSegmentOrd(), pb.getSegmentOrd());
+                if (cmp != 0) {
+                    return cmp;
+                }
+                cmp = Integer.compare(pa.getMinDocId(), pb.getMinDocId());
+                if (cmp != 0) {
+                    return cmp;
+                }
+                cmp = Integer.compare(pa.getMaxDocId(), pb.getMaxDocId());
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return Integer.compare(a.partitions.size(), b.partitions.size());
+        };
     }
 
     /**
@@ -562,6 +589,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {
         // Each slice (or collector) is executed by single thread. So the list for a key will always be updated by a single thread only
         sliceCollectorsToLeaves.computeIfAbsent(collector, k -> new ArrayList<>()).add(leaf);
+        // Record the thread searching this slice so the reduce can reconstruct the (thread, leaf)
+        // breakdown key. Called on the slice's own search thread, before that slice scores its leaves.
+        sliceCollectorThreads.putIfAbsent(collector, Thread.currentThread());
     }
 
     @Override
@@ -596,6 +626,21 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     /** Copies parent doc-range associations into this (child) breakdown. */
     void associateSliceLeafDocRanges(Map<Collector, Map<LeafReaderContext, int[]>> docRanges) {
         sliceLeafDocRanges.putAll(docRanges);
+    }
+
+    /**
+     * The collector→thread mapping recorded at associateCollectorToLeaves time. Exposed so the tree
+     * can propagate it to child breakdowns (whose weights are not exposed by Lucene and so never
+     * receive the searchLeaf association directly); without it a child's reduce cannot reconstruct the
+     * (thread, leaf) key its breakdowns were stored under. Mirrors {@link #getSliceCollectorsToLeaves()}.
+     */
+    Map<Collector, Thread> getSliceCollectorThreads() {
+        return Collections.unmodifiableMap(sliceCollectorThreads);
+    }
+
+    /** Copies parent collector→thread associations into this (child) breakdown. */
+    void associateSliceCollectorThreads(Map<Collector, Thread> collectorThreads) {
+        sliceCollectorThreads.putAll(collectorThreads);
     }
 
     // used by tests

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -14,6 +14,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.search.profile.AbstractProfileBreakdown;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileMetric;
+import org.opensearch.search.profile.SliceProfileResult;
 import org.opensearch.search.profile.Timer;
 
 import java.util.ArrayList;
@@ -54,6 +55,21 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
     // represents slice to leaves mapping as for each slice a unique collector instance is created
     private final Map<Collector, List<LeafReaderContext>> sliceCollectorsToLeaves = new ConcurrentHashMap<>();
+
+    // Additive per-slice breakdowns captured during the eager reduce. These are the raw per-slice
+    // detail from which max_/min_/avg_ are derived; retained (instead of discarded) so consumers can
+    // inspect individual slices. Populated in buildSliceLevelBreakdown; does not affect the existing
+    // aggregates.
+    private final List<SliceProfileResult> sliceProfileResults = new ArrayList<>();
+
+    // Additive side map recording the doc-id range [minDocId, maxDocId) each leaf was searched with,
+    // captured at the searchLeaf seam (where the bounds are in scope). Used only to attach doc-ranges
+    // to the per-slice partitions; the existing sliceCollectorsToLeaves reduce is unaffected.
+    // Keyed by (collector, leaf) so that when a single segment is split across multiple slices
+    // (intra-segment search), each slice's partition of that leaf records its OWN doc-id range.
+    // Whole-segment partitions record [0, segment maxDoc) (resolved from the NO_MORE_DOCS sentinel at
+    // the searchLeaf seam) so the reported doc_range reflects the real segment size.
+    private final Map<Collector, Map<LeafReaderContext, int[]>> sliceLeafDocRanges = new ConcurrentHashMap<>();
 
     private final Collection<Supplier<ProfileMetric>> metricSuppliers;
     private final Set<String> timingMetrics;
@@ -165,6 +181,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     Map<Collector, Map<String, Long>> buildSliceLevelBreakdown() {
         final Map<Collector, Map<String, Long>> sliceLevelBreakdowns = new HashMap<>();
         long totalSliceNodeTime = 0L;
+        // Rebuild the per-slice results from scratch; toBreakdownMap() (hence this method) may be
+        // invoked more than once for the same breakdown, and we must not accumulate duplicates.
+        sliceProfileResults.clear();
         for (Map.Entry<Collector, List<LeafReaderContext>> slice : sliceCollectorsToLeaves.entrySet()) {
             final Collector sliceCollector = slice.getKey();
             // initialize each slice level breakdown
@@ -293,6 +312,32 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
             minSliceNodeTime = Math.min(minSliceNodeTime, currentSliceNodeTime);
             // total time at query level
             totalSliceNodeTime += currentSliceNodeTime;
+
+            // Additively capture this slice's raw breakdown (the detail behind max_/min_/avg_) along
+            // with the partitions (segment ordinal + doc-id range) it searched, so consumers can
+            // inspect individual slices/partitions — mirroring Lucene's per-slice/per-partition shape.
+            final Map<LeafReaderContext, int[]> leafRangesForSlice = sliceLeafDocRanges.getOrDefault(
+                sliceCollector,
+                Collections.emptyMap()
+            );
+            final List<SliceProfileResult.PartitionInfo> slicePartitions = new ArrayList<>(slice.getValue().size());
+            for (LeafReaderContext sliceLeaf : slice.getValue()) {
+                // Fall back to the whole segment (0 .. segment maxDoc) when no explicit doc-range was
+                // recorded, using the real segment size rather than a sentinel so doc_range is meaningful.
+                final int[] docRange = leafRangesForSlice.getOrDefault(
+                    sliceLeaf,
+                    new int[] { 0, sliceLeaf.reader().maxDoc() }
+                );
+                slicePartitions.add(new SliceProfileResult.PartitionInfo(sliceLeaf.ord, docRange[0], docRange[1]));
+            }
+            sliceProfileResults.add(
+                new SliceProfileResult(
+                    sliceProfileResults.size(),
+                    currentSliceNodeTime,
+                    slicePartitions,
+                    new TreeMap<>(currentSliceBreakdown)
+                )
+            );
         }
         avgSliceNodeTime = totalSliceNodeTime / sliceCollectorsToLeaves.size();
         return sliceLevelBreakdowns;
@@ -456,6 +501,16 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     }
 
     @Override
+    public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf, int minDocId, int maxDocId) {
+        associateCollectorToLeaves(collector, leaf);
+        // Additively record the doc-id range this (collector=slice, leaf) was searched with, from the
+        // searchLeaf seam where the bounds are in scope. Keyed by (collector, leaf) so that under
+        // intra-segment search — where one segment is split across multiple slices — each slice's
+        // partition of that leaf keeps its own range. Does not affect the existing reduce.
+        sliceLeafDocRanges.computeIfAbsent(collector, k -> new HashMap<>()).put(leaf, new int[] { minDocId, maxDocId });
+    }
+
+    @Override
     public void associateCollectorsToLeaves(Map<Collector, List<LeafReaderContext>> collectorsToLeaves) {
         sliceCollectorsToLeaves.putAll(collectorsToLeaves);
     }
@@ -464,9 +519,33 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         return Collections.unmodifiableMap(sliceCollectorsToLeaves);
     }
 
+    /**
+     * The per-(collector, leaf) doc-id ranges recorded at the searchLeaf seam. Exposed so the tree
+     * can propagate them to child breakdowns (whose weights are not exposed by Lucene and therefore
+     * never receive the searchLeaf association directly), mirroring how {@link
+     * #getSliceCollectorsToLeaves()} is propagated.
+     */
+    Map<Collector, Map<LeafReaderContext, int[]>> getSliceLeafDocRanges() {
+        return Collections.unmodifiableMap(sliceLeafDocRanges);
+    }
+
+    /** Copies parent doc-range associations into this (child) breakdown. */
+    void associateSliceLeafDocRanges(Map<Collector, Map<LeafReaderContext, int[]>> docRanges) {
+        sliceLeafDocRanges.putAll(docRanges);
+    }
+
     // used by tests
     Map<Object, AbstractProfileBreakdown> getContexts() {
         return contexts;
+    }
+
+    /**
+     * Returns the additive per-slice breakdowns captured during {@link #buildSliceLevelBreakdown()}.
+     * Empty until {@link #toBreakdownMap()} has run. These are the raw per-slice detail behind the
+     * {@code max_/min_/avg_} aggregates.
+     */
+    public List<SliceProfileResult> getSliceProfileResults() {
+        return Collections.unmodifiableList(sliceProfileResults);
     }
 
     long getMaxSliceNodeTime() {

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -49,16 +49,20 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
     ) {
         assert breakdown instanceof ConcurrentQueryProfileBreakdown;
         final ConcurrentQueryProfileBreakdown concurrentBreakdown = (ConcurrentQueryProfileBreakdown) breakdown;
+        // toBreakdownMap() populates the per-slice results (via buildSliceLevelBreakdown), so it must
+        // run before getSliceProfileResults() is read.
+        final Map<String, Long> breakdownMap = concurrentBreakdown.toBreakdownMap();
         return new ProfileResult(
             type,
             description,
-            concurrentBreakdown.toBreakdownMap(),
+            breakdownMap,
             concurrentBreakdown.toDebugMap(),
             concurrentBreakdown.toNodeTime(),
             childrenProfileResults,
             concurrentBreakdown.getMaxSliceNodeTime(),
             concurrentBreakdown.getMinSliceNodeTime(),
-            concurrentBreakdown.getAvgSliceNodeTime()
+            concurrentBreakdown.getAvgSliceNodeTime(),
+            concurrentBreakdown.getSliceProfileResults()
         );
     }
 
@@ -76,10 +80,11 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
         for (Integer root : roots) {
             final ContextualProfileBreakdown parentBreakdown = breakdowns.get(root);
             assert parentBreakdown instanceof ConcurrentQueryProfileBreakdown;
-            final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
-                .getSliceCollectorsToLeaves();
-            // update all the children with the parent collectorToLeaves association
-            updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves);
+            final ConcurrentQueryProfileBreakdown concurrentParent = (ConcurrentQueryProfileBreakdown) parentBreakdown;
+            final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = concurrentParent.getSliceCollectorsToLeaves();
+            // update all the children with the parent collectorToLeaves association (and the doc-id
+            // ranges, so child nodes report the same per-partition doc_range as the parent)
+            updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves, concurrentParent.getSliceLeafDocRanges());
         }
         // once the collector to leaves mapping is updated, get the result
         return super.getTree();
@@ -89,14 +94,22 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
      * Updates the children with collector to leaves mapping as recorded by parent breakdown
      * @param parentToken parent token number in the tree
      * @param collectorToLeaves collector to leaves mapping recorded by parent
+     * @param sliceLeafDocRanges per-(collector, leaf) doc-id ranges recorded by parent
      */
-    private void updateCollectorToLeavesForChildBreakdowns(Integer parentToken, Map<Collector, List<LeafReaderContext>> collectorToLeaves) {
+    private void updateCollectorToLeavesForChildBreakdowns(
+        Integer parentToken,
+        Map<Collector, List<LeafReaderContext>> collectorToLeaves,
+        Map<Collector, Map<LeafReaderContext, int[]>> sliceLeafDocRanges
+    ) {
         final List<Integer> children = tree.get(parentToken);
         if (children != null) {
             for (Integer currentChild : children) {
                 final ContextualProfileBreakdown currentChildBreakdown = breakdowns.get(currentChild);
                 currentChildBreakdown.associateCollectorsToLeaves(collectorToLeaves);
-                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves);
+                if (currentChildBreakdown instanceof ConcurrentQueryProfileBreakdown) {
+                    ((ConcurrentQueryProfileBreakdown) currentChildBreakdown).associateSliceLeafDocRanges(sliceLeafDocRanges);
+                }
+                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves, sliceLeafDocRanges);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -83,8 +83,14 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
             final ConcurrentQueryProfileBreakdown concurrentParent = (ConcurrentQueryProfileBreakdown) parentBreakdown;
             final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = concurrentParent.getSliceCollectorsToLeaves();
             // update all the children with the parent collectorToLeaves association (and the doc-id
-            // ranges, so child nodes report the same per-partition doc_range as the parent)
-            updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves, concurrentParent.getSliceLeafDocRanges());
+            // ranges, so child nodes report the same per-partition doc_range as the parent; and the
+            // collector->thread map, so children can reconstruct the (thread, leaf) breakdown key)
+            updateCollectorToLeavesForChildBreakdowns(
+                root,
+                parentCollectorToLeaves,
+                concurrentParent.getSliceLeafDocRanges(),
+                concurrentParent.getSliceCollectorThreads()
+            );
         }
         // once the collector to leaves mapping is updated, get the result
         return super.getTree();
@@ -99,7 +105,8 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
     private void updateCollectorToLeavesForChildBreakdowns(
         Integer parentToken,
         Map<Collector, List<LeafReaderContext>> collectorToLeaves,
-        Map<Collector, Map<LeafReaderContext, int[]>> sliceLeafDocRanges
+        Map<Collector, Map<LeafReaderContext, int[]>> sliceLeafDocRanges,
+        Map<Collector, Thread> sliceCollectorThreads
     ) {
         final List<Integer> children = tree.get(parentToken);
         if (children != null) {
@@ -108,8 +115,9 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
                 currentChildBreakdown.associateCollectorsToLeaves(collectorToLeaves);
                 if (currentChildBreakdown instanceof ConcurrentQueryProfileBreakdown) {
                     ((ConcurrentQueryProfileBreakdown) currentChildBreakdown).associateSliceLeafDocRanges(sliceLeafDocRanges);
+                    ((ConcurrentQueryProfileBreakdown) currentChildBreakdown).associateSliceCollectorThreads(sliceCollectorThreads);
                 }
-                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves, sliceLeafDocRanges);
+                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves, sliceLeafDocRanges, sliceCollectorThreads);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -106,7 +106,7 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
         Integer parentToken,
         Map<Collector, List<LeafReaderContext>> collectorToLeaves,
         Map<Collector, Map<LeafReaderContext, int[]>> sliceLeafDocRanges,
-        Map<Collector, Thread> sliceCollectorThreads
+        Map<Collector, Long> sliceCollectorThreads
     ) {
         final List<Integer> children = tree.get(parentToken);
         if (children != null) {

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
@@ -118,4 +118,8 @@ public final class ProfileWeight extends Weight {
     public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {
         profile.associateCollectorToLeaves(collector, leaf);
     }
+
+    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector, int minDocId, int maxDocId) {
+        profile.associateCollectorToLeaves(collector, leaf, minDocId, maxDocId);
+    }
 }

--- a/server/src/test/java/org/opensearch/search/profile/SliceProfileResultTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/SliceProfileResultTests.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class SliceProfileResultTests extends OpenSearchTestCase {
+
+    public static SliceProfileResult createTestItem() {
+        final int sliceId = randomIntBetween(0, 16);
+        final long sliceNodeTime = randomNonNegativeLong();
+        final int numPartitions = randomIntBetween(1, 4);
+        final List<SliceProfileResult.PartitionInfo> partitions = new ArrayList<>(numPartitions);
+        for (int i = 0; i < numPartitions; i++) {
+            final int min = randomIntBetween(0, 1000);
+            // half the time a whole-segment partition (MAX_VALUE sentinel), half a bounded sub-range
+            final int max = randomBoolean() ? Integer.MAX_VALUE : min + randomIntBetween(1, 1000);
+            partitions.add(new SliceProfileResult.PartitionInfo(randomIntBetween(0, 32), min, max));
+        }
+        final int numTimings = randomIntBetween(1, 6);
+        final Map<String, Long> breakdown = new LinkedHashMap<>();
+        for (int i = 0; i < numTimings; i++) {
+            breakdown.put(randomAlphaOfLengthBetween(3, 10) + "_" + i, randomNonNegativeLong());
+        }
+        return new SliceProfileResult(sliceId, sliceNodeTime, partitions, breakdown);
+    }
+
+    private static void assertPartitionsEqual(List<SliceProfileResult.PartitionInfo> a, List<SliceProfileResult.PartitionInfo> b) {
+        assertEquals(a.size(), b.size());
+        for (int i = 0; i < a.size(); i++) {
+            assertEquals(a.get(i).getSegmentOrd(), b.get(i).getSegmentOrd());
+            assertEquals(a.get(i).getMinDocId(), b.get(i).getMinDocId());
+            assertEquals(a.get(i).getMaxDocId(), b.get(i).getMaxDocId());
+        }
+    }
+
+    public void testStreamRoundTrip() throws IOException {
+        final SliceProfileResult original = createTestItem();
+        final SliceProfileResult copy;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                copy = new SliceProfileResult(in);
+            }
+        }
+        assertEquals(original.getSliceId(), copy.getSliceId());
+        assertEquals(original.getSliceNodeTime(), copy.getSliceNodeTime());
+        assertPartitionsEqual(original.getPartitions(), copy.getPartitions());
+        assertEquals(original.getBreakdown(), copy.getBreakdown());
+    }
+
+    public void testXContentRoundTrip() throws IOException {
+        final SliceProfileResult original = createTestItem();
+        final BytesReference bytes;
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            bytes = BytesReference.bytes(builder);
+        }
+
+        final SliceProfileResult parsed;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, bytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            parsed = SliceProfileResult.fromXContent(parser);
+            assertNull(parser.nextToken());
+        }
+
+        assertEquals(original.getSliceId(), parsed.getSliceId());
+        assertEquals(original.getSliceNodeTime(), parsed.getSliceNodeTime());
+        assertPartitionsEqual(original.getPartitions(), parsed.getPartitions());
+        assertEquals(original.getBreakdown(), parsed.getBreakdown());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -29,14 +29,17 @@ import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileMetric;
 import org.opensearch.search.profile.ProfileMetricTests;
 import org.opensearch.search.profile.ProfileMetricUtil;
+import org.opensearch.search.profile.SliceProfileResult;
 import org.opensearch.search.profile.Timer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.opensearch.search.profile.Timer.TIMING_TYPE_COUNT_SUFFIX;
@@ -210,6 +213,37 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         assertEquals(10, testQueryProfileBreakdown.getMaxSliceNodeTime());
         assertEquals(10, testQueryProfileBreakdown.getMinSliceNodeTime());
         assertEquals(10, testQueryProfileBreakdown.getAvgSliceNodeTime());
+
+        // The additive per-slice breakdowns are captured alongside the (unchanged) max/min/avg
+        // aggregates: one SliceProfileResult per slice, each covering exactly its one segment, with a
+        // node time equal to the slice node time computed above (10 for both slices here).
+        final List<SliceProfileResult> sliceProfileResults = testQueryProfileBreakdown.getSliceProfileResults();
+        assertEquals(2, sliceProfileResults.size());
+        final Set<Integer> sliceIds = new HashSet<>();
+        final Set<Integer> coveredSegmentOrds = new HashSet<>();
+        for (SliceProfileResult sliceProfileResult : sliceProfileResults) {
+            sliceIds.add(sliceProfileResult.getSliceId());
+            assertEquals(1, sliceProfileResult.getPartitions().size());
+            final SliceProfileResult.PartitionInfo partition = sliceProfileResult.getPartitions().get(0);
+            coveredSegmentOrds.add(partition.getSegmentOrd());
+            // These leaves were associated without an explicit doc-range, so the whole-segment
+            // fallback applies: [0, segment maxDoc). Each leaf here holds exactly one document.
+            assertEquals(0, partition.getMinDocId());
+            assertEquals(1, partition.getMaxDocId());
+            assertEquals(10, sliceProfileResult.getSliceNodeTime());
+            // create_weight is a query-level timing and must not appear in a per-slice breakdown
+            assertNull(sliceProfileResult.getBreakdown().get(QueryTimingType.CREATE_WEIGHT.toString()));
+            // a leaf-level timing is present
+            assertNotNull(sliceProfileResult.getBreakdown().get(QueryTimingType.NEXT_DOC.toString()));
+        }
+        assertEquals(Set.of(0, 1), sliceIds);
+        assertEquals(Set.of(0, 1), coveredSegmentOrds);
+
+        // buildSliceLevelBreakdown may be invoked more than once for the same breakdown; the
+        // captured per-slice results must be rebuilt (not appended), so the count stays stable.
+        testQueryProfileBreakdown.buildSliceLevelBreakdown();
+        assertEquals(2, testQueryProfileBreakdown.getSliceProfileResults().size());
+
         directoryReader.close();
         directory.close();
     }

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -122,7 +122,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), sliceLeaf), leafProfileBreakdown);
+            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());
@@ -174,12 +174,12 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
             .put(
-                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), directoryReader.leaves().get(0)),
                 leafProfileBreakdown_1
             );
         testQueryProfileBreakdown.getContexts()
             .put(
-                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(1)),
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), directoryReader.leaves().get(1)),
                 leafProfileBreakdown_2
             );
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
@@ -292,12 +292,12 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
             .put(
-                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), directoryReader.leaves().get(0)),
                 leafProfileBreakdown_1
             );
         testQueryProfileBreakdown.getContexts()
             .put(
-                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(1)),
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), directoryReader.leaves().get(1)),
                 leafProfileBreakdown_2
             );
 
@@ -354,7 +354,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
             .put(
-                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), directoryReader.leaves().get(0)),
                 leafProfileBreakdown_1
             );
         // leaf2 profile breakdown is not present in contexts map
@@ -501,7 +501,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdownCombined.associateCollectorToLeaves(sliceCollector, sliceLeaf);
         testQueryProfileBreakdownCombined.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), sliceLeaf), leafProfileBreakdown);
+            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread().threadId(), sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdownCombined.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -122,7 +122,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector, sliceLeaf), leafProfileBreakdown);
+            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());
@@ -173,9 +173,15 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
+            .put(
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                leafProfileBreakdown_1
+            );
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_2, directoryReader.leaves().get(1)), leafProfileBreakdown_2);
+            .put(
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(1)),
+                leafProfileBreakdown_2
+            );
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(2, sliceBreakdownMap.size());
@@ -253,8 +259,19 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
 
         // buildSliceLevelBreakdown may be invoked more than once for the same breakdown; the
         // captured per-slice results must be rebuilt (not appended), so the count stays stable.
+        // Also assert slice_id is STABLE across invocations: the id maps to the same partition
+        // (segment ordinal) each time, rather than depending on the ConcurrentHashMap iteration order.
+        final Map<Integer, Integer> firstIdToSegment = new HashMap<>();
+        for (SliceProfileResult r : testQueryProfileBreakdown.getSliceProfileResults()) {
+            firstIdToSegment.put(r.getSliceId(), r.getPartitions().get(0).getSegmentOrd());
+        }
         testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertEquals(2, testQueryProfileBreakdown.getSliceProfileResults().size());
+        final Map<Integer, Integer> secondIdToSegment = new HashMap<>();
+        for (SliceProfileResult r : testQueryProfileBreakdown.getSliceProfileResults()) {
+            secondIdToSegment.put(r.getSliceId(), r.getPartitions().get(0).getSegmentOrd());
+        }
+        assertEquals("slice_id -> segment mapping must be stable across invocations", firstIdToSegment, secondIdToSegment);
 
         directoryReader.close();
         directory.close();
@@ -274,9 +291,15 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
+            .put(
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                leafProfileBreakdown_1
+            );
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_2, directoryReader.leaves().get(1)), leafProfileBreakdown_2);
+            .put(
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(1)),
+                leafProfileBreakdown_2
+            );
 
         Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
         assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
@@ -330,7 +353,10 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
         testQueryProfileBreakdown.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
+            .put(
+                ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), directoryReader.leaves().get(0)),
+                leafProfileBreakdown_1
+            );
         // leaf2 profile breakdown is not present in contexts map
 
         Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
@@ -374,45 +400,40 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         directory.close();
     }
 
-    public void testIntraSegmentPartitionsGetSeparateBreakdownPerSlice() throws Exception {
-        // Reproduces the intra-segment race: one segment (leaf) is searched by two slices (collectors)
-        // on two threads. Before the fix, context() keyed breakdowns by segment only, so both slices
-        // shared ONE breakdown — and therefore one non-thread-safe Timer — corrupting the timings.
-        // The fix keys by (slice, segment); this asserts each slice gets its OWN breakdown instance.
+    public void testIntraSegmentPartitionsGetSeparateBreakdownPerThread() throws Exception {
+        // Reproduces the intra-segment race: one segment (leaf) is searched by two partitions on two
+        // different threads. Before the fix, context() keyed breakdowns by segment only, so both
+        // threads shared ONE breakdown — and therefore one non-thread-safe Timer — corrupting the
+        // timings. The fix keys by (thread, segment); this asserts each thread gets its OWN breakdown.
         final DirectoryReader directoryReader = getDirectoryReader(1);
         final Directory directory = directoryReader.directory();
         try {
             final LeafReaderContext sharedLeaf = directoryReader.leaves().get(0);
-            final Collector sliceCollector1 = mock(Collector.class);
-            final Collector sliceCollector2 = mock(Collector.class);
 
-            // Simulate slice 1's searchLeaf: set the slice, resolve the breakdown for the segment.
-            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(sliceCollector1);
-            final AbstractProfileBreakdown breakdownSlice1;
-            try {
-                breakdownSlice1 = testQueryProfileBreakdown.context(sharedLeaf);
-                // A second call within the same slice must return the SAME instance (per-partition reuse).
-                assertSame(breakdownSlice1, testQueryProfileBreakdown.context(sharedLeaf));
-            } finally {
-                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
-            }
+            // Thread A resolves the breakdown for the segment; a second call on the same thread must
+            // return the SAME instance (per-partition reuse within one thread).
+            final AbstractProfileBreakdown[] fromThreadA = new AbstractProfileBreakdown[2];
+            final Thread threadA = new Thread(() -> {
+                fromThreadA[0] = testQueryProfileBreakdown.context(sharedLeaf);
+                fromThreadA[1] = testQueryProfileBreakdown.context(sharedLeaf);
+            });
+            threadA.start();
+            threadA.join();
+            assertSame("same thread must reuse its breakdown for a leaf", fromThreadA[0], fromThreadA[1]);
 
-            // Simulate slice 2's searchLeaf over the SAME segment.
-            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(sliceCollector2);
-            final AbstractProfileBreakdown breakdownSlice2;
-            try {
-                breakdownSlice2 = testQueryProfileBreakdown.context(sharedLeaf);
-            } finally {
-                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
-            }
+            // Thread B resolves the breakdown for the SAME segment.
+            final AbstractProfileBreakdown[] fromThreadB = new AbstractProfileBreakdown[1];
+            final Thread threadB = new Thread(() -> fromThreadB[0] = testQueryProfileBreakdown.context(sharedLeaf));
+            threadB.start();
+            threadB.join();
 
-            // The crux: two slices searching the same segment must NOT share a breakdown (or its Timer).
+            // The crux: two threads searching the same segment must NOT share a breakdown (or its Timer).
             assertNotSame(
-                "intra-segment partitions of the same segment in different slices must get distinct breakdowns",
-                breakdownSlice1,
-                breakdownSlice2
+                "intra-segment partitions of the same segment on different threads must get distinct breakdowns",
+                fromThreadA[0],
+                fromThreadB[0]
             );
-            // Two distinct breakdowns are stored (one per slice), not one shared by segment.
+            // Two distinct breakdowns are stored (one per thread), not one shared by segment.
             assertEquals(2, testQueryProfileBreakdown.getContexts().size());
         } finally {
             directoryReader.close();
@@ -480,7 +501,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdownCombined.associateCollectorToLeaves(sliceCollector, sliceLeaf);
         testQueryProfileBreakdownCombined.getContexts()
-            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector, sliceLeaf), leafProfileBreakdown);
+            .put(ConcurrentQueryProfileBreakdown.contextKey(Thread.currentThread(), sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdownCombined.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.store.Directory;
+import org.opensearch.search.profile.AbstractProfileBreakdown;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileMetric;
 import org.opensearch.search.profile.ProfileMetricTests;
@@ -120,7 +121,8 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final Map<String, Long> leafProfileBreakdownMap = getLeafBreakdownMap(createWeightEndTime + 10, 10, 1);
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
-        testQueryProfileBreakdown.getContexts().put(sliceLeaf, leafProfileBreakdown);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector, sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());
@@ -170,8 +172,10 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown_2 = new TestQueryProfileBreakdown(leafProfileBreakdownMap_2);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
-        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
-        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_2, directoryReader.leaves().get(1)), leafProfileBreakdown_2);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(2, sliceBreakdownMap.size());
@@ -235,6 +239,14 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
             assertNull(sliceProfileResult.getBreakdown().get(QueryTimingType.CREATE_WEIGHT.toString()));
             // a leaf-level timing is present
             assertNotNull(sliceProfileResult.getBreakdown().get(QueryTimingType.NEXT_DOC.toString()));
+            // the internal *_slice_start_time/*_slice_end_time scratch keys (raw nanoTime timestamps
+            // used only to derive durations) must be stripped from the user-facing per-slice breakdown
+            for (String key : sliceProfileResult.getBreakdown().keySet()) {
+                assertFalse(
+                    "per-slice breakdown must not leak internal key: " + key,
+                    key.endsWith(SLICE_START_TIME_SUFFIX) || key.endsWith(SLICE_END_TIME_SUFFIX)
+                );
+            }
         }
         assertEquals(Set.of(0, 1), sliceIds);
         assertEquals(Set.of(0, 1), coveredSegmentOrds);
@@ -261,8 +273,10 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown_2 = new TestQueryProfileBreakdown(leafProfileBreakdownMap_2);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
-        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
-        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_2, directoryReader.leaves().get(1)), leafProfileBreakdown_2);
 
         Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
         assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
@@ -315,7 +329,8 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final ContextualProfileBreakdown leafProfileBreakdown_1 = new TestQueryProfileBreakdown(leafProfileBreakdownMap_1);
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
-        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector_1, directoryReader.leaves().get(0)), leafProfileBreakdown_1);
         // leaf2 profile breakdown is not present in contexts map
 
         Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
@@ -357,6 +372,52 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         assertEquals(5, testQueryProfileBreakdown.getAvgSliceNodeTime());
         directoryReader.close();
         directory.close();
+    }
+
+    public void testIntraSegmentPartitionsGetSeparateBreakdownPerSlice() throws Exception {
+        // Reproduces the intra-segment race: one segment (leaf) is searched by two slices (collectors)
+        // on two threads. Before the fix, context() keyed breakdowns by segment only, so both slices
+        // shared ONE breakdown — and therefore one non-thread-safe Timer — corrupting the timings.
+        // The fix keys by (slice, segment); this asserts each slice gets its OWN breakdown instance.
+        final DirectoryReader directoryReader = getDirectoryReader(1);
+        final Directory directory = directoryReader.directory();
+        try {
+            final LeafReaderContext sharedLeaf = directoryReader.leaves().get(0);
+            final Collector sliceCollector1 = mock(Collector.class);
+            final Collector sliceCollector2 = mock(Collector.class);
+
+            // Simulate slice 1's searchLeaf: set the slice, resolve the breakdown for the segment.
+            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(sliceCollector1);
+            final AbstractProfileBreakdown breakdownSlice1;
+            try {
+                breakdownSlice1 = testQueryProfileBreakdown.context(sharedLeaf);
+                // A second call within the same slice must return the SAME instance (per-partition reuse).
+                assertSame(breakdownSlice1, testQueryProfileBreakdown.context(sharedLeaf));
+            } finally {
+                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
+            }
+
+            // Simulate slice 2's searchLeaf over the SAME segment.
+            ConcurrentQueryProfileBreakdown.setCurrentSliceCollector(sliceCollector2);
+            final AbstractProfileBreakdown breakdownSlice2;
+            try {
+                breakdownSlice2 = testQueryProfileBreakdown.context(sharedLeaf);
+            } finally {
+                ConcurrentQueryProfileBreakdown.clearCurrentSliceCollector();
+            }
+
+            // The crux: two slices searching the same segment must NOT share a breakdown (or its Timer).
+            assertNotSame(
+                "intra-segment partitions of the same segment in different slices must get distinct breakdowns",
+                breakdownSlice1,
+                breakdownSlice2
+            );
+            // Two distinct breakdowns are stored (one per slice), not one shared by segment.
+            assertEquals(2, testQueryProfileBreakdown.getContexts().size());
+        } finally {
+            directoryReader.close();
+            directory.close();
+        }
     }
 
     public void testOneLeafContextWithEmptySliceCollectorsToLeaves() throws Exception {
@@ -418,7 +479,8 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         final Map<String, Long> leafProfileBreakdownMap = getCombinedLeafBreakdownMap(createWeightEndTime + 10, 10, 1);
         final ContextualProfileBreakdown leafProfileBreakdown = new TestQueryProfileBreakdown(leafProfileBreakdownMap);
         testQueryProfileBreakdownCombined.associateCollectorToLeaves(sliceCollector, sliceLeaf);
-        testQueryProfileBreakdownCombined.getContexts().put(sliceLeaf, leafProfileBreakdown);
+        testQueryProfileBreakdownCombined.getContexts()
+            .put(ConcurrentQueryProfileBreakdown.contextKey(sliceCollector, sliceLeaf), leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdownCombined.buildSliceLevelBreakdown();
         assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
         assertEquals(1, sliceBreakdownMap.size());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
 Adds a nested `slices[] → partitions[]` breakdown to the query profiler, showing per-slice and (under intra-segment search) per-partition timings that were previously collapsed into only the `max_/min_/avg_slice_*` aggregates.

This change adds per-slice/per-partition detail to the **query** section only (`profile.shards[].searches[].query[]`). The same pattern can be extended, as follow-ups, to the **collector** and **aggregation** sections so the whole profile output shows slice/partition granularity consistently.

### Related Issues
- Related to https://github.com/opensearch-project/OpenSearch/issues/20344 
- Part to https://github.com/opensearch-project/OpenSearch/issues/20202


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
