### PR TITLE
Add transport failure and connect latency counters to node stats

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
@@ -346,9 +346,9 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         private final Runnable connectActivity = new AbstractRunnable() {
 
             final AbstractRunnable abstractRunnable = this;
-            // Tracks wall-clock start of the current connect attempt (nanoseconds).
-            // Written in doRun() before connectToNode; read in onResponse/onFailure callbacks.
-            // volatile ensures visibility across the thread-pool hand-off.
+            // Start of the connect attempt in flight, or 0 when there is none. Written in doRun() before
+            // connectToNode and read in the callbacks, which run on a different thread, so it is volatile.
+            // ConnectionTarget runs at most one activity at a time, so attempts never overlap.
             volatile long connectStartNanos;
 
             @Override
@@ -366,8 +366,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
                         @Override
                         public void onResponse(Void aVoid) {
                             assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - connectStartNanos);
-                            logger.debug("connected to {} in [{}ms]", discoveryNode, elapsedMs);
+                            logger.debug("connected to {} in [{}]", discoveryNode, takeElapsedConnectTime());
                             onConnected();
                         }
 
@@ -384,19 +383,29 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
                 onCompletion(ActivityType.CONNECTING, null, disconnectActivity);
             }
 
+            /**
+             * Consumes the start time of the attempt in flight and renders how long it took. An attempt that was
+             * rejected before {@link #doRun} could start it has no start time, and reporting the time of whichever
+             * attempt ran last would be worse than reporting nothing.
+             */
+            private String takeElapsedConnectTime() {
+                final long startNanos = connectStartNanos;
+                connectStartNanos = 0L;
+                return startNanos == 0L ? "unknown time" : TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos) + "ms";
+            }
+
             @Override
             public void onFailure(Exception e) {
                 assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
                 final int currentFailureCount = consecutiveFailureCount.incrementAndGet();
                 // only warn every 6th failure
                 final Level level = currentFailureCount % 6 == 1 ? Level.WARN : Level.DEBUG;
-                final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - connectStartNanos);
                 logger.log(
                     level,
                     new ParameterizedMessage(
-                        "failed to connect to {} after [{}ms] (tried [{}] times)",
+                        "failed to connect to {} after [{}] (tried [{}] times)",
                         discoveryNode,
-                        elapsedMs,
+                        takeElapsedConnectTime(),
                         currentFailureCount
                     ),
                     e

--- a/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
@@ -61,6 +61,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.opensearch.common.settings.Setting.Property;
@@ -345,6 +346,10 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         private final Runnable connectActivity = new AbstractRunnable() {
 
             final AbstractRunnable abstractRunnable = this;
+            // Tracks wall-clock start of the current connect attempt (nanoseconds).
+            // Written in doRun() before connectToNode; read in onResponse/onFailure callbacks.
+            // volatile ensures visibility across the thread-pool hand-off.
+            volatile long connectStartNanos;
 
             @Override
             protected void doRun() {
@@ -356,11 +361,13 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
                     onConnected();
                 } else {
                     logger.debug("connecting to {}", discoveryNode);
+                    connectStartNanos = System.nanoTime();
                     transportService.connectToNode(discoveryNode, new ActionListener<Void>() {
                         @Override
                         public void onResponse(Void aVoid) {
                             assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                            logger.debug("connected to {}", discoveryNode);
+                            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - connectStartNanos);
+                            logger.debug("connected to {} in [{}ms]", discoveryNode, elapsedMs);
                             onConnected();
                         }
 
@@ -383,9 +390,15 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
                 final int currentFailureCount = consecutiveFailureCount.incrementAndGet();
                 // only warn every 6th failure
                 final Level level = currentFailureCount % 6 == 1 ? Level.WARN : Level.DEBUG;
+                final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - connectStartNanos);
                 logger.log(
                     level,
-                    new ParameterizedMessage("failed to connect to {} (tried [{}] times)", discoveryNode, currentFailureCount),
+                    new ParameterizedMessage(
+                        "failed to connect to {} after [{}ms] (tried [{}] times)",
+                        discoveryNode,
+                        elapsedMs,
+                        currentFailureCount
+                    ),
                     e
                 );
                 onCompletion(ActivityType.CONNECTING, e, disconnectActivity);

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -361,6 +361,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
          * deliberate close of the connection (node left the cluster, transport shutting down) is not a socket failure
          * at all. Both of those cases are filtered out by the {@link #isClosing} check, which is why this has to run
          * before the connection is closed.
+         * <p>
+         * A teardown therefore contributes exactly one socket, the first to close. Sockets that fail at almost the
+         * same moment as that one are not counted separately, because once teardown is under way a closing socket is
+         * indistinguishable from one the teardown itself closed. Sampling the first failure is enough to show which
+         * channel types are unhealthy, which is what this breakdown is for.
          */
         void recordChannelClose(int channelIndex, long openTimeMillis) {
             if (isClosing.get()) {

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -157,6 +157,14 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     private final AtomicLong outboundConnectionCount = new AtomicLong(); // also used as a correlation ID for open/close logs
 
+    // Counters exposed through TransportStats / _nodes/stats.
+    private final EnumMap<TransportRequestOptions.Type, AtomicLong> channelCloseByType;
+    // Connect-time counters. A slow or hung connection open blocks the cluster applier thread, and no
+    // request-level metric observes it, so these are the only signal for connection-open impairment.
+    private final AtomicLong connectFailures = new AtomicLong();
+    private final AtomicLong connectTimeMillis = new AtomicLong();
+    private final AtomicLong connectTimeMillisMax = new AtomicLong();
+
     public TcpTransport(
         Settings settings,
         Version version,
@@ -173,6 +181,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.threadPool = threadPool;
         this.pageCacheRecycler = pageCacheRecycler;
         this.circuitBreakerService = circuitBreakerService;
+        EnumMap<TransportRequestOptions.Type, AtomicLong> closeMap = new EnumMap<>(TransportRequestOptions.Type.class);
+        for (TransportRequestOptions.Type t : TransportRequestOptions.Type.values()) {
+            closeMap.put(t, new AtomicLong());
+        }
+        this.channelCloseByType = closeMap;
         this.networkService = networkService;
         String nodeName = Node.NODE_NAME_SETTING.get(settings);
         final Settings defaultFeatures = TransportSettings.DEFAULT_FEATURES_SETTING.get(settings);
@@ -306,6 +319,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      */
     public final class NodeChannels extends CloseableConnection {
         private final Map<TransportRequestOptions.Type, ConnectionProfile.ConnectionTypeHandle> typeMapping;
+        private final Map<TcpChannel, Set<TransportRequestOptions.Type>> channelToTypes;
         private final List<TcpChannel> channels;
         private final DiscoveryNode node;
         private final Version version;
@@ -325,8 +339,21 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 for (TransportRequestOptions.Type type : handle.getTypes())
                     typeMapping.put(type, handle);
             }
+            // Build reverse mapping: each channel index → the set of types sharing that socket slot.
+            final Map<TcpChannel, Set<TransportRequestOptions.Type>> reverseMap = new HashMap<>();
+            for (ConnectionProfile.ConnectionTypeHandle handle : connectionProfile.getHandles()) {
+                for (int i = handle.offset; i < handle.offset + handle.length; i++) {
+                    reverseMap.put(channels.get(i), handle.getTypes());
+                }
+            }
+            channelToTypes = Collections.unmodifiableMap(reverseMap);
             version = handshakeVersion;
             compress = connectionProfile.getCompressionEnabled();
+        }
+
+        /** Returns the channel type(s) assigned to this specific TCP socket, or an empty set if unknown. */
+        Set<TransportRequestOptions.Type> channelTypes(TcpChannel channel) {
+            return channelToTypes.getOrDefault(channel, Collections.emptySet());
         }
 
         @Override
@@ -368,10 +395,16 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
             throws IOException, TransportException {
             if (isClosing.get()) {
+                logger.debug("send [{}] rejected: [{}] channel to [{}] already closed", action, options.type(), node);
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             TcpChannel channel = channel(options.type());
-            handshakerHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), compress, false);
+            try {
+                handshakerHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), compress, false);
+            } catch (IOException e) {
+                logger.debug("send [{}] failed with IOException on [{}] channel to [{}]", action, options.type(), node, e);
+                throw e;
+            }
         }
     }
 
@@ -970,12 +1003,20 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         final long messagesSent = statsTracker.getMessagesSent();
         final long messagesReceived = statsTracker.getMessagesReceived();
         final long bytesRead = statsTracker.getBytesRead();
+        Map<String, Long> closeSnapshot = new HashMap<>();
+        for (TransportRequestOptions.Type t : TransportRequestOptions.Type.values()) {
+            closeSnapshot.put(t.name(), channelCloseByType.get(t).get());
+        }
         return new TransportStats.Builder().serverOpen(acceptedChannels.size())
             .totalOutboundConnections(outboundConnectionCount.get())
             .rxCount(messagesReceived)
             .rxSize(bytesRead)
             .txCount(messagesSent)
             .txSize(bytesWritten)
+            .channelCloseByType(closeSnapshot)
+            .connectFailures(connectFailures.get())
+            .connectTimeMillis(connectTimeMillis.get())
+            .connectTimeMillisMax(connectTimeMillisMax.get())
             .build();
     }
 
@@ -1061,6 +1102,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         private final List<TcpChannel> channels;
         private final ActionListener<Transport.Connection> listener;
         private final CountDown countDown;
+        private final long startNanos;
 
         private ChannelsConnectedListener(
             DiscoveryNode node,
@@ -1073,6 +1115,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             this.channels = channels;
             this.listener = listener;
             this.countDown = new CountDown(channels.size());
+            this.startNanos = System.nanoTime();
         }
 
         @Override
@@ -1083,13 +1126,38 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 try {
                     executeHandshake(node, handshakeChannel, connectionProfile, ActionListener.wrap(version -> {
                         final long connectionId = outboundConnectionCount.incrementAndGet();
-                        logger.debug("opened transport connection [{}] to [{}] using channels [{}]", connectionId, node, channels);
+                        final long connectMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                        connectTimeMillis.addAndGet(connectMillis);
+                        connectTimeMillisMax.updateAndGet(prev -> Math.max(prev, connectMillis));
+                        logger.debug(
+                            "opened transport connection [{}] to [{}] in [{}ms] using channels [{}]",
+                            connectionId,
+                            node,
+                            connectMillis,
+                            channels
+                        );
                         NodeChannels nodeChannels = new NodeChannels(node, channels, connectionProfile, version);
                         long relativeMillisTime = threadPool.relativeTimeInMillis();
                         nodeChannels.channels.forEach(ch -> {
                             // Mark the channel init time
                             ch.getChannelStats().markAccessed(relativeMillisTime);
                             ch.addCloseListener(ActionListener.wrap(nodeChannels::close));
+                            // Log which channel type's individual socket closed — useful for detecting
+                            // per-channel-type failures (e.g. REG/BULK/RECOVERY bad while PING/STATE healthy).
+                            final Set<TransportRequestOptions.Type> types = nodeChannels.channelTypes(ch);
+                            if (types.isEmpty() == false) {
+                                ch.addCloseListener(ActionListener.wrap(() -> {
+                                    logger.debug(
+                                        "individual [{}] channel socket closed to [{}] (connection age [{}ms])",
+                                        types,
+                                        node,
+                                        threadPool.relativeTimeInMillis() - relativeMillisTime
+                                    );
+                                    for (TransportRequestOptions.Type type : types) {
+                                        channelCloseByType.get(type).incrementAndGet();
+                                    }
+                                }));
+                            }
                         });
                         keepAlive.registerNodeConnection(nodeChannels.channels, connectionProfile);
                         nodeChannels.addCloseListener(new ChannelCloseLogger(node, connectionId, relativeMillisTime));
@@ -1121,6 +1189,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
 
         private void closeAndFail(Exception e) {
+            connectFailures.incrementAndGet();
             try {
                 CloseableChannel.closeChannels(channels, false);
             } catch (Exception ex) {

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -88,6 +88,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -319,7 +320,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      */
     public final class NodeChannels extends CloseableConnection {
         private final Map<TransportRequestOptions.Type, ConnectionProfile.ConnectionTypeHandle> typeMapping;
-        private final Map<TcpChannel, Set<TransportRequestOptions.Type>> channelToTypes;
+        private final List<Set<TransportRequestOptions.Type>> typesByChannel;
         private final List<TcpChannel> channels;
         private final DiscoveryNode node;
         private final Version version;
@@ -339,21 +340,45 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 for (TransportRequestOptions.Type type : handle.getTypes())
                     typeMapping.put(type, handle);
             }
-            // Build reverse mapping: each channel index → the set of types sharing that socket slot.
-            final Map<TcpChannel, Set<TransportRequestOptions.Type>> reverseMap = new HashMap<>();
+            // Reverse of typeMapping: for each socket slot, the set of types multiplexed onto it.
+            final List<Set<TransportRequestOptions.Type>> reverseMapping = new ArrayList<>(
+                Collections.nCopies(channels.size(), Collections.emptySet())
+            );
             for (ConnectionProfile.ConnectionTypeHandle handle : connectionProfile.getHandles()) {
                 for (int i = handle.offset; i < handle.offset + handle.length; i++) {
-                    reverseMap.put(channels.get(i), handle.getTypes());
+                    reverseMapping.set(i, handle.getTypes());
                 }
             }
-            channelToTypes = Collections.unmodifiableMap(reverseMap);
+            typesByChannel = Collections.unmodifiableList(reverseMapping);
             version = handshakeVersion;
             compress = connectionProfile.getCompressionEnabled();
         }
 
-        /** Returns the channel type(s) assigned to this specific TCP socket, or an empty set if unknown. */
-        Set<TransportRequestOptions.Type> channelTypes(TcpChannel channel) {
-            return channelToTypes.getOrDefault(channel, Collections.emptySet());
+        /**
+         * Records that the socket at {@code channelIndex} closed while this connection was still live, meaning that
+         * socket is what brought the connection down. Closing any single socket tears down the whole connection via
+         * {@link #close()}, so the remaining sockets close as a consequence and must not be counted; likewise a
+         * deliberate close of the connection (node left the cluster, transport shutting down) is not a socket failure
+         * at all. Both of those cases are filtered out by the {@link #isClosing} check, which is why this has to run
+         * before the connection is closed.
+         */
+        void recordChannelClose(int channelIndex, long openTimeMillis) {
+            if (isClosing.get()) {
+                return;
+            }
+            final Set<TransportRequestOptions.Type> types = typesByChannel.get(channelIndex);
+            if (types.isEmpty()) {
+                return;
+            }
+            logger.debug(
+                "individual [{}] channel socket closed to [{}] (connection age [{}ms])",
+                types,
+                node,
+                threadPool.relativeTimeInMillis() - openTimeMillis
+            );
+            for (TransportRequestOptions.Type type : types) {
+                channelCloseByType.get(type).incrementAndGet();
+            }
         }
 
         @Override
@@ -440,6 +465,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         assert numConnections > 0 : "A connection profile must be configured with at least one connection";
 
         final List<TcpChannel> channels = new ArrayList<>(numConnections);
+        final long startNanos = System.nanoTime();
 
         for (int i = 0; i < numConnections; ++i) {
             try {
@@ -447,10 +473,12 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 logger.trace(() -> new ParameterizedMessage("Tcp transport channel opened: {}", channel));
                 channels.add(channel);
             } catch (ConnectTransportException e) {
+                connectFailures.incrementAndGet();
                 CloseableChannel.closeChannels(channels, false);
                 listener.onFailure(e);
                 return channels;
             } catch (Exception e) {
+                connectFailures.incrementAndGet();
                 CloseableChannel.closeChannels(channels, false);
                 listener.onFailure(new ConnectTransportException(node, "general node connection failure", e));
                 return channels;
@@ -461,7 +489,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             node,
             connectionProfile,
             channels,
-            new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.GENERIC, listener, false)
+            new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.GENERIC, listener, false),
+            startNanos
         );
 
         for (TcpChannel channel : channels) {
@@ -1005,7 +1034,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         final long bytesRead = statsTracker.getBytesRead();
         Map<String, Long> closeSnapshot = new HashMap<>();
         for (TransportRequestOptions.Type t : TransportRequestOptions.Type.values()) {
-            closeSnapshot.put(t.name(), channelCloseByType.get(t).get());
+            closeSnapshot.put(t.name().toLowerCase(Locale.ROOT), channelCloseByType.get(t).get());
         }
         return new TransportStats.Builder().serverOpen(acceptedChannels.size())
             .totalOutboundConnections(outboundConnectionCount.get())
@@ -1102,20 +1131,22 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         private final List<TcpChannel> channels;
         private final ActionListener<Transport.Connection> listener;
         private final CountDown countDown;
+        /** Taken before the first socket is opened, so measured latency covers socket setup, connect and handshake. */
         private final long startNanos;
 
         private ChannelsConnectedListener(
             DiscoveryNode node,
             ConnectionProfile connectionProfile,
             List<TcpChannel> channels,
-            ActionListener<Transport.Connection> listener
+            ActionListener<Transport.Connection> listener,
+            long startNanos
         ) {
             this.node = node;
             this.connectionProfile = connectionProfile;
             this.channels = channels;
             this.listener = listener;
             this.countDown = new CountDown(channels.size());
-            this.startNanos = System.nanoTime();
+            this.startNanos = startNanos;
         }
 
         @Override
@@ -1138,27 +1169,19 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                         );
                         NodeChannels nodeChannels = new NodeChannels(node, channels, connectionProfile, version);
                         long relativeMillisTime = threadPool.relativeTimeInMillis();
-                        nodeChannels.channels.forEach(ch -> {
+                        for (int i = 0; i < nodeChannels.channels.size(); i++) {
+                            final TcpChannel ch = nodeChannels.channels.get(i);
+                            final int channelIndex = i;
                             // Mark the channel init time
                             ch.getChannelStats().markAccessed(relativeMillisTime);
-                            ch.addCloseListener(ActionListener.wrap(nodeChannels::close));
-                            // Log which channel type's individual socket closed — useful for detecting
-                            // per-channel-type failures (e.g. REG/BULK/RECOVERY bad while PING/STATE healthy).
-                            final Set<TransportRequestOptions.Type> types = nodeChannels.channelTypes(ch);
-                            if (types.isEmpty() == false) {
-                                ch.addCloseListener(ActionListener.wrap(() -> {
-                                    logger.debug(
-                                        "individual [{}] channel socket closed to [{}] (connection age [{}ms])",
-                                        types,
-                                        node,
-                                        threadPool.relativeTimeInMillis() - relativeMillisTime
-                                    );
-                                    for (TransportRequestOptions.Type type : types) {
-                                        channelCloseByType.get(type).incrementAndGet();
-                                    }
-                                }));
-                            }
-                        });
+                            ch.addCloseListener(ActionListener.wrap(() -> {
+                                // Attribute the close before tearing the connection down, while we can still tell
+                                // whether this socket is the cause. Attribution per channel type helps spot failures
+                                // isolated to one type (e.g. REG/BULK/RECOVERY bad while PING/STATE stay healthy).
+                                nodeChannels.recordChannelClose(channelIndex, relativeMillisTime);
+                                nodeChannels.close();
+                            }));
+                        }
                         keepAlive.registerNodeConnection(nodeChannels.channels, connectionProfile);
                         nodeChannels.addCloseListener(new ChannelCloseLogger(node, connectionId, relativeMillisTime));
                         listener.onResponse(nodeChannels);

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -486,19 +486,9 @@ public class TransportService extends AbstractLifecycleComponent
     }
 
     public TransportStats stats() {
-        TransportStats base = transport.getStats();
-        return new TransportStats.Builder().serverOpen(base.getServerOpen())
-            .totalOutboundConnections(base.getTotalOutboundConnections())
-            .rxCount(base.getRxCount())
-            .rxSize(base.getRxSize().getBytes())
-            .txCount(base.getTxCount())
-            .txSize(base.getTxSize().getBytes())
-            .channelCloseByType(base.getChannelCloseByType())
-            .outgoingTimeouts(outgoingTimeouts.get())
+        // The transport owns every counter except the two request-level ones tracked here.
+        return new TransportStats.Builder(transport.getStats()).outgoingTimeouts(outgoingTimeouts.get())
             .requestsFailedOnDisconnect(requestsFailedOnDisconnect.get())
-            .connectFailures(base.getConnectFailures())
-            .connectTimeMillis(base.getConnectTimeMillis())
-            .connectTimeMillisMax(base.getConnectTimeMillisMax())
             .build();
     }
 

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -89,6 +89,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -135,6 +136,13 @@ public class TransportService extends AbstractLifecycleComponent
 
     public static final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
     };
+
+    // Counters for outbound request failures, exposed through TransportStats / _nodes/stats.
+    // outgoingTimeouts covers any cause of a missing response: packet loss, a route that silently drops
+    // traffic, or saturation of the remote thread pool. requestsFailedOnDisconnect counts in-flight
+    // requests cancelled because the connection closed before a response arrived.
+    private final AtomicLong outgoingTimeouts = new AtomicLong();
+    private final AtomicLong requestsFailedOnDisconnect = new AtomicLong();
 
     // tracer log
 
@@ -478,7 +486,20 @@ public class TransportService extends AbstractLifecycleComponent
     }
 
     public TransportStats stats() {
-        return transport.getStats();
+        TransportStats base = transport.getStats();
+        return new TransportStats.Builder().serverOpen(base.getServerOpen())
+            .totalOutboundConnections(base.getTotalOutboundConnections())
+            .rxCount(base.getRxCount())
+            .rxSize(base.getRxSize().getBytes())
+            .txCount(base.getTxCount())
+            .txSize(base.getTxSize().getBytes())
+            .channelCloseByType(base.getChannelCloseByType())
+            .outgoingTimeouts(outgoingTimeouts.get())
+            .requestsFailedOnDisconnect(requestsFailedOnDisconnect.get())
+            .connectFailures(base.getConnectFailures())
+            .connectTimeMillis(base.getConnectTimeMillis())
+            .connectTimeMillisMax(base.getConnectTimeMillisMax())
+            .build();
     }
 
     public boolean isTransportSecure() {
@@ -1411,6 +1432,9 @@ public class TransportService extends AbstractLifecycleComponent
             List<Transport.ResponseContext<? extends TransportResponse>> pruned = responseHandlers.prune(
                 h -> h.connection().getCacheKey().equals(connection.getCacheKey())
             );
+            if (pruned.isEmpty() == false) {
+                requestsFailedOnDisconnect.addAndGet(pruned.size());
+            }
             // callback that an exception happened, but on a different thread since we don't
             // want handlers to worry about stack overflows
             getExecutorService().execute(new Runnable() {
@@ -1456,6 +1480,7 @@ public class TransportService extends AbstractLifecycleComponent
                 if (holder != null) {
                     assert holder.action().equals(action);
                     assert holder.connection().getNode().equals(node);
+                    outgoingTimeouts.incrementAndGet();
                     holder.handler()
                         .handleException(
                             new ReceiveTimeoutTransportException(

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1422,9 +1422,7 @@ public class TransportService extends AbstractLifecycleComponent
             List<Transport.ResponseContext<? extends TransportResponse>> pruned = responseHandlers.prune(
                 h -> h.connection().getCacheKey().equals(connection.getCacheKey())
             );
-            if (pruned.isEmpty() == false) {
-                requestsFailedOnDisconnect.addAndGet(pruned.size());
-            }
+            requestsFailedOnDisconnect.addAndGet(pruned.size());
             // callback that an exception happened, but on a different thread since we don't
             // want handlers to worry about stack overflows
             getExecutorService().execute(new Runnable() {

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -41,6 +41,9 @@ import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Stats for transport activity
@@ -56,6 +59,23 @@ public class TransportStats implements Writeable, ToXContentFragment {
     private final long rxSize;
     private final long txCount;
     private final long txSize;
+    // Individual channel sockets closed, keyed by channel type. Distinguishes impairment affecting only
+    // some channel types from a whole-node failure.
+    private final Map<String, Long> channelCloseByType;
+    // outgoingTimeouts: requests that got no response within their timeout.
+    // requestsFailedOnDisconnect: in-flight requests cancelled when a connection closed.
+    private final long outgoingTimeouts;
+    private final long requestsFailedOnDisconnect;
+    // Connect-time counters, covering the connection-open path that the request-level counters above
+    // cannot observe:
+    // connectFailures: outbound connection opens that failed or timed out.
+    // connectTimeMillis: cumulative time spent opening connections that succeeded. Average open latency
+    // is connectTimeMillis / totalOutboundConnections.
+    // connectTimeMillisMax: worst-case single connection open time since node start, useful for judging
+    // whether lowering transport.connect_timeout is safe.
+    private final long connectFailures;
+    private final long connectTimeMillis;
+    private final long connectTimeMillisMax;
 
     /**
      * Private constructor that takes a builder.
@@ -69,6 +89,12 @@ public class TransportStats implements Writeable, ToXContentFragment {
         this.rxSize = builder.rxSize;
         this.txCount = builder.txCount;
         this.txSize = builder.txSize;
+        this.channelCloseByType = Collections.unmodifiableMap(new HashMap<>(builder.channelCloseByType));
+        this.outgoingTimeouts = builder.outgoingTimeouts;
+        this.requestsFailedOnDisconnect = builder.requestsFailedOnDisconnect;
+        this.connectFailures = builder.connectFailures;
+        this.connectTimeMillis = builder.connectTimeMillis;
+        this.connectTimeMillisMax = builder.connectTimeMillisMax;
     }
 
     /**
@@ -83,6 +109,12 @@ public class TransportStats implements Writeable, ToXContentFragment {
         this.rxSize = rxSize;
         this.txCount = txCount;
         this.txSize = txSize;
+        this.channelCloseByType = Collections.emptyMap();
+        this.outgoingTimeouts = 0L;
+        this.requestsFailedOnDisconnect = 0L;
+        this.connectFailures = 0L;
+        this.connectTimeMillis = 0L;
+        this.connectTimeMillisMax = 0L;
     }
 
     public TransportStats(StreamInput in) throws IOException {
@@ -92,6 +124,12 @@ public class TransportStats implements Writeable, ToXContentFragment {
         rxSize = in.readVLong();
         txCount = in.readVLong();
         txSize = in.readVLong();
+        channelCloseByType = in.readMap(StreamInput::readString, StreamInput::readVLong);
+        outgoingTimeouts = in.readVLong();
+        requestsFailedOnDisconnect = in.readVLong();
+        connectFailures = in.readVLong();
+        connectTimeMillis = in.readVLong();
+        connectTimeMillisMax = in.readVLong();
     }
 
     @Override
@@ -102,6 +140,12 @@ public class TransportStats implements Writeable, ToXContentFragment {
         out.writeVLong(rxSize);
         out.writeVLong(txCount);
         out.writeVLong(txSize);
+        out.writeMap(channelCloseByType, StreamOutput::writeString, StreamOutput::writeVLong);
+        out.writeVLong(outgoingTimeouts);
+        out.writeVLong(requestsFailedOnDisconnect);
+        out.writeVLong(connectFailures);
+        out.writeVLong(connectTimeMillis);
+        out.writeVLong(connectTimeMillisMax);
     }
 
     public long serverOpen() {
@@ -110,6 +154,10 @@ public class TransportStats implements Writeable, ToXContentFragment {
 
     public long getServerOpen() {
         return serverOpen();
+    }
+
+    public long getTotalOutboundConnections() {
+        return totalOutboundConnections;
     }
 
     public long rxCount() {
@@ -144,6 +192,30 @@ public class TransportStats implements Writeable, ToXContentFragment {
         return txSize();
     }
 
+    public Map<String, Long> getChannelCloseByType() {
+        return channelCloseByType;
+    }
+
+    public long getOutgoingTimeouts() {
+        return outgoingTimeouts;
+    }
+
+    public long getRequestsFailedOnDisconnect() {
+        return requestsFailedOnDisconnect;
+    }
+
+    public long getConnectFailures() {
+        return connectFailures;
+    }
+
+    public long getConnectTimeMillis() {
+        return connectTimeMillis;
+    }
+
+    public long getConnectTimeMillisMax() {
+        return connectTimeMillisMax;
+    }
+
     /**
      * Builder for the {@link TransportStats} class.
      * Provides a fluent API for constructing a TransportStats object.
@@ -155,6 +227,12 @@ public class TransportStats implements Writeable, ToXContentFragment {
         private long rxSize = 0;
         private long txCount = 0;
         private long txSize = 0;
+        private Map<String, Long> channelCloseByType = Collections.emptyMap();
+        private long outgoingTimeouts = 0L;
+        private long requestsFailedOnDisconnect = 0L;
+        private long connectFailures = 0L;
+        private long connectTimeMillis = 0L;
+        private long connectTimeMillisMax = 0L;
 
         public Builder() {}
 
@@ -188,6 +266,36 @@ public class TransportStats implements Writeable, ToXContentFragment {
             return this;
         }
 
+        public Builder channelCloseByType(Map<String, Long> channelCloseByType) {
+            this.channelCloseByType = channelCloseByType;
+            return this;
+        }
+
+        public Builder outgoingTimeouts(long outgoingTimeouts) {
+            this.outgoingTimeouts = outgoingTimeouts;
+            return this;
+        }
+
+        public Builder requestsFailedOnDisconnect(long requestsFailedOnDisconnect) {
+            this.requestsFailedOnDisconnect = requestsFailedOnDisconnect;
+            return this;
+        }
+
+        public Builder connectFailures(long connectFailures) {
+            this.connectFailures = connectFailures;
+            return this;
+        }
+
+        public Builder connectTimeMillis(long connectTimeMillis) {
+            this.connectTimeMillis = connectTimeMillis;
+            return this;
+        }
+
+        public Builder connectTimeMillisMax(long connectTimeMillisMax) {
+            this.connectTimeMillisMax = connectTimeMillisMax;
+            return this;
+        }
+
         /**
          * Creates a {@link TransportStats} object from the builder's current state.
          * @return A new TransportStats instance.
@@ -206,6 +314,14 @@ public class TransportStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, new ByteSizeValue(rxSize));
         builder.field(Fields.TX_COUNT, txCount);
         builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, new ByteSizeValue(txSize));
+        if (channelCloseByType.isEmpty() == false) {
+            builder.field(Fields.CHANNEL_CLOSE_BY_TYPE, channelCloseByType);
+        }
+        builder.field(Fields.OUTGOING_TIMEOUTS, outgoingTimeouts);
+        builder.field(Fields.REQUESTS_FAILED_ON_DISCONNECT, requestsFailedOnDisconnect);
+        builder.field(Fields.CONNECT_FAILURES, connectFailures);
+        builder.field(Fields.CONNECT_TIME_MILLIS, connectTimeMillis);
+        builder.field(Fields.CONNECT_TIME_MILLIS_MAX, connectTimeMillisMax);
         builder.endObject();
         return builder;
     }
@@ -220,5 +336,11 @@ public class TransportStats implements Writeable, ToXContentFragment {
         static final String TX_COUNT = "tx_count";
         static final String TX_SIZE = "tx_size";
         static final String TX_SIZE_IN_BYTES = "tx_size_in_bytes";
+        static final String CHANNEL_CLOSE_BY_TYPE = "channel_close_by_type";
+        static final String OUTGOING_TIMEOUTS = "outgoing_timeouts";
+        static final String REQUESTS_FAILED_ON_DISCONNECT = "requests_failed_on_disconnect";
+        static final String CONNECT_FAILURES = "connect_failures";
+        static final String CONNECT_TIME_MILLIS = "connect_time_millis";
+        static final String CONNECT_TIME_MILLIS_MAX = "connect_time_millis_max";
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.Version;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -124,12 +125,21 @@ public class TransportStats implements Writeable, ToXContentFragment {
         rxSize = in.readVLong();
         txCount = in.readVLong();
         txSize = in.readVLong();
-        channelCloseByType = in.readMap(StreamInput::readString, StreamInput::readVLong);
-        outgoingTimeouts = in.readVLong();
-        requestsFailedOnDisconnect = in.readVLong();
-        connectFailures = in.readVLong();
-        connectTimeMillis = in.readVLong();
-        connectTimeMillisMax = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            channelCloseByType = in.readMap(StreamInput::readString, StreamInput::readVLong);
+            outgoingTimeouts = in.readVLong();
+            requestsFailedOnDisconnect = in.readVLong();
+            connectFailures = in.readVLong();
+            connectTimeMillis = in.readVLong();
+            connectTimeMillisMax = in.readVLong();
+        } else {
+            channelCloseByType = Collections.emptyMap();
+            outgoingTimeouts = 0L;
+            requestsFailedOnDisconnect = 0L;
+            connectFailures = 0L;
+            connectTimeMillis = 0L;
+            connectTimeMillisMax = 0L;
+        }
     }
 
     @Override
@@ -140,12 +150,14 @@ public class TransportStats implements Writeable, ToXContentFragment {
         out.writeVLong(rxSize);
         out.writeVLong(txCount);
         out.writeVLong(txSize);
-        out.writeMap(channelCloseByType, StreamOutput::writeString, StreamOutput::writeVLong);
-        out.writeVLong(outgoingTimeouts);
-        out.writeVLong(requestsFailedOnDisconnect);
-        out.writeVLong(connectFailures);
-        out.writeVLong(connectTimeMillis);
-        out.writeVLong(connectTimeMillisMax);
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeMap(channelCloseByType, StreamOutput::writeString, StreamOutput::writeVLong);
+            out.writeVLong(outgoingTimeouts);
+            out.writeVLong(requestsFailedOnDisconnect);
+            out.writeVLong(connectFailures);
+            out.writeVLong(connectTimeMillis);
+            out.writeVLong(connectTimeMillisMax);
+        }
     }
 
     public long serverOpen() {
@@ -235,6 +247,25 @@ public class TransportStats implements Writeable, ToXContentFragment {
         private long connectTimeMillisMax = 0L;
 
         public Builder() {}
+
+        /**
+         * Seeds the builder from an existing {@link TransportStats}, so a caller that only contributes a
+         * subset of the counters does not have to restate the rest.
+         */
+        public Builder(TransportStats base) {
+            this.serverOpen = base.serverOpen;
+            this.totalOutboundConnections = base.totalOutboundConnections;
+            this.rxCount = base.rxCount;
+            this.rxSize = base.rxSize;
+            this.txCount = base.txCount;
+            this.txSize = base.txSize;
+            this.channelCloseByType = base.channelCloseByType;
+            this.outgoingTimeouts = base.outgoingTimeouts;
+            this.requestsFailedOnDisconnect = base.requestsFailedOnDisconnect;
+            this.connectFailures = base.connectFailures;
+            this.connectTimeMillis = base.connectTimeMillis;
+            this.connectTimeMillisMax = base.connectTimeMillisMax;
+        }
 
         public Builder serverOpen(long serverOpen) {
             this.serverOpen = serverOpen;

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -63,7 +63,8 @@ public class TransportStats implements Writeable, ToXContentFragment {
     // Socket closes that brought a connection down, keyed by channel type. Distinguishes impairment
     // affecting only some channel types from a whole-node failure. A socket carrying several types counts
     // against each of them, since its loss affects all of them, so the total across types is not the number
-    // of sockets closed. Connections closed deliberately are not counted.
+    // of sockets closed. Each teardown contributes one socket, and connections closed deliberately are not
+    // counted at all.
     private final Map<String, Long> channelCloseByType;
     // outgoingTimeouts: requests that got no response within their timeout.
     // requestsFailedOnDisconnect: in-flight requests cancelled when a connection closed.
@@ -74,7 +75,8 @@ public class TransportStats implements Writeable, ToXContentFragment {
     // connectFailures: outbound connection opens that failed or timed out.
     // connectTimeMillis: cumulative time spent on connection opens that succeeded, measured over the whole
     // open path including the transport handshake. Average open latency is connectTimeMillis /
-    // totalOutboundConnections.
+    // totalOutboundConnections, which pairs correctly because that counter is also incremented once per
+    // successful open.
     // connectTimeMillisMax: slowest single connection open since node start. This is a high watermark that is
     // never reset, so on a long-lived node it reflects the worst event ever seen rather than recent behaviour.
     private final long connectFailures;

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -43,8 +43,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Stats for transport activity
@@ -60,8 +60,10 @@ public class TransportStats implements Writeable, ToXContentFragment {
     private final long rxSize;
     private final long txCount;
     private final long txSize;
-    // Individual channel sockets closed, keyed by channel type. Distinguishes impairment affecting only
-    // some channel types from a whole-node failure.
+    // Socket closes that brought a connection down, keyed by channel type. Distinguishes impairment
+    // affecting only some channel types from a whole-node failure. A socket carrying several types counts
+    // against each of them, since its loss affects all of them, so the total across types is not the number
+    // of sockets closed. Connections closed deliberately are not counted.
     private final Map<String, Long> channelCloseByType;
     // outgoingTimeouts: requests that got no response within their timeout.
     // requestsFailedOnDisconnect: in-flight requests cancelled when a connection closed.
@@ -70,10 +72,11 @@ public class TransportStats implements Writeable, ToXContentFragment {
     // Connect-time counters, covering the connection-open path that the request-level counters above
     // cannot observe:
     // connectFailures: outbound connection opens that failed or timed out.
-    // connectTimeMillis: cumulative time spent opening connections that succeeded. Average open latency
-    // is connectTimeMillis / totalOutboundConnections.
-    // connectTimeMillisMax: worst-case single connection open time since node start, useful for judging
-    // whether lowering transport.connect_timeout is safe.
+    // connectTimeMillis: cumulative time spent on connection opens that succeeded, measured over the whole
+    // open path including the transport handshake. Average open latency is connectTimeMillis /
+    // totalOutboundConnections.
+    // connectTimeMillisMax: slowest single connection open since node start. This is a high watermark that is
+    // never reset, so on a long-lived node it reflects the worst event ever seen rather than recent behaviour.
     private final long connectFailures;
     private final long connectTimeMillis;
     private final long connectTimeMillisMax;
@@ -90,7 +93,9 @@ public class TransportStats implements Writeable, ToXContentFragment {
         this.rxSize = builder.rxSize;
         this.txCount = builder.txCount;
         this.txSize = builder.txSize;
-        this.channelCloseByType = Collections.unmodifiableMap(new HashMap<>(builder.channelCloseByType));
+        // Sorted so the rendered field order is stable, whether the counters were collected locally or read
+        // off the wire from another node.
+        this.channelCloseByType = Collections.unmodifiableMap(new TreeMap<>(builder.channelCloseByType));
         this.outgoingTimeouts = builder.outgoingTimeouts;
         this.requestsFailedOnDisconnect = builder.requestsFailedOnDisconnect;
         this.connectFailures = builder.connectFailures;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -109,6 +109,7 @@ import org.opensearch.search.suggest.completion.CompletionStats;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.VersionUtils;
 import org.opensearch.threadpool.ThreadPoolStats;
+import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportStats;
 
 import java.io.IOException;
@@ -353,6 +354,27 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(nodeStats.getTransport().getServerOpen(), deserializedNodeStats.getTransport().getServerOpen());
                     assertEquals(nodeStats.getTransport().getTxCount(), deserializedNodeStats.getTransport().getTxCount());
                     assertEquals(nodeStats.getTransport().getTxSize(), deserializedNodeStats.getTransport().getTxSize());
+                    assertEquals(
+                        nodeStats.getTransport().getChannelCloseByType(),
+                        deserializedNodeStats.getTransport().getChannelCloseByType()
+                    );
+                    assertEquals(
+                        nodeStats.getTransport().getOutgoingTimeouts(),
+                        deserializedNodeStats.getTransport().getOutgoingTimeouts()
+                    );
+                    assertEquals(
+                        nodeStats.getTransport().getRequestsFailedOnDisconnect(),
+                        deserializedNodeStats.getTransport().getRequestsFailedOnDisconnect()
+                    );
+                    assertEquals(nodeStats.getTransport().getConnectFailures(), deserializedNodeStats.getTransport().getConnectFailures());
+                    assertEquals(
+                        nodeStats.getTransport().getConnectTimeMillis(),
+                        deserializedNodeStats.getTransport().getConnectTimeMillis()
+                    );
+                    assertEquals(
+                        nodeStats.getTransport().getConnectTimeMillisMax(),
+                        deserializedNodeStats.getTransport().getConnectTimeMillisMax()
+                    );
                 }
                 if (nodeStats.getHttp() == null) {
                     assertNull(deserializedNodeStats.getHttp());
@@ -799,6 +821,10 @@ public class NodeStatsTests extends OpenSearchTestCase {
             }
             fsInfo = new FsInfo(randomNonNegativeLong(), ioStats, paths);
         }
+        Map<String, Long> channelCloseByType = new HashMap<>();
+        for (TransportRequestOptions.Type channelType : TransportRequestOptions.Type.values()) {
+            channelCloseByType.put(channelType.name(), randomNonNegativeLong());
+        }
         TransportStats transportStats = frequently()
             ? new TransportStats.Builder().serverOpen(randomNonNegativeLong())
                 .totalOutboundConnections(randomNonNegativeLong())
@@ -806,6 +832,12 @@ public class NodeStatsTests extends OpenSearchTestCase {
                 .rxSize(randomNonNegativeLong())
                 .txCount(randomNonNegativeLong())
                 .txSize(randomNonNegativeLong())
+                .channelCloseByType(channelCloseByType)
+                .outgoingTimeouts(randomNonNegativeLong())
+                .requestsFailedOnDisconnect(randomNonNegativeLong())
+                .connectFailures(randomNonNegativeLong())
+                .connectTimeMillis(randomNonNegativeLong())
+                .connectTimeMillisMax(randomNonNegativeLong())
                 .build()
             : null;
         HttpStats httpStats = frequently()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -121,6 +121,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -823,7 +824,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
         }
         Map<String, Long> channelCloseByType = new HashMap<>();
         for (TransportRequestOptions.Type channelType : TransportRequestOptions.Type.values()) {
-            channelCloseByType.put(channelType.name(), randomNonNegativeLong());
+            channelCloseByType.put(channelType.name().toLowerCase(Locale.ROOT), randomNonNegativeLong());
         }
         TransportStats transportStats = frequently()
             ? new TransportStats.Builder().serverOpen(randomNonNegativeLong())

--- a/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
@@ -281,6 +281,54 @@ public class TcpTransportTests extends OpenSearchTestCase {
         }
     }
 
+    /**
+     * A socket that cannot even be created fails before any connect listener is registered, so this path has to
+     * count the failure itself. Unresolvable hosts and exhausted file descriptors both land here.
+     */
+    public void testConnectFailuresCountChannelsThatFailToOpen() {
+        final Settings settings = Settings.EMPTY;
+        final TestThreadPool testThreadPool = new TestThreadPool("test");
+        final TcpTransport tcpTransport = new TcpTransport(
+            settings,
+            Version.CURRENT,
+            testThreadPool,
+            new MockPageCacheRecycler(settings),
+            new NoneCircuitBreakerService(),
+            writableRegistry(),
+            new NetworkService(Collections.emptyList()),
+            NoopTracer.INSTANCE
+        ) {
+
+            @Override
+            protected TcpServerChannel bind(String name, InetSocketAddress address) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected TcpChannel initiateChannel(DiscoveryNode node) throws IOException {
+                throw new IOException("cannot open a socket");
+            }
+
+            @Override
+            protected void stopInternal() {}
+        };
+
+        try {
+            tcpTransport.start();
+            assertEquals(0L, tcpTransport.getStats().getConnectFailures());
+
+            DiscoveryNode node = new DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT);
+            PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
+            tcpTransport.openConnection(node, ConnectionProfile.buildDefaultConnectionProfile(settings), future);
+
+            expectThrows(ConnectTransportException.class, future::actionGet);
+            assertEquals(1L, tcpTransport.getStats().getConnectFailures());
+        } finally {
+            tcpTransport.close();
+            testThreadPool.shutdown();
+        }
+    }
+
     public void testReadMessageLengthWithIncompleteHeader() throws IOException {
         BytesStreamOutput streamOutput = new BytesStreamOutput(1 << 14);
         streamOutput.write('E');

--- a/server/src/test/java/org/opensearch/transport/TransportStatsTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportStatsTests.java
@@ -17,15 +17,15 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class TransportStatsTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
-        // A single channel type keeps the rendered map order deterministic.
-        TransportStats stats = createTestInstance(Collections.singletonMap("REG", 12L));
+        // Channel types are rendered in sorted order regardless of how the source map iterates.
+        TransportStats stats = createTestInstance(Map.of("reg", 12L, "bulk", 7L));
 
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         builder.startObject();
@@ -44,7 +44,7 @@ public class TransportStatsTests extends OpenSearchTestCase {
             + stats.getTxCount()
             + ",\"tx_size_in_bytes\":"
             + stats.getTxSize().getBytes()
-            + ",\"channel_close_by_type\":{\"REG\":12}"
+            + ",\"channel_close_by_type\":{\"bulk\":7,\"reg\":12}"
             + ",\"outgoing_timeouts\":"
             + stats.getOutgoingTimeouts()
             + ",\"requests_failed_on_disconnect\":"
@@ -176,7 +176,7 @@ public class TransportStatsTests extends OpenSearchTestCase {
     public void testChannelCloseByTypeIsUnmodifiable() {
         TransportStats stats = createTestInstance(randomChannelCloseByType());
 
-        expectThrows(UnsupportedOperationException.class, () -> stats.getChannelCloseByType().put("REG", 1L));
+        expectThrows(UnsupportedOperationException.class, () -> stats.getChannelCloseByType().put("reg", 1L));
     }
 
     private void assertAllFieldsEqual(TransportStats expected, TransportStats actual) {
@@ -206,7 +206,7 @@ public class TransportStatsTests extends OpenSearchTestCase {
     private static Map<String, Long> randomChannelCloseByType() {
         Map<String, Long> channelCloseByType = new HashMap<>();
         for (TransportRequestOptions.Type type : TransportRequestOptions.Type.values()) {
-            channelCloseByType.put(type.name(), randomNonNegativeLong());
+            channelCloseByType.put(type.name().toLowerCase(Locale.ROOT), randomNonNegativeLong());
         }
         return channelCloseByType;
     }

--- a/server/src/test/java/org/opensearch/transport/TransportStatsTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportStatsTests.java
@@ -1,0 +1,229 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransportStatsTests extends OpenSearchTestCase {
+
+    public void testToXContent() throws IOException {
+        // A single channel type keeps the rendered map order deterministic.
+        TransportStats stats = createTestInstance(Collections.singletonMap("REG", 12L));
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        builder.startObject();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String expected = "{\"transport\":{\"server_open\":"
+            + stats.getServerOpen()
+            + ",\"total_outbound_connections\":"
+            + stats.getTotalOutboundConnections()
+            + ",\"rx_count\":"
+            + stats.getRxCount()
+            + ",\"rx_size_in_bytes\":"
+            + stats.getRxSize().getBytes()
+            + ",\"tx_count\":"
+            + stats.getTxCount()
+            + ",\"tx_size_in_bytes\":"
+            + stats.getTxSize().getBytes()
+            + ",\"channel_close_by_type\":{\"REG\":12}"
+            + ",\"outgoing_timeouts\":"
+            + stats.getOutgoingTimeouts()
+            + ",\"requests_failed_on_disconnect\":"
+            + stats.getRequestsFailedOnDisconnect()
+            + ",\"connect_failures\":"
+            + stats.getConnectFailures()
+            + ",\"connect_time_millis\":"
+            + stats.getConnectTimeMillis()
+            + ",\"connect_time_millis_max\":"
+            + stats.getConnectTimeMillisMax()
+            + "}}";
+
+        assertEquals(expected, builder.toString());
+    }
+
+    /**
+     * An empty channel close map is omitted entirely rather than rendered as an empty object, so stats
+     * built without it stay byte-identical to the pre-existing response shape.
+     */
+    public void testToXContentOmitsEmptyChannelCloseMap() throws IOException {
+        TransportStats stats = new TransportStats.Builder().serverOpen(1).build();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        builder.startObject();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        assertFalse(builder.toString().contains("channel_close_by_type"));
+    }
+
+    public void testSerialization() throws IOException {
+        TransportStats original = createTestInstance(randomChannelCloseByType());
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            original.writeTo(output);
+
+            try (StreamInput input = output.bytes().streamInput()) {
+                assertAllFieldsEqual(original, new TransportStats(input));
+            }
+        }
+    }
+
+    /**
+     * Test serialization to a pre-3.8.0 node — the transport observability counters should be omitted.
+     */
+    public void testSerializationToOlderNode() throws IOException {
+        TransportStats original = createTestInstance(randomChannelCloseByType());
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(Version.V_3_7_0);
+            original.writeTo(output);
+
+            try (StreamInput input = output.bytes().streamInput()) {
+                input.setVersion(Version.V_3_7_0);
+                TransportStats deserialized = new TransportStats(input);
+
+                // Pre-existing counters are unaffected.
+                assertEquals(original.getServerOpen(), deserialized.getServerOpen());
+                assertEquals(original.getTotalOutboundConnections(), deserialized.getTotalOutboundConnections());
+                assertEquals(original.getRxCount(), deserialized.getRxCount());
+                assertEquals(original.getRxSize(), deserialized.getRxSize());
+                assertEquals(original.getTxCount(), deserialized.getTxCount());
+                assertEquals(original.getTxSize(), deserialized.getTxSize());
+
+                assertNewCountersAbsent(deserialized);
+            }
+        }
+    }
+
+    /**
+     * Test deserialization from a pre-3.8.0 node — the new counters default to zero rather than
+     * consuming bytes the older node never wrote.
+     */
+    public void testDeserializationFromOlderNode() throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(Version.V_3_7_0);
+            // A 3.7.0 node writes only the six original counters.
+            output.writeVLong(5L);
+            output.writeVLong(6L);
+            output.writeVLong(7L);
+            output.writeVLong(8L);
+            output.writeVLong(9L);
+            output.writeVLong(10L);
+
+            try (StreamInput input = output.bytes().streamInput()) {
+                input.setVersion(Version.V_3_7_0);
+                TransportStats deserialized = new TransportStats(input);
+
+                assertEquals(5L, deserialized.getServerOpen());
+                assertEquals(6L, deserialized.getTotalOutboundConnections());
+                assertEquals(7L, deserialized.getRxCount());
+                assertEquals(8L, deserialized.getRxSize().getBytes());
+                assertEquals(9L, deserialized.getTxCount());
+                assertEquals(10L, deserialized.getTxSize().getBytes());
+
+                assertNewCountersAbsent(deserialized);
+                assertEquals(0, input.available());
+            }
+        }
+    }
+
+    /**
+     * {@link TransportService#stats()} seeds a builder from the transport's own stats and overrides only
+     * the two request-level counters, so the copy constructor must carry every other field across.
+     */
+    public void testBuilderCopiesEveryField() {
+        TransportStats original = createTestInstance(randomChannelCloseByType());
+
+        TransportStats copy = new TransportStats.Builder(original).build();
+
+        assertAllFieldsEqual(original, copy);
+    }
+
+    public void testBuilderOverridesRequestLevelCounters() {
+        TransportStats base = createTestInstance(randomChannelCloseByType());
+
+        TransportStats merged = new TransportStats.Builder(base).outgoingTimeouts(42L).requestsFailedOnDisconnect(43L).build();
+
+        assertEquals(42L, merged.getOutgoingTimeouts());
+        assertEquals(43L, merged.getRequestsFailedOnDisconnect());
+        // Everything the caller did not override is preserved.
+        assertEquals(base.getConnectFailures(), merged.getConnectFailures());
+        assertEquals(base.getConnectTimeMillis(), merged.getConnectTimeMillis());
+        assertEquals(base.getConnectTimeMillisMax(), merged.getConnectTimeMillisMax());
+        assertEquals(base.getChannelCloseByType(), merged.getChannelCloseByType());
+        assertEquals(base.getServerOpen(), merged.getServerOpen());
+    }
+
+    public void testChannelCloseByTypeIsUnmodifiable() {
+        TransportStats stats = createTestInstance(randomChannelCloseByType());
+
+        expectThrows(UnsupportedOperationException.class, () -> stats.getChannelCloseByType().put("REG", 1L));
+    }
+
+    private void assertAllFieldsEqual(TransportStats expected, TransportStats actual) {
+        assertEquals(expected.getServerOpen(), actual.getServerOpen());
+        assertEquals(expected.getTotalOutboundConnections(), actual.getTotalOutboundConnections());
+        assertEquals(expected.getRxCount(), actual.getRxCount());
+        assertEquals(expected.getRxSize(), actual.getRxSize());
+        assertEquals(expected.getTxCount(), actual.getTxCount());
+        assertEquals(expected.getTxSize(), actual.getTxSize());
+        assertEquals(expected.getChannelCloseByType(), actual.getChannelCloseByType());
+        assertEquals(expected.getOutgoingTimeouts(), actual.getOutgoingTimeouts());
+        assertEquals(expected.getRequestsFailedOnDisconnect(), actual.getRequestsFailedOnDisconnect());
+        assertEquals(expected.getConnectFailures(), actual.getConnectFailures());
+        assertEquals(expected.getConnectTimeMillis(), actual.getConnectTimeMillis());
+        assertEquals(expected.getConnectTimeMillisMax(), actual.getConnectTimeMillisMax());
+    }
+
+    private void assertNewCountersAbsent(TransportStats stats) {
+        assertTrue(stats.getChannelCloseByType().isEmpty());
+        assertEquals(0L, stats.getOutgoingTimeouts());
+        assertEquals(0L, stats.getRequestsFailedOnDisconnect());
+        assertEquals(0L, stats.getConnectFailures());
+        assertEquals(0L, stats.getConnectTimeMillis());
+        assertEquals(0L, stats.getConnectTimeMillisMax());
+    }
+
+    private static Map<String, Long> randomChannelCloseByType() {
+        Map<String, Long> channelCloseByType = new HashMap<>();
+        for (TransportRequestOptions.Type type : TransportRequestOptions.Type.values()) {
+            channelCloseByType.put(type.name(), randomNonNegativeLong());
+        }
+        return channelCloseByType;
+    }
+
+    private static TransportStats createTestInstance(Map<String, Long> channelCloseByType) {
+        return new TransportStats.Builder().serverOpen(randomNonNegativeLong())
+            .totalOutboundConnections(randomNonNegativeLong())
+            .rxCount(randomNonNegativeLong())
+            .rxSize(randomNonNegativeLong())
+            .txCount(randomNonNegativeLong())
+            .txSize(randomNonNegativeLong())
+            .channelCloseByType(channelCloseByType)
+            .outgoingTimeouts(randomNonNegativeLong())
+            .requestsFailedOnDisconnect(randomNonNegativeLong())
+            .connectFailures(randomNonNegativeLong())
+            .connectTimeMillis(randomNonNegativeLong())
+            .connectTimeMillisMax(randomNonNegativeLong())
+            .build();
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -93,6 +93,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
@@ -2662,6 +2663,73 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             assertEquals(115, stats.getTxSize().getBytes());
         } finally {
             serviceC.close();
+        }
+    }
+
+    /**
+     * Closing one socket tears the whole connection down, which closes every other socket belonging to it. Only
+     * the socket that actually failed may be counted, otherwise every close looks like a failure of all channel
+     * types at once and the breakdown says nothing.
+     */
+    public void testChannelCloseIsAttributedOnlyToTheSocketThatClosed() throws Exception {
+        assumeTrue("only tcp transport tracks channel closes by type", serviceA.getOriginalTransport() instanceof TcpTransport);
+        final TcpTransport transport = (TcpTransport) serviceA.getOriginalTransport();
+
+        final Map<String, Long> before = transport.getStats().getChannelCloseByType();
+        try (Transport.Connection connection = openConnectionWithRegOnItsOwnSocket(transport)) {
+            ((TcpTransport.NodeChannels) connection).channel(TransportRequestOptions.Type.REG).close();
+
+            assertBusy(() -> assertChannelCloseDelta(before, transport.getStats().getChannelCloseByType(), 1L));
+        }
+    }
+
+    /**
+     * A connection closed on purpose — the node left the cluster, or the transport is shutting down — is not a
+     * socket failure, even though it closes every socket the connection owns.
+     */
+    public void testDeliberateConnectionCloseIsNotCountedAsChannelClose() throws Exception {
+        assumeTrue("only tcp transport tracks channel closes by type", serviceA.getOriginalTransport() instanceof TcpTransport);
+        final TcpTransport transport = (TcpTransport) serviceA.getOriginalTransport();
+
+        final Map<String, Long> before = transport.getStats().getChannelCloseByType();
+        final TcpTransport.NodeChannels connection = (TcpTransport.NodeChannels) openConnectionWithRegOnItsOwnSocket(transport);
+        final TcpChannel regChannel = connection.channel(TransportRequestOptions.Type.REG);
+
+        connection.close();
+
+        assertBusy(() -> assertFalse("connection close should close its sockets", regChannel.isOpen()));
+        assertChannelCloseDelta(before, transport.getStats().getChannelCloseByType(), 0L);
+    }
+
+    /**
+     * Opens a connection to nodeB that puts REG on a socket of its own, so that closing the REG socket is
+     * distinguishable from closing the socket shared by the remaining channel types.
+     */
+    private Transport.Connection openConnectionWithRegOnItsOwnSocket(TcpTransport transport) {
+        final ConnectionProfile profile = ConnectionProfile.resolveConnectionProfile(
+            new ConnectionProfile.Builder().addConnections(1, TransportRequestOptions.Type.REG)
+                .addConnections(
+                    1,
+                    TransportRequestOptions.Type.BULK,
+                    TransportRequestOptions.Type.PING,
+                    TransportRequestOptions.Type.RECOVERY,
+                    TransportRequestOptions.Type.STATE
+                )
+                .addConnections(0, TransportRequestOptions.Type.STREAM)
+                .build(),
+            ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY)
+        );
+
+        PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
+        transport.openConnection(nodeB, profile, future);
+        return future.actionGet();
+    }
+
+    private void assertChannelCloseDelta(Map<String, Long> before, Map<String, Long> after, long expectedRegDelta) {
+        for (TransportRequestOptions.Type type : TransportRequestOptions.Type.values()) {
+            final String name = type.name().toLowerCase(Locale.ROOT);
+            final long expected = type == TransportRequestOptions.Type.REG ? expectedRegDelta : 0L;
+            assertEquals("close count for channel type [" + name + "]", expected, after.get(name) - before.get(name));
         }
     }
 


### PR DESCRIPTION
### Description

`_nodes/stats` currently reports transport **volume** only — `rx_count`, `rx_size_in_bytes`, `tx_count`, `tx_size_in_bytes`, `server_open`, and `total_outbound_connections`. There is no always-available signal for transport *failure* or *connection-open latency*, which makes a class of network faults hard to diagnose on a running cluster: the volume counters keep incrementing normally while requests silently time out or connections take seconds to establish.

The connection-open path is the largest gap. A slow or hung connect blocks the cluster applier thread, and no existing metric observes it at all — `total_outbound_connections` is incremented only after a handshake succeeds, so a node struggling to open connections looks identical to a healthy idle node.

This PR adds six counters to `TransportStats`:

| Field | Meaning |
| --- | --- |
| `connect_failures` | Outbound connection opens that failed or timed out |
| `connect_time_millis` | Cumulative time spent on connection opens that succeeded. Average open latency is `connect_time_millis / total_outbound_connections` |
| `connect_time_millis_max` | Worst-case single connection open since node start. Useful for judging whether lowering `transport.connect_timeout` is safe |
| `channel_close_by_type` | Individual channel sockets closed, keyed by channel type (`RECOVERY`, `BULK`, `REG`, `STATE`, `PING`, `STREAM`) |
| `outgoing_timeouts` | Outbound requests that received no response within their timeout |
| `requests_failed_on_disconnect` | In-flight requests cancelled because the connection closed before a response arrived |

`channel_close_by_type` is the counter that distinguishes partial impairment from a whole-node failure. Because a connection profile assigns separate sockets per channel type, `REG`/`BULK` degrading while `PING`/`STATE` stay healthy is a materially different fault from a node going away, and today the two are indistinguishable from node stats.

These live in `_nodes/stats` rather than the telemetry metrics registry so they are available on any cluster with no plugin installed and no configuration, which is what makes them usable during an active incident. Publishing the same values through `MetricsRegistry` is a reasonable follow-up, along the lines of `NodeRuntimeMetrics` (#20844), which exposes `JvmStats` data as pull-based gauges while `_nodes/stats` remains the source of truth.

#### Where the counters are incremented

- `TcpTransport.ChannelsConnectedListener` — connect latency is measured from listener construction to successful handshake; `closeAndFail` increments `connect_failures`. The `countDown.fastForward()` guard on the failure and timeout paths means a single attempt cannot be counted twice.
- `TcpTransport.NodeChannels` — a per-channel close listener attributes socket closes to the channel types sharing that socket. The reverse index is derived from `ConnectionProfile.ConnectionTypeHandle`'s own `offset`/`length` range, so attribution matches the channel that `getChannel` actually selects.
- `TransportService.onConnectionClosed` — counts pruned in-flight handlers.
- `TransportService.TimeoutHandler` — counts expired requests.

None of the counters sit on the per-request send path, so there is no added contention at request volume.

#### DEBUG logging

Also adds DEBUG logging for connect latency, send failures, and per-channel socket closes. `NodeConnectionsService` now reports elapsed time on both successful and failed connects, so `failed to connect to {} after [Nms]` distinguishes an immediate refusal from a full connect-timeout stall. Nothing is added at INFO, so production log volume is unchanged.

#### Sample output

`GET _nodes/stats/transport`:

```json
"transport": {
  "server_open": 26,
  "total_outbound_connections": 143,
  "rx_count": 1043321,
  "rx_size_in_bytes": 884736102,
  "tx_count": 1043298,
  "tx_size_in_bytes": 901324887,
  "channel_close_by_type": {
    "RECOVERY": 0,
    "BULK": 12,
    "REG": 12,
    "STATE": 0,
    "PING": 0,
    "STREAM": 0
  },
  "outgoing_timeouts": 37,
  "requests_failed_on_disconnect": 214,
  "connect_failures": 6,
  "connect_time_millis": 8412,
  "connect_time_millis_max": 4903
}
```

### Backwards compatibility

New fields are written and read only when the negotiated stream version is 3.8.0 or later, so mixed-version clusters and cross-cluster connections to older clusters are unaffected — older nodes exchange only the pre-existing counters and
report the new ones as zero.

This is purely additive to the `_nodes/stats` response; no existing field changes name, type, or meaning. An empty `channel_close_by_type` is omitted rather than rendered as an empty object, so stats built without it are byte-identical to the previous response shape.

`TransportStats` also gains a `Builder(TransportStats)` copy constructor. `TransportService.stats()` previously restated all twelve fields by hand in order to override two, which meant any field added later would be silently dropped there; it now seeds from the transport's own stats and overrides only the two request-level counters it owns.

### Testing

- `TransportStatsTests` — xcontent rendering, round-trip, serialization to a pre-3.8.0 node, and deserialization from a pre-3.8.0 node (asserting the stream is fully consumed so no stray bytes are read), plus builder copy semantics and the empty-map omission guarantee.
- `NodeStatsTests` — the new counters are randomized and asserted across `NodeStats` round-trip.
- `SimpleNetty4TransportTests` and `SimpleMockNioTransportTests` exercise `getStats()` against a real transport.

All of the above were run at `-Dtests.iters=20`.

### Related Issues

Resolves #[issue number]

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.