### PR TITLE
[BUG] derived_source forces store=true on text multi-fields, wasting disk for no reconstruction benefit

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -802,6 +802,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     return empty();
                 } else {
                     context.path().add(mainFieldBuilder.name());
+                    context.setMultiField(true);
                     Map mapperBuilders = this.mapperBuilders;
                     for (final Map.Entry<String, Mapper.Builder> cursor : this.mapperBuilders.entrySet()) {
                         String key = cursor.getKey();
@@ -810,6 +811,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                         assert mapper instanceof FieldMapper;
                         mapperBuilders.put(key, mapper);
                     }
+                    context.setMultiField(false);
                     context.path().remove();
                     final Map<String, FieldMapper> mappers = (Map<String, FieldMapper>) mapperBuilders;
                     return new MultiFields(mappers);

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -96,6 +96,16 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             return this.indexSettings;
         }
 
+        private boolean multiField = false;
+
+        public boolean isMultiField() {
+            return multiField;
+        }
+
+        public void setMultiField(boolean multiField) {
+            this.multiField = multiField;
+        }
+
         public void assignCapabilities(MappedFieldType fieldType) {
             if (capabilityAssigner != null) {
                 capabilityAssigner.accept(fieldType);

--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -473,8 +473,9 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         public TextFieldMapper build(BuilderContext context) {
             FieldType fieldType = TextParams.buildFieldType(index, store, indexOptions, norms, termVectors);
             TextFieldType tft = buildFieldType(fieldType, context);
-            if (context.indexSettings().getAsBoolean(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), false)
-                || context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)) {
+            if ((context.indexSettings().getAsBoolean(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), false)
+                || context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false))
+                && !context.isMultiField()) {
                 fieldType.setStored(true);
             }
             return new TextFieldMapper(


### PR DESCRIPTION
### Description

Fixes #22536 — When `index.derived_source.enabled=true`, `TextFieldMapper.build()` unconditionally forces `store=true` on **every** text mapper, including **multi-field** text subfields (e.g. `keyword + fields.analyzed: text`).

Multi-fields are **not** walked by derived-source `_source` reconstruction (`ObjectMapper.deriveSource()` only iterates top-level / object child mappers). The parent `keyword` field is rebuilt from `doc_values`. The text multi-field is never consulted for `_source`, so forcing stored fields wastes disk for no reconstruction benefit.

### Root Cause

In `TextFieldMapper.Builder.build()`:

```java
if (context.indexSettings().getAsBoolean(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), false)
    || context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)) {
    fieldType.setStored(true);
}
```

This runs for ALL text fields, including multi-fields built via `MultiFields.Builder.build()`. Multi-fields are not walked by `deriveSource()`, so forcing `store=true` on them is unnecessary.

### Fix

Three changes across three files:

1. **Mapper.java (BuilderContext)**: Added `isMultiField()` / `setMultiField()` methods to track whether a field is being built as a multi-field.

2. **FieldMapper.java (MultiFields.Builder.build())**: Set `context.setMultiField(true)` before building multi-field mappers and reset to `false` after.

3. **TextFieldMapper.java (Builder.build())**: Added `&& !context.isMultiField()` check before forcing `store=true`, so multi-fields are no longer forced to be stored.

### Expected Behavior

| Field | Auto `store=true` with derived source? |
|-------|----------------------------------------|
| Top-level `type: text` | Yes — needed to reconstruct `_source` |
| Object child text field | Yes — in `deriveSource` tree |
| Multi-field `*.analyzed` under `keyword` parent | **No** — not part of `_source` reconstruction |

Explicit `"store": true` on a multi-field is still honored if the user asked for it.

### Testing

- Existing tests should continue to pass — no functional change for top-level or object-child text fields
- Multi-fields under derived source will no longer be unnecessarily stored, reducing disk usage

Closes #22536