### PR TITLE
Fix NPE explaining function_score when the sub-query produces no scorer

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -473,6 +473,12 @@ public class FunctionScoreQuery extends Query {
                     factorExplanation = functionsExplanations.get(0);
                 } else {
                     FunctionFactorScorer scorer = functionScorer(context);
+                    if (scorer == null) {
+                        // The sub-query explains this document as a match but produces no scorer for this segment.
+                        // functionScorer() returns null there, and scorerSupplier() treats that state as "no matches
+                        // on this segment", so report no match instead of dereferencing a null scorer.
+                        return Explanation.noMatch("sub-query produced no scorer for this segment", expl);
+                    }
                     int actualDoc = scorer.iterator().advance(doc);
                     assert (actualDoc == doc);
                     double score = scorer.computeScore(doc, expl.getValue().floatValue());

--- a/server/src/test/java/org/opensearch/index/query/functionscore/FunctionScoreTests.java
+++ b/server/src/test/java/org/opensearch/index/query/functionscore/FunctionScoreTests.java
@@ -45,7 +45,9 @@ import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
@@ -615,6 +617,74 @@ public class FunctionScoreTests extends OpenSearchTestCase {
         assertThat(functionExplanation.getDescription(), equalTo("function score, product of:"));
         assertThat(functionExplanation.getDetails()[0].getDescription(), equalTo("match filter: " + FIELD + ":" + TERM.text()));
         assertThat(functionExplanation.getDetails()[1].getDescription(), equalTo(functionExpl));
+    }
+
+    public void testExplainFunctionScoreQueryWhenSubQueryHasNoScorer() throws IOException {
+        // Two functions keep the explanation on the FunctionFactorScorer path, which is where a null sub-query scorer
+        // used to be dereferenced.
+        FunctionScoreQuery functionScoreQuery = new FunctionScoreQuery(
+            new MatchingExplanationNullScorerQuery(),
+            ScoreMode.AVG,
+            new ScoreFunction[] { new WeightFactorFunction(2), new WeightFactorFunction(3) },
+            CombineFunction.AVG,
+            null,
+            Float.MAX_VALUE
+        );
+
+        Explanation explanation = getExplanation(searcher, functionScoreQuery);
+
+        assertNotNull(explanation);
+        assertFalse(explanation.isMatch());
+        assertThat(explanation.getDescription(), containsString("sub-query produced no scorer for this segment"));
+    }
+
+    /**
+     * A query whose weight explains every document as a match but never produces a scorer. That disagreement between
+     * explain() and the scorer is what used to make {@link FunctionScoreQuery} throw a NullPointerException while
+     * explaining a document.
+     */
+    private static class MatchingExplanationNullScorerQuery extends Query {
+
+        @Override
+        public String toString(String field) {
+            return getClass().getSimpleName();
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+            visitor.visitLeaf(this);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return this == obj;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, org.apache.lucene.search.ScoreMode scoreMode, float boost) {
+            return new Weight(this) {
+
+                @Override
+                public Explanation explain(LeafReaderContext context, int doc) {
+                    return Explanation.match(1.0f, "matches");
+                }
+
+                @Override
+                public ScorerSupplier scorerSupplier(LeafReaderContext context) {
+                    return null;
+                }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
+            };
+        }
     }
 
     private static float[] randomPositiveFloats(int size) {


### PR DESCRIPTION
### Description

`FunctionScoreQuery.CustomBoostFactorWeight.explain()` dereferenced the scorer from `functionScorer(context)` without a null check:

```java
FunctionFactorScorer scorer = functionScorer(context);
int actualDoc = scorer.iterator().advance(doc);
```

`functionScorer()` returns `null` when `subQueryWeight.scorer(context)` is null, so a sub-query whose weight explains a document as a match while producing no scorer for that segment made `explain()` throw a `NullPointerException`. Since `explain()` runs in the fetch phase, one such clause failed the whole search request for requests that succeed fine with `explain` disabled.

`scorerSupplier()` in the same weight returns `null` for the equivalent state, which means "no matches on this segment". This change makes `explain()` agree with it: a null scorer now yields `Explanation.noMatch(...)` wrapping the sub-query explanation instead of dereferencing the null scorer.

The `assert (actualDoc == doc)` below the new guard is deliberately left alone. A sub-query that returns a scorer which does not position on the document is the same class of disagreement, but handling it changes the explanation for a different state and is better done as its own change once this one lands.

Testing:

- `FunctionScoreTests#testExplainFunctionScoreQueryWhenSubQueryHasNoScorer` covers the scorer/explain mismatch with a sub-query whose weight always explains a match and never returns a scorer. Reverting the guard makes it fail with the `NullPointerException` described above.
- `./gradlew :server:test --tests "org.opensearch.index.query.functionscore.FunctionScoreTests"` passes.

The CHANGELOG is not updated, since as of 3.6 it is no longer used to generate release notes (#21071).

### Related Issues
Resolves #22634

Same defect class as #18446, fixed by #19650 in `scorerSupplier()`, and #22619, which #22624 addresses in `ScriptScoreQuery.explain()`. `FunctionScoreQuery.explain()` is the remaining site, which neither change touches, so this PR does not overlap with #22624.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
