### PR TITLE
Cap testLimitsInFlightRequests at the Netty pipeline depth of 128

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -94,7 +94,9 @@ public class Netty4HttpRequestSizeLimitIT extends OpenSearchNetty4IntegTestCase 
         }
 
         List<Tuple<String, CharSequence>> requests = new ArrayList<>();
-        for (int i = 0; i < 150; i++) {
+        // See please https://github.com/netty/netty/pull/17068 why 128 is the cap, we should be able to
+        // make it configurable in the Netty next release.
+        for (int i = 0; i < 128; i++) {
             requests.add(Tuple.tuple("/index/_bulk", bulkRequest));
         }
 


### PR DESCRIPTION
### Description

Netty 4.2.16 added a `maxPipelineDepth` to `HttpContentEncoder` with a default of 128 (netty/netty#17063). A single connection carrying more pipelined requests than that gets `IllegalStateException: maxPipelineDepth exceeded: 128`, the server closes the connection, and the client receives none of its responses — failing on the 30s latch with `Failed to get all expected responses: 150 left`.

The Netty upgrade in #22403 already applied this cap to `testDoesNotLimitExcludedRequests` in this same class (1500 → 128, with a comment pointing at netty/netty#17068). `testLimitsInFlightRequests` was left at 150 and hits the same wall.

That is why this class keeps appearing in flaky reports (#18875) with a failure that is not random: the encoder queue drains as responses are written, so the limit is only reached when requests outrun responses — which happens on a loaded CI host and not on a fast local one. The autocut report attributes the class to cluster-state timeouts; this failure mode is different, and its stack trace shows `maxPipelineDepth exceeded: 128` instead.

128 still exercises what the test is for: the in-flight-requests breaker is set to 2 KB and trips at 2880 bytes, i.e. after a handful of requests. Mutation-checked — raising the breaker to 2 GB fails the test, so the `TOO_MANY_REQUESTS` assertion still bites.

The configurable variant added in netty/netty#17068 is not available yet: it merged on 2026-07-10, three days after 4.2.16.Final was released, and there is no 4.2.17. Once there is, this cap can be driven from `http.pipelining.max_events` instead.

### Related Issues

Relates to #18875, #22403

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable. (n/a)
- [ ] Public documentation issue/PR created, if applicable. (n/a — test-only)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
