### PR TITLE
Drain active streams before closing Flight channel

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
@@ -13,6 +13,7 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.Ticket;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.arrow.flight.stats.FlightCallTracker;
 import org.opensearch.arrow.flight.stats.FlightStatsCollector;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -33,9 +34,14 @@ import org.opensearch.transport.stream.StreamTransportResponse;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -61,9 +67,20 @@ class FlightClientChannel implements TcpChannel {
     private final TransportMessageListener messageListener;
     private final NamedWriteableRegistry namedWriteableRegistry;
     private final HeaderContext headerContext;
+    private final AtomicBoolean closeStarted = new AtomicBoolean();
     private volatile boolean isClosed;
     private final FlightStatsCollector statsCollector;
     private final FlightTransportConfig config;
+    /**
+     * Streams created by this channel whose buffers may still be accounted against the client's
+     * allocator. Entries remove themselves via {@link FlightTransportResponse#setOnClosed} once
+     * their underlying flight stream is closed. {@link #close()} cancels every remaining stream
+     * and waits for the set to drain before closing the {@link FlightClient}, whose allocator
+     * close treats any outstanding buffer as a leak.
+     */
+    private final Set<FlightTransportResponse<?>> activeStreams = ConcurrentHashMap.newKeySet();
+    /** Signalled whenever a stream leaves {@link #activeStreams}, to wake {@link #close()}. */
+    private final Object activeStreamsMonitor = new Object();
 
     /**
      * Constructs a new FlightClientChannel for handling Arrow Flight streams.
@@ -138,7 +155,7 @@ class FlightClientChannel implements TcpChannel {
 
     @Override
     public void close() {
-        if (isClosed) {
+        if (closeStarted.compareAndSet(false, true) == false) {
             return;
         }
 
@@ -147,6 +164,23 @@ class FlightClientChannel implements TcpChannel {
         }
 
         isClosed = true;
+
+        // The FlightClient's allocator close treats any outstanding buffer as a leak, and live
+        // streams legitimately hold buffers (current batch root, retained heartbeat metadata)
+        // until their consumer closes them. So: cancel every active stream — FlightStream.cancel
+        // is safe from this thread and unblocks consumers parked in nextResponse()
+        for (FlightTransportResponse<?> streamResponse : activeStreams) {
+            try {
+                streamResponse.cancelStreamOnly("channel to node [" + node.getId() + "] closed");
+            } catch (Exception e) {
+                logger.warn(
+                    () -> new ParameterizedMessage("Error cancelling active stream while closing channel to node [{}]", node.getId()),
+                    e
+                );
+            }
+        }
+        awaitActiveStreamsClosed();
+
         closeFuture.complete(null);
         notifyListeners(closeListeners, closeFuture);
         try {
@@ -154,6 +188,68 @@ class FlightClientChannel implements TcpChannel {
         } catch (Exception e) {
             logger.warn("Failed to close FlightClient for node [" + node.getId() + "]", e);
         }
+    }
+
+    /**
+     * Waits up to {@link FlightTransportConfig#getStreamCloseTimeout()} for active streams to be
+     * released by their consumers (each removes itself from {@link #activeStreams} once its buffers
+     * are released). On timeout, proceeds anyway — the subsequent {@link FlightClient#close()} may
+     * then report the stragglers' buffers as leaked, which is logged, not thrown.
+     *
+     * <p>Streams whose consumer callback is running on this very thread are excluded from the wait:
+     * their release cannot happen until the callback returns, which cannot happen until this close
+     * returns, so waiting for them would burn the whole timeout to no effect.
+     */
+    private void awaitActiveStreamsClosed() {
+        final long timeoutMillis = config.getStreamCloseTimeout().millis();
+        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        synchronized (activeStreamsMonitor) {
+            long remainingNanos;
+            while (hasStreamsToAwait() && (remainingNanos = deadlineNanos - System.nanoTime()) > 0) {
+                try {
+                    // Wake on the next release, or at the deadline; never wait(0), which waits forever.
+                    activeStreamsMonitor.wait(Math.max(1, TimeUnit.NANOSECONDS.toMillis(remainingNanos)));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        Thread current = Thread.currentThread();
+        List<FlightTransportResponse<?>> remaining = new ArrayList<>(activeStreams);
+        long selfOwned = remaining.stream().filter(s -> s.getDispatchThread() == current).count();
+        long straggling = remaining.size() - selfOwned;
+        if (straggling > 0) {
+            logger.warn(
+                "Gave up after [{}ms] waiting for [{}] active stream(s) to be released while closing channel to node [{}]; "
+                    + "their buffers may be reported as leaked",
+                timeoutMillis,
+                straggling,
+                node.getId()
+            );
+        }
+        if (selfOwned > 0) {
+            logger.warn(
+                "Channel to node [{}] is being closed from a stream consumer callback; [{}] stream(s) owned by this thread "
+                    + "cannot be released before close returns and their buffers may be reported as leaked",
+                node.getId(),
+                selfOwned
+            );
+        }
+    }
+
+    /**
+     * Whether any active stream can still be released while this close is waiting — that is, any
+     * stream not owned by the calling thread. See {@link #awaitActiveStreamsClosed()}.
+     */
+    private boolean hasStreamsToAwait() {
+        Thread current = Thread.currentThread();
+        for (FlightTransportResponse<?> streamResponse : activeStreams) {
+            if (streamResponse.getDispatchThread() != current) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -239,6 +335,27 @@ class FlightClientChannel implements TcpChannel {
                 config
             );
 
+            // Track the stream until its buffers are released, so close() can wait for it before
+            // closing the FlightClient. Set the callback before any consumer can close the stream.
+            streamResponse.setOnClosed(() -> {
+                activeStreams.remove(streamResponse);
+                synchronized (activeStreamsMonitor) {
+                    activeStreamsMonitor.notifyAll();
+                }
+            });
+            activeStreams.add(streamResponse);
+            if (isOpen() == false) {
+                // close() may have iterated activeStreams before this add; make sure this stream
+                // is cancelled rather than left running against a closing client. The response
+                // handler was already removed from responseHandlers above, so notify it directly
+                // rather than leaving the request without a terminal callback.
+                StreamException exception = new StreamException(StreamErrorCode.UNAVAILABLE, "FlightClientChannel is closed");
+                streamResponse.cancelStreamOnly("channel to node [" + node.getId() + "] closed");
+                notifyHandlerOfException(handler, exception);
+                listener.onFailure(exception);
+                return;
+            }
+
             // Open stream and prefetch first batch, invoke handler when ready
             openStreamAndInvokeHandler(streamResponse);
             listener.onResponse(null);
@@ -275,15 +392,19 @@ class FlightClientChannel implements TcpChannel {
             }
 
             Runnable task = () -> {
-                try (var ignored = threadContext.stashContext()) {
-                    if (header == null) {
-                        handleStreamException(streamResponse, new StreamException(StreamErrorCode.INTERNAL, "Header is null"));
+                // While the consumer callback runs, this thread owns the stream: it is the only one
+                // that can release it, so a close() reaching this thread must not wait for it.
+                try (var dispatchMark = streamResponse.markDispatchThread()) {
+                    try (var ignored = threadContext.stashContext()) {
+                        if (header == null) {
+                            handleStreamException(streamResponse, new StreamException(StreamErrorCode.INTERNAL, "Header is null"));
+                        }
+                        threadContext.setHeaders(header.getHeaders());
+                        handler.handleStreamResponse(streamResponse);
+                    } catch (Exception e) {
+                        cleanupStreamResponse(streamResponse);
+                        throw e;
                     }
-                    threadContext.setHeaders(header.getHeaders());
-                    handler.handleStreamResponse(streamResponse);
-                } catch (Exception e) {
-                    cleanupStreamResponse(streamResponse);
-                    throw e;
                 }
             };
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -18,6 +18,7 @@ import org.apache.arrow.flight.OSFlightServer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.flight.bootstrap.ServerConfig;
@@ -25,6 +26,7 @@ import org.opensearch.arrow.flight.bootstrap.tls.SslContextProvider;
 import org.opensearch.arrow.flight.stats.FlightStatsCollector;
 import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.Settings;
@@ -289,19 +291,22 @@ class FlightTransport extends TcpTransport {
 
     @Override
     protected void stopInternal() {
-        try {
-
+        // Each step is isolated so a failure (e.g. an allocator reporting leaked buffers) cannot
+        // skip the remaining teardown — most importantly the event-loop-group shutdowns, whose
+        // threads would otherwise leak.
+        safeStop("flight server", () -> {
             if (flightServer != null) {
                 flightServer.shutdown();
                 flightServer.awaitTermination();
                 flightServer.close();
                 flightServer = null;
             }
-            serverAllocator.close();
-            clientAllocator.close();
-            gracefullyShutdownELG(bossEventLoopGroup, "os-grpc-boss-ELG");
-            gracefullyShutdownELG(workerEventLoopGroup, "os-grpc-worker-ELG");
-
+        });
+        safeStop("server allocator", () -> serverAllocator.close());
+        safeStop("client allocator", () -> clientAllocator.close());
+        safeStop("boss event loop group", () -> gracefullyShutdownELG(bossEventLoopGroup, "os-grpc-boss-ELG"));
+        safeStop("worker event loop group", () -> gracefullyShutdownELG(workerEventLoopGroup, "os-grpc-worker-ELG"));
+        safeStop("flight event loops", () -> {
             for (ExecutorService executor : flightEventLoopGroup) {
                 executor.shutdown();
                 try {
@@ -313,11 +318,17 @@ class FlightTransport extends TcpTransport {
                     Thread.currentThread().interrupt();
                 }
             }
-            if (statsCollector != null) {
-                statsCollector.decrementServerChannelsActive();
-            }
+        });
+        if (statsCollector != null) {
+            safeStop("server channel stats", () -> statsCollector.decrementServerChannelsActive());
+        }
+    }
+
+    private void safeStop(String what, CheckedRunnable<Exception> action) {
+        try {
+            action.run();
         } catch (Exception e) {
-            logger.error("Error stopping FlightTransport", e);
+            logger.error(() -> new ParameterizedMessage("Error stopping FlightTransport: failed to stop {}", what), e);
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportConfig.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 class FlightTransportConfig {
     private final AtomicReference<TimeValue> slowLogThreshold = new AtomicReference<>(TimeValue.timeValueMillis(5000));
+    private final AtomicReference<TimeValue> streamCloseTimeout = new AtomicReference<>(TimeValue.timeValueSeconds(5));
 
     public TimeValue getSlowLogThreshold() {
         return slowLogThreshold.get();
@@ -24,5 +25,17 @@ class FlightTransportConfig {
 
     public void setSlowLogThreshold(TimeValue threshold) {
         slowLogThreshold.set(threshold);
+    }
+
+    /**
+     * How long a client channel close waits for active stream consumers to release their streams'
+     * buffers before closing the underlying flight client.
+     */
+    public TimeValue getStreamCloseTimeout() {
+        return streamCloseTimeout.get();
+    }
+
+    public void setStreamCloseTimeout(TimeValue timeout) {
+        streamCloseTimeout.set(timeout);
     }
 }

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -18,6 +18,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.transport.Header;
@@ -54,9 +55,31 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     private volatile long currentBatchSize;
     private volatile boolean firstBatchConsumed;
     private volatile boolean closed;
-    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+    private final Object streamCloseLock = new Object();
+    /** Guarded by {@link #streamCloseLock}: set once a thread has entered {@code FlightStream#close}. */
+    private boolean streamCloseAttempted;
+    /** Guarded by {@link #streamCloseLock}: set when the stream's buffers are known to be released. */
+    private boolean streamReleased;
     private volatile boolean prefetchStarted;
     private volatile Header initialHeader;
+
+    /**
+     * Notified exactly once, after the underlying flight stream (if any) has been closed and its
+     * buffers returned to the allocator. Used by {@link FlightClientChannel} to track streams that
+     * are still holding allocator memory, so channel close can wait for them before closing the
+     * {@link FlightClient} (whose allocator close treats outstanding buffers as a leak).
+     */
+    private volatile Runnable onClosed;
+    /** Ensures {@link #onClosed} runs exactly once. */
+    private final AtomicBoolean closeNotified = new AtomicBoolean();
+    /** Set when the open/prefetch task has finished (whether or not it published a stream). */
+    private volatile boolean prefetchCompleted;
+    /**
+     * The thread currently executing the consumer's stream callback, or {@code null} when no
+     * callback is in progress. A closer running on this thread cannot wait for this stream to be
+     * released, because the release can only happen once the callback it is executing returns.
+     */
+    private volatile Thread dispatchThread;
 
     FlightTransportResponse(
         TransportResponseHandler<T> handler,
@@ -95,16 +118,26 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                 try {
                     long start = System.nanoTime();
                     flightStream = flightClient.getStream(ticket, new HeaderCallOption(callHeaders));
+                    afterStreamPublished();
                     // close() may have run while we were inside getStream() and missed the stream because
                     // flightStream was still null. Now that it is published, re-check the flag: if a close()
                     // already happened, self-close the stream we just opened so the prefetched first-batch
                     // root is not stranded, then abort. This check is performed *before* future.complete(),
                     // so once the future completes, any subsequent close() always observes flightStream != null
-                    // and owns the close itself. There is no post-completion window in which both this thread
-                    // and a racing close() could close the same stream.
+                    // and owns the close itself.
+                    //
+                    // A close() can still slip in between publishing the stream and reading the flag here, in
+                    // which case both paths reach releaseStream(); it closes the stream once and blocks the
+                    // second caller until that close has completed.
                     if (closed) {
                         try {
-                            closeStreamQuietly();
+                            // Notify only once the stream's buffers are actually released, so a
+                            // channel waiting on stream shutdown does not proceed while they may
+                            // still be allocated. releaseStream() blocks if a racing close() is
+                            // the one performing the close, and reports whether it succeeded.
+                            if (releaseStream()) {
+                                notifyClosed();
+                            }
                         } catch (StreamException e) {
                             logger.warn("Error closing flight stream after close() raced the prefetch", e);
                         }
@@ -123,6 +156,19 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                     future.completeExceptionally(FlightErrorMapper.fromFlightException(e));
                 } catch (Exception e) {
                     future.completeExceptionally(new StreamException(StreamErrorCode.INTERNAL, "Stream open/prefetch failed", e));
+                } finally {
+                    // Lets a racing close() distinguish "prefetch still running, it will handle
+                    // the closed re-check" from "prefetch finished without publishing a stream
+                    // (getStream failed), close() owns notification".
+                    prefetchCompleted = true;
+                    // A close() that raced this prefetch and found neither a published stream nor
+                    // a completed prefetch deferred to us. If the stream never got published
+                    // (getStream failed), there is nothing to close but the notification must
+                    // still fire so a waiting channel is not left hanging. (No-op when the closed
+                    // re-check or the racing close() already notified — notification is one-shot.)
+                    if (closed && flightStream == null) {
+                        notifyClosed();
+                    }
                 }
             });
         }
@@ -131,6 +177,14 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     TransportResponseHandler<T> getHandler() {
         return handler;
     }
+
+    /**
+     * Test seam, invoked after the stream is published and before the closed re-check below it —
+     * the window in which a concurrent {@link #close()} can observe the published stream and reach
+     * {@link #releaseStream()} first. No-op in production; overridden by tests that need to force
+     * that interleaving, which is only a few instructions wide and cannot be hit reliably by racing.
+     */
+    void afterStreamPublished() {}
 
     @Override
     public T nextResponse() {
@@ -202,21 +256,126 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         }
     }
 
-    @Override
-    public void close() {
-        if (closed) return;
-        closed = true;
-        closeStreamQuietly();
+    /**
+     * Sets the callback notified exactly once, after the underlying flight stream (if any) has been
+     * closed and its buffers released. Must be set before the response is handed to a consumer.
+     */
+    void setOnClosed(Runnable onClosed) {
+        assert closed == false : "onClosed callback must be set before the response is closed";
+        this.onClosed = onClosed;
     }
 
-    private void closeStreamQuietly() {
+    /**
+     * Marks the calling thread as the one executing the consumer's stream callback, and returns a
+     * handle that clears the mark. Used by {@link FlightClientChannel#close()} to recognise streams
+     * it cannot wait for: a close running on the dispatch thread would block until the timeout,
+     * because the stream can only be released once the callback it is executing returns.
+     */
+    Releasable markDispatchThread() {
+        dispatchThread = Thread.currentThread();
+        return () -> dispatchThread = null;
+    }
+
+    /**
+     * The thread currently executing the consumer's stream callback, or {@code null} if none is.
+     */
+    Thread getDispatchThread() {
+        return dispatchThread;
+    }
+
+    /**
+     * Requests cancellation of the underlying flight stream without closing it. Safe to call from
+     * any thread: {@link FlightStream#cancel} unblocks a consumer parked in {@link #nextResponse()}
+     * (it observes a CANCELLED error), and that consumer remains responsible for {@link #close()}.
+     * Closing here instead would race with a consumer concurrently reading the stream's root.
+     *
+     * <p>If the stream has not been published yet (open/prefetch still in flight, or never started),
+     * this falls back to {@link #close()}: the prefetch's closed re-check self-closes the stream it
+     * publishes, so no consumer-owned resource is torn down from under a reader.
+     */
+    void cancelStreamOnly(String reason) {
         FlightStream stream = flightStream;
-        if (stream != null && streamClosed.compareAndSet(false, true)) {
-            try {
-                stream.close();
-            } catch (IllegalStateException ignore) {} catch (Exception e) {
-                throw new StreamException(StreamErrorCode.INTERNAL, "Error closing flight stream", e);
+        if (stream == null) {
+            close();
+            return;
+        }
+        try {
+            stream.cancel(reason, null);
+        } catch (Exception e) {
+            logger.warn("Error requesting flight stream cancellation", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        final boolean hadPrefetch;
+        // Decide who owns stream shutdown under the same lock openAndPrefetchAsync uses, so a
+        // prefetch cannot start after close() concluded none was running.
+        synchronized (this) {
+            if (closed) return;
+            closed = true;
+            hadPrefetch = prefetchStarted;
+        }
+        if (hadPrefetch == false) {
+            // No stream was ever opened and none can start now (closed is set under the lock).
+            notifyClosed();
+            return;
+        }
+        if (flightStream != null || prefetchCompleted) {
+            // Stream published (release it), or the prefetch finished without publishing one
+            // (getStream failed — nothing to release). Notify only once the buffers are known to be
+            // released; a failed close may still retain them and must remain tracked by the channel.
+            if (releaseStream()) {
+                notifyClosed();
             }
+        }
+        // else: the prefetch is still in flight; its closed re-check sees closed == true and
+        // self-closes the stream it publishes, then notifies.
+    }
+
+    /** Runs the {@link #onClosed} callback exactly once, if set. */
+    private void notifyClosed() {
+        Runnable callback = onClosed;
+        if (callback != null && closeNotified.compareAndSet(false, true)) {
+            callback.run();
+        }
+    }
+
+    /**
+     * Closes the underlying flight stream at most once, and does not return until the close has
+     * completed — including when another thread is the one performing it. That makes a normal
+     * return a reliable statement about allocator state: {@code true} means the stream's buffers
+     * have been released, so it is safe to notify a channel that is waiting to close its client.
+     *
+     * <p>Both {@link #close()} and the prefetch's closed re-check can reach this method for the
+     * same stream (they write {@code flightStream} and {@code closed} in opposite orders, so each
+     * may observe the other's write). Blocking the loser rather than letting it return early is
+     * what prevents it from reporting the stream released while the winner is still inside
+     * {@link FlightStream#close()}.
+     *
+     * @return true if the stream's buffers are known to be released, false if the close failed
+     * @throws StreamException if this thread's close attempt failed unexpectedly
+     */
+    private boolean releaseStream() {
+        FlightStream stream = flightStream;
+        if (stream == null) {
+            // Nothing was ever published, so nothing is holding allocator memory.
+            return true;
+        }
+        synchronized (streamCloseLock) {
+            if (streamCloseAttempted == false) {
+                streamCloseAttempted = true;
+                try {
+                    stream.close();
+                    streamReleased = true;
+                } catch (IllegalStateException ignore) {
+                    // Already closed underneath us; the buffers are gone either way.
+                    streamReleased = true;
+                } catch (Exception e) {
+                    throw new StreamException(StreamErrorCode.INTERNAL, "Error closing flight stream", e);
+                }
+            }
+            return streamReleased;
         }
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
@@ -9,7 +9,13 @@
 package org.opensearch.arrow.flight.transport;
 
 import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.Ticket;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -17,9 +23,12 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.Header;
 import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportMessageListener;
+import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.stream.StreamErrorCode;
@@ -28,15 +37,24 @@ import org.opensearch.transport.stream.StreamTransportResponse;
 import org.junit.After;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class FlightClientChannelTests extends FlightTransportTestBase {
@@ -110,7 +128,368 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
         assertEquals("FlightClientChannel is closed", exception.get().getMessage());
     }
 
+    public void testSendMessageNotifiesHandlerWhenCloseRacesRegistration() throws Exception {
+        CountDownLatch handlerRemoved = new CountDownLatch(1);
+        CountDownLatch continueSend = new CountDownLatch(1);
+        AtomicInteger handlerNotifications = new AtomicInteger();
+        AtomicReference<TransportException> handlerFailure = new AtomicReference<>();
+        AtomicReference<Exception> sendListenerFailure = new AtomicReference<>();
+        AtomicReference<Throwable> sendThreadFailure = new AtomicReference<>();
+
+        TransportResponseHandler<TestResponse> responseHandler = new TransportResponseHandler<>() {
+            @Override
+            public TestResponse read(StreamInput in) throws IOException {
+                return new TestResponse(in);
+            }
+
+            @Override
+            public void handleResponse(TestResponse response) {
+                fail("stream response should not be dispatched after channel close");
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handlerFailure.set(exp);
+                handlerNotifications.incrementAndGet();
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+        };
+
+        TransportMessageListener blockingListener = new TransportMessageListener() {
+            @Override
+            @SuppressWarnings("rawtypes")
+            public void onResponseReceived(long requestId, Transport.ResponseContext context) {
+                handlerRemoved.countDown();
+                try {
+                    if (continueSend.await(5, TimeUnit.SECONDS) == false) {
+                        throw new IllegalStateException("timed out waiting to continue send");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("interrupted while waiting to continue send", e);
+                }
+            }
+        };
+
+        channel = new FlightClientChannel(
+            boundAddress,
+            mockFlightClient,
+            remoteNode,
+            serverLocation,
+            headerContext,
+            "test-profile",
+            flightTransport.getResponseHandlers(),
+            threadPool,
+            blockingListener,
+            namedWriteableRegistry,
+            statsCollector,
+            new FlightTransportConfig()
+        );
+
+        Transport.Connection connection = new Transport.Connection() {
+            @Override
+            public DiscoveryNode getNode() {
+                return remoteNode;
+            }
+
+            @Override
+            public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options) {
+                channel.sendMessage(
+                    requestId,
+                    new BytesArray("test message"),
+                    ActionListener.wrap(response -> {}, sendListenerFailure::set)
+                );
+            }
+
+            @Override
+            public void addCloseListener(ActionListener<Void> listener) {}
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        Thread sendThread = new Thread(() -> {
+            try {
+                streamTransportService.sendRequest(
+                    connection,
+                    "internal:test/channel-close-race",
+                    new TestRequest(),
+                    TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+                    responseHandler
+                );
+            } catch (Throwable t) {
+                sendThreadFailure.set(t);
+            }
+        }, "flight-send-close-race-test");
+        sendThread.start();
+        try {
+            assertTrue("send must remove its response handler before channel close", handlerRemoved.await(5, TimeUnit.SECONDS));
+            channel.close();
+        } finally {
+            continueSend.countDown();
+            sendThread.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        assertFalse("send thread did not finish", sendThread.isAlive());
+        assertNull("send thread failed", sendThreadFailure.get());
+        assertEquals("response handler must be notified exactly once", 1, handlerNotifications.get());
+        assertNotNull(handlerFailure.get());
+        assertTrue(handlerFailure.get() instanceof StreamException);
+        assertEquals(StreamErrorCode.UNAVAILABLE, ((StreamException) handlerFailure.get()).getErrorCode());
+        assertNotNull(sendListenerFailure.get());
+        assertTrue(sendListenerFailure.get() instanceof StreamException);
+        assertEquals(StreamErrorCode.UNAVAILABLE, ((StreamException) sendListenerFailure.get()).getErrorCode());
+    }
+
+    // ── channel close vs. active streams ───────────────────────────────────────
+
+    /**
+     * Close must cancel an active stream and then wait for its consumer — running on another
+     * thread — to release it, so the FlightClient's allocator is not closed while buffers are out.
+     */
+    public void testCloseWaitsForStreamHeldByAnotherThread() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+        when(mockFlightClient.getStream(any(Ticket.class), any())).thenReturn(stream);
+
+        CountDownLatch consumerHoldingStream = new CountDownLatch(1);
+        CountDownLatch releaseConsumer = new CountDownLatch(1);
+        AtomicBoolean consumerClosedStream = new AtomicBoolean();
+
+        // A long timeout: if the wait ever expires, that is a failure rather than a slow pass.
+        FlightTransportConfig config = new FlightTransportConfig();
+        config.setStreamCloseTimeout(TimeValue.timeValueSeconds(30));
+        channel = createChannel(mockFlightClient, stubHeaderContext(), config);
+
+        sendStreamRequest(streamingHandler(ThreadPool.Names.GENERIC, streamResponse -> {
+            consumerHoldingStream.countDown();
+            assertTrue("test must release the consumer", releaseConsumer.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+            streamResponse.close();
+            consumerClosedStream.set(true);
+        }));
+
+        assertTrue("consumer must take the stream", consumerHoldingStream.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+
+        Thread closer = new Thread(channel::close, "channel-closer");
+        closer.start();
+        // Cancellation is issued up front, before the wait, to unblock a parked consumer.
+        verify(stream, timeout(TimeUnit.SECONDS.toMillis(TIMEOUT_SEC))).cancel(anyString(), isNull());
+
+        closer.join(500);
+        assertTrue("close must wait for the consumer to release the stream", closer.isAlive());
+
+        releaseConsumer.countDown();
+        closer.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SEC));
+        assertFalse("close must return once the stream is released", closer.isAlive());
+        assertTrue(consumerClosedStream.get());
+        verify(stream, times(1)).close();
+    }
+
+    /**
+     * A close reaching the channel from inside a consumer callback must not wait for that
+     * consumer's own stream: it can only be released after the callback returns, which cannot
+     * happen until the close returns. Waiting would burn the whole timeout to no effect.
+     */
+    public void testCloseFromConsumerCallbackDoesNotWaitForItsOwnStream() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+        when(mockFlightClient.getStream(any(Ticket.class), any())).thenReturn(stream);
+
+        final long timeoutMillis = TimeUnit.SECONDS.toMillis(10);
+        FlightTransportConfig config = new FlightTransportConfig();
+        config.setStreamCloseTimeout(TimeValue.timeValueMillis(timeoutMillis));
+        channel = createChannel(mockFlightClient, stubHeaderContext(), config);
+
+        CountDownLatch consumerDone = new CountDownLatch(1);
+        AtomicLong closeElapsedMillis = new AtomicLong(-1);
+
+        sendStreamRequest(streamingHandler(ThreadPool.Names.SAME, streamResponse -> {
+            long start = System.nanoTime();
+            channel.close();
+            closeElapsedMillis.set(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+            streamResponse.close();
+            consumerDone.countDown();
+        }));
+
+        // Generous: a regression here shows up as the elapsed-time assertion below, not as a timeout.
+        assertTrue("consumer must finish", consumerDone.await(3 * TIMEOUT_SEC, TimeUnit.SECONDS));
+        assertThat(closeElapsedMillis.get(), greaterThanOrEqualTo(0L));
+        assertThat(
+            "close must skip the stream owned by the calling thread instead of waiting for it",
+            closeElapsedMillis.get(),
+            lessThan(timeoutMillis / 2)
+        );
+        verify(stream, times(1)).close();
+    }
+
+    /**
+     * A stream that never gets released bounds the close at the configured timeout rather than
+     * blocking shutdown indefinitely. Here the stream is registered but stuck in getStream(), so
+     * there is nothing to cancel and nothing that can report itself released.
+     */
+    public void testCloseGivesUpAfterStreamCloseTimeout() throws Exception {
+        CountDownLatch insideGetStream = new CountDownLatch(1);
+        CountDownLatch releaseGetStream = new CountDownLatch(1);
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+        when(mockFlightClient.getStream(any(Ticket.class), any())).thenAnswer(inv -> {
+            insideGetStream.countDown();
+            assertTrue("test must release getStream", releaseGetStream.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+            return stream;
+        });
+
+        final long timeoutMillis = 300;
+        FlightTransportConfig config = new FlightTransportConfig();
+        config.setStreamCloseTimeout(TimeValue.timeValueMillis(timeoutMillis));
+        channel = createChannel(mockFlightClient, stubHeaderContext(), config);
+
+        try {
+            AtomicReference<TransportException> handlerException = new AtomicReference<>();
+            // The channel closes while the stream is still opening, so the handler is failed; that
+            // is expected here and must not fail the test.
+            sendStreamRequest(streamingHandler(ThreadPool.Names.GENERIC, streamResponse -> streamResponse.close(), handlerException));
+            assertTrue("stream must be registered and opening", insideGetStream.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+
+            long start = System.nanoTime();
+            channel.close();
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+            assertThat("close must wait for the stream", elapsedMillis, greaterThanOrEqualTo(timeoutMillis));
+            assertThat("close must give up at the timeout", elapsedMillis, lessThan(TimeUnit.SECONDS.toMillis(TIMEOUT_SEC)));
+        } finally {
+            releaseGetStream.countDown();
+        }
+    }
+
+    /** A header context that answers any correlation id, so a mocked client can drive dispatch. */
+    private HeaderContext stubHeaderContext() {
+        Header header = mock(Header.class);
+        when(header.getHeaders()).thenReturn(new Tuple<>(Map.of(), Map.of()));
+        when(header.getVersion()).thenReturn(Version.CURRENT);
+        return new HeaderContext() {
+            @Override
+            Header getHeader(long correlationId) {
+                return header;
+            }
+        };
+    }
+
+    private FlightClientChannel createChannel(FlightClient flightClient, HeaderContext context, FlightTransportConfig config) {
+        return new FlightClientChannel(
+            boundAddress,
+            flightClient,
+            remoteNode,
+            serverLocation,
+            context,
+            "test-profile",
+            flightTransport.getResponseHandlers(),
+            threadPool,
+            new TransportMessageListener() {
+            },
+            namedWriteableRegistry,
+            statsCollector,
+            config
+        );
+    }
+
+    /** Consumer body for {@link #streamingHandler}, allowed to block and to throw. */
+    private interface StreamConsumer {
+        void accept(StreamTransportResponse<TestResponse> streamResponse) throws Exception;
+    }
+
+    private StreamTransportResponseHandler<TestResponse> streamingHandler(String executor, StreamConsumer consumer) {
+        return streamingHandler(executor, consumer, null);
+    }
+
+    /**
+     * @param exceptionSink where an expected handler exception is recorded; when {@code null}, any
+     *                      handler exception fails the test.
+     */
+    private StreamTransportResponseHandler<TestResponse> streamingHandler(
+        String executor,
+        StreamConsumer consumer,
+        AtomicReference<TransportException> exceptionSink
+    ) {
+        return new StreamTransportResponseHandler<>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<TestResponse> streamResponse) {
+                try {
+                    consumer.accept(streamResponse);
+                } catch (Exception e) {
+                    throw new AssertionError("stream consumer failed", e);
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                if (exceptionSink == null) {
+                    throw new AssertionError("unexpected handler exception", exp);
+                }
+                exceptionSink.set(exp);
+            }
+
+            @Override
+            public String executor() {
+                return executor;
+            }
+
+            @Override
+            public TestResponse read(StreamInput in) throws IOException {
+                return new TestResponse(in);
+            }
+        };
+    }
+
+    /**
+     * Sends a stream request over {@link #channel}, registering the handler through the transport
+     * service so the channel resolves it from its response handlers as it would in production.
+     */
+    private void sendStreamRequest(TransportResponseHandler<TestResponse> handler) {
+        Transport.Connection connection = new Transport.Connection() {
+            @Override
+            public DiscoveryNode getNode() {
+                return remoteNode;
+            }
+
+            @Override
+            public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options) {
+                channel.sendMessage(requestId, new BytesArray("test message"), ActionListener.wrap(r -> {}, e -> {
+                    throw new AssertionError("send failed", e);
+                }));
+            }
+
+            @Override
+            public void addCloseListener(ActionListener<Void> listener) {}
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        streamTransportService.sendRequest(
+            connection,
+            "internal:test/channel-close",
+            new TestRequest(),
+            TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+            handler
+        );
+    }
+
     public void testStreamResponseProcessingWithValidHandler() throws InterruptedException, IOException {
+
         channel = createChannel(mockFlightClient);
 
         String action = "internal:test/stream";

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportResponseTests.java
@@ -30,8 +30,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -186,11 +189,14 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
         doThrow(new RuntimeException("boom")).when(stream).close();
 
         FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        response.setOnClosed(notifications::incrementAndGet);
         CompletableFuture<Header> future = new CompletableFuture<>();
         response.openAndPrefetchAsync(future);
         future.get(5, TimeUnit.SECONDS);
 
         expectThrows(StreamException.class, response::close);
+        assertEquals("failed stream close must not report allocator buffers released", 0, notifications.get());
     }
 
     public void testCopyMetadataNullBuffer() {
@@ -213,6 +219,257 @@ public class FlightTransportResponseTests extends OpenSearchTestCase {
             // The copy is independent of the wire buffer.
             assertNotSame(payload, copy);
         }
+    }
+
+    // ── cancelStreamOnly() / onClosed notification (channel-close support) ──────
+
+    /** cancelStreamOnly on a published stream cancels it but must NOT close it: the consumer owns close. */
+    public void testCancelStreamOnlyCancelsWithoutClosing() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        response.cancelStreamOnly("channel closed");
+        verify(stream, times(1)).cancel("channel closed", null);
+        verify(stream, never()).close();
+
+        // The consumer's close still runs and releases the stream.
+        response.close();
+        verify(stream, times(1)).close();
+    }
+
+    /** cancelStreamOnly before the stream is published falls back to close() so the prefetch self-closes. */
+    public void testCancelStreamOnlyBeforePublishClosesResponse() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+
+        CountDownLatch enteredGetStream = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenAnswer(inv -> {
+            enteredGetStream.countDown();
+            assertTrue("test must release getStream", proceed.await(5, TimeUnit.SECONDS));
+            return stream;
+        });
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        assertTrue(enteredGetStream.await(5, TimeUnit.SECONDS));
+
+        response.cancelStreamOnly("channel closed"); // stream not yet published → close()
+        proceed.countDown();
+        verify(stream, timeout(5_000)).close(); // prefetch closed re-check self-closes
+    }
+
+    /** onClosed fires exactly once, after the published stream has been closed. */
+    public void testOnClosedFiresOnceAfterStreamClose() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        response.setOnClosed(notifications::incrementAndGet);
+
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+
+        assertEquals(0, notifications.get());
+        response.close();
+        assertEquals(1, notifications.get());
+        response.close();
+        assertEquals(1, notifications.get());
+    }
+
+    /** onClosed fires even when the response is closed before any prefetch started. */
+    public void testOnClosedFiresWhenClosedBeforePrefetch() {
+        FlightClient client = mock(FlightClient.class);
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        response.setOnClosed(notifications::incrementAndGet);
+
+        response.close();
+        assertEquals(1, notifications.get());
+    }
+
+    /** onClosed fires when close() raced the prefetch: notification follows the self-close. */
+    public void testOnClosedFiresAfterPrefetchSelfClose() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+
+        CountDownLatch enteredGetStream = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenAnswer(inv -> {
+            enteredGetStream.countDown();
+            assertTrue("test must release getStream", proceed.await(5, TimeUnit.SECONDS));
+            return stream;
+        });
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        CountDownLatch notified = new CountDownLatch(1);
+        response.setOnClosed(() -> {
+            notifications.incrementAndGet();
+            notified.countDown();
+        });
+
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        assertTrue(enteredGetStream.await(5, TimeUnit.SECONDS));
+
+        response.close(); // prefetch still in flight → its closed re-check owns close + notify
+        proceed.countDown();
+        assertTrue("onClosed should fire after prefetch self-close", notified.await(5, TimeUnit.SECONDS));
+        assertEquals(1, notifications.get());
+        verify(stream, times(1)).close();
+    }
+
+    /** onClosed fires when the prefetch failed before publishing a stream and close() runs later. */
+    public void testOnClosedFiresWhenPrefetchFailedBeforePublish() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenThrow(new RuntimeException("connection refused"));
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        response.setOnClosed(notifications::incrementAndGet);
+
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        expectThrows(Exception.class, () -> future.get(5, TimeUnit.SECONDS));
+
+        response.close();
+        // Whichever of close() and the prefetch's finally runs second fires the notification, so
+        // it may arrive asynchronously on the prefetch thread.
+        assertBusy(() -> assertEquals(1, notifications.get()), 5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * {@link FlightTransportResponse#close()} and the prefetch's closed re-check can both reach the
+     * stream close: they write {@code flightStream} and {@code closed} in opposite orders, so each
+     * may observe the other's write. Whichever loses the race must not report the buffers released
+     * while the winner is still inside {@link FlightStream#close()}, or a channel waiting on that
+     * notification closes its allocator too early.
+     *
+     * <p>The window is only a few instructions wide, so the interleaving is forced through the
+     * {@code afterStreamPublished} seam rather than raced: close() runs (and gets as far as being
+     * inside {@code FlightStream#close}) while the prefetch is parked between publishing the stream
+     * and re-checking the closed flag.
+     */
+    public void testLosingThreadDoesNotReportReleaseWhileCloseInProgress() throws Exception {
+        CountDownLatch streamPublished = new CountDownLatch(1);
+        CountDownLatch resumePrefetch = new CountDownLatch(1);
+        CountDownLatch insideStreamClose = new CountDownLatch(1);
+        CountDownLatch finishStreamClose = new CountDownLatch(1);
+        AtomicBoolean streamCloseInProgress = new AtomicBoolean();
+        AtomicBoolean notifiedDuringStreamClose = new AtomicBoolean();
+        AtomicInteger notifications = new AtomicInteger();
+
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+        doAnswer(inv -> {
+            streamCloseInProgress.set(true);
+            insideStreamClose.countDown();
+            assertTrue("test must release the stream close", finishStreamClose.await(5, TimeUnit.SECONDS));
+            streamCloseInProgress.set(false);
+            return null;
+        }).when(stream).close();
+
+        FlightClient client = mock(FlightClient.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+
+        FlightTransportResponse<TestArrowResponse> response = new FlightTransportResponse<>(
+            new TestArrowHandler(),
+            1L,
+            client,
+            new HeaderContext(),
+            new Ticket(new byte[0]),
+            new NamedWriteableRegistry(List.of()),
+            new FlightTransportConfig()
+        ) {
+            @Override
+            void afterStreamPublished() {
+                streamPublished.countDown();
+                try {
+                    assertTrue("test must resume the prefetch", resumePrefetch.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+        };
+        response.setOnClosed(() -> {
+            if (streamCloseInProgress.get()) {
+                notifiedDuringStreamClose.set(true);
+            }
+            notifications.incrementAndGet();
+        });
+
+        response.openAndPrefetchAsync(new CompletableFuture<>());
+        assertTrue("prefetch must publish the stream", streamPublished.await(5, TimeUnit.SECONDS));
+
+        // Winner: sees the published stream and parks inside FlightStream#close.
+        Thread closer = new Thread(response::close, "stream-close-winner");
+        closer.start();
+        assertTrue("close must reach the stream close", insideStreamClose.await(5, TimeUnit.SECONDS));
+
+        // Loser: the prefetch now observes closed == true and reaches the same stream close.
+        resumePrefetch.countDown();
+        assertFalse(
+            "no release may be reported while the stream close is in progress",
+            waitUntil(() -> notifications.get() > 0, 300, TimeUnit.MILLISECONDS)
+        );
+        assertTrue("the stream close must still be in progress", streamCloseInProgress.get());
+
+        finishStreamClose.countDown();
+        closer.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse("closer did not finish", closer.isAlive());
+        assertBusy(() -> assertEquals("stream must be reported released exactly once", 1, notifications.get()));
+        assertFalse("release was reported while FlightStream#close was still in progress", notifiedDuringStreamClose.get());
+        verify(stream, times(1)).close();
+    }
+
+    /** A failed stream close must not report the buffers released, on either racing thread. */
+    public void testFailedStreamCloseNeverNotifies() throws Exception {
+        FlightClient client = mock(FlightClient.class);
+        FlightStream stream = mock(FlightStream.class);
+        when(client.getStream(any(Ticket.class), any())).thenReturn(stream);
+        when(stream.next()).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(stream).close();
+
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+        AtomicInteger notifications = new AtomicInteger();
+        CompletableFuture<Header> future = new CompletableFuture<>();
+        response.openAndPrefetchAsync(future);
+        future.get(5, TimeUnit.SECONDS);
+        response.setOnClosed(notifications::incrementAndGet);
+
+        expectThrows(StreamException.class, response::close);
+        // A second caller observes the recorded failure instead of re-closing, and still must not notify.
+        response.close();
+        assertEquals(0, notifications.get());
+        verify(stream, times(1)).close();
+    }
+
+    /** The dispatch-thread mark identifies the thread running the consumer callback, and clears after. */
+    public void testDispatchThreadMarkIsScopedToTheCallback() {
+        FlightClient client = mock(FlightClient.class);
+        FlightTransportResponse<TestArrowResponse> response = newResponse(client, new HeaderContext());
+
+        assertNull(response.getDispatchThread());
+        try (var ignored = response.markDispatchThread()) {
+            assertSame(Thread.currentThread(), response.getDispatchThread());
+        }
+        assertNull(response.getDispatchThread());
     }
 
     private static final class TestArrowHandler extends ArrowBatchResponseHandler<TestArrowResponse> {


### PR DESCRIPTION
Closing a Flight client channel closed the underlying FlightClient, whose allocator close reports any outstanding buffer as a leak. Live streams legitimately hold buffers (the current batch root and retained metadata) until their consumer closes them, so closing a channel with active streams produced spurious leak errors on shutdown.

The channel now cancels every active stream on close and waits, bounded by a new stream-close timeout (default 5s), for consumers to release their buffers before closing the client. Streams whose consumer callback runs on the closing thread are excluded from the wait, since they cannot be released until close returns. On timeout the client is closed anyway and any straggler buffers are logged rather than blocking shutdown indefinitely.

FlightTransportResponse now exposes a one-shot onClosed notification that fires only after the stream's buffers are actually released, handling the race between close() and the async open/prefetch so neither reports release while the other is still inside the stream close.

FlightTransport.stopInternal now isolates each teardown step so a failure in one (for example an allocator reporting leaked buffers) can no longer skip the remaining steps, most importantly the event-loop group shutdowns whose threads would otherwise leak.

### Check List
- [x] Functionality includes testing.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
