### PR TITLE
fix: restore fasterxml JsonParseException mapping in ExceptionsHelper.status() (#21612) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -131,6 +131,7 @@ public final class ExceptionsHelper {
             case IllegalArgumentException ignored -> RestStatus.BAD_REQUEST;
             case InputCoercionException ignored -> RestStatus.BAD_REQUEST;
             case JsonParseException ignored -> RestStatus.BAD_REQUEST;
+            case com.fasterxml.jackson.core.JsonParseException ignored -> RestStatus.BAD_REQUEST;
             case NotXContentException ignored -> RestStatus.BAD_REQUEST;
             case IndexSearcher.TooManyClauses ignored -> RestStatus.BAD_REQUEST;
             case OpenSearchRejectedExecutionException ignored -> RestStatus.TOO_MANY_REQUESTS;
@@ -144,6 +145,7 @@ public final class ExceptionsHelper {
             case IllegalArgumentException ignored -> ErrorMessages.INVALID_ARGUMENT;
             case InputCoercionException ignored -> ErrorMessages.JSON_COERCION_FAILED;
             case JsonParseException ignored -> ErrorMessages.JSON_PARSE_FAILED;
+            case com.fasterxml.jackson.core.JsonParseException ignored -> ErrorMessages.JSON_PARSE_FAILED;
             case OpenSearchRejectedExecutionException ignored -> ErrorMessages.TOO_MANY_REQUESTS;
             case null, default -> "Internal failure";
         };


### PR DESCRIPTION
### Description

PR #21029 (Jackson 3.x migration) changed `ExceptionsHelper.status()` to use `org.opensearch.tools.jackson.core.JsonParseException` in the switch statement, but `com.fasterxml.jackson.core.JsonParseException` (fasterxml variant) is still on the classpath and used by plugins.

### Impact

This is a silent behavioral regression. Any plugin that encounters a fasterxml `JsonParseException` now gets `RestStatus.INTERNAL_SERVER_ERROR` (500) instead of `BAD_REQUEST` (400), causing infinite retries in exception-based retry logic (e.g. opensearch-project/anomaly-detection#1714).

### Fix

Added fully-qualified `com.fasterxml.jackson.core.JsonParseException` cases to both `status()` and `summaryMessage()` methods, so both Jackson 2.x (fasterxml) and 3.x (opensearch-tools) variants are handled correctly.

### Related Issues

Resolves #21612
