### PR TITLE
[BUG] Dynamic pruning failure in cardinality aggregation falls back instead of failing the shard (#22582)

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -53,7 +53,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.opensearch.OpenSearchStatusException;
+
 import org.opensearch.common.Nullable;
 import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.common.lease.Releasable;
@@ -65,7 +65,7 @@ import org.opensearch.common.util.BitMixer;
 import org.opensearch.common.util.LongArray;
 import org.opensearch.common.util.ObjectArray;
 import org.opensearch.core.common.unit.ByteSizeValue;
-import org.opensearch.core.rest.RestStatus;
+
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
 import org.opensearch.index.fielddata.SortedNumericDoubleValues;
 import org.opensearch.search.aggregations.Aggregator;
@@ -278,6 +278,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             Weight weight = context.query().rewrite(context.searcher()).createWeight(context.searcher(), ScoreMode.TOP_DOCS, 1f);
             Scorer scorer = weight.scorer(ctx);
             if (scorer == null) {
+                Releasables.close(pruningCollector);
                 return false;
             }
             pruningCollector.setScorer(scorer);
@@ -287,13 +288,14 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             pruningCollector.postCollect();
             Releasables.close(pruningCollector);
         } catch (Exception e) {
-            throw new OpenSearchStatusException(
-                "Failed when performing dynamic pruning in cardinality aggregation. You can set cluster setting ["
-                    + CARDINALITY_AGGREGATION_PRUNING_THRESHOLD.getKey()
-                    + "] to 0 to disable.",
-                RestStatus.INTERNAL_SERVER_ERROR,
+            Releasables.closeWhileHandlingException(pruningCollector);
+            logger.warn(
+                "Dynamic pruning failed for cardinality aggregation, falling back to non-pruning path. "
+                    + "You can set cluster setting [{}] to 0 to disable this optimization.",
+                CARDINALITY_AGGREGATION_PRUNING_THRESHOLD.getKey(),
                 e
             );
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
### Description

When a `cardinality` aggregation is used together with a `hybrid` query that has two or more subqueries, the dynamic pruning optimization in `CardinalityAggregator` can read past the end of a doc-values slice, producing an `EOFException: read past EOF`.

### Root Cause

The dynamic pruning path in `tryScoreWithPruningCollector` assumes scorer/iterator semantics that the hybrid scorer (from the neural-search plugin) does not provide. When the pruning fails, the original code wraps the exception in an `OpenSearchStatusException` with `RestStatus.INTERNAL_SERVER_ERROR`, which:
1. Causes the entire shard to fail (`_shards.failed > 0`)
2. Returns HTTP 200 with silently truncated results
3. Clients that only check the HTTP status code never see the partial failure

### Fix

Changed `tryScoreWithPruningCollector` to:
1. **Log a warning** instead of throwing an error when pruning fails
2. **Return `false`** to trigger the non-pruning fallback path in `pickCollector`
3. **Close the pruning collector** on all failure paths to prevent resource leaks

This means the cardinality aggregation will still compute correctly — just without the pruning optimization for the affected segment. The user sees the correct result instead of a silent partial failure.

### Related Issues

Closes #22582

### Testing

- Dynamic pruning is an optimization; the non-pruning path is always available as a fallback
- The existing test suite for cardinality aggregation continues to exercise the non-pruning path
- The error message in the warning log (with the setting name to disable pruning) is preserved for debugging