### PR TITLE
Fix cache stats race during dimension removal

### DIFF
--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsHolder.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsHolder.java
@@ -174,12 +174,12 @@ public class TieredSpilloverCacheStatsHolder extends DefaultCacheStatsHolder {
     public void removeDimensions(List<String> dimensionValues) {
         assert dimensionValues.size() == dimensionNames.size() - 1
             : "Must specify a value for every dimension except tier when removing from StatsHolder";
-        // As we are removing nodes from the tree, obtain the lock
-        lock.lock();
+        // As we are removing nodes from the tree, obtain the write lock.
+        lock.writeLock().lock();
         try {
             removeDimensionsHelper(dimensionValues, statsRoot, 0);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
 /**
@@ -38,9 +38,8 @@ public class DefaultCacheStatsHolder implements CacheStatsHolder {
     // We use a tree structure, rather than a map with concatenated keys, to save on memory usage. If there are many leaf
     // nodes that share a parent, that parent's dimension value will only be stored once, not many times.
     protected final Node statsRoot;
-    // To avoid sync problems, obtain a lock before creating or removing nodes in the stats tree.
-    // No lock is needed to edit stats on existing nodes.
-    protected final Lock lock = new ReentrantLock();
+    // Read locks protect counter updates from tree changes; the write lock protects node creation, removal, and reset.
+    protected final ReadWriteLock lock = new ReentrantReadWriteLock();
     // The name of the cache type using these stats
     private final String storeName;
 
@@ -99,7 +98,12 @@ public class DefaultCacheStatsHolder implements CacheStatsHolder {
      */
     @Override
     public void reset() {
-        resetHelper(statsRoot);
+        lock.writeLock().lock();
+        try {
+            resetHelper(statsRoot);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     private void resetHelper(Node current) {
@@ -117,15 +121,23 @@ public class DefaultCacheStatsHolder implements CacheStatsHolder {
 
     protected void internalIncrement(List<String> dimensionValues, Consumer<Node> adder, boolean createNodesIfAbsent) {
         assert dimensionValues.size() == dimensionNames.size();
-        // First try to increment without creating nodes
-        boolean didIncrement = internalIncrementHelper(dimensionValues, statsRoot, 0, adder, false);
-        // If we failed to increment, because nodes had to be created, obtain the lock and run again while creating nodes if needed
-        if (!didIncrement && createNodesIfAbsent) {
+        lock.readLock().lock();
+        try {
+            // First try to increment without creating nodes.
+            if (internalIncrementHelper(dimensionValues, statsRoot, 0, adder, false)) {
+                return;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        // If we failed to increment because nodes had to be created, obtain the write lock and run again.
+        if (createNodesIfAbsent) {
             try {
-                lock.lock();
+                lock.writeLock().lock();
                 internalIncrementHelper(dimensionValues, statsRoot, 0, adder, true);
             } finally {
-                lock.unlock();
+                lock.writeLock().unlock();
             }
         }
     }
@@ -178,12 +190,12 @@ public class DefaultCacheStatsHolder implements CacheStatsHolder {
     @Override
     public void removeDimensions(List<String> dimensionValues) {
         assert dimensionValues.size() == dimensionNames.size() : "Must specify a value for every dimension when removing from StatsHolder";
-        // As we are removing nodes from the tree, obtain the lock
-        lock.lock();
+        // As we are removing nodes from the tree, obtain the write lock.
+        lock.writeLock().lock();
         try {
             removeDimensionsHelper(dimensionValues, statsRoot, 0);
         } finally {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 

--- a/server/src/test/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolderTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolderTests.java
@@ -20,6 +20,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultCacheStatsHolderTests extends OpenSearchTestCase {
     private final String storeName = "dummy_store";
@@ -178,6 +179,92 @@ public class DefaultCacheStatsHolderTests extends OpenSearchTestCase {
             DefaultCacheStatsHolder.Node intermediateLevelNode = getNode(List.of("A" + indexA), cacheStatsHolder.getStatsRoot());
             assertNotNull(intermediateLevelNode);
             assertEquals(b1LeafNode.getImmutableStats(), intermediateLevelNode.getImmutableStats());
+        }
+    }
+
+    public void testRemovalDoesNotRaceWithDecrement() throws Exception {
+        List<String> dimensionNames = List.of("index", "shard");
+        List<String> dimensions = List.of("index-1", "shard-0");
+        BlockingCacheStatsHolder cacheStatsHolder = new BlockingCacheStatsHolder(dimensionNames, storeName);
+        cacheStatsHolder.incrementItems(dimensions);
+        cacheStatsHolder.incrementSizeInBytes(dimensions, 151325);
+
+        assertRemovalBlocksMutation(cacheStatsHolder, dimensions, () -> {
+            cacheStatsHolder.decrementItems(dimensions);
+            cacheStatsHolder.decrementSizeInBytes(dimensions, 151325);
+        }, "decrement");
+    }
+
+    public void testResetDoesNotRaceWithDimensionRemoval() throws Exception {
+        List<String> dimensionNames = List.of("index", "shard");
+        List<String> dimensions = List.of("index-1", "shard-0");
+        BlockingCacheStatsHolder cacheStatsHolder = new BlockingCacheStatsHolder(dimensionNames, storeName);
+        cacheStatsHolder.incrementItems(dimensions);
+        cacheStatsHolder.incrementSizeInBytes(dimensions, 151325);
+
+        assertRemovalBlocksMutation(cacheStatsHolder, dimensions, cacheStatsHolder::reset, "reset");
+    }
+
+    private static void assertRemovalBlocksMutation(
+        BlockingCacheStatsHolder cacheStatsHolder,
+        List<String> dimensions,
+        Runnable mutation,
+        String mutationName
+    ) throws Exception {
+        Thread removalThread = new Thread(() -> cacheStatsHolder.removeDimensions(dimensions), "stats-removal");
+        CountDownLatch mutationStarted = new CountDownLatch(1);
+        CountDownLatch mutationFinished = new CountDownLatch(1);
+        Thread mutationThread = new Thread(() -> {
+            mutationStarted.countDown();
+            mutation.run();
+            mutationFinished.countDown();
+        }, "stats-" + mutationName);
+
+        removalThread.start();
+        assertTrue(cacheStatsHolder.snapshotCaptured.await(10, TimeUnit.SECONDS));
+        mutationThread.start();
+        assertTrue(mutationStarted.await(10, TimeUnit.SECONDS));
+        try {
+            assertFalse(
+                mutationName + " completed while removeDimensions held the tree lock",
+                mutationFinished.await(100, TimeUnit.MILLISECONDS)
+            );
+        } finally {
+            cacheStatsHolder.allowRemoval.countDown();
+        }
+
+        removalThread.join(TimeUnit.SECONDS.toMillis(10));
+        mutationThread.join(TimeUnit.SECONDS.toMillis(10));
+        assertFalse(removalThread.isAlive());
+        assertFalse(mutationThread.isAlive());
+        assertEquals(0, cacheStatsHolder.getStatsRoot().getImmutableStats().getItems());
+        assertEquals(0, cacheStatsHolder.getStatsRoot().getImmutableStats().getSizeInBytes());
+        assertNull(getNode(dimensions, cacheStatsHolder.getStatsRoot()));
+    }
+
+    private static class BlockingCacheStatsHolder extends DefaultCacheStatsHolder {
+        private final CountDownLatch snapshotCaptured = new CountDownLatch(1);
+        private final CountDownLatch allowRemoval = new CountDownLatch(1);
+
+        BlockingCacheStatsHolder(List<String> dimensionNames, String storeName) {
+            super(dimensionNames, storeName);
+        }
+
+        @Override
+        protected ImmutableCacheStats removeDimensionsHelper(List<String> dimensionValues, Node node, int depth) {
+            ImmutableCacheStats snapshot = super.removeDimensionsHelper(dimensionValues, node, depth);
+            if (depth == dimensionValues.size()) {
+                snapshotCaptured.countDown();
+                try {
+                    if (allowRemoval.await(10, TimeUnit.SECONDS) == false) {
+                        throw new AssertionError("timed out waiting to continue removal");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while waiting to continue removal", e);
+                }
+            }
+            return snapshot;
         }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
DefaultCacheStatsHolder.removeDimensions() takes a snapshot of a cache entry before subtracting its stats from ancestor nodes. If a concurrent cache-removal callback decrements the same entry first, the stale snapshot is subtracted again, causing aggregate counters to become negative and _nodes/stats serialization to fail. Same can happen during reset().

This change serializes dimension removal with counter updates and adds a deterministic regression test for the race. Tests to reproduce are in the PR.

### Related Issues
N/A. Plmk if I should open an issue for this.
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
