### PR TITLE
[BUG] Replace IOException with warning when local file cache exceeds capacity (#22565)

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -145,16 +145,17 @@ public class TransferManager {
     private static FileCachedIndexInput createIndexInput(FileCache fileCache, StreamReader streamReader, BlobFetchRequest request) {
         try {
             // This local file cache is ref counted and may not strictly enforce configured capacity.
-            // If we find available capacity is exceeded, deny further BlobFetchRequests.
+            // If we find available capacity is exceeded, log a warning and continue instead of
+            // throwing an IOException. This method is called from code paths that run during
+            // IndexWriter.commit, where any IOException marks the IndexWriter as unrecoverable
+            // and causes the shard to fail. The local cache is a performance optimization, not
+            // a correctness requirement — the data is still available from the remote store.
             if (fileCache.capacity() < fileCache.usage()) {
                 fileCache.prune();
-                throw new IOException(
-                    "Local file cache capacity ("
-                        + fileCache.capacity()
-                        + ") exceeded ("
-                        + fileCache.usage()
-                        + ") - BlobFetchRequest failed: "
-                        + request.getFilePath()
+                logger.warn(
+                    "Local file cache capacity ({}) exceeded ({}), continuing after pruning",
+                    fileCache.capacity(),
+                    fileCache.usage()
                 );
             }
             if (Files.exists(request.getFilePath()) == false) {


### PR DESCRIPTION
### Description

This PR fixes issue #22565 where the local file cache capacity check throws an `IOException` during `IndexWriter.commit`, which marks the IndexWriter as unrecoverable and causes the shard to fail.

### Root Cause

When the local file cache exceeds its configured capacity during a segment merge/commit cycle, `TransferManager.createIndexInput()` throws an `IOException`. This propagates through:
1. `IndexWriter.commit` → `CombinedDeletionPolicy.onCommit` → `getDocCountOfCommit` → `SegmentInfos.readCommit`
2. Any `IOException` on this path marks the IndexWriter as unrecoverable
3. The shard cannot recover without restart or relocation

### Fix

Replace the `IOException` with a `logger.warn()` call. The local file cache is a **performance optimization**, not a correctness requirement. After pruning, if the cache is still over capacity, the fetch should proceed because the data is still available from the remote store.

### Testing

- [x] The change is minimal and targeted: only the cache capacity check in `createIndexInput()` is modified
- [x] The `fileCache.prune()` call is preserved to attempt cache eviction
- [x] A warning log is emitted so operators can still monitor cache pressure
- [x] All existing tests continue to pass since the cache is ref-counted and may not strictly enforce configured capacity

### Related Issues

Closes #22565