### PR TITLE
Remove duplicate native memory limit setting from NodeDuressSettings

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/backpressure/NativeMemorySearchBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/backpressure/NativeMemorySearchBackpressureIT.java
@@ -30,6 +30,7 @@ import org.opensearch.core.tasks.TaskId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -118,10 +119,9 @@ public class NativeMemorySearchBackpressureIT extends OpenSearchIntegTestCase {
             .put(NodeDuressSettings.SETTING_HEAP_THRESHOLD.getKey(), 1.0) // disable heap duress
             .put(NodeDuressSettings.SETTING_NATIVE_MEMORY_THRESHOLD.getKey(), 0.0)
             .put(NodeDuressSettings.SETTING_NUM_SUCCESSIVE_BREACHES.getKey(), 1)
-            // search_backpressure.node_duress.native_memory_limit must be > 0 or the duress
-            // lambda short-circuits ("totalNative is zero"). 1 byte is enough — the probe
-            // reports a non-zero RssAnon.
-            .put(NodeDuressSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "1b")
+            // node.native_memory.limit must be > 0 or the duress lambda short-circuits
+            // ("totalNative is zero"). 1 byte is enough — the probe reports a non-zero RssAnon.
+            .put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "1b")
             .build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(request).get());
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -738,7 +738,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 NodeDuressSettings.SETTING_NUM_SUCCESSIVE_BREACHES,
                 NodeDuressSettings.SETTING_CPU_THRESHOLD,
                 NodeDuressSettings.SETTING_HEAP_THRESHOLD,
-                NodeDuressSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING,
                 NodeDuressSettings.SETTING_NATIVE_MEMORY_THRESHOLD,
                 SearchTaskSettings.SETTING_CANCELLATION_RATIO,
                 SearchTaskSettings.SETTING_CANCELLATION_RATE,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -738,6 +738,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 NodeDuressSettings.SETTING_NUM_SUCCESSIVE_BREACHES,
                 NodeDuressSettings.SETTING_CPU_THRESHOLD,
                 NodeDuressSettings.SETTING_HEAP_THRESHOLD,
+                NodeDuressSettings.SETTING_NATIVE_MEMORY_LIMIT_LEGACY,
                 NodeDuressSettings.SETTING_NATIVE_MEMORY_THRESHOLD,
                 SearchTaskSettings.SETTING_CANCELLATION_RATIO,
                 SearchTaskSettings.SETTING_CANCELLATION_RATE,
@@ -945,7 +946,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
         )
     );
 
-    public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.emptyList();
+    public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.unmodifiableList(
+        Collections.singletonList(NodeDuressSettings.NATIVE_MEMORY_LIMIT_UPGRADER)
+    );
 
     /**
      * Map of feature flag name to feature-flagged cluster settings. Once each feature

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
@@ -12,6 +12,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 
 /**
  * Defines the settings for a node to be considered in duress.
@@ -89,19 +90,14 @@ public class NodeDuressSettings {
     );
 
     /**
-     * Absolute native-memory budget for this node, in bytes, scoped to the search-backpressure
-     * duress probe. Independent from the node-level resource-tracker's
-     * {@code node.native_memory.limit} so the two features can be tuned separately. When this
-     * value is {@link ByteSizeValue#ZERO} (default), the duress probe treats the budget as
-     * unconfigured and stays inert.
+     * Absolute native-memory budget for this node in bytes, used by the search-backpressure
+     * duress probe. Reads from the shared node-level setting
+     * {@link ResourceTrackerSettings#NODE_NATIVE_MEMORY_LIMIT_SETTING} ({@code node.native_memory.limit})
+     * so that a single cluster-level configuration drives both Admission Control and Search
+     * Back Pressure. When the shared setting is {@link ByteSizeValue#ZERO} (unconfigured), the
+     * duress probe stays inert.
      */
     private volatile ByteSizeValue nodeNativeMemory;
