### PR TITLE
Fix flat_object to support subfield access in Painless scripts (Resolves #7138)

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.FieldExistsQuery;
@@ -34,6 +35,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.fielddata.SortedBinaryDocValues;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.opensearch.index.query.QueryShardContext;
@@ -227,7 +229,58 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
+            if (isSubField()) {
+                String prefix = getPathPrefix(name());
+                return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), (SortedSetDocValues sdv) -> {
+                    SortedBinaryDocValues sbdv = org.opensearch.index.fielddata.FieldData.toString(sdv);
+                    return new org.opensearch.index.fielddata.ScriptDocValues.Strings(
+                        new PrefixFilteredSortedBinaryDocValues(sbdv, prefix)
+                    );
+                }, CoreValuesSourceType.BYTES);
+            }
             return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), CoreValuesSourceType.BYTES);
+        }
+
+        private static class PrefixFilteredSortedBinaryDocValues extends org.opensearch.index.fielddata.SortedBinaryDocValues {
+            private final org.opensearch.index.fielddata.SortedBinaryDocValues in;
+            private final BytesRef prefix;
+            private int docValueCount;
+            private final java.util.List<BytesRef> matches = new java.util.ArrayList<>();
+            private int index;
+
+            PrefixFilteredSortedBinaryDocValues(org.opensearch.index.fielddata.SortedBinaryDocValues in, String prefix) {
+                this.in = in;
+                this.prefix = new BytesRef(prefix);
+            }
+
+            @Override
+            public boolean advanceExact(int doc) throws IOException {
+                if (in.advanceExact(doc)) {
+                    matches.clear();
+                    int count = in.docValueCount();
+                    for (int i = 0; i < count; i++) {
+                        BytesRef val = in.nextValue();
+                        if (val.length >= prefix.length && org.apache.lucene.util.StringHelper.startsWith(val, prefix)) {
+                            BytesRef stripped = new BytesRef(val.bytes, val.offset + prefix.length, val.length - prefix.length);
+                            matches.add(BytesRef.deepCopyOf(stripped));
+                        }
+                    }
+                    docValueCount = matches.size();
+                    index = 0;
+                    return docValueCount > 0;
+                }
+                return false;
+            }
+
+            @Override
+            public int docValueCount() {
+                return docValueCount;
+            }
+
+            @Override
+            public BytesRef nextValue() throws IOException {
+                return matches.get(index++);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -236,9 +236,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                 String prefix = getDVPrefix(rootFieldName) + getPathPrefix(name());
                 return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), (SortedSetDocValues sdv) -> {
                     SortedBinaryDocValues sbdv = FieldData.toString(sdv);
-                    return new ScriptDocValues.Strings(
-                        new PrefixFilteredSortedBinaryDocValues(sbdv, prefix)
-                    );
+                    return new ScriptDocValues.Strings(new PrefixFilteredSortedBinaryDocValues(sbdv, prefix));
                 }, CoreValuesSourceType.BYTES);
             }
             return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), CoreValuesSourceType.BYTES);

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.opensearch.OpenSearchException;
@@ -34,7 +35,9 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.fielddata.FieldData;
 import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
