### PR TITLE
Reject out-of-range WLM node threshold updates at validation time

### DIFF
--- a/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
@@ -14,6 +14,10 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Main class to declare Workload Management related settings
  */
@@ -93,6 +97,7 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_REJECTION_THRESHOLD,
+        new NodeLevelMemoryRejectionThresholdValidator(),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -106,6 +111,7 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_REJECTION_THRESHOLD,
+        new NodeLevelCpuRejectionThresholdValidator(),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -119,6 +125,7 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD,
+        new NodeLevelMemoryCancellationThresholdValidator(),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -132,6 +139,7 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_CANCELLATION_THRESHOLD,
+        new NodeLevelCpuCancellationThresholdValidator(),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -231,22 +239,19 @@ public class WorkloadManagementSettings {
     /**
      * Method to set the node level memory based cancellation threshold
      * @param nodeLevelMemoryCancellationThreshold sets the new node level memory based cancellation threshold
-     * @throws IllegalArgumentException if the value is &gt; 0.95 and cancellation &lt; rejection threshold
+     * @throws IllegalArgumentException if the value is negative or &gt; 0.95
      */
     public void setNodeLevelMemoryCancellationThreshold(Double nodeLevelMemoryCancellationThreshold) {
-        if (Double.compare(nodeLevelMemoryCancellationThreshold, NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.95 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelMemoryRejectionThreshold,
+        // NOTE: the rejection <= cancellation ordering invariant is intentionally NOT checked here. This setter runs as
+        // the settings-update consumer at apply time, one setting at a time, so the sibling field may still hold its
+        // previous value; checking ordering here throws when both thresholds are lowered together (a consistent final
+        // state), destabilizing the cluster-manager. Ordering is enforced at validation time by the Setting.Validator
+        // against the final, consistent settings, and at startup by the constructor.
+        ensureThresholdIsWithinAllowedRange(
             nodeLevelMemoryCancellationThreshold,
-            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
             NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
         );
-
         this.nodeLevelMemoryCancellationThreshold = nodeLevelMemoryCancellationThreshold;
     }
 
@@ -261,22 +266,15 @@ public class WorkloadManagementSettings {
     /**
      * Method to set the node level cpu based cancellation threshold
      * @param nodeLevelCpuCancellationThreshold sets the new node level cpu based cancellation threshold
-     * @throws IllegalArgumentException if the value is &gt; 0.95 and cancellation &lt; rejection threshold
+     * @throws IllegalArgumentException if the value is negative or &gt; 0.95
      */
     public void setNodeLevelCpuCancellationThreshold(Double nodeLevelCpuCancellationThreshold) {
-        if (Double.compare(nodeLevelCpuCancellationThreshold, NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.95 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelCpuRejectionThreshold,
+        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
+        ensureThresholdIsWithinAllowedRange(
             nodeLevelCpuCancellationThreshold,
-            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
             NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
         );
-
         this.nodeLevelCpuCancellationThreshold = nodeLevelCpuCancellationThreshold;
     }
 
@@ -291,22 +289,15 @@ public class WorkloadManagementSettings {
     /**
      * Method to set the node level memory based rejection threshold
      * @param nodeLevelMemoryRejectionThreshold sets the new memory based rejection threshold
-     * @throws IllegalArgumentException if rejection &gt; 0.90 and rejection &lt; cancellation threshold
+     * @throws IllegalArgumentException if the value is negative or &gt; 0.90
      */
     public void setNodeLevelMemoryRejectionThreshold(Double nodeLevelMemoryRejectionThreshold) {
-        if (Double.compare(nodeLevelMemoryRejectionThreshold, NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.90 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
+        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
+        ensureThresholdIsWithinAllowedRange(
             nodeLevelMemoryRejectionThreshold,
-            nodeLevelMemoryCancellationThreshold,
-            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
+            NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
+            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME
         );
-
         this.nodeLevelMemoryRejectionThreshold = nodeLevelMemoryRejectionThreshold;
     }
 
@@ -321,23 +312,58 @@ public class WorkloadManagementSettings {
     /**
      * Method to set the node level cpu based rejection threshold
      * @param nodeLevelCpuRejectionThreshold sets the new cpu based rejection threshold
-     * @throws IllegalArgumentException if rejection &gt; 0.90 and rejection &lt; cancellation threshold
+     * @throws IllegalArgumentException if the value is negative or &gt; 0.90
      */
     public void setNodeLevelCpuRejectionThreshold(Double nodeLevelCpuRejectionThreshold) {
-        if (Double.compare(nodeLevelCpuRejectionThreshold, NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE) > 0) {
+        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
+        ensureThresholdIsWithinAllowedRange(
+            nodeLevelCpuRejectionThreshold,
+            NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
+            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME
+        );
+        this.nodeLevelCpuRejectionThreshold = nodeLevelCpuRejectionThreshold;
+    }
+
+    /**
+     * Method to validate that a threshold does not exceed its allowed maximum.
+     * @param thresholdValue the threshold value being set
+     * @param maxValue the maximum allowed value for this threshold
+     * @param thresholdSettingName name of the threshold setting
+     * @throws IllegalArgumentException if the value is greater than the allowed maximum
+     */
+    private static void ensureThresholdIsNotGreaterThanMax(Double thresholdValue, double maxValue, String thresholdSettingName) {
+        if (Double.compare(thresholdValue, maxValue) > 0) {
             throw new IllegalArgumentException(
-                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.90 as it can result in a node drop"
+                thresholdSettingName + " value cannot be greater than " + maxValue + " as it can result in a node drop"
             );
         }
+    }
 
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelCpuRejectionThreshold,
-            nodeLevelCpuCancellationThreshold,
-            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
+    /**
+     * Method to validate that a threshold is not negative.
+     * @param thresholdValue the threshold value being set
+     * @param thresholdSettingName name of the threshold setting
+     * @throws IllegalArgumentException if the value is less than 0
+     */
+    private static void ensureThresholdIsNotNegative(Double thresholdValue, String thresholdSettingName) {
+        if (Double.compare(thresholdValue, 0.0) < 0) {
+            throw new IllegalArgumentException(thresholdSettingName + " value cannot be negative");
+        }
+    }
 
-        this.nodeLevelCpuRejectionThreshold = nodeLevelCpuRejectionThreshold;
+    /**
+     * Runs every single-setting validation for a threshold (i.e. the checks that do not depend on a sibling setting):
+     * the value must be non-negative and must not exceed its allowed maximum. This is the single place both enforcement
+     * paths call — the settings-update {@link Setting.Validator} (validation time) and the setters (apply time) — so the
+     * two cannot drift as new standalone bounds are added.
+     * @param thresholdValue the threshold value being set
+     * @param maxValue the maximum allowed value for this threshold
+     * @param thresholdSettingName name of the threshold setting
+     * @throws IllegalArgumentException if the value is negative or greater than the allowed maximum
+     */
+    private static void ensureThresholdIsWithinAllowedRange(Double thresholdValue, double maxValue, String thresholdSettingName) {
+        ensureThresholdIsNotNegative(thresholdValue, thresholdSettingName);
+        ensureThresholdIsNotGreaterThanMax(thresholdValue, maxValue, thresholdSettingName);
     }
 
     /**
@@ -348,7 +374,7 @@ public class WorkloadManagementSettings {
      * @param cancellationThresholdSettingName name of the cancellation threshold setting
      * @throws IllegalArgumentException if cancellation threshold is less than rejection threshold
      */
-    private void ensureRejectionThresholdIsLessThanCancellation(
+    private static void ensureRejectionThresholdIsLessThanCancellation(
         Double nodeLevelRejectionThreshold,
         Double nodeLevelCancellationThreshold,
         String rejectionThresholdSettingName,
@@ -358,6 +384,128 @@ public class WorkloadManagementSettings {
             throw new IllegalArgumentException(
                 cancellationThresholdSettingName + " value should not be less than " + rejectionThresholdSettingName
             );
+        }
+    }
+
+    /**
+     * Validator for {@link #NODE_LEVEL_CPU_CANCELLATION_THRESHOLD}. Enforced at settings-update validation time so that an
+     * invalid value is rejected before the new cluster state is published, rather than throwing while the state is applied
+     * (which would destabilize the cluster-manager).
+     */
+    static final class NodeLevelCpuCancellationThresholdValidator implements Setting.Validator<Double> {
+        @Override
+        public void validate(Double value) {
+            ensureThresholdIsWithinAllowedRange(
+                value,
+                NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
+                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public void validate(Double value, Map<Setting<?>, Object> settings) {
+            final Double rejectionThreshold = (Double) settings.get(NODE_LEVEL_CPU_REJECTION_THRESHOLD);
+            ensureRejectionThresholdIsLessThanCancellation(
+                rejectionThreshold,
+                value,
+                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(NODE_LEVEL_CPU_REJECTION_THRESHOLD).iterator();
+        }
+    }
+
+    /**
+     * Validator for {@link #NODE_LEVEL_CPU_REJECTION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
+     */
+    static final class NodeLevelCpuRejectionThresholdValidator implements Setting.Validator<Double> {
+        @Override
+        public void validate(Double value) {
+            ensureThresholdIsWithinAllowedRange(
+                value,
+                NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
+                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public void validate(Double value, Map<Setting<?>, Object> settings) {
+            final Double cancellationThreshold = (Double) settings.get(NODE_LEVEL_CPU_CANCELLATION_THRESHOLD);
+            ensureRejectionThresholdIsLessThanCancellation(
+                value,
+                cancellationThreshold,
+                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(NODE_LEVEL_CPU_CANCELLATION_THRESHOLD).iterator();
+        }
+    }
+
+    /**
+     * Validator for {@link #NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
+     */
+    static final class NodeLevelMemoryCancellationThresholdValidator implements Setting.Validator<Double> {
+        @Override
+        public void validate(Double value) {
+            ensureThresholdIsWithinAllowedRange(
+                value,
+                NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
+                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public void validate(Double value, Map<Setting<?>, Object> settings) {
+            final Double rejectionThreshold = (Double) settings.get(NODE_LEVEL_MEMORY_REJECTION_THRESHOLD);
+            ensureRejectionThresholdIsLessThanCancellation(
+                rejectionThreshold,
+                value,
+                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
+                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(NODE_LEVEL_MEMORY_REJECTION_THRESHOLD).iterator();
+        }
+    }
+
+    /**
+     * Validator for {@link #NODE_LEVEL_MEMORY_REJECTION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
+     */
+    static final class NodeLevelMemoryRejectionThresholdValidator implements Setting.Validator<Double> {
+        @Override
+        public void validate(Double value) {
+            ensureThresholdIsWithinAllowedRange(
+                value,
+                NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
+                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public void validate(Double value, Map<Setting<?>, Object> settings) {
+            final Double cancellationThreshold = (Double) settings.get(NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD);
+            ensureRejectionThresholdIsLessThanCancellation(
+                value,
+                cancellationThreshold,
+                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
+                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
+            );
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD).iterator();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
@@ -17,6 +17,7 @@ import org.opensearch.common.unit.TimeValue;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Main class to declare Workload Management related settings
@@ -97,7 +98,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_REJECTION_THRESHOLD,
-        new NodeLevelMemoryRejectionThresholdValidator(),
+        NodeLevelThresholdValidator.forRejectionThreshold(
+            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -111,7 +116,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_REJECTION_THRESHOLD,
-        new NodeLevelCpuRejectionThresholdValidator(),
+        NodeLevelThresholdValidator.forRejectionThreshold(
+            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -125,7 +134,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD,
-        new NodeLevelMemoryCancellationThresholdValidator(),
+        NodeLevelThresholdValidator.forCancellationThreshold(
+            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_MEMORY_REJECTION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -139,7 +152,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_CANCELLATION_THRESHOLD,
-        new NodeLevelCpuCancellationThresholdValidator(),
+        NodeLevelThresholdValidator.forCancellationThreshold(
+            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_CPU_REJECTION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -237,21 +254,12 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level memory based cancellation threshold
+     * Method to set the node level memory based cancellation threshold. This runs as the settings-update consumer at
+     * apply time; the value has already been checked by {@link NodeLevelThresholdValidator} during settings-update
+     * validation, so the setter only assigns.
      * @param nodeLevelMemoryCancellationThreshold sets the new node level memory based cancellation threshold
-     * @throws IllegalArgumentException if the value is negative or &gt; 0.95
      */
     public void setNodeLevelMemoryCancellationThreshold(Double nodeLevelMemoryCancellationThreshold) {
-        // NOTE: the rejection <= cancellation ordering invariant is intentionally NOT checked here. This setter runs as
-        // the settings-update consumer at apply time, one setting at a time, so the sibling field may still hold its
-        // previous value; checking ordering here throws when both thresholds are lowered together (a consistent final
-        // state), destabilizing the cluster-manager. Ordering is enforced at validation time by the Setting.Validator
-        // against the final, consistent settings, and at startup by the constructor.
-        ensureThresholdIsWithinAllowedRange(
-            nodeLevelMemoryCancellationThreshold,
-            NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
-            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
         this.nodeLevelMemoryCancellationThreshold = nodeLevelMemoryCancellationThreshold;
     }
 
@@ -264,17 +272,11 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level cpu based cancellation threshold
+     * Method to set the node level cpu based cancellation threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelCpuCancellationThreshold sets the new node level cpu based cancellation threshold
-     * @throws IllegalArgumentException if the value is negative or &gt; 0.95
      */
     public void setNodeLevelCpuCancellationThreshold(Double nodeLevelCpuCancellationThreshold) {
-        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
-        ensureThresholdIsWithinAllowedRange(
-            nodeLevelCpuCancellationThreshold,
-            NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
-            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
         this.nodeLevelCpuCancellationThreshold = nodeLevelCpuCancellationThreshold;
     }
 
@@ -287,17 +289,11 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level memory based rejection threshold
+     * Method to set the node level memory based rejection threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelMemoryRejectionThreshold sets the new memory based rejection threshold
-     * @throws IllegalArgumentException if the value is negative or &gt; 0.90
      */
     public void setNodeLevelMemoryRejectionThreshold(Double nodeLevelMemoryRejectionThreshold) {
-        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
-        ensureThresholdIsWithinAllowedRange(
-            nodeLevelMemoryRejectionThreshold,
-            NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
-            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME
-        );
         this.nodeLevelMemoryRejectionThreshold = nodeLevelMemoryRejectionThreshold;
     }
 
@@ -310,17 +306,11 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level cpu based rejection threshold
+     * Method to set the node level cpu based rejection threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelCpuRejectionThreshold sets the new cpu based rejection threshold
-     * @throws IllegalArgumentException if the value is negative or &gt; 0.90
      */
     public void setNodeLevelCpuRejectionThreshold(Double nodeLevelCpuRejectionThreshold) {
-        // See setNodeLevelMemoryCancellationThreshold: ordering is enforced by the Validator at validation time, not here.
-        ensureThresholdIsWithinAllowedRange(
-            nodeLevelCpuRejectionThreshold,
-            NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
-            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME
-        );
         this.nodeLevelCpuRejectionThreshold = nodeLevelCpuRejectionThreshold;
     }
 
@@ -352,21 +342,6 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Runs every single-setting validation for a threshold (i.e. the checks that do not depend on a sibling setting):
-     * the value must be non-negative and must not exceed its allowed maximum. This is the single place both enforcement
-     * paths call — the settings-update {@link Setting.Validator} (validation time) and the setters (apply time) — so the
-     * two cannot drift as new standalone bounds are added.
-     * @param thresholdValue the threshold value being set
-     * @param maxValue the maximum allowed value for this threshold
-     * @param thresholdSettingName name of the threshold setting
-     * @throws IllegalArgumentException if the value is negative or greater than the allowed maximum
-     */
-    private static void ensureThresholdIsWithinAllowedRange(Double thresholdValue, double maxValue, String thresholdSettingName) {
-        ensureThresholdIsNotNegative(thresholdValue, thresholdSettingName);
-        ensureThresholdIsNotGreaterThanMax(thresholdValue, maxValue, thresholdSettingName);
-    }
-
-    /**
      * Method to validate that the cancellation threshold is greater than or equal to rejection threshold
      * @param nodeLevelRejectionThreshold rejection threshold to be compared
      * @param nodeLevelCancellationThreshold cancellation threshold to be compared
@@ -388,124 +363,82 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Validator for {@link #NODE_LEVEL_CPU_CANCELLATION_THRESHOLD}. Enforced at settings-update validation time so that an
+     * Validator shared by all four node-level threshold settings. Enforced at settings-update validation time so that an
      * invalid value is rejected before the new cluster state is published, rather than throwing while the state is applied
      * (which would destabilize the cluster-manager).
+     * <p>
+     * It enforces two invariants: the value is within {@code [0, max]} (single-setting), and the rejection threshold does
+     * not exceed the cancellation threshold (cross-setting). The paired setting is supplied lazily via a {@link Supplier}
+     * because the four settings reference each other and are initialized in sequence; resolving it inside the method
+     * bodies (which only run at validation time) avoids a forward-reference to a not-yet-initialized field.
      */
-    static final class NodeLevelCpuCancellationThresholdValidator implements Setting.Validator<Double> {
+    static final class NodeLevelThresholdValidator implements Setting.Validator<Double> {
+        private final String settingName;
+        private final double maxValue;
+        private final Supplier<Setting<Double>> pairedSetting;
+        private final boolean isCancellation;
+
+        private NodeLevelThresholdValidator(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> pairedSetting,
+            boolean isCancellation
+        ) {
+            this.settingName = settingName;
+            this.maxValue = maxValue;
+            this.pairedSetting = pairedSetting;
+            this.isCancellation = isCancellation;
+        }
+
+        /**
+         * Builds a validator for a cancellation threshold (the upper bound of the pair).
+         * @param settingName this cancellation setting's key
+         * @param maxValue the maximum allowed value for this cancellation threshold
+         * @param rejectionSetting supplier of the paired rejection setting
+         */
+        static NodeLevelThresholdValidator forCancellationThreshold(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> rejectionSetting
+        ) {
+            return new NodeLevelThresholdValidator(settingName, maxValue, rejectionSetting, true);
+        }
+
+        /**
+         * Builds a validator for a rejection threshold (the lower bound of the pair).
+         * @param settingName this rejection setting's key
+         * @param maxValue the maximum allowed value for this rejection threshold
+         * @param cancellationSetting supplier of the paired cancellation setting
+         */
+        static NodeLevelThresholdValidator forRejectionThreshold(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> cancellationSetting
+        ) {
+            return new NodeLevelThresholdValidator(settingName, maxValue, cancellationSetting, false);
+        }
+
         @Override
         public void validate(Double value) {
-            ensureThresholdIsWithinAllowedRange(
-                value,
-                NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
-                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
+            ensureThresholdIsNotNegative(value, settingName);
+            ensureThresholdIsNotGreaterThanMax(value, maxValue, settingName);
         }
 
         @Override
         public void validate(Double value, Map<Setting<?>, Object> settings) {
-            final Double rejectionThreshold = (Double) settings.get(NODE_LEVEL_CPU_REJECTION_THRESHOLD);
-            ensureRejectionThresholdIsLessThanCancellation(
-                rejectionThreshold,
-                value,
-                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
-                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
+            final String pairedName = pairedSetting.get().getKey();
+            final Double pairedValue = (Double) settings.get(pairedSetting.get());
+            // Substitute this setting's incoming value for its own side of the rejection <= cancellation comparison.
+            if (isCancellation) {
+                ensureRejectionThresholdIsLessThanCancellation(pairedValue, value, pairedName, settingName);
+            } else {
+                ensureRejectionThresholdIsLessThanCancellation(value, pairedValue, settingName, pairedName);
+            }
         }
 
         @Override
         public Iterator<Setting<?>> settings() {
-            return List.<Setting<?>>of(NODE_LEVEL_CPU_REJECTION_THRESHOLD).iterator();
-        }
-    }
-
-    /**
-     * Validator for {@link #NODE_LEVEL_CPU_REJECTION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
-     */
-    static final class NodeLevelCpuRejectionThresholdValidator implements Setting.Validator<Double> {
-        @Override
-        public void validate(Double value) {
-            ensureThresholdIsWithinAllowedRange(
-                value,
-                NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
-                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public void validate(Double value, Map<Setting<?>, Object> settings) {
-            final Double cancellationThreshold = (Double) settings.get(NODE_LEVEL_CPU_CANCELLATION_THRESHOLD);
-            ensureRejectionThresholdIsLessThanCancellation(
-                value,
-                cancellationThreshold,
-                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
-                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public Iterator<Setting<?>> settings() {
-            return List.<Setting<?>>of(NODE_LEVEL_CPU_CANCELLATION_THRESHOLD).iterator();
-        }
-    }
-
-    /**
-     * Validator for {@link #NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
-     */
-    static final class NodeLevelMemoryCancellationThresholdValidator implements Setting.Validator<Double> {
-        @Override
-        public void validate(Double value) {
-            ensureThresholdIsWithinAllowedRange(
-                value,
-                NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
-                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public void validate(Double value, Map<Setting<?>, Object> settings) {
-            final Double rejectionThreshold = (Double) settings.get(NODE_LEVEL_MEMORY_REJECTION_THRESHOLD);
-            ensureRejectionThresholdIsLessThanCancellation(
-                rejectionThreshold,
-                value,
-                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
-                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public Iterator<Setting<?>> settings() {
-            return List.<Setting<?>>of(NODE_LEVEL_MEMORY_REJECTION_THRESHOLD).iterator();
-        }
-    }
-
-    /**
-     * Validator for {@link #NODE_LEVEL_MEMORY_REJECTION_THRESHOLD}. See {@link NodeLevelCpuCancellationThresholdValidator}.
-     */
-    static final class NodeLevelMemoryRejectionThresholdValidator implements Setting.Validator<Double> {
-        @Override
-        public void validate(Double value) {
-            ensureThresholdIsWithinAllowedRange(
-                value,
-                NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
-                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public void validate(Double value, Map<Setting<?>, Object> settings) {
-            final Double cancellationThreshold = (Double) settings.get(NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD);
-            ensureRejectionThresholdIsLessThanCancellation(
-                value,
-                cancellationThreshold,
-                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
-                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-            );
-        }
-
-        @Override
-        public Iterator<Setting<?>> settings() {
-            return List.<Setting<?>>of(NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD).iterator();
+            return List.<Setting<?>>of(pairedSetting.get()).iterator();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.wlm.WorkloadManagementSettings.NODE_CPU_CANCELLATIO
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME;
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME;
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME;
+import static org.hamcrest.Matchers.containsString;
 
 public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
@@ -86,16 +87,19 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.cpu_rejection_threshold}
-     * When the value is set more than {@code wlm.workload_group.node.cpu_cancellation_threshold}
+     * When the value is set more than {@code wlm.workload_group.node.cpu_cancellation_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelCpuRejectionThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection 0.85 > cancellation 0.8 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
             .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
             .build();
-        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuRejectionThreshold(0.85));
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -133,16 +137,19 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.cpu_cancellation_threshold}
-     * When the value is set less than {@code wlm.workload_group.node.cpu_rejection_threshold}
+     * When the value is set less than {@code wlm.workload_group.node.cpu_rejection_threshold}. The ordering invariant
+     * is enforced at settings-update validation time (not in the setter), so it is exercised here through the
+     * validation path.
      */
     public void testInvalidNodeLevelCpuCancellationThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
-            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
-            .build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuCancellationThreshold(0.65));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // cancellation 0.65 < rejection 0.7 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.65)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -180,16 +187,19 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.memory_cancellation_threshold}
-     * When the value is set less than {@code wlm.workload_group.node.memory_rejection_threshold}
+     * When the value is set less than {@code wlm.workload_group.node.memory_rejection_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelMemoryCancellationThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
-            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
-            .build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryCancellationThreshold(0.65));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // cancellation 0.65 < rejection 0.7 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.65)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -227,15 +237,236 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.memory_rejection_threshold}
-     * When the value is set more than {@code wlm.workload_group.node.memory_cancellation_threshold}
+     * When the value is set more than {@code wlm.workload_group.node.memory_cancellation_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelMemoryRejectionThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection 0.85 > cancellation 0.8 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
             .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
             .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * Reproduces the production incident where a dynamic cluster settings update set
+     * {@code wlm.workload_group.node.cpu_cancellation_threshold} above its maximum. Prior to the fix, the value passed
+     * the settings-update dry-run validation ({@link ClusterSettings#validateUpdate}) and was committed to cluster state,
+     * only to throw while the new state was being applied on every node. That apply-time failure destabilized the
+     * cluster-manager. This test asserts the update is instead rejected up-front at validation time.
+     */
+    public void testCpuCancellationThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryRejectionThreshold(0.85));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        // validateUpdate is the dry-run the cluster settings API runs before committing the new cluster state.
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+        assertThat(e.getMessage(), containsString(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+
+        // validate(...) is the other check the settings API applies to the final persistent/transient settings.
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
+        assertThat(e2.getMessage(), containsString(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * A value at exactly the maximum must be accepted through the settings-update validation path.
+     */
+    public void testCpuCancellationThresholdAtMaxAcceptedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update);
+        assertEquals(
+            WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
+            wlm.getNodeLevelCpuCancellationThreshold(),
+            1e-9
+        );
+    }
+
+    /**
+     * The same up-front rejection must hold for the memory cancellation threshold.
+     */
+    public void testMemoryCancellationThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+        assertThat(e.getMessage(), containsString(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * The rejection-vs-cancellation ordering invariant must also be enforced at settings-update validation time,
+     * not only via the setters.
+     */
+    public void testCpuCancellationBelowRejectionRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection (0.85) > cancellation (0.8) violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * The rejection-threshold max (0.90) must be enforced through the validation path for both cpu and memory, so a
+     * mis-wired rejection validator (wrong MAX constant / not attached) would be caught. The paired cancellation is
+     * raised to 0.95 in the same update so that the ordering invariant is satisfied and the rejection max is the sole
+     * trigger.
+     */
+    public void testRejectionThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        Settings cpu = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.95) // > 0.90 rejection max
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.95) // keeps rejection <= cancellation
+            .build();
+        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(cpu));
+        assertThat(e1.getMessage(), containsString(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME));
+
+        Settings memory = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.95)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.95)
+            .build();
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(memory));
+        assertThat(e2.getMessage(), containsString(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * The memory ordering violation must be rejected via the validation path (mirror of the cpu ordering test), so a
+     * regression swapping the memory validators' dependency setting or argument order is caught.
+     */
+    public void testMemoryCancellationBelowRejectionRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * Boundary: rejection == cancellation is consistent (invariant is {@code rejection <= cancellation}) and must be
+     * accepted, so the ordering check is not wrongly strict.
+     */
+    public void testEqualRejectionAndCancellationAcceptedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.8)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.8, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        assertEquals(0.8, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * Lowering BOTH thresholds in a single update to a new, consistent state (rejection stays below cancellation) must
+     * succeed end-to-end. This guards against a regression where the ordering check ran in the apply-time setter against
+     * a stale sibling field: the cancellation consumer applied first would compare the new cancellation against the old
+     * (higher) rejection and throw while applying committed state, destabilizing the cluster-manager.
+     */
+    public void testLoweringBothCpuThresholdsTogetherIsAppliedCleanly() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs); // rejection=0.8, cancellation=0.9
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.6)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.7)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.6, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        assertEquals(0.7, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * Same as above for the memory pair.
+     */
+    public void testLoweringBothMemoryThresholdsTogetherIsAppliedCleanly() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.6)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.7)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.6, wlm.getNodeLevelMemoryRejectionThreshold(), 1e-9);
+        assertEquals(0.7, wlm.getNodeLevelMemoryCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * The setters enforce the single-value (non-negativity, max) bounds, so a direct setter call with a negative value
+     * is rejected. Ordering is intentionally NOT enforced in the setters (see the lower-both tests above).
+     */
+    public void testNegativeNodeThresholdsRejectedBySetters() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelCpuCancellationThreshold(-0.1));
+        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelCpuRejectionThreshold(-0.1));
+        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelMemoryCancellationThreshold(-0.1));
+        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelMemoryRejectionThreshold(-0.1));
+    }
+
+    /**
+     * A negative threshold is nonsensical and must be rejected at settings-update validation time by the validator's
+     * lower bound, for each of the four node threshold settings.
+     */
+    public void testNegativeNodeThresholdsRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        for (String key : new String[] {
+            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME }) {
+            Settings update = Settings.builder().put(key, -0.1).build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+            assertThat(e.getMessage(), containsString(key));
+        }
+    }
+
+    /**
+     * A cluster that already carries an out-of-range value in persisted cluster state (as in the incident, where
+     * {@code 0.98} was committed before the fix) must be able to recover: on state recovery the invalid setting is
+     * archived rather than applied. This verifies the recovery/self-heal path enabled by the validator.
+     */
+    public void testOutOfRangeCpuCancellationThresholdIsArchivedOnRecovery() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        Settings poisoned = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        Settings archived = cs.archiveUnknownOrInvalidSettings(poisoned, e -> {}, (e, ex) -> {});
+
+        // The active (non-archived) key is dropped and preserved under the archived prefix for visibility.
+        assertNull(archived.get(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+        assertEquals("0.98", archived.get("archived." + NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
@@ -76,13 +76,13 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.cpu_rejection_threshold}
-     * When the value is set more than {@literal 0.9}
+     * When the value is set more than {@literal 0.9}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelCpuRejectionThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.8).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuRejectionThreshold(0.95));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.95).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
@@ -126,13 +126,13 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.cpu_cancellation_threshold}
-     * When the value is set more than {@literal 0.95}
+     * When the value is set more than {@literal 0.95}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelCpuCancellationThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuCancellationThreshold(0.96));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.96).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
@@ -176,13 +176,13 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.memory_cancellation_threshold}
-     * When the value is set more than {@literal 0.95}
+     * When the value is set more than {@literal 0.95}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelMemoryCancellationThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryCancellationThreshold(0.96));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.96).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
@@ -226,13 +226,13 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.workload_group.node.memory_rejection_threshold}
-     * When the value is set more than {@literal 0.9}
+     * When the value is set more than {@literal 0.9}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelMemoryRejectionThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryRejectionThreshold(0.92));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.92).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
@@ -422,17 +422,23 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
     }
 
     /**
-     * The setters enforce the single-value (non-negativity, max) bounds, so a direct setter call with a negative value
-     * is rejected. Ordering is intentionally NOT enforced in the setters (see the lower-both tests above).
+     * The setters run as the settings-update consumers at apply time and only assign; all bounds and ordering are
+     * enforced up front by {@code NodeLevelThresholdValidator} at validation time. This guards against reintroducing an
+     * apply-time throw in a setter (which, for the cross-setting ordering invariant, destabilized the cluster-manager).
      */
-    public void testNegativeNodeThresholdsRejectedBySetters() {
+    public void testSettersOnlyAssignAndDoNotThrow() {
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
 
-        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelCpuCancellationThreshold(-0.1));
-        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelCpuRejectionThreshold(-0.1));
-        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelMemoryCancellationThreshold(-0.1));
-        assertThrows(IllegalArgumentException.class, () -> wlm.setNodeLevelMemoryRejectionThreshold(-0.1));
+        // Values that validation would reject (out of range, and cancellation < rejection) are still assigned by the
+        // raw setters without throwing, because the setters no longer validate.
+        wlm.setNodeLevelCpuCancellationThreshold(0.99);
+        assertEquals(0.99, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+        wlm.setNodeLevelCpuRejectionThreshold(-0.1);
+        assertEquals(-0.1, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        wlm.setNodeLevelMemoryCancellationThreshold(0.1);
+        wlm.setNodeLevelMemoryRejectionThreshold(0.9); // rejection > cancellation; setter does not enforce ordering
+        assertEquals(0.9, wlm.getNodeLevelMemoryRejectionThreshold(), 1e-9);
     }
 
     /**


### PR DESCRIPTION
### Description

The four node-level WLM threshold settings — `wlm.workload_group.node.{cpu,memory}_{rejection,cancellation}_threshold` — had their range checks (max value, and the `rejection <= cancellation` ordering invariant) enforced only inside their settings-update consumers (the setters registered via `addSettingsUpdateConsumer`).

Cluster settings updates are validated by a dry run (`ClusterSettings.validateUpdate` / `validate`) that runs each setting's parser and its `Setting.Validator`, but **not** its update consumer. The consumer runs later, when the committed cluster state is applied. So an out-of-range value (e.g. `cpu_cancellation_threshold = 0.98`, above the 0.95 max) passed validation, was committed to cluster state, and only threw `IllegalArgumentException` at apply time. On the elected cluster-manager that aborts cluster-state application, causing it to step down and re-elect repeatedly; because the bad value is already persisted, a corrective update cannot be published either.

This change attaches a `Setting.Validator` to each of the four settings so the bounds and ordering invariant are enforced at validation time — the update is rejected up front with a `400` and never committed. Key points:

- **Single-value bounds** (non-negative, and max: 0.95 for cancellation, 0.90 for rejection) are enforced by the validator and by the setters, via a shared helper so the two paths cannot drift.
- **The cross-setting `rejection <= cancellation` ordering invariant is enforced only in the validator** (against the final, consistent settings) and at startup in the constructor — deliberately **not** in the setters. Consumers are applied one setting at a time, so a setter checking ordering against the sibling's not-yet-updated field would throw when both thresholds are lowered together (a consistent final state), reintroducing the same apply-time failure.
- Values already persisted from before this change are archived on gateway recovery rather than applied, so an affected cluster self-heals on restart.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
