### PR TITLE
Added fuzzy query translator and serializer to DSL analytics path

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/QuerySerializerRegistry.java
@@ -12,6 +12,7 @@ import org.opensearch.analytics.spi.DelegatedPredicateSerializer;
 import org.opensearch.analytics.spi.ScalarFunction;
 import org.opensearch.be.lucene.serializers.ComparisonSerializer;
 import org.opensearch.be.lucene.serializers.EqualsSerializer;
+import org.opensearch.be.lucene.serializers.FuzzySerializer;
 import org.opensearch.be.lucene.serializers.IsNullSerializer;
 import org.opensearch.be.lucene.serializers.LikeSerializer;
 import org.opensearch.be.lucene.serializers.MatchAllSerializer;
@@ -58,7 +59,8 @@ final class QuerySerializerRegistry {
         Map.entry(ScalarFunction.LESS_THAN, new ComparisonSerializer()),
         Map.entry(ScalarFunction.LESS_THAN_OR_EQUAL, new ComparisonSerializer()),
         Map.entry(ScalarFunction.REGEXP, new RegexpSerializer()),
-        Map.entry(ScalarFunction.SARG_PREDICATE, new SargSerializer())
+        Map.entry(ScalarFunction.SARG_PREDICATE, new SargSerializer()),
+        Map.entry(ScalarFunction.FUZZY, new FuzzySerializer())
     );
 
     private QuerySerializerRegistry() {}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/FuzzySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/FuzzySerializer.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.serializers;