-    public static final Setting<ByteSizeValue> NODE_NATIVE_MEMORY_LIMIT_SETTING = Setting.byteSizeSetting(
-        "search_backpressure.node_duress.native_memory_limit",
-        ByteSizeValue.ZERO,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
 
     public NodeDuressSettings(Settings settings, ClusterSettings clusterSettings) {
         numSuccessiveBreaches = SETTING_NUM_SUCCESSIVE_BREACHES.get(settings);
@@ -116,8 +112,8 @@ public class NodeDuressSettings {
         nativeMemoryThreshold = SETTING_NATIVE_MEMORY_THRESHOLD.get(settings);
         clusterSettings.addSettingsUpdateConsumer(SETTING_NATIVE_MEMORY_THRESHOLD, this::setNativeMemoryThreshold);
 
-        nodeNativeMemory = NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(NODE_NATIVE_MEMORY_LIMIT_SETTING, this::setNodeNativeMemory);
+        nodeNativeMemory = ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING, this::setNodeNativeMemory);
     }
 
     public int getNumSuccessiveBreaches() {

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
@@ -10,6 +10,7 @@ package org.opensearch.search.backpressure.settings;
 
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.SettingUpgrader;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
@@ -88,6 +89,39 @@ public class NodeDuressSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+
+    /**
+     * @deprecated Use {@link ResourceTrackerSettings#NODE_NATIVE_MEMORY_LIMIT_SETTING}
+     *             ({@code node.native_memory.limit}) instead. This key is retained solely for
+     *             BWC upgrade migration via {@link #NATIVE_MEMORY_LIMIT_UPGRADER}; it is no
+     *             longer read at runtime.
+     */
+    @Deprecated
+    public static final Setting<ByteSizeValue> SETTING_NATIVE_MEMORY_LIMIT_LEGACY = Setting.byteSizeSetting(
+        "search_backpressure.node_duress.native_memory_limit",
+        ByteSizeValue.ZERO,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope,
+        Setting.Property.Deprecated
+    );
+
+    /**
+     * Upgrades the legacy {@code search_backpressure.node_duress.native_memory_limit} key
+     * to the unified {@code node.native_memory.limit} key during cluster-state recovery.
+     * Wired into {@link org.opensearch.common.settings.ClusterSettings#BUILT_IN_SETTING_UPGRADERS}
+     * so the migration happens automatically on the first node startup after upgrade.
+     */
+    public static final SettingUpgrader<ByteSizeValue> NATIVE_MEMORY_LIMIT_UPGRADER = new SettingUpgrader<ByteSizeValue>() {
+        @Override
+        public Setting<ByteSizeValue> getSetting() {
+            return SETTING_NATIVE_MEMORY_LIMIT_LEGACY;
+        }
+
+        @Override
+        public String getKey(final String key) {
+            return ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey();
+        }
+    };
 
     /**
      * Absolute native-memory budget for this node in bytes, used by the search-backpressure

--- a/server/src/test/java/org/opensearch/search/backpressure/settings/NodeDuressSettingsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/settings/NodeDuressSettingsTests.java
@@ -104,4 +104,31 @@ public class NodeDuressSettingsTests extends OpenSearchTestCase {
         settings.setNodeNativeMemory(new ByteSizeValue(4096L));
         assertEquals(4096L, settings.getNodeNativeMemory());
     }
+
+    /**
+     * BWC: a cluster that had {@code search_backpressure.node_duress.native_memory_limit} set
+     * in its persistent cluster state must have that value transparently migrated to
+     * {@code node.native_memory.limit} by {@link NodeDuressSettings#NATIVE_MEMORY_LIMIT_UPGRADER}
+     * during cluster-state recovery, so the SBP duress probe still honours the operator's
+     * original intent after upgrade.
+     */
+    public void testLegacySettingUpgraderMigratesKeyToNodeNativeMemoryLimit() {
+        // Simulate old cluster-state that contains the legacy SBP-specific key.
+        Settings legacyClusterState = Settings.builder().put(NodeDuressSettings.SETTING_NATIVE_MEMORY_LIMIT_LEGACY.getKey(), "4gb").build();
+
+        // Must pass BUILT_IN_SETTING_UPGRADERS explicitly — the two-arg ClusterSettings
+        // constructor defaults to an empty upgrader set, mirroring the path SettingsModule takes.
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS,
+            new java.util.HashSet<>(ClusterSettings.BUILT_IN_SETTING_UPGRADERS)
+        );
+        Settings upgraded = clusterSettings.upgradeSettings(legacyClusterState);
+
+        // Old key must be gone after upgrade.
+        assertNull(upgraded.get(NodeDuressSettings.SETTING_NATIVE_MEMORY_LIMIT_LEGACY.getKey()));
+        // New unified key must carry the original value, compared as bytes to avoid
+        // depending on the internal string representation produced by the upgrader.
+        assertEquals(4L * 1024 * 1024 * 1024, ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(upgraded).getBytes());
+    }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/settings/NodeDuressSettingsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/settings/NodeDuressSettingsTests.java
@@ -11,6 +11,7 @@ package org.opensearch.search.backpressure.settings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.test.OpenSearchTestCase;
 
 /**
@@ -59,35 +60,36 @@ public class NodeDuressSettingsTests extends OpenSearchTestCase {
         );
     }
 
-    public void testDefaultNodeNativeMemoryLimitIsZero() {
-        // Default ByteSizeValue.ZERO — operator hasn't configured a native pool, so the
-        // duress probe must self-report "unconfigured" and the SBP path treats it as 0.
-        NodeDuressSettings settings = new NodeDuressSettings(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-        );
+    public void testDefaultNodeNativeMemoryLimitUsesNodeLevelSetting() {
+        // Setting node.native_memory.limit to 0b disables the native-memory budget and
+        // the duress probe reports an unconfigured limit.
+        Settings raw = Settings.builder().put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "0b").build();
+        NodeDuressSettings settings = new NodeDuressSettings(raw, new ClusterSettings(raw, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
         assertEquals(0L, settings.getNodeNativeMemory());
     }
 
     public void testInitialNodeNativeMemoryLimitRespectsSetting() {
-        // ByteSizeValue parses unit-suffixed strings; verify the configured value reaches the field.
-        Settings raw = Settings.builder().put(NodeDuressSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "2gb").build();
+        // Configuring node.native_memory.limit is picked up by the duress probe.
+        Settings raw = Settings.builder().put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "2gb").build();
         NodeDuressSettings settings = new NodeDuressSettings(raw, new ClusterSettings(raw, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
         assertEquals(2L * 1024 * 1024 * 1024, settings.getNodeNativeMemory());
     }
 
     public void testNodeNativeMemoryLimitIsDynamic() {
-        // Operator must be able to flip the limit at runtime without a node restart.
-        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        NodeDuressSettings settings = new NodeDuressSettings(Settings.EMPTY, clusterSettings);
+        // A dynamic update to node.native_memory.limit must propagate to the duress probe.
+        Settings initial = Settings.builder().put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "0b").build();
+        ClusterSettings clusterSettings = new ClusterSettings(initial, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        NodeDuressSettings settings = new NodeDuressSettings(initial, clusterSettings);
         assertEquals(0L, settings.getNodeNativeMemory());
 
         clusterSettings.applySettings(
-            Settings.builder().put(NodeDuressSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "512mb").build()
+            Settings.builder().put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "512mb").build()
         );
         assertEquals(512L * 1024 * 1024, settings.getNodeNativeMemory());
 
-        clusterSettings.applySettings(Settings.builder().put(NodeDuressSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "1gb").build());
+        clusterSettings.applySettings(
+            Settings.builder().put(ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.getKey(), "1gb").build()
+        );
         assertEquals(1024L * 1024 * 1024, settings.getNodeNativeMemory());
     }
 


### PR DESCRIPTION
### Description
This change removes the duplicate Search Back Pressure native memory limit setting and reuses the shared node-level native memory limit setting (`node.native_memory.limit`) defined in `ResourceTrackerSettings`.

Changes include:
- Remove `search_backpressure.node_duress.native_memory_limit` from `NodeDuressSettings`.
- Read the native memory limit from `ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING`.
- Remove the duplicate setting registration from `ClusterSettings`.
- Update unit tests and integration tests to use the shared setting.

### Related Issues
Resolves #21818

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
