### PR TITLE
Fix NPE explaining script_score with no sub-scorer

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -182,15 +182,15 @@ public class ScriptScoreQuery extends Query {
                 if (subQueryExplanation.isMatch() == false) {
                     return subQueryExplanation;
                 }
+                Scorer subQueryScorer = subQueryWeight.scorer(context);
+                if (subQueryScorer == null) {
+                    // The sub-query explains this document as a match but produces no scorer for this segment.
+                    // scorerSupplier() treats that as "no matches on this segment", so explain() reports no match
+                    // as well instead of dereferencing a null scorer.
+                    return Explanation.noMatch("sub-query produced no scorer for this segment", subQueryExplanation);
+                }
                 ExplanationHolder explanationHolder = new ExplanationHolder();
-                Scorer scorer = new ScriptScorer(
-                    this,
-                    makeScoreScript(context),
-                    subQueryWeight.scorer(context),
-                    subQueryScoreMode,
-                    1f,
-                    explanationHolder
-                );
+                Scorer scorer = new ScriptScorer(this, makeScoreScript(context), subQueryScorer, subQueryScoreMode, 1f, explanationHolder);
                 int newDoc = scorer.iterator().advance(doc);
                 assert doc == newDoc; // subquery should have already matched above
                 float score = scorer.score(); // score without boost

--- a/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
@@ -185,6 +185,76 @@ public class ScriptScoreQueryTests extends OpenSearchTestCase {
         assertThat(explanation.getValue(), equalTo(2.0f));
     }
 
+    public void testExplainWhenSubQueryScorerIsNull() throws IOException {
+        Script script = new Script("script using explain");
+        ScoreScript.LeafFactory factory = newFactory(script, true, explanation -> {
+            throw new AssertionError("the script must not run when the sub-query has no scorer");
+        });
+
+        ScriptScoreQuery query = new ScriptScoreQuery(
+            new MatchingExplanationNullScorerQuery(),
+            script,
+            factory,
+            null,
+            "index",
+            0,
+            Version.CURRENT
+        );
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        Explanation explanation = weight.explain(leafReaderContext, 0);
+        assertNotNull(explanation);
+        assertFalse(explanation.isMatch());
+        assertThat(explanation.getDescription(), containsString("sub-query produced no scorer for this segment"));
+    }
+
+    /**
+     * A query whose weight explains every document as a match but never produces a scorer, which is the
+     * scorer/explain mismatch that used to make {@link ScriptScoreQuery} throw a NullPointerException.
+     */
+    private static class MatchingExplanationNullScorerQuery extends Query {
+
+        @Override
+        public String toString(String field) {
+            return getClass().getSimpleName();
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+            visitor.visitLeaf(this);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return this == obj;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+            return new Weight(this) {
+
+                @Override
+                public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                    return Explanation.match(1.0f, "matches");
+                }
+
+                @Override
+                public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                    return null;
+                }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
+            };
+        }
+    }
+
     public void testScriptScoreErrorOnNegativeScore() {
         Script script = new Script("script that returns a negative score");
         ScoreScript.LeafFactory factory = newFactory(script, false, explanation -> -1000.0);


### PR DESCRIPTION
### Description

`ScriptScoreQuery`'s `Weight.explain()` passes the sub-query scorer straight into `ScriptScorer` without a null check:

```java
Scorer scorer = new ScriptScorer(this, makeScoreScript(context), subQueryWeight.scorer(context), subQueryScoreMode, 1f, explanationHolder);
int newDoc = scorer.iterator().advance(doc);
```

When a sub-query's weight explains a document as a match but produces no scorer for that segment, `scorer.iterator()` throws `NullPointerException: Cannot invoke "org.apache.lucene.search.Scorer.iterator()" because "this.subQueryScorer" is null`. Because `explain()` runs in the fetch phase, one such clause fails the whole search request for requests that succeed fine with `explain`/`profile` disabled.

`scorerSupplier()` in the same anonymous `Weight` was fixed for the equivalent case in #19650 and returns `null` there, meaning "no matches on this segment". This change makes `explain()` agree with it: a null sub-query scorer now yields `Explanation.noMatch(...)` wrapping the sub-query explanation instead of dereferencing the null scorer.

Testing:

- `ScriptScoreQueryTests#testExplainWhenSubQueryScorerIsNull` covers the scorer/explain mismatch with a sub-query whose weight always explains a match and never returns a scorer. Reverting the `explain()` guard makes it fail with the same NPE quoted above.
- `./gradlew :server:test --tests "*ScriptScore*" --tests "org.opensearch.index.query.functionscore.*" --tests "*FunctionScoreQuery*"` passes, as do `:server:spotlessJavaCheck` and `:server:forbiddenApisMain`.

No CHANGELOG entry: the file records that it is no longer used for release notes as of 3.6 (#21071).

### Related Issues
Resolves #22619

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

### AI tool disclosure

Following the disclosure request in opensearch-project's CONTRIBUTING guide: I used an AI coding tool, Claude Code (Anthropic Claude), to write the change and the test in this pull request. The failure mode, the reproduction and the verification runs quoted above were checked against a local build before submitting, and I can answer questions about any part of the diff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

