### PR TITLE
[BUG] 'forPattern()' performs up to 120 redundant 'String.equals()' comparisons on every date-field request [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/server/src/main/java/org/opensearch/common/joda/Joda.java
+++ b/server/src/main/java/org/opensearch/common/joda/Joda.java
@@ -106,182 +106,270 @@ public class Joda {
         }
 
         DateTimeFormatter formatter;
-        if (FormatNames.BASIC_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicDate();
-        } else if (FormatNames.BASIC_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicDateTime();
-        } else if (FormatNames.BASIC_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicDateTimeNoMillis();
-        } else if (FormatNames.BASIC_ORDINAL_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDate();
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDateTime();
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDateTimeNoMillis();
-        } else if (FormatNames.BASIC_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicTime();
-        } else if (FormatNames.BASIC_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicTimeNoMillis();
-        } else if (FormatNames.BASIC_T_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicTTime();
-        } else if (FormatNames.BASIC_T_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicTTimeNoMillis();
-        } else if (FormatNames.BASIC_WEEK_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDate();
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDateTime();
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDateTimeNoMillis();
-        } else if (FormatNames.DATE.matches(input)) {
-            formatter = ISODateTimeFormat.date();
-        } else if (FormatNames.DATE_HOUR.matches(input)) {
-            formatter = ISODateTimeFormat.dateHour();
-        } else if (FormatNames.DATE_HOUR_MINUTE.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinute();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecond();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecondFraction();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecondMillis();
-        } else if (FormatNames.DATE_OPTIONAL_TIME.matches(input)) {
-            // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
-            // this sucks we should use the root local by default and not be dependent on the node
-            return new JodaDateFormatter(
-                input,
-                ISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
-                ISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
-            );
-        } else if (FormatNames.DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.dateTime();
-        } else if (FormatNames.DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.dateTimeNoMillis();
-        } else if (FormatNames.HOUR.matches(input)) {
-            formatter = ISODateTimeFormat.hour();
-        } else if (FormatNames.HOUR_MINUTE.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinute();
-        } else if (FormatNames.HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecond();
-        } else if (FormatNames.HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecondFraction();
-        } else if (FormatNames.HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecondMillis();
-        } else if (FormatNames.ORDINAL_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDate();
-        } else if (FormatNames.ORDINAL_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDateTime();
-        } else if (FormatNames.ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDateTimeNoMillis();
-        } else if (FormatNames.TIME.matches(input)) {
-            formatter = ISODateTimeFormat.time();
-        } else if (FormatNames.TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.timeNoMillis();
-        } else if (FormatNames.T_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.tTime();
-        } else if (FormatNames.T_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.tTimeNoMillis();
-        } else if (FormatNames.WEEK_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.weekDate();
-        } else if (FormatNames.WEEK_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.weekDateTime();
-        } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.weekDateTimeNoMillis();
-        } else if (FormatNames.WEEKYEAR.matches(input)) {
-            getDeprecationLogger().deprecate(
-                "week_year_format_name",
-                "Format name \"week_year\" is deprecated and will be removed in a future version. " + "Use \"weekyear\" format instead"
-            );
-            formatter = ISODateTimeFormat.weekyear();
-        } else if (FormatNames.WEEK_YEAR.matches(input)) {
-            formatter = ISODateTimeFormat.weekyear();
-        } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {
-            formatter = ISODateTimeFormat.weekyearWeek();
-        } else if (FormatNames.WEEKYEAR_WEEK_DAY.matches(input)) {
-            formatter = ISODateTimeFormat.weekyearWeekDay();
-        } else if (FormatNames.YEAR.matches(input)) {
-            formatter = ISODateTimeFormat.year();
-        } else if (FormatNames.YEAR_MONTH.matches(input)) {
-            formatter = ISODateTimeFormat.yearMonth();
-        } else if (FormatNames.YEAR_MONTH_DAY.matches(input)) {
-            formatter = ISODateTimeFormat.yearMonthDay();
-        } else if (FormatNames.EPOCH_SECOND.matches(input)) {
-            formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(false), new EpochTimeParser(false)).toFormatter();
-        } else if (FormatNames.EPOCH_MILLIS.matches(input)) {
-            formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(true), new EpochTimeParser(true)).toFormatter();
-            // strict date formats here, must be at least 4 digits for year and two for months and two for day
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDate();
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDateTime();
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDateTimeNoMillis();
-        } else if (FormatNames.STRICT_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.date();
-        } else if (FormatNames.STRICT_DATE_HOUR.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHour();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinute();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecond();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecondFraction();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecondMillis();
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME.matches(input)) {
-            // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
-            // this sucks we should use the root local by default and not be dependent on the node
-            return new JodaDateFormatter(
-                input,
-                StrictISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
-                StrictISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
-            );
-        } else if (FormatNames.STRICT_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateTime();
-        } else if (FormatNames.STRICT_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateTimeNoMillis();
-        } else if (FormatNames.STRICT_HOUR.matches(input)) {
-            formatter = StrictISODateTimeFormat.hour();
-        } else if (FormatNames.STRICT_HOUR_MINUTE.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinute();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecond();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecondFraction();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecondMillis();
-        } else if (FormatNames.STRICT_ORDINAL_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDate();
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDateTime();
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDateTimeNoMillis();
-        } else if (FormatNames.STRICT_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.time();
-        } else if (FormatNames.STRICT_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.timeNoMillis();
-        } else if (FormatNames.STRICT_T_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.tTime();
-        } else if (FormatNames.STRICT_T_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.tTimeNoMillis();
-        } else if (FormatNames.STRICT_WEEK_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDate();
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDateTime();
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDateTimeNoMillis();
-        } else if (FormatNames.STRICT_WEEKYEAR.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyear();
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyearWeek();
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK_DAY.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyearWeekDay();
-        } else if (FormatNames.STRICT_YEAR.matches(input)) {
-            formatter = StrictISODateTimeFormat.year();
-        } else if (FormatNames.STRICT_YEAR_MONTH.matches(input)) {
-            formatter = StrictISODateTimeFormat.yearMonth();
-        } else if (FormatNames.STRICT_YEAR_MONTH_DAY.matches(input)) {
-            formatter = StrictISODateTimeFormat.yearMonthDay();
-        } else if (Strings.hasLength(input) && input.contains("||")) {
+        if (formatName != null) {
+            switch (formatName) {
+                case BASIC_DATE:
+                    formatter = ISODateTimeFormat.basicDate();
+                    break;
+                case BASIC_DATE_TIME:
+                    formatter = ISODateTimeFormat.basicDateTime();
+                    break;
+                case BASIC_DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.basicDateTimeNoMillis();
+                    break;
+                case BASIC_ORDINAL_DATE:
+                    formatter = ISODateTimeFormat.basicOrdinalDate();
+                    break;
+                case BASIC_ORDINAL_DATE_TIME:
+                    formatter = ISODateTimeFormat.basicOrdinalDateTime();
+                    break;
+                case BASIC_ORDINAL_DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.basicOrdinalDateTimeNoMillis();
+                    break;
+                case BASIC_TIME:
+                    formatter = ISODateTimeFormat.basicTime();
+                    break;
+                case BASIC_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.basicTimeNoMillis();
+                    break;
+                case BASIC_T_TIME:
+                    formatter = ISODateTimeFormat.basicTTime();
+                    break;
+                case BASIC_T_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.basicTTimeNoMillis();
+                    break;
+                case BASIC_WEEK_DATE:
+                    formatter = ISODateTimeFormat.basicWeekDate();
+                    break;
+                case BASIC_WEEK_DATE_TIME:
+                    formatter = ISODateTimeFormat.basicWeekDateTime();
+                    break;
+                case BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.basicWeekDateTimeNoMillis();
+                    break;
+                case DATE:
+                    formatter = ISODateTimeFormat.date();
+                    break;
+                case DATE_HOUR:
+                    formatter = ISODateTimeFormat.dateHour();
+                    break;
+                case DATE_HOUR_MINUTE:
+                    formatter = ISODateTimeFormat.dateHourMinute();
+                    break;
+                case DATE_HOUR_MINUTE_SECOND:
+                    formatter = ISODateTimeFormat.dateHourMinuteSecond();
+                    break;
+                case DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    formatter = ISODateTimeFormat.dateHourMinuteSecondFraction();
+                    break;
+                case DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    formatter = ISODateTimeFormat.dateHourMinuteSecondMillis();
+                    break;
+                case DATE_OPTIONAL_TIME:
+                    // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
+                    // this sucks we should use the root local by default and not be dependent on the node
+                    return new JodaDateFormatter(
+                        input,
+                        ISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
+                        ISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
+                    );
+                case DATE_TIME:
+                    formatter = ISODateTimeFormat.dateTime();
+                    break;
+                case DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.dateTimeNoMillis();
+                    break;
+                case HOUR:
+                    formatter = ISODateTimeFormat.hour();
+                    break;
+                case HOUR_MINUTE:
+                    formatter = ISODateTimeFormat.hourMinute();
+                    break;
+                case HOUR_MINUTE_SECOND:
+                    formatter = ISODateTimeFormat.hourMinuteSecond();
+                    break;
+                case HOUR_MINUTE_SECOND_FRACTION:
+                    formatter = ISODateTimeFormat.hourMinuteSecondFraction();
+                    break;
+                case HOUR_MINUTE_SECOND_MILLIS:
+                    formatter = ISODateTimeFormat.hourMinuteSecondMillis();
+                    break;
+                case ORDINAL_DATE:
+                    formatter = ISODateTimeFormat.ordinalDate();
+                    break;
+                case ORDINAL_DATE_TIME:
+                    formatter = ISODateTimeFormat.ordinalDateTime();
+                    break;
+                case ORDINAL_DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.ordinalDateTimeNoMillis();
+                    break;
+                case TIME:
+                    formatter = ISODateTimeFormat.time();
+                    break;
+                case TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.timeNoMillis();
+                    break;
+                case T_TIME:
+                    formatter = ISODateTimeFormat.tTime();
+                    break;
+                case T_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.tTimeNoMillis();
+                    break;
+                case WEEK_DATE:
+                    formatter = ISODateTimeFormat.weekDate();
+                    break;
+                case WEEK_DATE_TIME:
+                    formatter = ISODateTimeFormat.weekDateTime();
+                    break;
+                case WEEK_DATE_TIME_NO_MILLIS:
+                    formatter = ISODateTimeFormat.weekDateTimeNoMillis();
+                    break;
+                case WEEKYEAR:
+                    getDeprecationLogger().deprecate(
+                        "week_year_format_name",
+                        "Format name \"week_year\" is deprecated and will be removed in a future version. " + "Use \"weekyear\" format instead"
+                    );
+                    formatter = ISODateTimeFormat.weekyear();
+                    break;
+                case WEEK_YEAR:
+                    formatter = ISODateTimeFormat.weekyear();
+                    break;
+                case WEEK_YEAR_WEEK:
+                    formatter = ISODateTimeFormat.weekyearWeek();
+                    break;
+                case WEEKYEAR_WEEK_DAY:
+                    formatter = ISODateTimeFormat.weekyearWeekDay();
+                    break;
+                case YEAR:
+                    formatter = ISODateTimeFormat.year();
+                    break;
+                case YEAR_MONTH:
+                    formatter = ISODateTimeFormat.yearMonth();
+                    break;
+                case YEAR_MONTH_DAY:
+                    formatter = ISODateTimeFormat.yearMonthDay();
+                    break;
+                case EPOCH_SECOND:
+                    formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(false), new EpochTimeParser(false)).toFormatter();
+                    break;
+                case EPOCH_MILLIS:
+                    formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(true), new EpochTimeParser(true)).toFormatter();
+                    break;
+                    // strict date formats here, must be at least 4 digits for year and two for months and two for day
+                case STRICT_BASIC_WEEK_DATE:
+                    formatter = StrictISODateTimeFormat.basicWeekDate();
+                    break;
+                case STRICT_BASIC_WEEK_DATE_TIME:
+                    formatter = StrictISODateTimeFormat.basicWeekDateTime();
+                    break;
+                case STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.basicWeekDateTimeNoMillis();
+                    break;
+                case STRICT_DATE:
+                    formatter = StrictISODateTimeFormat.date();
+                    break;
+                case STRICT_DATE_HOUR:
+                    formatter = StrictISODateTimeFormat.dateHour();
+                    break;
+                case STRICT_DATE_HOUR_MINUTE:
+                    formatter = StrictISODateTimeFormat.dateHourMinute();
+                    break;
+                case STRICT_DATE_HOUR_MINUTE_SECOND:
+                    formatter = StrictISODateTimeFormat.dateHourMinuteSecond();
+                    break;
+                case STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    formatter = StrictISODateTimeFormat.dateHourMinuteSecondFraction();
+                    break;
+                case STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    formatter = StrictISODateTimeFormat.dateHourMinuteSecondMillis();
+                    break;
+                case STRICT_DATE_OPTIONAL_TIME:
+                    // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
+                    // this sucks we should use the root local by default and not be dependent on the node
+                    return new JodaDateFormatter(
+                        input,
+                        StrictISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
+                        StrictISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
+                    );
+                case STRICT_DATE_TIME:
+                    formatter = StrictISODateTimeFormat.dateTime();
+                    break;
+                case STRICT_DATE_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.dateTimeNoMillis();
+                    break;
+                case STRICT_HOUR:
+                    formatter = StrictISODateTimeFormat.hour();
+                    break;
+                case STRICT_HOUR_MINUTE:
+                    formatter = StrictISODateTimeFormat.hourMinute();
+                    break;
+                case STRICT_HOUR_MINUTE_SECOND:
+                    formatter = StrictISODateTimeFormat.hourMinuteSecond();
+                    break;
+                case STRICT_HOUR_MINUTE_SECOND_FRACTION:
+                    formatter = StrictISODateTimeFormat.hourMinuteSecondFraction();
+                    break;
+                case STRICT_HOUR_MINUTE_SECOND_MILLIS:
+                    formatter = StrictISODateTimeFormat.hourMinuteSecondMillis();
+                    break;
+                case STRICT_ORDINAL_DATE:
+                    formatter = StrictISODateTimeFormat.ordinalDate();
+                    break;
+                case STRICT_ORDINAL_DATE_TIME:
+                    formatter = StrictISODateTimeFormat.ordinalDateTime();
+                    break;
+                case STRICT_ORDINAL_DATE_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.ordinalDateTimeNoMillis();
+                    break;
+                case STRICT_TIME:
+                    formatter = StrictISODateTimeFormat.time();
+                    break;
+                case STRICT_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.timeNoMillis();
+                    break;
+                case STRICT_T_TIME:
+                    formatter = StrictISODateTimeFormat.tTime();
+                    break;
+                case STRICT_T_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.tTimeNoMillis();
+                    break;
+                case STRICT_WEEK_DATE:
+                    formatter = StrictISODateTimeFormat.weekDate();
+                    break;
+                case STRICT_WEEK_DATE_TIME:
+                    formatter = StrictISODateTimeFormat.weekDateTime();
+                    break;
+                case STRICT_WEEK_DATE_TIME_NO_MILLIS:
+                    formatter = StrictISODateTimeFormat.weekDateTimeNoMillis();
+                    break;
+                case STRICT_WEEKYEAR:
+                    formatter = StrictISODateTimeFormat.weekyear();
+                    break;
+                case STRICT_WEEKYEAR_WEEK:
+                    formatter = StrictISODateTimeFormat.weekyearWeek();
+                    break;
+                case STRICT_WEEKYEAR_WEEK_DAY:
+                    formatter = StrictISODateTimeFormat.weekyearWeekDay();
+                    break;
+                case STRICT_YEAR:
+                    formatter = StrictISODateTimeFormat.year();
+                    break;
+                case STRICT_YEAR_MONTH:
+                    formatter = StrictISODateTimeFormat.yearMonth();
+                    break;
+                case STRICT_YEAR_MONTH_DAY:
+                    formatter = StrictISODateTimeFormat.yearMonthDay();
+                    break;
+                default:
+                    formatter = null;
+                    break;
+            }
+        } else {
+            formatter = null;
+        }
+
+        if (formatter == null) {
+            if (Strings.hasLength(input) && input.contains("||")) {
             String[] formats = Strings.delimitedListToStringArray(input, "||");
             DateTimeParser[] parsers = new DateTimeParser[formats.length];
 


### PR DESCRIPTION
### Description

Replaces the redundant if-else chain in  and  with a  statement on the  enum value that is **already resolved** by .

### Problem

Both  and  contain a chain of 60+  branches. Each branch calls , which does **two  comparisons** (one for camel-case, one for snake-case). A format name near the end of the chain must walk through all previous branches first — up to **120 string comparisons** before a match.

Worse, the code already calls  at the top (used for the camel-case deprecation warning), which resolves the enum constant. The result is then thrown away and the same linear scan is repeated from scratch.

### Fix

Replace the if-else chain with a  on the already-resolved  enum value. A  on an enum compiles to a JVM  or  instruction — **O(1) dispatch** regardless of the number of cases.

| Scenario | Before | After |
|---|---|---|
| Format near start of chain (e.g. `basic_date`) | 2 comparisons | O(1) |
| Format near end of chain (e.g. `strict_year_month_day`) | up to 120 comparisons | O(1) |
| Unknown / raw pattern (e.g. `yyyy/MM/dd`) | 120+ comparisons + `forName` scan | `forName` scan + O(1) `default` |

### Files changed

- `server/src/main/java/org/opensearch/common/joda/Joda.java` — `forPattern()` switch on `formatName` instead of if-else chain
- `server/src/main/java/org/opensearch/common/time/DateFormatters.java` — `forPattern()` switch on `formatName` instead of if-else chain

### Verification

- No functional change — the switch produces the same formatter for every known `FormatNames` value
- Covered entirely by existing test suites
- Issue includes a branch with related changes: `refactor/date-format-if-else-to-switch`

Closes #22567

[fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]