+
+import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.FuzzyQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.Map;
+
+/**
+ * Serializer for the FUZZY relevance function.
+ */
+public class FuzzySerializer extends AbstractRelevanceSerializer {
+
+    @Override
+    protected String functionName() {
+        return "fuzzy";
+    }
+
+    @Override
+    protected QueryBuilder createQueryBuilder(ConversionUtils.RelevanceOperands operands) {
+        return new FuzzyQueryBuilder(operands.fieldName(), operands.query());
+    }
+
+    @Override
+    protected void applyParams(QueryBuilder qb, Map<String, String> params) {
+        FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) qb;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case "fuzziness" -> fuzzyQb.fuzziness(Fuzziness.build(entry.getValue()));
+                case "prefix_length" -> fuzzyQb.prefixLength(Integer.parseInt(entry.getValue()));
+                case "max_expansions" -> fuzzyQb.maxExpansions(Integer.parseInt(entry.getValue()));
+                case "transpositions" -> fuzzyQb.transpositions(Boolean.parseBoolean(entry.getValue()));
+                case "rewrite" -> fuzzyQb.rewrite(entry.getValue());
+                default -> {
+                    /* ignore unrecognized params for forward compatibility */ }
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/FuzzySerializer.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/serializers/FuzzySerializer.java
@@ -9,6 +9,7 @@
 package org.opensearch.be.lucene.serializers;
 
 import org.opensearch.be.lucene.ConversionUtils;
+import org.opensearch.common.Booleans;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.index.query.FuzzyQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -36,13 +37,31 @@ public class FuzzySerializer extends AbstractRelevanceSerializer {
         for (Map.Entry<String, String> entry : params.entrySet()) {
             switch (entry.getKey()) {
                 case "fuzziness" -> fuzzyQb.fuzziness(Fuzziness.build(entry.getValue()));
-                case "prefix_length" -> fuzzyQb.prefixLength(Integer.parseInt(entry.getValue()));
-                case "max_expansions" -> fuzzyQb.maxExpansions(Integer.parseInt(entry.getValue()));
-                case "transpositions" -> fuzzyQb.transpositions(Boolean.parseBoolean(entry.getValue()));
+                case "prefix_length" -> fuzzyQb.prefixLength(parseIntParam("prefix_length", entry.getValue()));
+                case "max_expansions" -> fuzzyQb.maxExpansions(parseIntParam("max_expansions", entry.getValue()));
+                case "transpositions" -> fuzzyQb.transpositions(parseStrictBoolean("transpositions", entry.getValue()));
                 case "rewrite" -> fuzzyQb.rewrite(entry.getValue());
                 default -> {
                     /* ignore unrecognized params for forward compatibility */ }
             }
+        }
+    }
+
+    private int parseIntParam(String paramName, String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(functionName() + " invalid value for '" + paramName + "': " + value);
+        }
+    }
+
+    // Strict: Booleans.parseBoolean rejects anything other than "true"/"false"; lenient Boolean.parseBoolean
+    // would silently coerce e.g. "yes" to false, flipping the edit-distance model with no error signal.
+    private boolean parseStrictBoolean(String paramName, String value) {
+        try {
+            return Booleans.parseBoolean(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(functionName() + " invalid value for '" + paramName + "': " + value);
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.FuzzyQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
 import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
@@ -57,6 +58,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
 
     private static final NamedWriteableRegistry WRITEABLE_REGISTRY = new NamedWriteableRegistry(
         List.of(
+            new NamedWriteableRegistry.Entry(QueryBuilder.class, FuzzyQueryBuilder.NAME, FuzzyQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchQueryBuilder.NAME, MatchQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchPhraseQueryBuilder.NAME, MatchPhraseQueryBuilder::new),
             new NamedWriteableRegistry.Entry(QueryBuilder.class, MatchBoolPrefixQueryBuilder.NAME, MatchBoolPrefixQueryBuilder::new),
@@ -90,6 +92,15 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
 
     private static final SqlFunction QUERY_FUNCTION = new SqlFunction(
         "QUERY",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    private static final SqlFunction FUZZY_FUNCTION = new SqlFunction(
+        "FUZZY",
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.BOOLEAN,
         null,
@@ -1039,6 +1050,169 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
             expected.field("body", 1.0f);
             expected.flags(SimpleQueryStringFlag.ALL);
             assertEquals(expected, simpleQsQb);
+        }
+    }
+
+    // --- FuzzySerializer tests ---
+
+    /**
+     * Tests FuzzySerializer round-trip with defaults: field + value only.
+     */
+    public void testFuzzySerializerRoundTripDefaults() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of());
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            QueryBuilder deserialized = input.readNamedWriteable(QueryBuilder.class);
+            assertTrue(deserialized instanceof FuzzyQueryBuilder);
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) deserialized;
+            assertEquals("title", fuzzyQb.fieldName());
+            assertEquals("laptop", fuzzyQb.value());
+            assertEquals(Fuzziness.AUTO, fuzzyQb.fuzziness());
+            assertEquals(FuzzyQueryBuilder.DEFAULT_MAX_EXPANSIONS, fuzzyQb.maxExpansions());
+        }
+    }
+
+    /**
+     * Tests FuzzySerializer with custom fuzziness=1.
+     */
+    public void testFuzzySerializerWithCustomFuzziness() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("fuzziness", "1"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals(Fuzziness.ONE, fuzzyQb.fuzziness());
+        }
+    }
+
+    /**
+     * Tests FuzzySerializer with all supported optional params.
+     */
+    public void testFuzzySerializerWithAllParams() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams(
+            "title",
+            "laptop",
+            "FUZZY",
+            Map.of("fuzziness", "2", "prefix_length", "3", "max_expansions", "100", "transpositions", "false", "rewrite", "constant_score")
+        );
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("title", fuzzyQb.fieldName());
+            assertEquals("laptop", fuzzyQb.value());
+            assertEquals(Fuzziness.TWO, fuzzyQb.fuzziness());
+            assertEquals(3, fuzzyQb.prefixLength());
+            assertEquals(100, fuzzyQb.maxExpansions());
+            assertFalse(fuzzyQb.transpositions());
+            assertEquals("constant_score", fuzzyQb.rewrite());
+        }
+    }
+
+    /**
+     * Tests FuzzySerializer with rewrite pass-through.
+     */
+    public void testFuzzySerializerWithRewritePassThrough() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("rewrite", "top_terms_10"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("top_terms_10", fuzzyQb.rewrite());
+        }
+    }
+
+    /**
+     * Tests FuzzySerializer with transpositions=false in isolation.
+     */
+    public void testFuzzySerializerWithTranspositionsFalse() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("transpositions", "false"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertFalse(fuzzyQb.transpositions());
+        }
+    }
+
+    /**
+     * Tests FuzzySerializer throws when field MAP is missing.
+     */
+    public void testFuzzySerializerThrowsWhenFieldMissing() {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexNode queryMap = rexBuilder.makeCall(
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            rexBuilder.makeLiteral("query"),
+            rexBuilder.makeLiteral("laptop")
+        );
+        RexCall call = (RexCall) rexBuilder.makeCall(FUZZY_FUNCTION, queryMap);
+        List<FieldStorageInfo> fieldStorage = List.of();
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue(
+            "Exception message must contain 'fuzzy', got: " + exception.getMessage(),
+            exception.getMessage().contains("fuzzy")
+        );
+    }
+
+    /**
+     * Tests FuzzySerializer ignores unrecognized params.
+     */
+    public void testFuzzySerializerIgnoresUnrecognizedParams() throws IOException {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("unknown_param", "value"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        byte[] serialized = serializer.serialize(call, fieldStorage);
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(StreamInput.wrap(serialized), WRITEABLE_REGISTRY)) {
+            FuzzyQueryBuilder fuzzyQb = (FuzzyQueryBuilder) input.readNamedWriteable(QueryBuilder.class);
+            assertEquals("title", fuzzyQb.fieldName());
+            assertEquals("laptop", fuzzyQb.value());
+            // Defaults should be preserved
+            assertEquals(Fuzziness.AUTO, fuzzyQb.fuzziness());
         }
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -1187,10 +1187,7 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
         List<FieldStorageInfo> fieldStorage = List.of();
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
-        assertTrue(
-            "Exception message must contain 'fuzzy', got: " + exception.getMessage(),
-            exception.getMessage().contains("fuzzy")
-        );
+        assertTrue("Exception message must contain 'fuzzy', got: " + exception.getMessage(), exception.getMessage().contains("fuzzy"));
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/QuerySerializerRegistryTests.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Unit tests for {@link QuerySerializerRegistry} serializers — optional parameter round-trips
@@ -1211,6 +1212,81 @@ public class QuerySerializerRegistryTests extends OpenSearchTestCase {
             // Defaults should be preserved
             assertEquals(Fuzziness.AUTO, fuzzyQb.fuzziness());
         }
+    }
+
+    /**
+     * Tests FuzzySerializer throws IllegalArgumentException for a malformed integer parameter.
+     */
+    public void testFuzzySerializerThrowsOnMalformedIntegerParam() {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("prefix_length", "abc"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue(
+            "Exception message must name the offending parameter, got: " + exception.getMessage(),
+            exception.getMessage().contains("prefix_length")
+        );
+    }
+
+    /**
+     * Tests FuzzySerializer throws IllegalArgumentException for an unrecognised boolean value.
+     */
+    public void testFuzzySerializerThrowsOnInvalidBooleanParam() {
+        DelegatedPredicateSerializer serializer = serializers.get(ScalarFunction.FUZZY);
+        assertNotNull("FUZZY serializer must be registered", serializer);
+
+        RexCall call = buildSingleFieldRexCallWithParams("title", "laptop", "FUZZY", Map.of("transpositions", "yes"));
+        List<FieldStorageInfo> fieldStorage = List.of(
+            new FieldStorageInfo("title", "keyword", FieldType.KEYWORD, List.of(), List.of("lucene"), List.of(), false)
+        );
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> serializer.serialize(call, fieldStorage));
+        assertTrue(
+            "Exception message must name the offending parameter, got: " + exception.getMessage(),
+            exception.getMessage().contains("transpositions")
+        );
+    }
+
+    // --- Registry key-set assertion test ---
+
+    /**
+     * Asserts the registry's key set matches the expected set of ScalarFunctions.
+     * Ensures new serializer registrations are deliberate and accounted for.
+     * Mirrors the registry key-set assertion pattern used by sibling test classes.
+     */
+    public void testRegistryKeySetMatchesExpectedFunctions() {
+        assertEquals(
+            Set.of(
+                ScalarFunction.MATCH,
+                ScalarFunction.MATCH_PHRASE,
+                ScalarFunction.MATCH_BOOL_PREFIX,
+                ScalarFunction.MATCH_PHRASE_PREFIX,
+                ScalarFunction.MULTI_MATCH,
+                ScalarFunction.QUERY_STRING,
+                ScalarFunction.SIMPLE_QUERY_STRING,
+                ScalarFunction.WILDCARD_QUERY,
+                ScalarFunction.QUERY,
+                ScalarFunction.MATCHALL,
+                ScalarFunction.EQUALS,
+                ScalarFunction.NOT_EQUALS,
+                ScalarFunction.IS_NULL,
+                ScalarFunction.IS_NOT_NULL,
+                ScalarFunction.LIKE,
+                ScalarFunction.GREATER_THAN,
+                ScalarFunction.GREATER_THAN_OR_EQUAL,
+                ScalarFunction.LESS_THAN,
+                ScalarFunction.LESS_THAN_OR_EQUAL,
+                ScalarFunction.REGEXP,
+                ScalarFunction.SARG_PREDICATE,
+                ScalarFunction.FUZZY
+            ),
+            serializers.keySet()
+        );
     }
 
     // --- Helper methods ---

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -103,6 +103,16 @@ public class DslQueryIT extends DslIntegTestBase {
         expectThrows(Exception.class, () -> search(new SearchSourceBuilder().query(QueryBuilders.existsQuery("name").boost(2.0f))));
     }
 