@@ -42,9 +45,6 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.lookup.SearchLookup;
-import org.opensearch.index.fielddata.FieldData;
-import org.opensearch.index.fielddata.ScriptDocValues;
-import org.apache.lucene.util.StringHelper;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -233,7 +233,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
             if (isSubField()) {
-                String prefix = getPathPrefix(name());
+                String prefix = getDVPrefix(rootFieldName) + getPathPrefix(name());
                 return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), (SortedSetDocValues sdv) -> {
                     SortedBinaryDocValues sbdv = FieldData.toString(sdv);
                     return new ScriptDocValues.Strings(

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -42,6 +42,9 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.index.fielddata.FieldData;
+import org.opensearch.index.fielddata.ScriptDocValues;
+import org.apache.lucene.util.StringHelper;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -232,8 +235,8 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             if (isSubField()) {
                 String prefix = getPathPrefix(name());
                 return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), (SortedSetDocValues sdv) -> {
-                    SortedBinaryDocValues sbdv = org.opensearch.index.fielddata.FieldData.toString(sdv);
-                    return new org.opensearch.index.fielddata.ScriptDocValues.Strings(
+                    SortedBinaryDocValues sbdv = FieldData.toString(sdv);
+                    return new ScriptDocValues.Strings(
                         new PrefixFilteredSortedBinaryDocValues(sbdv, prefix)
                     );
                 }, CoreValuesSourceType.BYTES);
@@ -241,14 +244,14 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             return new SortedSetOrdinalsIndexFieldData.Builder(valueFieldType().name(), CoreValuesSourceType.BYTES);
         }
 
-        private static class PrefixFilteredSortedBinaryDocValues extends org.opensearch.index.fielddata.SortedBinaryDocValues {
-            private final org.opensearch.index.fielddata.SortedBinaryDocValues in;
+        private static class PrefixFilteredSortedBinaryDocValues extends SortedBinaryDocValues {
+            private final SortedBinaryDocValues in;
             private final BytesRef prefix;
             private int docValueCount;
-            private final java.util.List<BytesRef> matches = new java.util.ArrayList<>();
+            private final List<BytesRef> matches = new ArrayList<>();
             private int index;
 
-            PrefixFilteredSortedBinaryDocValues(org.opensearch.index.fielddata.SortedBinaryDocValues in, String prefix) {
+            PrefixFilteredSortedBinaryDocValues(SortedBinaryDocValues in, String prefix) {
                 this.in = in;
                 this.prefix = new BytesRef(prefix);
             }
@@ -260,7 +263,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                     int count = in.docValueCount();
                     for (int i = 0; i < count; i++) {
                         BytesRef val = in.nextValue();
-                        if (val.length >= prefix.length && org.apache.lucene.util.StringHelper.startsWith(val, prefix)) {
+                        if (val.length >= prefix.length && StringHelper.startsWith(val, prefix)) {
                             BytesRef stripped = new BytesRef(val.bytes, val.offset + prefix.length, val.length - prefix.length);
                             matches.add(BytesRef.deepCopyOf(stripped));
                         }

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
@@ -15,6 +15,8 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.fielddata.AbstractFieldDataTestCase;
 import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.fielddata.LeafOrdinalsFieldData;
+import org.opensearch.index.fielddata.ScriptDocValues;
 
 import java.util.List;
 
@@ -130,22 +132,22 @@ public class FlatObjectFieldDataTests extends AbstractFieldDataTestCase {
         assertEquals(1, readers.size());
 
         IndexFieldData<?> detailNameFieldData = getForField("field.detail.name");
-        org.opensearch.index.fielddata.LeafOrdinalsFieldData detailNameLeafData = 
-            (org.opensearch.index.fielddata.LeafOrdinalsFieldData) detailNameFieldData.load(readers.get(0));
-        
-        org.opensearch.index.fielddata.ScriptDocValues<?> scriptValues = detailNameLeafData.getScriptValues();
+        LeafOrdinalsFieldData detailNameLeafData =
+            (LeafOrdinalsFieldData) detailNameFieldData.load(readers.get(0));
+
+        ScriptDocValues<?> scriptValues = detailNameLeafData.getScriptValues();
         scriptValues.setNextDocId(0);
-        
+
         assertEquals(1, scriptValues.size());
         assertEquals("foo", scriptValues.get(0));
 
         IndexFieldData<?> detailAgeFieldData = getForField("field.detail.age");
-        org.opensearch.index.fielddata.LeafOrdinalsFieldData detailAgeLeafData = 
-            (org.opensearch.index.fielddata.LeafOrdinalsFieldData) detailAgeFieldData.load(readers.get(0));
-        
+        LeafOrdinalsFieldData detailAgeLeafData =
+            (LeafOrdinalsFieldData) detailAgeFieldData.load(readers.get(0));
+
         scriptValues = detailAgeLeafData.getScriptValues();
         scriptValues.setNextDocId(0);
-        
+
         assertEquals(1, scriptValues.size());
         assertEquals("25", scriptValues.get(0));
     }

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
@@ -132,8 +132,7 @@ public class FlatObjectFieldDataTests extends AbstractFieldDataTestCase {
         assertEquals(1, readers.size());
 
         IndexFieldData<?> detailNameFieldData = getForField("field.detail.name");
-        LeafOrdinalsFieldData detailNameLeafData =
-            (LeafOrdinalsFieldData) detailNameFieldData.load(readers.get(0));
+        LeafOrdinalsFieldData detailNameLeafData = (LeafOrdinalsFieldData) detailNameFieldData.load(readers.get(0));
 
         ScriptDocValues<?> scriptValues = detailNameLeafData.getScriptValues();
         scriptValues.setNextDocId(0);
@@ -142,8 +141,7 @@ public class FlatObjectFieldDataTests extends AbstractFieldDataTestCase {
         assertEquals("foo", scriptValues.get(0));
 
         IndexFieldData<?> detailAgeFieldData = getForField("field.detail.age");
-        LeafOrdinalsFieldData detailAgeLeafData =
-            (LeafOrdinalsFieldData) detailAgeFieldData.load(readers.get(0));
+        LeafOrdinalsFieldData detailAgeLeafData = (LeafOrdinalsFieldData) detailAgeFieldData.load(readers.get(0));
 
         scriptValues = detailAgeLeafData.getScriptValues();
         scriptValues.setNextDocId(0);

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
@@ -97,6 +97,59 @@ public class FlatObjectFieldDataTests extends AbstractFieldDataTestCase {
         assertEquals(1, valueReaders.size());
     }
 
+    public void testSubfieldDocValue() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("test")
+            .startObject("properties")
+            .startObject("field")
+            .field("type", FIELD_TYPE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        final DocumentMapper mapper = mapperService.documentMapperParser().parse("test", new CompressedXContent(mapping));
+
+        XContentBuilder json = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("field")
+            .startObject("detail")
+            .field("name", "foo")
+            .field("age", 25)
+            .endObject()
+            .field("other", "bar")
+            .endObject()
+            .endObject();
+
+        ParsedDocument d = mapper.parse(new SourceToParse("test", "1", BytesReference.bytes(json), MediaTypeRegistry.JSON));
+        writer.addDocument(d.rootDoc());
+        writer.commit();
+
+        List<LeafReaderContext> readers = refreshReader();
+        assertEquals(1, readers.size());
+
+        IndexFieldData<?> detailNameFieldData = getForField("field.detail.name");
+        org.opensearch.index.fielddata.LeafOrdinalsFieldData detailNameLeafData = 
+            (org.opensearch.index.fielddata.LeafOrdinalsFieldData) detailNameFieldData.load(readers.get(0));
+        
+        org.opensearch.index.fielddata.ScriptDocValues<?> scriptValues = detailNameLeafData.getScriptValues();
+        scriptValues.setNextDocId(0);
+        
+        assertEquals(1, scriptValues.size());
+        assertEquals("foo", scriptValues.get(0));
+
+        IndexFieldData<?> detailAgeFieldData = getForField("field.detail.age");
+        org.opensearch.index.fielddata.LeafOrdinalsFieldData detailAgeLeafData = 
+            (org.opensearch.index.fielddata.LeafOrdinalsFieldData) detailAgeFieldData.load(readers.get(0));
+        
+        scriptValues = detailAgeLeafData.getScriptValues();
+        scriptValues.setNextDocId(0);
+        
+        assertEquals(1, scriptValues.size());
+        assertEquals("25", scriptValues.get(0));
+    }
+
     @Override
     protected String getFieldDataType() {
         return FIELD_TYPE;


### PR DESCRIPTION
### Description
This PR enables Painless Scripts to accurately fetch and evaluate doc values for `flat_object` subfields. 

Previously, if a script attempted to read a subfield via `doc['flat_object_field.subfield'].value`, it would receive the unparsed internal format containing the path prefix (e.g., `subfield=value`). This broke script evaluations because the `fielddataBuilder` was returning the raw `_valueAndPath` data stream.

**How it was solved:**
- Modified `FlatObjectFieldType.fielddataBuilder()` to dynamically wrap `IndexFieldData` if the requested field is a subfield.
- Introduced `PrefixFilteredSortedBinaryDocValues` which wraps the standard `SortedBinaryDocValues`. During iteration within the script context, it filters the `_valueAndPath` stream for the exact subfield prefix (e.g., `subfield=`) and strips the prefix before yielding the value.
- Added a new unit test `testSubfieldDocValue()` in `FlatObjectFieldDataTests.java` to explicitly test script interactions with `flat_object` subfields and guarantee accurate filtering.

### Related Issues
Resolves #7138

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