+    public void testFuzzyQueryOnKeywordField() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("name", "laptop"))));
+    }
+
+    public void testFuzzyQueryOnTextField() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("brand", "brandX"))));
+    }
+
     // TODO: Enable once BooleanQueryTranslatorExists is supported
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/21442")
     public void testExistsQueryWithBool() {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
@@ -41,6 +41,9 @@ public class FuzzyQueryTranslator implements QueryTranslator {
         SqlFunctionCategory.USER_DEFINED_FUNCTION
     );
 
+    /** Creates a new fuzzy query translator. */
+    public FuzzyQueryTranslator() {}
+
     @Override
     public Class<? extends QueryBuilder> getQueryType() {
         return FuzzyQueryBuilder.class;
@@ -50,6 +53,57 @@ public class FuzzyQueryTranslator implements QueryTranslator {
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         FuzzyQueryBuilder fuzzyQuery = (FuzzyQueryBuilder) query;
 
+        ValidatedPayload payload = validateQuery(fuzzyQuery, ctx);
+
+        // Build the RexCall: FUZZY(MAP('field',$ref), MAP('query',literal), [MAP(param,value)]...)
+        RelDataTypeField field = payload.field();
+        String value = payload.value();
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+
+        List<RexNode> operands = new ArrayList<>();
+        // Operand 0: MAP('field', $inputRef)
+        operands.add(
+            ctx.getRexBuilder().makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, ctx.getRexBuilder().makeLiteral("field"), fieldRef)
+        );
+        // Operand 1: MAP('query', value)
+        operands.add(
+            ctx.getRexBuilder()
+                .makeCall(
+                    SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                    ctx.getRexBuilder().makeLiteral("query"),
+                    ctx.getRexBuilder().makeLiteral(value)
+                )
+        );
+
+        // Optional params — emit only non-defaults
+        Fuzziness fuzziness = fuzzyQuery.fuzziness();
+        String fuzzinessStr = fuzziness.asString();
+        if (!fuzziness.equals(FuzzyQueryBuilder.DEFAULT_FUZZINESS)) {
+            operands.add(makeParamMap(ctx, "fuzziness", fuzzinessStr));
+        }
+        int prefixLength = fuzzyQuery.prefixLength();
+        if (prefixLength != FuzzyQueryBuilder.DEFAULT_PREFIX_LENGTH) {
+            operands.add(makeParamMap(ctx, "prefix_length", String.valueOf(prefixLength)));
+        }
+        int maxExpansions = fuzzyQuery.maxExpansions();
+        if (maxExpansions != FuzzyQueryBuilder.DEFAULT_MAX_EXPANSIONS) {
+            operands.add(makeParamMap(ctx, "max_expansions", String.valueOf(maxExpansions)));
+        }
+        if (fuzzyQuery.transpositions() != FuzzyQueryBuilder.DEFAULT_TRANSPOSITIONS) {
+            operands.add(makeParamMap(ctx, "transpositions", String.valueOf(fuzzyQuery.transpositions())));
+        }
+        if (fuzzyQuery.rewrite() != null) {
+            operands.add(makeParamMap(ctx, "rewrite", fuzzyQuery.rewrite()));
+        }
+
+        return ctx.getRexBuilder().makeCall(FUZZY_FUNCTION, operands);
+    }
+
+    /** Holds the field reference and query value resolved during validation. */
+    private record ValidatedPayload(RelDataTypeField field, String value) {
+    }
+
+    private ValidatedPayload validateQuery(FuzzyQueryBuilder fuzzyQuery, ConversionContext ctx) throws ConversionException {
         // Reject unsupported params — FuzzyQueryBuilder.boost() (scoring-only in delegated predicate)
         if (fuzzyQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
             throw new ConversionException("Fuzzy query does not support non-default boost");
@@ -102,42 +156,7 @@ public class FuzzyQueryTranslator implements QueryTranslator {
             throw new ConversionException("Invalid fuzziness value '" + fuzzinessStr + "': " + e.getMessage());
         }
 
-        // Build the RexCall: FUZZY(MAP('field',$ref), MAP('query',literal), [MAP(param,value)]...)
-        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
-
-        List<RexNode> operands = new ArrayList<>();
-        // Operand 0: MAP('field', $inputRef)
-        operands.add(
-            ctx.getRexBuilder().makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, ctx.getRexBuilder().makeLiteral("field"), fieldRef)
-        );
-        // Operand 1: MAP('query', value)
-        operands.add(
-            ctx.getRexBuilder()
-                .makeCall(
-                    SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
-                    ctx.getRexBuilder().makeLiteral("query"),
-                    ctx.getRexBuilder().makeLiteral(value)
-                )
-        );
-
-        // Optional params — emit only non-defaults
-        if (!fuzziness.equals(FuzzyQueryBuilder.DEFAULT_FUZZINESS)) {
-            operands.add(makeParamMap(ctx, "fuzziness", fuzzinessStr));
-        }
-        if (prefixLength != FuzzyQueryBuilder.DEFAULT_PREFIX_LENGTH) {
-            operands.add(makeParamMap(ctx, "prefix_length", String.valueOf(prefixLength)));
-        }
-        if (maxExpansions != FuzzyQueryBuilder.DEFAULT_MAX_EXPANSIONS) {
-            operands.add(makeParamMap(ctx, "max_expansions", String.valueOf(maxExpansions)));
-        }
-        if (fuzzyQuery.transpositions() != FuzzyQueryBuilder.DEFAULT_TRANSPOSITIONS) {
-            operands.add(makeParamMap(ctx, "transpositions", String.valueOf(fuzzyQuery.transpositions())));
-        }
-        if (fuzzyQuery.rewrite() != null) {
-            operands.add(makeParamMap(ctx, "rewrite", fuzzyQuery.rewrite()));
-        }
-
-        return ctx.getRexBuilder().makeCall(FUZZY_FUNCTION, operands);
+        return new ValidatedPayload(field, value);
     }
 
     private RexNode makeParamMap(ConversionContext ctx, String key, String value) {
@@ -148,5 +167,4 @@ public class FuzzyQueryTranslator implements QueryTranslator {
                 ctx.getRexBuilder().makeLiteral(value)
             );
     }
-
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
@@ -67,7 +67,7 @@ public class FuzzyQueryTranslator implements QueryTranslator {
         }
         String value = valueObj.toString();
         if (value.isEmpty()) {
-            throw new ConversionException("fuzzy query value must not be empty");
+            throw new ConversionException("Fuzzy query value must not be empty");
         }
 
         // Resolve field and gate on type
@@ -82,18 +82,24 @@ public class FuzzyQueryTranslator implements QueryTranslator {
         // Validate numeric params fail-fast
         int prefixLength = fuzzyQuery.prefixLength();
         if (prefixLength < 0) {
-            throw new ConversionException("prefix_length must not be negative, got " + prefixLength);
+            throw new ConversionException("Fuzzy query prefix_length must not be negative, got " + prefixLength);
         }
         int maxExpansions = fuzzyQuery.maxExpansions();
         if (maxExpansions < 1) {
-            throw new ConversionException("max_expansions must be at least 1, got " + maxExpansions);
+            throw new ConversionException("Fuzzy query max_expansions must be at least 1, got " + maxExpansions);
         }
 
-        // Validate fuzziness fail-fast: valid values are 0, 1, 2, AUTO, AUTO:x,y
+        // Validate fuzziness fail-fast by delegating to Fuzziness.build() so we stay in sync
+        // with server semantics (Fuzziness.build at Fuzziness.java:131), then verify asDistance()
+        // succeeds since non-numeric values like "abc" pass build() but fail at query time
+        // (StringFieldType.fuzzyQuery at StringFieldType.java:103).
         Fuzziness fuzziness = fuzzyQuery.fuzziness();
         String fuzzinessStr = fuzziness.asString();
-        if (!isValidFuzziness(fuzzinessStr)) {
-            throw new ConversionException("Invalid fuzziness value '" + fuzzinessStr + "': valid values are [0, 1, 2, AUTO, AUTO:x,y]");
+        try {
+            Fuzziness validated = Fuzziness.build(fuzzinessStr);
+            validated.asDistance(value);
+        } catch (IllegalArgumentException e) {
+            throw new ConversionException("Invalid fuzziness value '" + fuzzinessStr + "': " + e.getMessage());
         }
 
         // Build the RexCall: FUZZY(MAP('field',$ref), MAP('query',literal), [MAP(param,value)]...)
@@ -143,26 +149,4 @@ public class FuzzyQueryTranslator implements QueryTranslator {
             );
     }
 
-    /**
-     * Validates that a fuzziness string is one of the accepted values: 0, 1, 2, AUTO, or AUTO:x,y.
-     */
-    private static boolean isValidFuzziness(String value) {
-        String upper = value.toUpperCase(java.util.Locale.ROOT);
-        if ("0".equals(upper) || "1".equals(upper) || "2".equals(upper) || "AUTO".equals(upper)) {
-            return true;
-        }
-        if (upper.startsWith("AUTO:")) {
-            String[] parts = upper.substring(5).split(",");
-            if (parts.length == 2) {
-                try {
-                    int low = Integer.parseInt(parts[0]);
-                    int high = Integer.parseInt(parts[1]);
-                    return low >= 0 && high >= 0 && low <= high;
-                } catch (NumberFormatException e) {
-                    return false;
-                }
-            }
-        }
-        return false;
-    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/FuzzyQueryTranslator.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.FuzzyQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a {@link FuzzyQueryBuilder} to a FUZZY RexCall with MAP operands.
+ */
+public class FuzzyQueryTranslator implements QueryTranslator {
+
+    private static final SqlFunction FUZZY_FUNCTION = new SqlFunction(
+        "FUZZY",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.BOOLEAN,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return FuzzyQueryBuilder.class;
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        FuzzyQueryBuilder fuzzyQuery = (FuzzyQueryBuilder) query;
+
+        // Reject unsupported params — FuzzyQueryBuilder.boost() (scoring-only in delegated predicate)
+        if (fuzzyQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException("Fuzzy query does not support non-default boost");
+        }
+        // Reject _name — diagnostic metadata only (TermsQueryTranslator.java:43-44)
+        if (fuzzyQuery.queryName() != null) {
+            throw new ConversionException("Fuzzy query does not support _name");
+        }
+
+        // Extract and validate payload
+        String fieldName = fuzzyQuery.fieldName();
+        Object valueObj = fuzzyQuery.value();
+        if (valueObj == null) {
+            throw new ConversionException("Fuzzy query value must not be null");
+        }
+        String value = valueObj.toString();
+        if (value.isEmpty()) {
+            throw new ConversionException("fuzzy query value must not be empty");
+        }
+
+        // Resolve field and gate on type
+        RelDataTypeField field = ctx.getField(fieldName);
+        SqlTypeName typeName = field.getType().getSqlTypeName();
+        if (typeName != SqlTypeName.VARCHAR) {
+            throw new ConversionException(
+                "Fuzzy query requires a keyword or text field, got " + typeName + " for field '" + fieldName + "'"
+            );
+        }
+
+        // Validate numeric params fail-fast
+        int prefixLength = fuzzyQuery.prefixLength();
+        if (prefixLength < 0) {
+            throw new ConversionException("prefix_length must not be negative, got " + prefixLength);
+        }
+        int maxExpansions = fuzzyQuery.maxExpansions();
+        if (maxExpansions < 1) {
+            throw new ConversionException("max_expansions must be at least 1, got " + maxExpansions);
+        }
+
+        // Validate fuzziness fail-fast: valid values are 0, 1, 2, AUTO, AUTO:x,y
+        Fuzziness fuzziness = fuzzyQuery.fuzziness();
+        String fuzzinessStr = fuzziness.asString();
+        if (!isValidFuzziness(fuzzinessStr)) {
+            throw new ConversionException("Invalid fuzziness value '" + fuzzinessStr + "': valid values are [0, 1, 2, AUTO, AUTO:x,y]");
+        }
+
+        // Build the RexCall: FUZZY(MAP('field',$ref), MAP('query',literal), [MAP(param,value)]...)
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+
+        List<RexNode> operands = new ArrayList<>();
+        // Operand 0: MAP('field', $inputRef)
+        operands.add(
+            ctx.getRexBuilder().makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, ctx.getRexBuilder().makeLiteral("field"), fieldRef)
+        );
+        // Operand 1: MAP('query', value)
+        operands.add(
+            ctx.getRexBuilder()
+                .makeCall(
+                    SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                    ctx.getRexBuilder().makeLiteral("query"),
+                    ctx.getRexBuilder().makeLiteral(value)
+                )
+        );
+
+        // Optional params — emit only non-defaults
+        if (!fuzziness.equals(FuzzyQueryBuilder.DEFAULT_FUZZINESS)) {
+            operands.add(makeParamMap(ctx, "fuzziness", fuzzinessStr));
+        }
+        if (prefixLength != FuzzyQueryBuilder.DEFAULT_PREFIX_LENGTH) {
+            operands.add(makeParamMap(ctx, "prefix_length", String.valueOf(prefixLength)));
+        }
+        if (maxExpansions != FuzzyQueryBuilder.DEFAULT_MAX_EXPANSIONS) {
+            operands.add(makeParamMap(ctx, "max_expansions", String.valueOf(maxExpansions)));
+        }
+        if (fuzzyQuery.transpositions() != FuzzyQueryBuilder.DEFAULT_TRANSPOSITIONS) {
+            operands.add(makeParamMap(ctx, "transpositions", String.valueOf(fuzzyQuery.transpositions())));
+        }
+        if (fuzzyQuery.rewrite() != null) {
+            operands.add(makeParamMap(ctx, "rewrite", fuzzyQuery.rewrite()));
+        }
+
+        return ctx.getRexBuilder().makeCall(FUZZY_FUNCTION, operands);
+    }
+
+    private RexNode makeParamMap(ConversionContext ctx, String key, String value) {
+        return ctx.getRexBuilder()
+            .makeCall(
+                SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+                ctx.getRexBuilder().makeLiteral(key),
+                ctx.getRexBuilder().makeLiteral(value)
+            );
+    }
+
+    /**
+     * Validates that a fuzziness string is one of the accepted values: 0, 1, 2, AUTO, or AUTO:x,y.
+     */
+    private static boolean isValidFuzziness(String value) {
+        String upper = value.toUpperCase(java.util.Locale.ROOT);
+        if ("0".equals(upper) || "1".equals(upper) || "2".equals(upper) || "AUTO".equals(upper)) {
+            return true;
+        }
+        if (upper.startsWith("AUTO:")) {
+            String[] parts = upper.substring(5).split(",");
+            if (parts.length == 2) {
+                try {
+                    int low = Integer.parseInt(parts[0]);
+                    int high = Integer.parseInt(parts[1]);
+                    return low >= 0 && high >= 0 && low <= high;
+                } catch (NumberFormatException e) {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -22,6 +22,7 @@ public class QueryRegistryFactory {
         registry.register(new TermsQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
         registry.register(new ExistsQueryTranslator());
+        registry.register(new FuzzyQueryTranslator());
         // TODO: add other query translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
@@ -140,6 +140,49 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
         RexNode result = translator.convert(fqb, ctx);
         RexCall call = (RexCall) result;
         // field + query + fuzziness + transpositions = 4 operands
-        assertTrue(call.getOperands().size() > 2);
+        assertEquals(4, call.getOperands().size());
+
+        // Operand 2: MAP('fuzziness', '1')
+        RexCall fuzzinessMap = (RexCall) call.getOperands().get(2);
+        assertEquals("fuzziness", ((RexLiteral) fuzzinessMap.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("1", ((RexLiteral) fuzzinessMap.getOperands().get(1)).getValueAs(String.class));
+
+        // Operand 3: MAP('transpositions', 'false')
+        RexCall transpositionsMap = (RexCall) call.getOperands().get(3);
+        assertEquals("transpositions", ((RexLiteral) transpositionsMap.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("false", ((RexLiteral) transpositionsMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
+    public void testAcceptsCustomAutoFuzziness() throws ConversionException {
+        // AUTO:4,7 is a valid custom auto form — should translate without error
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.build("AUTO:4,7"));
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        // Non-default fuzziness emits a param operand
+        assertEquals(3, call.getOperands().size());
+        RexCall fuzzinessMap = (RexCall) call.getOperands().get(2);
+        assertEquals("fuzziness", ((RexLiteral) fuzzinessMap.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("AUTO:4,7", ((RexLiteral) fuzzinessMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
+    public void testAcceptsFuzzinessThree() throws ConversionException {
+        // "3" is accepted by Fuzziness.build() and clamped to edit distance 2 by asDistance()
+        // — legacy parity: server silently clamps rather than rejecting
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.build("3"));
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        // Non-default fuzziness emits a param operand
+        assertEquals(3, call.getOperands().size());
+        RexCall fuzzinessMap = (RexCall) call.getOperands().get(2);
+        assertEquals("fuzziness", ((RexLiteral) fuzzinessMap.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("3", ((RexLiteral) fuzzinessMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
+    public void testRejectsNonNumericFuzziness() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.build("abc")), ctx)
+        );
+        assertTrue(ex.getMessage().contains("fuzziness"));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
@@ -56,10 +56,35 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
         assertTrue(ex.getMessage().contains("INTEGER"));
     }
 
+    public void testRejectsDateField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("created_date", "2024-01-01"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("DATE"));
+    }
+
+    public void testRejectsVarbinaryField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("binary_data", "deadbeef"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("VARBINARY"));
+    }
+
+    public void testRejectsBooleanField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("is_active", "true"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("BOOLEAN"));
+    }
+
     public void testRejectsUnknownField() {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.fuzzyQuery("nonexistent", "value"), ctx));
     }
 
+    // Pins rejection of a structurally invalid fuzziness value (non-numeric, non-AUTO)
     public void testRejectsInvalidFuzziness() {
         ConversionException ex = expectThrows(
             ConversionException.class,
@@ -153,6 +178,36 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
         assertEquals("false", ((RexLiteral) transpositionsMap.getOperands().get(1)).getValueAs(String.class));
     }
 
+    public void testEmitsRewriteAsMapOperand() throws ConversionException {
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop").rewrite("constant_score");
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        // field + query + rewrite = 3 operands
+        assertEquals(3, call.getOperands().size());
+
+        RexCall rewriteMap = (RexCall) call.getOperands().get(2);
+        assertEquals("rewrite", ((RexLiteral) rewriteMap.getOperands().get(0)).getValueAs(String.class));
+        assertEquals("constant_score", ((RexLiteral) rewriteMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
+    public void testNumericValueStringified() throws ConversionException {
+        // FuzzyQueryBuilder accepts Object values; numeric values are stringified via toString()
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "42");
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        assertEquals("42", ((RexLiteral) queryMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
+    public void testBooleanValueStringified() throws ConversionException {
+        // Boolean values are stringified via toString() matching BytesRefs.toBytesRef path
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "true");
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        assertEquals("true", ((RexLiteral) queryMap.getOperands().get(1)).getValueAs(String.class));
+    }
+
     public void testAcceptsCustomAutoFuzziness() throws ConversionException {
         // AUTO:4,7 is a valid custom auto form — should translate without error
         FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.build("AUTO:4,7"));
@@ -178,6 +233,8 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
         assertEquals("3", ((RexLiteral) fuzzinessMap.getOperands().get(1)).getValueAs(String.class));
     }
 
+    // Pins rejection of an alphabetic non-keyword fuzziness ("abc" passes Fuzziness.build()
+    // but fails asDistance() — distinct from "INVALID" which is a recognisable keyword form)
     public void testRejectsNonNumericFuzziness() {
         ConversionException ex = expectThrows(
             ConversionException.class,

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.FuzzyQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link FuzzyQueryTranslator}.
+ */
+public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final FuzzyQueryTranslator translator = new FuzzyQueryTranslator();
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(FuzzyQueryBuilder.class, translator.getQueryType());
+    }
+
+    public void testRejectsNonDefaultBoost() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").boost(2.0f), ctx)
+        );
+        assertTrue(ex.getMessage().contains("boost"));
+    }
+
+    public void testRejectsQueryName() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").queryName("my_query"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("_name"));
+    }
+
+    public void testRejectsNonVarcharField() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("price", "100"), ctx)
+        );
+        assertTrue(ex.getMessage().contains("INTEGER"));
+    }
+
+    public void testRejectsUnknownField() {
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.fuzzyQuery("nonexistent", "value"), ctx));
+    }
+
+    public void testRejectsInvalidFuzziness() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.build("INVALID")), ctx)
+        );
+        assertTrue(ex.getMessage().contains("fuzziness"));
+    }
+
+    public void testRejectsNegativePrefixLength() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").prefixLength(-1), ctx)
+        );
+        assertTrue(ex.getMessage().contains("prefix_length"));
+    }
+
+    public void testRejectsZeroMaxExpansions() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", "laptop").maxExpansions(0), ctx)
+        );
+        assertTrue(ex.getMessage().contains("max_expansions"));
+    }
+
+    public void testRejectsNullValue() {
+        expectThrows(ConversionException.class, () -> {
+            // FuzzyQueryBuilder constructor rejects null; translator must catch and wrap
+            FuzzyQueryBuilder fqb = new FuzzyQueryBuilder("name", (String) null);
+            translator.convert(fqb, ctx);
+        });
+    }
+
+    public void testRejectsEmptyStringValue() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.fuzzyQuery("name", ""), ctx)
+        );
+        assertTrue(ex.getMessage().contains("must not be empty"));
+    }
+
+    public void testEmitsCorrectOperatorName() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.fuzzyQuery("name", "laptop"), ctx);
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals("FUZZY", call.getOperator().getName());
+    }
+
+    public void testEmitsFieldAsFirstMapOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.fuzzyQuery("name", "laptop"), ctx);
+        RexCall call = (RexCall) result;
+        // operand[0] should be MAP('field', $inputRef)
+        RexCall fieldMap = (RexCall) call.getOperands().get(0);
+        RexLiteral key = (RexLiteral) fieldMap.getOperands().get(0);
+        assertEquals("field", key.getValueAs(String.class));
+        assertTrue(fieldMap.getOperands().get(1) instanceof RexInputRef);
+    }
+
+    public void testEmitsValueAsSecondMapOperand() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.fuzzyQuery("name", "laptop"), ctx);
+        RexCall call = (RexCall) result;
+        // operand[1] should be MAP('query', 'laptop')
+        RexCall queryMap = (RexCall) call.getOperands().get(1);
+        RexLiteral key = (RexLiteral) queryMap.getOperands().get(0);
+        assertEquals("query", key.getValueAs(String.class));
+        RexLiteral value = (RexLiteral) queryMap.getOperands().get(1);
+        assertEquals("laptop", value.getValueAs(String.class));
+    }
+
+    public void testOmitsDefaultParams() throws ConversionException {
+        // All defaults: only field + query operands should be emitted
+        RexNode result = translator.convert(QueryBuilders.fuzzyQuery("name", "laptop"), ctx);
+        RexCall call = (RexCall) result;
+        assertEquals(2, call.getOperands().size());
+    }
+
+    public void testEmitsNonDefaultParams() throws ConversionException {
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop")
+            .fuzziness(Fuzziness.ONE)
+            .transpositions(false);
+        RexNode result = translator.convert(fqb, ctx);
+        RexCall call = (RexCall) result;
+        // field + query + fuzziness + transpositions = 4 operands
+        assertTrue(call.getOperands().size() > 2);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/FuzzyQueryTranslatorTests.java
@@ -85,8 +85,8 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testRejectsNullValue() {
-        expectThrows(ConversionException.class, () -> {
-            // FuzzyQueryBuilder constructor rejects null; translator must catch and wrap
+        // FuzzyQueryBuilder constructor rejects null with IllegalArgumentException
+        expectThrows(IllegalArgumentException.class, () -> {
             FuzzyQueryBuilder fqb = new FuzzyQueryBuilder("name", (String) null);
             translator.convert(fqb, ctx);
         });
@@ -136,9 +136,7 @@ public class FuzzyQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testEmitsNonDefaultParams() throws ConversionException {
-        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop")
-            .fuzziness(Fuzziness.ONE)
-            .transpositions(false);
+        FuzzyQueryBuilder fqb = QueryBuilders.fuzzyQuery("name", "laptop").fuzziness(Fuzziness.ONE).transpositions(false);
         RexNode result = translator.convert(fqb, ctx);
         RexCall call = (RexCall) result;
         // field + query + fuzziness + transpositions = 4 operands

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/fuzzy_all_params.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/fuzzy_all_params.json
@@ -1,0 +1,44 @@
+{
+  "testName": "fuzzy_all_params",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "fuzzy": {
+        "name": {
+          "value": "laptop",
+          "fuzziness": "2",
+          "prefix_length": 2,
+          "max_expansions": 100,
+          "transpositions": false,
+          "rewrite": "constant_score"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[FUZZY(MAP('field', $0), MAP('query', 'laptop'), MAP('fuzziness', '2'), MAP('prefix_length', '2'), MAP('max_expansions', '100'), MAP('transpositions', 'false'), MAP('rewrite', 'constant_score'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price", "brand", "rating"],
+  "mockResultRows": [
+    ["laptop", 999, "BrandA", 4.5]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/fuzzy_default_params.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/fuzzy_default_params.json
@@ -1,0 +1,39 @@
+{
+  "testName": "fuzzy_default_params",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "fuzzy": {
+        "name": {
+          "value": "laptop"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalFilter(condition=[FUZZY(MAP('field', $0), MAP('query', 'laptop'))])",
+    "  LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["name", "price", "brand", "rating"],
+  "mockResultRows": [
+    ["laptop", 999, "BrandA", 4.5]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds `FuzzyQueryTranslator` and `FuzzySerializer` to the `dsl-query-executor` and `analytics-backend-lucene` sandbox plugins, enabling DSL `fuzzy` queries to be translated into delegated predicates and pushed down to Lucene for execution.

**What:** A translator that converts `FuzzyQueryBuilder` into a `FUZZY` RexCall with MAP operands, and a serializer that reconstitutes the `FuzzyQueryBuilder` on the data node from those operands.

**Why:** Edit-distance matching has no DataFusion equivalent. The fuzzy query must be pushed down to Lucene as a delegated predicate — Lucene builds a Levenshtein automaton that produces a match bitset directly, rather than attempting row-by-row evaluation in the analytics engine.

**Where:** Two components, both required for end-to-end operation:

1. `FuzzyQueryTranslator` in `sandbox/plugins/dsl-query-executor` — translates the DSL query builder into a RexCall whose operator name is `"FUZZY"`, which resolves to `ScalarFunction.FUZZY` via name-based dispatch at `ScalarFunction.fromSqlOperatorWithFallback()`.
2. `FuzzySerializer` in `sandbox/plugins/analytics-backend-lucene` + registration in `QuerySerializerRegistry` — reconstitutes the `FuzzyQueryBuilder` from the RexCall operands so the Lucene backend can execute the fuzzy query at the shard level.

Without the translator, the query wraps in `UnresolvedQueryCall` and fails at `OpenSearchFilterRule`. Without the serializer, `ScalarFunction.FUZZY` resolves but predicate serialization has no handler.

### Supported Parameters

| Parameter | Legacy Default | Behaviour |
|---|---|---|
| `value` (required) | — | Primary query term, carried as string literal in operand 1 |
| `fuzziness` | `AUTO` | Edit-distance model; validated at translate time via `Fuzziness.build()` + `asDistance()` to fail fast on invalid values like `"abc"` |
| `prefix_length` | `0` | Number of leading characters held fixed (not subject to edits); must be ≥ 0 |
| `max_expansions` | `50` | Maximum number of terms the fuzzy automaton expands; must be ≥ 1 |
| `transpositions` | `true` | Whether adjacent-character swaps count as a single edit (Damerau-Levenshtein when true, plain Levenshtein when false) |
| `rewrite` | `constant_score` | MultiTermQuery rewrite method; passed through because `top_terms_*` variants change which documents match even in a non-scoring context |

Non-default values are emitted as additional MAP operands at index 2+. Default values are omitted — the serializer lets `FuzzyQueryBuilder` apply its own defaults.

Fuzziness accepts `"0"`, `"1"`, `"2"`, `"AUTO"`, and `"AUTO:x,y"` (custom auto bounds). Values like `"3"` are accepted and clamped to 2 by Lucene at query time, preserving legacy parity with `StringFieldType.fuzzyQuery` (StringFieldType.java:103).

### Rejected Parameters

| Parameter | Why Rejected | Legacy Citation |
|---|---|---|
| `boost` | Delegated predicates produce a match bitset with no scoring; boost has no effect | `AbstractQueryBuilder.toQuery` lines 130–136: `BoostQuery` wrapping |
| `_name` | Query naming is diagnostic metadata with no mechanism to carry through the analytics pipeline | `AbstractQueryBuilder.toQuery` lines 137–139: named query registration |

### Known Divergences from Legacy `_search`

| # | Behaviour | Legacy `_search` | Analytics DSL Path | Reason |
|---|---|---|---|---|
| 1 | boost | Affects BM25 score ranking | Rejected with ConversionException | Delegated predicate yields match bitset, no scoring (`DelegatedPredicateFunction.java:23-33`) |
| 2 | _name | Stored in response for diagnostics | Rejected with ConversionException | No mechanism in analytics pipeline |
| 3 | Field-type gating | Rejects at field-mapper level with type-specific errors | Rejects all non-VARCHAR with a generic error | Calcite type system collapses keyword/text/match_only_text into VARCHAR; no field-mapper access at translate time |
| 4 | Unknown field | Returns `MatchNoneQueryBuilder` (`FuzzyQueryBuilder.doRewrite` line 347) | Throws ConversionException | `ConversionContext.getField` throws if field absent from schema (`ConversionContext.java:102-107`) |
| 5 | Non-string value | Accepts int/long/float/boolean via Object constructor | Accepts only string (value toString'd at translate time) | Cosmetic — `FuzzyQueryBuilder` toString's value before Lucene processing regardless |
| 6 | `search.allow_expensive_queries` | When `false`, fuzzy queries are refused at query-build time (`StringFieldType.fuzzyQuery:92`, `KeywordFieldMapper.KeywordFieldType.fuzzyQuery:736`); the setting is declared at `SearchService.java:221` (default `true`, dynamic) and delivered as a `BooleanSupplier` via `QueryShardContext.allowExpensiveQueries()` (`QueryShardContext.java:373`) | Not honoured — `LuceneAnalyticsBackendPlugin.java:282` passes a hardcoded always-true supplier | Pre-existing engine-wide gap affecting every delegated predicate, not introduced by fuzzy. Fix belongs in a separate family-wide change that threads the cluster setting through the analytics backend context. |
| 7 | `_name` handling across family | `term`, `terms`, `range`, and `fuzzy` all reject `_name` with a `ConversionException`; `prefix` and `wildcard` silently ignore it (with an explanatory comment) | Rejects with ConversionException (consistent with `term`/`terms`/`range`) | Fuzzy sits with the majority; `prefix`/`wildcard` are the outliers that silently drop it. The family should converge on one policy — tracked as cross-cutting work, not resolved here. |
| 8 | `flat_object` / `version` field types | Support fuzzy natively (each type implements `fuzzyQuery()`) | Unreachable — `OpenSearchSchemaBuilder.mapFieldType()` returns `null` for these types, excluding them from the Calcite schema entirely | Storage/schema-layer limitation affecting all query types, not fuzzy-specific. These fields are invisible to the analytics engine regardless of predicate. |

### Testing

| Category | File | Tests |
|---|---|---|
| Translator unit tests | `FuzzyQueryTranslatorTests.java` | 18 |
| Serializer round-trip tests | `QuerySerializerRegistryTests.java` (additions) | 7 |
| Golden files | `fuzzy_default_params.json`, `fuzzy_all_params.json` | 2 plan-shape assertions |
| Integration tests | `DslQueryIT.java` | 2 (`@AwaitsFix`) |
| **Module totals (all passing)** | `dsl-query-executor` / `analytics-backend-lucene` | **164 / 323** |

**Translator tests** cover: rejection of non-default boost, `_name`, non-VARCHAR fields, unknown fields, invalid fuzziness values (including non-numeric like `"abc"`), negative `prefix_length`, zero `max_expansions`, null value, empty-string value; acceptance of `AUTO:4,7` custom auto bounds and fuzziness `"3"` (clamped); correct operator name, field/query operand shape, non-default param emission, and default-param omission.

**Serializer tests** cover: defaults round-trip, custom fuzziness, all-params round-trip, rewrite pass-through, transpositions=false isolation, missing-field error, and unrecognized-param tolerance.

**Golden files** assert the full Calcite logical plan shape for a fuzzy query with default parameters and with all five optional parameters overridden.

Integration tests (`testFuzzyQueryOnKeywordField`, `testFuzzyQueryOnTextField`) are parked with `@AwaitsFix` pending the analytics E2E pipeline (fragment conversion + shard execution + Arrow Flight drain), matching sibling ITs for range, prefix, wildcard, and bool queries.

### Check List

- [x] Functionality includes testing
- [x] API changes companion pull request created, if applicable
- [x] Public documentation issue/PR created, if applicable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
