### PR TITLE
Dsl pipeline aggs

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -78,14 +78,13 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
+            final long startTime = System.currentTimeMillis();
             final QueryPlans plans;
-            final long convertTime;
+            final SearchSourceConverter converter;
             try {
                 String indexName = resolveToSingleIndex(request);
-                long convertStart = System.nanoTime();
-                SearchSourceConverter converter = new SearchSourceConverter(contextProvider.getContext().schema());
+                converter = new SearchSourceConverter(contextProvider.getContext().schema());
                 plans = converter.convert(request.source(), indexName);
-                convertTime = System.nanoTime() - convertStart;
             } catch (Exception e) {
                 logger.error("DSL conversion failed", e);
                 listener.onFailure(e);
@@ -94,7 +93,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             planExecutor.execute(plans, ActionListener.wrap(results -> {
                 final SearchResponse response;
                 try {
-                    response = SearchResponseBuilder.build(results, convertTime);
+                    long tookInMillis = System.currentTimeMillis() - startTime;
+                    response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
                 } catch (Exception buildEx) {
                     logger.error("DSL response building failed", buildEx);
                     listener.onFailure(buildEx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -30,6 +30,8 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
  * executes them via the analytics engine, and builds a SearchResponse.
@@ -78,7 +80,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
-            final long startTime = System.currentTimeMillis();
+            final long startNanos = System.nanoTime();
             final QueryPlans plans;
             final SearchSourceConverter converter;
             try {
@@ -93,7 +95,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             planExecutor.execute(plans, ActionListener.wrap(results -> {
                 final SearchResponse response;
                 try {
-                    long tookInMillis = System.currentTimeMillis() - startTime;
+                    long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
                     response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
                 } catch (Exception buildEx) {
                     logger.error("DSL response building failed", buildEx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -96,7 +96,13 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 final SearchResponse response;
                 try {
                     long tookInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-                    response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), tookInMillis);
+                    response = SearchResponseBuilder.build(
+                        results,
+                        request,
+                        converter.getAggregationRegistry(),
+                        converter.getPipelineRegistry(),
+                        tookInMillis
+                    );
                 } catch (Exception buildEx) {
                     logger.error("DSL response building failed", buildEx);
                     listener.onFailure(buildEx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTranslator.java
@@ -10,6 +10,8 @@ package org.opensearch.dsl.aggregation;
 
 import org.opensearch.search.aggregations.AggregationBuilder;
 
+import java.util.Map;
+
 /**
  * Base type interface for aggregation translators.
  * Provides type identification for the {@link AggregationRegistry}.
@@ -19,4 +21,15 @@ public interface AggregationTranslator<T extends AggregationBuilder> {
 
     /** Returns the concrete AggregationBuilder class this type handles. */
     Class<T> getAggregationType();
+
+    /**
+     * Returns the user-supplied {@code meta} map from the request, or null when absent so the
+     * response omits the {@code meta} section entirely (classic search renders {@code meta}
+     * only when supplied). {@link AggregationBuilder#getMetadata()} masks "absent" as an empty
+     * map, so an explicitly supplied empty {@code "meta": {}} is also treated as absent here.
+     */
+    static Map<String, Object> userMetadata(AggregationBuilder agg) {
+        Map<String, Object> metadata = agg.getMetadata();
+        return metadata == null || metadata.isEmpty() ? null : metadata;
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -96,6 +96,15 @@ public class AggregationTreeWalker {
         Map<String, AggregationMetadataBuilder> granularities,
         RelDataType rowType
     ) throws ConversionException {
+        if (aggBuilder.getPipelineAggregations().isEmpty() == false) {
+            throw new ConversionException(
+                "pipeline aggregation ["
+                    + aggBuilder.getPipelineAggregations().iterator().next().getName()
+                    + "] inside ["
+                    + aggBuilder.getName()
+                    + "] is not supported; pipeline aggregations are only supported at the root level"
+            );
+        }
         GroupingInfo grouping = translator.getGrouping(aggBuilder);
 
         List<GroupingInfo> accumulatedGroupings = new ArrayList<>(currentGroupings);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -8,14 +8,19 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -48,9 +53,39 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
         return agg.order();
     }
 
-    // TODO: implement response conversion
+    /**
+     * Builds a {@link StringTerms} (keys rendered via {@code toString}; per-key-type
+     * Long/Double variants are follow-up work). Shard accounting fields are zero — the
+     * analytics path computes exact groups with no per-shard truncation. Bucket order is
+     * already established by the plan's post-aggregate sort.
+     */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
-        throw new UnsupportedOperationException("toBucketAggregation not yet implemented");
+        List<StringTerms.Bucket> termBuckets = new ArrayList<>();
+        for (BucketEntry entry : buckets) {
+            Object key = entry.keys().get(0);
+            BytesRef term = new BytesRef(key == null ? "" : key.toString());
+            termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
+        }
+        BucketOrder order = agg.order();
+        TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(
+            agg.minDocCount(),
+            agg.shardMinDocCount(),
+            agg.size(),
+            agg.shardSize()
+        );
+        return new StringTerms(
+            agg.getName(),
+            order,
+            order,
+            null,
+            DocValueFormat.RAW,
+            agg.shardSize(),
+            false,
+            0,
+            termBuckets,
+            0,
+            thresholds
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -64,7 +64,12 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
         List<StringTerms.Bucket> termBuckets = new ArrayList<>();
         for (BucketEntry entry : buckets) {
             Object key = entry.keys().get(0);
-            BytesRef term = new BytesRef(key == null ? "" : key.toString());
+            if (key == null) {
+                // SQL GROUP BY emits a NULL group; legacy terms excludes docs with a
+                // missing field entirely (no bucket) unless "missing" is configured.
+                continue;
+            }
+            BytesRef term = new BytesRef(key.toString());
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
         BucketOrder order = agg.order();

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -55,10 +55,9 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
     }
 
     /**
-     * Builds a {@link StringTerms} (keys rendered via {@code toString}; per-key-type
-     * Long/Double variants are follow-up work). Shard accounting fields are zero — the
-     * analytics path computes exact groups with no per-shard truncation. Bucket order is
-     * already established by the plan's post-aggregate sort.
+     * Builds a {@link StringTerms}. Buckets are sorted by the requested order, filtered by
+     * {@code min_doc_count}, and truncated to {@code size}; truncated bucket counts are
+     * reported as {@code sum_other_doc_count}.
      */
     @Override
     public InternalAggregation toBucketAggregation(TermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
@@ -70,9 +69,25 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
                 // missing field entirely (no bucket) unless "missing" is configured.
                 continue;
             }
+            if (entry.docCount() < agg.minDocCount()) {
+                continue;
+            }
             BytesRef term = new BytesRef(key.toString());
             termBuckets.add(new StringTerms.Bucket(term, entry.docCount(), entry.subAggs(), false, 0, DocValueFormat.RAW));
         }
+
+        // Sort per this aggregation's own order: sibling aggregations sharing a granularity
+        // share one plan-level sort, which cannot satisfy two different requested orders.
+        termBuckets.sort(getBucketOrder(agg).comparator());
+
+        long otherDocCount = 0;
+        if (termBuckets.size() > agg.size()) {
+            for (int i = agg.size(); i < termBuckets.size(); i++) {
+                otherDocCount += termBuckets.get(i).getDocCount();
+            }
+            termBuckets = new ArrayList<>(termBuckets.subList(0, agg.size()));
+        }
+
         BucketOrder order = agg.order();
         TermsAggregator.BucketCountThresholds thresholds = new TermsAggregator.BucketCountThresholds(
             agg.minDocCount(),
@@ -88,7 +103,7 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             DocValueFormat.RAW,
             agg.shardSize(),
             false,
-            0,
+            otherDocCount,
             termBuckets,
             0,
             thresholds

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslator.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.result.BucketEntry;
@@ -83,7 +84,7 @@ public class TermsBucketTranslator implements BucketTranslator<TermsAggregationB
             agg.getName(),
             order,
             order,
-            null,
+            AggregationTranslator.userMetadata(agg),
             DocValueFormat.RAW,
             agg.shardSize(),
             false,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -76,6 +76,8 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
         if (value instanceof Number number) {
             return number.doubleValue();
         }
-        throw new IllegalStateException("Expected numeric aggregation result but got " + value.getClass().getSimpleName());
+        throw new IllegalStateException(
+            "Expected numeric aggregation result but got " + (value == null ? "null" : value.getClass().getSimpleName())
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -15,7 +15,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
-import org.opensearch.search.aggregations.InternalAggregation;
 
 import java.util.Collections;
 
@@ -67,9 +66,16 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
         return agg.getName();
     }
 
-    // TODO: implement response conversion per metric type (InternalAvg, InternalSum, etc.)
-    @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
-        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for " + getClass().getSimpleName());
+    /**
+     * Coerces an engine result cell to double. Calcite keeps the input column type (AVG over
+     * an INTEGER column returns an integral value), so the int→double widening happens here.
+     *
+     * @param value the raw cell value (must be a {@link Number})
+     */
+    protected static double toDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        throw new IllegalStateException("Expected numeric aggregation result but got " + value.getClass().getSimpleName());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
@@ -10,7 +10,10 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 
 /** Translates AVG metric aggregation to Calcite. */
 public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregationBuilder> {
@@ -31,5 +34,18 @@ public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregation
     @Override
     protected String getFieldName(AvgAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /**
+     * The engine returns the final average; encoded as (sum=value, count=1) so
+     * {@code InternalAvg.getValue()} reproduces it. Null (no matching docs) uses
+     * count=0, which renders as {@code "value": null} like legacy.
+     */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        if (value == null) {
+            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, null);
+        }
+        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
 
+import java.util.Map;
+
 /** Translates AVG metric aggregation to Calcite. */
 public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregationBuilder> {
 
@@ -42,10 +44,10 @@ public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregation
      * count=0, which renders as {@code "value": null} like legacy.
      */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         if (value == null) {
-            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, null);
+            return new InternalAvg(name, 0.0, 0, DocValueFormat.RAW, metadata);
         }
-        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, null);
+        return new InternalAvg(name, toDouble(value), 1, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalMax;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 
 /** Translates MAX metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregation
     @Override
     protected String getFieldName(MaxAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes -Infinity — legacy sentinel, rendered as {@code "value": null}. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double max = value == null ? Double.NEGATIVE_INFINITY : toDouble(value);
+        return new InternalMax(name, max, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalMax;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates MAX metric aggregation to Calcite. */
 public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregation
 
     /** Null (no matching docs) becomes -Infinity — legacy sentinel, rendered as {@code "value": null}. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double max = value == null ? Double.NEGATIVE_INFINITY : toDouble(value);
-        return new InternalMax(name, max, DocValueFormat.RAW, null);
+        return new InternalMax(name, max, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
 
+import java.util.Map;
+
 /**
  * Translates a metric aggregation (AVG, SUM, MIN, MAX, etc.) to a Calcite AggregateCall,
  * and converts raw result values back to OpenSearch InternalAggregation for response building.
@@ -47,7 +49,9 @@ public interface MetricTranslator<T extends AggregationBuilder> extends Aggregat
      *
      * @param name the aggregation name
      * @param value the raw value (may be null)
+     * @param metadata the user-supplied {@code meta} map from the aggregation request, echoed
+     *        back verbatim in the response like classic search (may be null)
      * @return the corresponding InternalAggregation
      */
-    InternalAggregation toInternalAggregation(String name, Object value);
+    InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata);
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 
 /** Translates MIN metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregation
     @Override
     protected String getFieldName(MinAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes +Infinity — legacy sentinel, rendered as {@code "value": null}. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double min = value == null ? Double.POSITIVE_INFINITY : toDouble(value);
+        return new InternalMin(name, min, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates MIN metric aggregation to Calcite. */
 public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregation
 
     /** Null (no matching docs) becomes +Infinity — legacy sentinel, rendered as {@code "value": null}. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double min = value == null ? Double.POSITIVE_INFINITY : toDouble(value);
-        return new InternalMin(name, min, DocValueFormat.RAW, null);
+        return new InternalMin(name, min, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
@@ -10,6 +10,9 @@ package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 
 /** Translates SUM metric aggregation to Calcite. */
@@ -31,5 +34,12 @@ public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregation
     @Override
     protected String getFieldName(SumAggregationBuilder agg) {
         return agg.field();
+    }
+
+    /** Null (no matching docs) becomes 0.0 — legacy sum-of-nothing semantics. */
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Object value) {
+        double sum = value == null ? 0.0 : toDouble(value);
+        return new InternalSum(name, sum, DocValueFormat.RAW, null);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
@@ -15,6 +15,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 
+import java.util.Map;
+
 /** Translates SUM metric aggregation to Calcite. */
 public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregationBuilder> {
 
@@ -38,8 +40,8 @@ public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregation
 
     /** Null (no matching docs) becomes 0.0 — legacy sum-of-nothing semantics. */
     @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
+    public InternalAggregation toInternalAggregation(String name, Object value, Map<String, Object> metadata) {
         double sum = value == null ? 0.0 : toDouble(value);
-        return new InternalSum(name, sum, DocValueFormat.RAW, null);
+        return new InternalSum(name, sum, DocValueFormat.RAW, metadata);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/AvgBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/AvgBucketTranslator.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.InternalSimpleValue;
+
+import java.util.Collections;
+
+/**
+ * Translates {@code avg_bucket} to an {@code AVG} aggregate call over the resolved metric
+ * column. An empty sibling yields SQL NULL, mapped to {@code NaN} which
+ * {@link InternalSimpleValue} renders as {@code "value": null} — vanilla's count==0 behavior.
+ */
+public class AvgBucketTranslator implements PipelineTranslator<AvgBucketPipelineAggregationBuilder> {
+
+    /** Creates an avg_bucket translator. */
+    public AvgBucketTranslator() {}
+
+    @Override
+    public Class<AvgBucketPipelineAggregationBuilder> getBuilderClass() {
+        return AvgBucketPipelineAggregationBuilder.class;
+    }
+
+    @Override
+    public AggregateCall createAggregateCall(AvgBucketPipelineAggregationBuilder builder, int inputColumn, RelDataTypeFactory typeFactory) {
+        // Declared DOUBLE so the engine's AVG decomposition divides in floating point
+        // even when the metric column is integral.
+        RelDataType doubleType = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+        return AggregateCall.create(
+            SqlStdOperatorTable.AVG,
+            false,
+            false,
+            false,
+            Collections.singletonList(inputColumn),
+            -1,
+            RelCollations.EMPTY,
+            doubleType,
+            builder.getName()
+        );
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(AvgBucketPipelineAggregationBuilder builder, Object cellValue) {
+        double value = cellValue instanceof Number number ? number.doubleValue() : Double.NaN;
+        return new InternalSimpleValue(builder.getName(), value, PipelineTranslator.resolveFormat(builder), null);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/BucketsPathResolver.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/BucketsPathResolver.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.support.AggregationPath;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves a sibling pipeline aggregation's {@code buckets_path} against the request's
+ * root-level aggregations.
+ *
+ * <p>Supported form: a single-level {@code "siblingAgg>metric"} path where the sibling is a
+ * root-level {@code terms} aggregation and the metric is one of its single-value metric
+ * sub-aggregations, or the built-in {@code _count}. Multi-level paths ({@code a>b>metric}),
+ * property paths ({@code stats.avg}), and bucket-key selectors ({@code terms[key]}) are
+ * rejected.
+ */
+public final class BucketsPathResolver {
+
+    private BucketsPathResolver() {}
+
+    /**
+     * A resolved buckets_path: the sibling bucket aggregation and the plan column
+     * holding the referenced per-bucket value.
+     *
+     * @param sibling the root-level sibling bucket aggregation the path points into
+     * @param metricColumn the column name of the referenced metric in the sibling's plan
+     */
+    public record ResolvedBucketsPath(TermsAggregationBuilder sibling, String metricColumn) {
+    }
+
+    /**
+     * Resolves the pipeline's buckets_path to a sibling aggregation and metric column.
+     *
+     * @param pipeline the sibling pipeline aggregation builder
+     * @param rootAggs the request's root-level aggregation builders
+     * @param registry the aggregation registry for metric/bucket classification
+     * @return the resolved sibling and metric column
+     * @throws ConversionException if the path is absent, malformed, or references
+     *         anything outside the supported form
+     */
+    public static ResolvedBucketsPath resolve(
+        PipelineAggregationBuilder pipeline,
+        Collection<AggregationBuilder> rootAggs,
+        AggregationRegistry registry
+    ) throws ConversionException {
+        String[] paths = pipeline.getBucketsPaths();
+        if (paths == null || paths.length != 1 || paths[0] == null || paths[0].isEmpty()) {
+            throw new ConversionException("pipeline aggregation [" + pipeline.getName() + "] requires exactly one buckets_path");
+        }
+        String path = paths[0];
+
+        List<AggregationPath.PathElement> elements;
+        try {
+            elements = AggregationPath.parse(path).getPathElements();
+        } catch (IllegalArgumentException e) {
+            throw new ConversionException(
+                "pipeline aggregation [" + pipeline.getName() + "] has an invalid buckets_path [" + path + "]: " + e.getMessage()
+            );
+        }
+        if (elements.size() != 2) {
+            throw new ConversionException(
+                "pipeline aggregation ["
+                    + pipeline.getName()
+                    + "] buckets_path ["
+                    + path
+                    + "] must be a single-level [sibling>metric] reference"
+            );
+        }
+        AggregationPath.PathElement siblingElement = elements.get(0);
+        AggregationPath.PathElement metricElement = elements.get(1);
+        if (siblingElement.key != null || metricElement.key != null) {
+            throw new ConversionException(
+                "pipeline aggregation [" + pipeline.getName() + "] buckets_path [" + path + "] uses an unsupported property or key path"
+            );
+        }
+
+        AggregationBuilder sibling = findSibling(pipeline, rootAggs, siblingElement.name);
+        if ((sibling instanceof TermsAggregationBuilder) == false) {
+            throw new ConversionException(
+                "pipeline aggregation ["
+                    + pipeline.getName()
+                    + "] sibling ["
+                    + sibling.getName()
+                    + "] of type ["
+                    + sibling.getType()
+                    + "] is not supported; only [terms] siblings are supported"
+            );
+        }
+
+        String metricColumn = resolveMetricColumn(pipeline, (TermsAggregationBuilder) sibling, metricElement.name, registry);
+        return new ResolvedBucketsPath((TermsAggregationBuilder) sibling, metricColumn);
+    }
+
+    private static AggregationBuilder findSibling(
+        PipelineAggregationBuilder pipeline,
+        Collection<AggregationBuilder> rootAggs,
+        String siblingName
+    ) throws ConversionException {
+        for (AggregationBuilder agg : rootAggs) {
+            if (agg.getName().equals(siblingName)) {
+                return agg;
+            }
+        }
+        throw new ConversionException(
+            "pipeline aggregation ["
+                + pipeline.getName()
+                + "] buckets_path references unknown aggregation ["
+                + siblingName
+                + "]. Available: "
+                + rootAggs.stream().map(AggregationBuilder::getName).collect(Collectors.toList())
+        );
+    }
+
+    private static String resolveMetricColumn(
+        PipelineAggregationBuilder pipeline,
+        TermsAggregationBuilder sibling,
+        String metricName,
+        AggregationRegistry registry
+    ) throws ConversionException {
+        if (AggregationMetadataBuilder.IMPLICIT_COUNT_NAME.equals(metricName)) {
+            return AggregationMetadataBuilder.IMPLICIT_COUNT_NAME;
+        }
+        for (AggregationBuilder subAgg : sibling.getSubAggregations()) {
+            if (subAgg.getName().equals(metricName)) {
+                MetricTranslator<AggregationBuilder> metric = registry.getMetric(subAgg.getClass());
+                if (metric == null) {
+                    throw new ConversionException(
+                        "pipeline aggregation ["
+                            + pipeline.getName()
+                            + "] buckets_path metric ["
+                            + metricName
+                            + "] must be a single-value metric aggregation"
+                    );
+                }
+                return metric.getAggregateFieldName(subAgg);
+            }
+        }
+        throw new ConversionException(
+            "pipeline aggregation ["
+                + pipeline.getName()
+                + "] buckets_path metric ["
+                + metricName
+                + "] not found under ["
+                + sibling.getName()
+                + "]. Available: "
+                + sibling.getSubAggregations().stream().map(AggregationBuilder::getName).collect(Collectors.toList())
+        );
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/MetricColumnPreparer.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/MetricColumnPreparer.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.search.aggregations.pipeline.BucketHelpers;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Prepares the sibling's metric columns for the second-level aggregate: applies
+ * {@code gap_policy} and widens each referenced column to DOUBLE in one projection.
+ *
+ * <p>{@code skip} needs no rewrite: a bucket whose metric is SQL NULL is excluded from
+ * both the numerator and denominator by the aggregate's native NULL handling — exactly
+ * vanilla's skip semantics. {@code insert_zeros} rewrites the column to
+ * {@code COALESCE(column, 0)}, so the bucket contributes zero and is counted.
+ *
+ * <p>The DOUBLE cast keeps the second-level call's declared and inferred types aligned
+ * and makes the engine's AVG decomposition divide in floating point even when the
+ * metric column is integral.
+ *
+ * <p>Vanilla additionally treats zero-doc-count buckets as gaps; those cannot occur here
+ * because a SQL group only exists when rows exist, so a gap is always a NULL metric.
+ */
+public final class MetricColumnPreparer {
+
+    private MetricColumnPreparer() {}
+
+    /**
+     * Wraps the input in a projection preparing the given metric columns. Non-referenced
+     * columns pass through unchanged; referenced columns keep their name and position.
+     *
+     * @param input the shaped sibling output (post filter/sort)
+     * @param rexBuilder the rex builder
+     * @param policiesByColumn gap policy per referenced metric column index
+     * @return the input, or a projection over it
+     */
+    public static RelNode prepare(RelNode input, RexBuilder rexBuilder, Map<Integer, BucketHelpers.GapPolicy> policiesByColumn) {
+        if (policiesByColumn.isEmpty()) {
+            return input;
+        }
+        RelDataType doubleType = rexBuilder.getTypeFactory()
+            .createTypeWithNullability(rexBuilder.getTypeFactory().createSqlType(SqlTypeName.DOUBLE), true);
+        List<RelDataTypeField> fields = input.getRowType().getFieldList();
+        List<RexNode> projects = new ArrayList<>(fields.size());
+        List<String> names = new ArrayList<>(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            RelDataTypeField field = fields.get(i);
+            RexNode ref = rexBuilder.makeInputRef(field.getType(), i);
+            BucketHelpers.GapPolicy policy = policiesByColumn.get(i);
+            if (policy != null) {
+                if (policy == BucketHelpers.GapPolicy.INSERT_ZEROS) {
+                    RexNode zero = rexBuilder.makeExactLiteral(BigDecimal.ZERO, field.getType());
+                    ref = rexBuilder.makeCall(SqlStdOperatorTable.COALESCE, ref, zero);
+                }
+                // matchNullability=false keeps the target's nullable DOUBLE even over
+                // NOT NULL columns (_count), so the AVG call's inferred type is stable.
+                ref = rexBuilder.makeCast(doubleType, ref, false);
+            }
+            projects.add(ref);
+            names.add(field.getName());
+        }
+        return LogicalProject.create(input, List.of(), projects, names);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelinePlanComposer.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelinePlanComposer.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
+import org.opensearch.dsl.converter.CollationResolver;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.BucketHelpers;
+import org.opensearch.search.aggregations.pipeline.BucketMetricsPipelineAggregationBuilder;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Composes the plan for sibling pipeline aggregations: the sibling's aggregate output,
+ * shaped to mirror its visible buckets, wrapped in a second-level global aggregate.
+ *
+ * <pre>
+ * LogicalAggregate(group=[{}], one call per pipeline)
+ *   [LogicalProject]           gap_policy insert_zeros — COALESCE(metric, 0)
+ *     LogicalSort(fetch=size)  sibling's bucket order + truncation
+ *       [LogicalFilter]        _count &gt;= min_doc_count (when &gt; 1)
+ *         &lt;sibling LogicalAggregate&gt;
+ * </pre>
+ *
+ * <p>The shaping exists because vanilla runs sibling pipelines at final reduce, after the
+ * sibling is min_doc_count-filtered, sorted, and truncated to {@code size} — the pipeline
+ * must aggregate over the buckets the response shows, not over every group in the data.
+ * All pipelines targeting one sibling share this plan; each contributes one aggregate
+ * call, and results map back to pipelines by column name.
+ */
+public final class PipelinePlanComposer {
+
+    private PipelinePlanComposer() {}
+
+    /**
+     * One pipeline aggregation to compose: the builder and its resolved metric column.
+     *
+     * @param pipeline the pipeline aggregation builder
+     * @param metricColumn the sibling-plan column its buckets_path resolved to
+     */
+    public record PipelineTarget(PipelineAggregationBuilder pipeline, String metricColumn) {
+    }
+
+    /**
+     * Composes the shared plan for all pipeline aggregations targeting one sibling.
+     *
+     * @param targets the pipelines and their resolved metric columns
+     * @param sibling the sibling terms aggregation
+     * @param siblingMetadata the walker metadata for the sibling's granularity
+     * @param siblingAggregate the sibling's LogicalAggregate node (pre-sort)
+     * @param rexBuilder the rex builder
+     * @param registry the pipeline translator registry
+     * @return the composed pipeline plan
+     * @throws ConversionException if a metric column or the count column cannot be resolved
+     */
+    public static RelNode compose(
+        List<PipelineTarget> targets,
+        TermsAggregationBuilder sibling,
+        AggregationMetadata siblingMetadata,
+        RelNode siblingAggregate,
+        RexBuilder rexBuilder,
+        PipelineRegistry registry
+    ) throws ConversionException {
+        RelDataType rowType = siblingAggregate.getRowType();
+        RelNode shaped = applyMinDocCount(siblingAggregate, sibling, rowType, rexBuilder);
+        shaped = applyOrderAndSize(shaped, sibling, siblingMetadata, rowType, rexBuilder);
+        shaped = prepareMetricColumns(shaped, targets, rowType, rexBuilder);
+
+        List<AggregateCall> calls = new ArrayList<>(targets.size());
+        for (PipelineTarget target : targets) {
+            int column = columnIndex(rowType, target.metricColumn(), target.pipeline().getName());
+            PipelineTranslator<PipelineAggregationBuilder> translator = registry.get(target.pipeline().getClass());
+            calls.add(translator.createAggregateCall(target.pipeline(), column, rexBuilder.getTypeFactory()));
+        }
+        return LogicalAggregate.create(shaped, ImmutableBitSet.of(), null, calls);
+    }
+
+    /** Excludes groups below the sibling's min_doc_count; a no-op at the default of 1. */
+    private static RelNode applyMinDocCount(RelNode input, TermsAggregationBuilder sibling, RelDataType rowType, RexBuilder rexBuilder)
+        throws ConversionException {
+        long minDocCount = sibling.minDocCount();
+        if (minDocCount <= 1) {
+            return input;
+        }
+        int countColumn = columnIndex(rowType, AggregationMetadataBuilder.IMPLICIT_COUNT_NAME, sibling.getName());
+        RelDataTypeField countField = rowType.getFieldList().get(countColumn);
+        RexNode countRef = rexBuilder.makeInputRef(countField.getType(), countColumn);
+        RexNode threshold = rexBuilder.makeExactLiteral(BigDecimal.valueOf(minDocCount), countField.getType());
+        return LogicalFilter.create(input, rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, countRef, threshold));
+    }
+
+    /**
+     * Mirrors the sibling's visible buckets: its bucket order with fetch = size.
+     * Resolves the sibling's own {@code order()} rather than the metadata's accumulated
+     * orders — same-field siblings share one metadata, and the response side truncates
+     * each aggregation by its own comparator, which this sort must match.
+     */
+    private static RelNode applyOrderAndSize(
+        RelNode input,
+        TermsAggregationBuilder sibling,
+        AggregationMetadata siblingMetadata,
+        RelDataType rowType,
+        RexBuilder rexBuilder
+    ) throws ConversionException {
+        List<RelFieldCollation> collations = CollationResolver.resolve(siblingMetadata, List.of(sibling.order()), rowType);
+        RexNode fetch = rexBuilder.makeExactLiteral(BigDecimal.valueOf(sibling.size()));
+        return LogicalSort.create(input, RelCollations.of(collations), null, fetch);
+    }
+
+    /**
+     * Prepares referenced metric columns: gap policy plus the DOUBLE widening cast.
+     * _count is never a gap (a group always has rows), so it takes only the cast.
+     */
+    private static RelNode prepareMetricColumns(RelNode input, List<PipelineTarget> targets, RelDataType rowType, RexBuilder rexBuilder)
+        throws ConversionException {
+        Map<Integer, BucketHelpers.GapPolicy> policiesByColumn = new HashMap<>();
+        for (PipelineTarget target : targets) {
+            int column = columnIndex(rowType, target.metricColumn(), target.pipeline().getName());
+            BucketHelpers.GapPolicy policy = gapPolicy(target.pipeline());
+            if (AggregationMetadataBuilder.IMPLICIT_COUNT_NAME.equals(target.metricColumn())) {
+                policy = BucketHelpers.GapPolicy.SKIP;
+            }
+            policiesByColumn.put(column, policy);
+        }
+        return MetricColumnPreparer.prepare(input, rexBuilder, policiesByColumn);
+    }
+
+    private static BucketHelpers.GapPolicy gapPolicy(PipelineAggregationBuilder pipeline) {
+        if (pipeline instanceof BucketMetricsPipelineAggregationBuilder<?> bucketMetrics) {
+            return bucketMetrics.gapPolicy();
+        }
+        return BucketHelpers.GapPolicy.SKIP;
+    }
+
+    private static int columnIndex(RelDataType rowType, String columnName, String forName) throws ConversionException {
+        RelDataTypeField field = rowType.getField(columnName, false, false);
+        if (field == null) {
+            throw new ConversionException(
+                "Pipeline aggregation [" + forName + "] column [" + columnName + "] not found. Available: " + rowType.getFieldNames()
+            );
+        }
+        return field.getIndex();
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelineRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelineRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry of pipeline aggregation translators, keyed by PipelineAggregationBuilder class.
+ * Mirrors {@link org.opensearch.dsl.aggregation.AggregationRegistry}.
+ */
+public class PipelineRegistry {
+
+    private final Map<Class<? extends PipelineAggregationBuilder>, PipelineTranslator<?>> translators = new HashMap<>();
+
+    private PipelineRegistry() {}
+
+    /** Creates a registry with all supported pipeline translators. */
+    public static PipelineRegistry create() {
+        PipelineRegistry registry = new PipelineRegistry();
+        registry.register(new AvgBucketTranslator());
+        return registry;
+    }
+
+    /**
+     * Registers a translator.
+     *
+     * @param translator the translator to register
+     */
+    public void register(PipelineTranslator<?> translator) {
+        translators.put(translator.getBuilderClass(), translator);
+    }
+
+    /**
+     * Returns the translator for the given builder class, or null when the pipeline
+     * aggregation type is not supported.
+     *
+     * @param builderClass the pipeline aggregation builder class
+     * @return the translator, or null
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends PipelineAggregationBuilder> PipelineTranslator<T> get(Class<? extends PipelineAggregationBuilder> builderClass) {
+        return (PipelineTranslator<T>) translators.get(builderClass);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelineTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/PipelineTranslator.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.BucketMetricsPipelineAggregationBuilder;
+
+/**
+ * Translates a sibling pipeline aggregation into a second-level SQL aggregate call over
+ * a sibling bucket aggregation's output, and converts the executed cell back to an
+ * {@link InternalAggregation} for response building.
+ *
+ * <p>All pipeline aggregations targeting the same sibling share one composed plan
+ * (see {@link PipelinePlanComposer}); each translator contributes one aggregate call
+ * named after its pipeline aggregation, so results map back by column name.
+ *
+ * @param <T> the concrete PipelineAggregationBuilder type
+ */
+public interface PipelineTranslator<T extends PipelineAggregationBuilder> {
+
+    /** Returns the concrete PipelineAggregationBuilder class this translator handles. */
+    Class<T> getBuilderClass();
+
+    /**
+     * Creates the second-level aggregate call over the resolved metric column.
+     *
+     * @param builder the pipeline aggregation builder from DSL
+     * @param inputColumn index of the metric column in the shaped sibling output
+     * @param typeFactory type factory for creating the call's return type
+     * @return the aggregate call, named after the pipeline aggregation
+     */
+    AggregateCall createAggregateCall(T builder, int inputColumn, RelDataTypeFactory typeFactory);
+
+    /**
+     * Converts the pipeline's single result cell into an {@link InternalAggregation}.
+     *
+     * @param builder the pipeline aggregation builder from DSL
+     * @param cellValue the result cell, or {@code null} when the engine returned SQL NULL
+     *        or no row (empty sibling)
+     * @return the InternalAggregation representing the pipeline result
+     */
+    InternalAggregation toInternalAggregation(T builder, Object cellValue);
+
+    /**
+     * Resolves the {@link DocValueFormat} from the builder's {@code format} parameter:
+     * {@link DocValueFormat.Decimal} when a pattern is set, {@link DocValueFormat#RAW} otherwise.
+     *
+     * @param builder the pipeline aggregation builder
+     * @return the resolved format
+     */
+    static DocValueFormat resolveFormat(PipelineAggregationBuilder builder) {
+        if (builder instanceof BucketMetricsPipelineAggregationBuilder<?> bucketMetrics && bucketMetrics.format() != null) {
+            return new DocValueFormat.Decimal(bucketMetrics.format());
+        }
+        return DocValueFormat.RAW;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/package-info.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/pipeline/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Sibling pipeline aggregation support: buckets_path resolution, gap policy handling,
+ * and composition of second-level aggregate plans over a sibling aggregation's
+ * visible buckets.
+ */
+package org.opensearch.dsl.aggregation.pipeline;

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/CollationResolver.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/CollationResolver.java
@@ -41,11 +41,34 @@ public final class CollationResolver {
      * @throws ConversionException if a sort field cannot be resolved
      */
     public static List<RelFieldCollation> resolve(AggregationMetadata metadata, RelDataType postAggRowType) throws ConversionException {
+        return resolve(metadata, metadata.getBucketOrders(), postAggRowType);
+    }
+
+    /**
+     * Resolves the given bucket orders against the post-agg schema. Compound orders are
+     * flattened. Callers needing one aggregation's own ordering — rather than every order
+     * accumulated at the granularity (same-field siblings share one metadata) — pass it
+     * explicitly.
+     *
+     * @param metadata the aggregation metadata providing the field name lists
+     * @param orders the bucket orders to resolve
+     * @param postAggRowType the actual row type of the LogicalAggregate node
+     * @return list of field collations for LogicalSort
+     * @throws ConversionException if a sort field cannot be resolved
+     */
+    public static List<RelFieldCollation> resolve(AggregationMetadata metadata, List<BucketOrder> orders, RelDataType postAggRowType)
+        throws ConversionException {
         Map<String, List<Integer>> postAggFieldIndex = buildPostAggFieldIndex(metadata, postAggRowType);
 
         List<RelFieldCollation> collations = new ArrayList<>();
-        for (BucketOrder order : metadata.getBucketOrders()) {
-            resolveOrder(order, postAggFieldIndex, collations);
+        for (BucketOrder order : orders) {
+            if (order instanceof InternalOrder.CompoundOrder compound) {
+                for (BucketOrder element : compound.orderElements()) {
+                    resolveOrder(element, postAggFieldIndex, collations);
+                }
+            } else {
+                resolveOrder(order, postAggFieldIndex, collations);
+            }
         }
         return collations;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
@@ -50,6 +51,7 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
+    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -77,8 +79,13 @@ public class SearchSourceConverter {
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        var aggRegistry = AggregationRegistryFactory.create();
+        this.aggRegistry = AggregationRegistryFactory.create();
         this.treeWalker = new AggregationTreeWalker(aggRegistry);
+    }
+
+    /** Returns the aggregation registry used by this converter. */
+    public AggregationRegistry getAggregationRegistry() {
+        return aggRegistry;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -26,13 +26,25 @@ import org.opensearch.dsl.aggregation.AggregationMetadata;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.pipeline.BucketsPathResolver;
+import org.opensearch.dsl.aggregation.pipeline.PipelinePlanComposer;
+import org.opensearch.dsl.aggregation.pipeline.PipelineRegistry;
+import org.opensearch.dsl.aggregation.pipeline.PipelineTranslator;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.search.SearchService;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -52,6 +64,7 @@ public class SearchSourceConverter {
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
     private final AggregationRegistry aggRegistry;
+    private final PipelineRegistry pipelineRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -81,11 +94,17 @@ public class SearchSourceConverter {
 
         this.aggRegistry = AggregationRegistryFactory.create();
         this.treeWalker = new AggregationTreeWalker(aggRegistry);
+        this.pipelineRegistry = PipelineRegistry.create();
     }
 
     /** Returns the aggregation registry used by this converter. */
     public AggregationRegistry getAggregationRegistry() {
         return aggRegistry;
+    }
+
+    /** Returns the pipeline aggregation registry used by this converter. */
+    public PipelineRegistry getPipelineRegistry() {
+        return pipelineRegistry;
     }
 
     /**
@@ -122,8 +141,10 @@ public class SearchSourceConverter {
         }
 
         // Aggregation path: Scan → Filter → Aggregate → PostAggregate (one per granularity level)
+        List<AggregationMetadata> metadataList = List.of();
+        Map<AggregationMetadata, RelNode> preSortAggregates = new LinkedHashMap<>();
         if (hasAggs) {
-            List<AggregationMetadata> metadataList = treeWalker.walk(
+            metadataList = treeWalker.walk(
                 searchSource.aggregations().getAggregatorFactories(),
                 table.getRowType(),
                 cluster.getTypeFactory()
@@ -131,12 +152,79 @@ public class SearchSourceConverter {
             for (AggregationMetadata metadata : metadataList) {
                 ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
                 RelNode aggs = aggConverter.convert(base, metadata);
+                preSortAggregates.put(metadata, aggs);
                 aggs = postAggConverter.convert(aggs, aggCtx);
                 builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
             }
         }
 
+        // Pipeline path: sibling aggregate shaped to its visible buckets → second-level aggregate
+        convertPipelines(searchSource, builder, metadataList, preSortAggregates);
+
         return builder.build();
+    }
+
+    /**
+     * Converts sibling pipeline aggregations into {@link QueryPlans.Type#PIPELINE} plans.
+     * Pipelines targeting the same sibling share one plan; results map back by column name.
+     */
+    private void convertPipelines(
+        SearchSourceBuilder searchSource,
+        QueryPlans.Builder builder,
+        List<AggregationMetadata> metadataList,
+        Map<AggregationMetadata, RelNode> preSortAggregates
+    ) throws ConversionException {
+        if (searchSource.aggregations() == null) {
+            return;
+        }
+        Collection<PipelineAggregationBuilder> pipelines = searchSource.aggregations().getPipelineAggregatorFactories();
+        if (pipelines == null || pipelines.isEmpty()) {
+            return;
+        }
+        Collection<AggregationBuilder> rootAggs = searchSource.aggregations().getAggregatorFactories();
+
+        Map<TermsAggregationBuilder, List<PipelinePlanComposer.PipelineTarget>> bySibling = new LinkedHashMap<>();
+        for (PipelineAggregationBuilder pipeline : pipelines) {
+            PipelineTranslator<PipelineAggregationBuilder> translator = pipelineRegistry.get(pipeline.getClass());
+            if (translator == null) {
+                throw new ConversionException(
+                    "pipeline aggregation [" + pipeline.getName() + "] of type [" + pipeline.getWriteableName() + "] is not supported"
+                );
+            }
+            BucketsPathResolver.ResolvedBucketsPath resolved = BucketsPathResolver.resolve(pipeline, rootAggs, aggRegistry);
+            bySibling.computeIfAbsent(resolved.sibling(), s -> new ArrayList<>())
+                .add(new PipelinePlanComposer.PipelineTarget(pipeline, resolved.metricColumn()));
+        }
+
+        for (Map.Entry<TermsAggregationBuilder, List<PipelinePlanComposer.PipelineTarget>> entry : bySibling.entrySet()) {
+            TermsAggregationBuilder sibling = entry.getKey();
+            AggregationMetadata metadata = findSiblingMetadata(sibling, metadataList);
+            RelNode plan = PipelinePlanComposer.compose(
+                entry.getValue(),
+                sibling,
+                metadata,
+                preSortAggregates.get(metadata),
+                cluster.getRexBuilder(),
+                pipelineRegistry
+            );
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.PIPELINE, plan, null));
+        }
+    }
+
+    /** Finds the walker metadata whose GROUP BY matches the sibling's own grouping fields. */
+    private AggregationMetadata findSiblingMetadata(TermsAggregationBuilder sibling, List<AggregationMetadata> metadataList)
+        throws ConversionException {
+        BucketTranslator<AggregationBuilder> bucketTranslator = aggRegistry.getBucket(sibling.getClass());
+        if (bucketTranslator == null) {
+            throw new ConversionException("No bucket translator registered for sibling aggregation [" + sibling.getName() + "]");
+        }
+        List<String> groupFields = bucketTranslator.getGrouping(sibling).getFieldNames();
+        for (AggregationMetadata metadata : metadataList) {
+            if (metadata.getGroupByFieldNames().equals(groupFields)) {
+                return metadata;
+            }
+        }
+        throw new ConversionException("No aggregation plan produced for pipeline sibling [" + sibling.getName() + "]");
     }
 
     private static boolean hasAggregations(SearchSourceBuilder searchSource) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -132,7 +132,7 @@ public class SearchSourceConverter {
                 ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
                 RelNode aggs = aggConverter.convert(base, metadata);
                 aggs = postAggConverter.convert(aggs, aggCtx);
-                builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs));
+                builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
             }
         }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
@@ -25,7 +25,9 @@ public final class QueryPlans {
         /** Document hits. */
         HITS,
         /** Aggregation results. */
-        AGGREGATION
+        AGGREGATION,
+        /** Pipeline aggregation results. */
+        PIPELINE
     }
 
     /**
@@ -34,7 +36,8 @@ public final class QueryPlans {
      * @param type what part of the response this plan produces
      * @param relNode the Calcite logical plan to execute
      * @param aggregationMetadata the walker-produced metadata this plan was built from, or
-     *        {@code null} for {@link Type#HITS} plans. Carried through to the response builder
+     *        {@code null} for {@link Type#HITS} and {@link Type#PIPELINE} plans. Carried
+     *        through to the response builder
      *        so granularity matching uses the walker's exact nesting-order group fields instead
      *        of re-deriving them from the plan (which loses nesting order).
      */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.executor;
 
 import org.apache.calcite.rel.RelNode;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,19 +33,34 @@ public final class QueryPlans {
      *
      * @param type what part of the response this plan produces
      * @param relNode the Calcite logical plan to execute
+     * @param aggregationMetadata the walker-produced metadata this plan was built from, or
+     *        {@code null} for {@link Type#HITS} plans. Carried through to the response builder
+     *        so granularity matching uses the walker's exact nesting-order group fields instead
+     *        of re-deriving them from the plan (which loses nesting order).
      */
     // TODO: Nested aggregations may require multiple RelNodes per aggregation.
     // Support linking child query plans for recursive nesting (e.g. nested sub-aggregations).
-    public record QueryPlan(Type type, RelNode relNode) {
+    public record QueryPlan(Type type, RelNode relNode, AggregationMetadata aggregationMetadata) {
         /**
          * Creates a query plan.
          *
          * @param type what part of the response this plan produces
          * @param relNode the Calcite logical plan to execute
+         * @param aggregationMetadata the source metadata for AGGREGATION plans, or null
          */
         public QueryPlan {
             Objects.requireNonNull(type, "type must not be null");
             Objects.requireNonNull(relNode, "relNode must not be null");
+        }
+
+        /**
+         * Creates a query plan without aggregation metadata (HITS plans).
+         *
+         * @param type what part of the response this plan produces
+         * @param relNode the Calcite logical plan to execute
+         */
+        public QueryPlan(Type type, RelNode relNode) {
+            this(type, relNode, null);
         }
 
         /** Returns what part of the response this plan produces. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -1,0 +1,304 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.util.ComparisonUtils;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Converts execution results into OpenSearch InternalAggregations format.
+ * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
+ */
+public final class AggregationResponseBuilder {
+
+    private static final String NO_GROUPING_KEY = "";
+    private static final String AGGREGATION_LEVEL_SEPARATOR = ",";
+
+    private final AggregationRegistry registry;
+    private final Map<String, ExecutionResult> granularityMap;
+
+    public AggregationResponseBuilder(AggregationRegistry registry, List<ExecutionResult> aggResults) {
+        this.registry = registry;
+        this.granularityMap = new HashMap<>();
+        for (ExecutionResult result : aggResults) {
+            String key = computeGranularityKey(result);
+            granularityMap.put(key, result);
+        }
+    }
+
+    /**
+     * Builds InternalAggregations from the original aggregation builders.
+     */
+    public InternalAggregations build(List<AggregationBuilder> originalAggs) throws ConversionException {
+        List<InternalAggregation> aggs = buildLevel(originalAggs, new ArrayList<>(), Map.of());
+        return InternalAggregations.from(aggs);
+    }
+
+    /**
+     * Recursively builds aggregations at a specific nesting level.
+     * Routes to buildMetric or buildBucket based on aggregation type.
+     */
+    private List<InternalAggregation> buildLevel(
+        List<AggregationBuilder> aggs,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) throws ConversionException {
+
+        List<InternalAggregation> result = new ArrayList<>();
+
+        for (AggregationBuilder agg : aggs) {
+            @SuppressWarnings("unchecked")
+            AggregationTranslator<AggregationBuilder> type = (AggregationTranslator<AggregationBuilder>) registry.get(agg.getClass());
+
+            if (type instanceof MetricTranslator) {
+                result.add(buildMetric((MetricTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+            } else if (type instanceof BucketTranslator) {
+                result.add(buildBucket((BucketTranslator<AggregationBuilder>) type, agg, accumulatedGroupFields, parentKeyFilter));
+            } else {
+                throw new ConversionException(
+                    "No response translator for aggregation [" + agg.getName() + "] of type " + agg.getClass().getSimpleName()
+                );
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Builds a metric aggregation by extracting the computed value from execution results.
+     * Finds the matching row using granularity key and parent filters.
+     */
+    private InternalAggregation buildMetric(
+        MetricTranslator<AggregationBuilder> translator,
+        AggregationBuilder agg,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) {
+
+        ExecutionResult result = granularityMap.get(granularityKey(accumulatedGroupFields));
+
+        if (result == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        Integer colIdx = colIndex.get(agg.getName());
+
+        if (colIdx == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
+        Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
+        return translator.toInternalAggregation(agg.getName(), value);
+    }
+
+    /**
+     * Builds an empty metric aggregation with no computed value.
+     */
+    private static InternalAggregation buildEmptyMetric(MetricTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
+        return translator.toInternalAggregation(agg.getName(), null);
+    }
+
+    /**
+     * Builds an empty bucket aggregation with no buckets.
+     */
+    private static InternalAggregation buildEmptyBucket(BucketTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
+        return translator.toBucketAggregation(agg, List.of());
+    }
+
+    /**
+     * Builds a bucket aggregation by grouping rows and recursively building sub-aggregations.
+     * Groups rows by bucket keys and recursively processes nested aggregations for each bucket.
+     */
+    private InternalAggregation buildBucket(
+        BucketTranslator<AggregationBuilder> translator,
+        AggregationBuilder agg,
+        List<String> accumulatedGroupFields,
+        Map<String, Object> parentKeyFilter
+    ) throws ConversionException {
+
+        GroupingInfo grouping = translator.getGrouping(agg);
+        List<String> newGroupFields = new ArrayList<>(accumulatedGroupFields);
+        newGroupFields.addAll(grouping.getFieldNames());
+
+        ExecutionResult result = granularityMap.get(granularityKey(newGroupFields));
+
+        if (result == null) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false).collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        List<Object[]> filteredRows = filterRows(rows, colIndex, parentKeyFilter);
+
+        List<String> currentGroupColumns = new ArrayList<>(grouping.getFieldNames());
+
+        Map<List<Object>, List<Object[]>> grouped = groupRowsByKeys(filteredRows, currentGroupColumns, colIndex);
+
+        List<BucketEntry> buckets = new ArrayList<>();
+        List<AggregationBuilder> subAggs = new ArrayList<>(translator.getSubAggregations(agg));
+
+        for (Map.Entry<List<Object>, List<Object[]>> entry : grouped.entrySet()) {
+            Map<String, Object> childFilter = new HashMap<>(parentKeyFilter);
+            for (int i = 0; i < currentGroupColumns.size(); i++) {
+                childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
+            }
+
+            Integer countIdx = colIndex.get("_count");
+            if (countIdx == null) {
+                throw new ConversionException("Missing _count column in aggregation result");
+            }
+            Object[] firstRowInGroup = entry.getValue().get(0);
+            long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
+
+            InternalAggregations subAggregations = subAggs.isEmpty()
+                ? InternalAggregations.EMPTY
+                : InternalAggregations.from(buildLevel(subAggs, newGroupFields, childFilter));
+
+            buckets.add(new BucketEntry(entry.getKey(), docCount, subAggregations));
+        }
+
+        return translator.toBucketAggregation(agg, buckets);
+    }
+
+    /**
+     * Builds a map from column names to their indices.
+     * Enables efficient column lookup by name during row processing.
+     */
+    private static Map<String, Integer> buildColumnIndex(ExecutionResult result) {
+        Map<String, Integer> index = new HashMap<>();
+        List<String> fieldNames = result.getFieldNames();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            index.put(fieldNames.get(i), i);
+        }
+        return index;
+    }
+
+    /**
+     * Finds the first row matching all filter criteria.
+     * Used to locate the specific row for nested metric aggregations.
+     */
+    private static Object[] findMatchingRow(List<Object[]> rows, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        for (Object[] row : rows) {
+            if (matchesFilter(row, colIndex, filter)) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Filters rows to only those matching all filter criteria.
+     * Ensures nested aggregations only process rows belonging to their parent bucket.
+     */
+    private static List<Object[]> filterRows(List<Object[]> rows, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        if (filter.isEmpty()) {
+            return rows;
+        }
+        return rows.stream().filter(row -> matchesFilter(row, colIndex, filter)).collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if a row matches all filter criteria.
+     * Uses type-coercion comparison to handle numeric type differences from execution engine.
+     */
+    private static boolean matchesFilter(Object[] row, Map<String, Integer> colIndex, Map<String, Object> filter) {
+        for (Map.Entry<String, Object> entry : filter.entrySet()) {
+            Integer idx = colIndex.get(entry.getKey());
+            if (idx == null || !ComparisonUtils.valuesEqual(row[idx], entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Groups rows by their grouping column values (the bucket keys). Group columns are
+     * resolved by name — they are not guaranteed to be the leading row positions.
+     */
+    private static Map<List<Object>, List<Object[]>> groupRowsByKeys(
+        List<Object[]> rows,
+        List<String> groupColumns,
+        Map<String, Integer> colIndex
+    ) throws ConversionException {
+        List<Integer> keyIndices = new ArrayList<>(groupColumns.size());
+        for (String column : groupColumns) {
+            Integer idx = colIndex.get(column);
+            if (idx == null) {
+                throw new ConversionException("Group column '" + column + "' not found in aggregation result columns");
+            }
+            keyIndices.add(idx);
+        }
+
+        Map<List<Object>, List<Object[]>> grouped = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            List<Object> key = new ArrayList<>(keyIndices.size());
+            for (int idx : keyIndices) {
+                key.add(row[idx]);
+            }
+            grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
+        }
+        return grouped;
+    }
+
+    /**
+     * Computes the granularity key for an execution result from its plan's aggregate.
+     * The aggregate is found by walking down the plan's single-input spine — post-aggregate
+     * nodes (bucket-order sort, future HAVING filters) sit on top of it.
+     */
+    private static String computeGranularityKey(ExecutionResult result) {
+        RelNode node = result.getPlan().relNode();
+        while (node != null && !(node instanceof LogicalAggregate)) {
+            node = node.getInputs().isEmpty() ? null : node.getInput(0);
+        }
+        if (node instanceof LogicalAggregate agg) {
+            int groupCount = agg.getGroupCount();
+            return granularityKey(agg.getRowType().getFieldNames().stream().limit(groupCount).collect(Collectors.toList()));
+        }
+        return NO_GROUPING_KEY;
+    }
+
+    /**
+     * Canonical granularity key: sorted, comma-joined group field names. Sorted because the
+     * plan emits group columns in schema order while the request walk accumulates them in
+     * nesting order — the two must produce the same key.
+     */
+    private static String granularityKey(List<String> groupFieldNames) {
+        return groupFieldNames.stream().sorted().collect(Collectors.joining(AGGREGATION_LEVEL_SEPARATOR));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -36,7 +36,8 @@ import java.util.stream.StreamSupport;
 public final class AggregationResponseBuilder {
 
     private static final String NO_GROUPING_KEY = "";
-    private static final String AGGREGATION_LEVEL_SEPARATOR = ",";
+    /** NUL cannot appear in field names, so joined keys cannot collide. */
+    private static final String AGGREGATION_LEVEL_SEPARATOR = "\u0000";
 
     private final AggregationRegistry registry;
     private final Map<String, ExecutionResult> granularityMap;
@@ -287,8 +288,10 @@ public final class AggregationResponseBuilder {
             node = node.getInputs().isEmpty() ? null : node.getInput(0);
         }
         if (node instanceof LogicalAggregate agg) {
-            int groupCount = agg.getGroupCount();
-            return granularityKey(agg.getRowType().getFieldNames().stream().limit(groupCount).collect(Collectors.toList()));
+            // Resolve group field names against the aggregate's INPUT row type via the group
+            // set — robust against output-side renames, unlike the aggregate's own row type.
+            List<String> inputFields = agg.getInput().getRowType().getFieldNames();
+            return granularityKey(agg.getGroupSet().asList().stream().map(inputFields::get).collect(Collectors.toList()));
         }
         return NO_GROUPING_KEY;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.dsl.result;
 
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationMetadataBuilder;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.GroupingInfo;
@@ -32,10 +32,18 @@ import java.util.stream.StreamSupport;
 /**
  * Converts execution results into OpenSearch InternalAggregations format.
  * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
+ *
+ * <p>A granularity is identified by its GROUP BY field names in <b>nesting order</b> (outer
+ * bucket first) — the same order the {@code AggregationTreeWalker} accumulated them in and the
+ * same order the response walk re-accumulates while descending the request's aggregation tree.
+ * Results are keyed by the walker-produced {@link AggregationMetadata} carried on each plan, so
+ * the key round-trips losslessly: sibling trees over the same field <em>set</em> but different
+ * nesting order (e.g. {@code brand→category} vs {@code category→brand}) produce distinct plans
+ * AND distinct keys. Re-deriving the key from the plan's group bit set would yield schema order
+ * instead, forcing an order-insensitive (sorted) key under which such siblings collide.
  */
 public final class AggregationResponseBuilder {
 
-    private static final String NO_GROUPING_KEY = "";
     /** NUL cannot appear in field names, so joined keys cannot collide. */
     private static final String AGGREGATION_LEVEL_SEPARATOR = "\u0000";
 
@@ -46,8 +54,23 @@ public final class AggregationResponseBuilder {
         this.registry = registry;
         this.granularityMap = new HashMap<>();
         for (ExecutionResult result : aggResults) {
-            String key = computeGranularityKey(result);
-            granularityMap.put(key, result);
+            AggregationMetadata metadata = result.getPlan().aggregationMetadata();
+            if (metadata == null) {
+                throw new IllegalArgumentException(
+                    "AGGREGATION plan is missing its AggregationMetadata — plans consumed by the "
+                        + "response builder must be created by SearchSourceConverter"
+                );
+            }
+            String key = granularityKey(metadata.getGroupByFieldNames());
+            ExecutionResult previous = granularityMap.putIfAbsent(key, result);
+            if (previous != null) {
+                // The walker produces exactly one plan per nesting-order granularity, so a
+                // duplicate key means the walker invariant broke upstream. Fail loudly instead
+                // of silently overwriting one plan's results with another's.
+                throw new IllegalStateException(
+                    "Duplicate aggregation granularity [" + String.join(",", metadata.getGroupByFieldNames()) + "]"
+                );
+            }
         }
     }
 
@@ -180,9 +203,11 @@ public final class AggregationResponseBuilder {
                 childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
             }
 
-            Integer countIdx = colIndex.get("_count");
+            Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
             if (countIdx == null) {
-                throw new ConversionException("Missing _count column in aggregation result");
+                throw new ConversionException(
+                    "Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result"
+                );
             }
             Object[] firstRowInGroup = entry.getValue().get(0);
             long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
@@ -278,30 +303,13 @@ public final class AggregationResponseBuilder {
     }
 
     /**
-     * Computes the granularity key for an execution result from its plan's aggregate.
-     * The aggregate is found by walking down the plan's single-input spine — post-aggregate
-     * nodes (bucket-order sort, future HAVING filters) sit on top of it.
-     */
-    private static String computeGranularityKey(ExecutionResult result) {
-        RelNode node = result.getPlan().relNode();
-        while (node != null && !(node instanceof LogicalAggregate)) {
-            node = node.getInputs().isEmpty() ? null : node.getInput(0);
-        }
-        if (node instanceof LogicalAggregate agg) {
-            // Resolve group field names against the aggregate's INPUT row type via the group
-            // set — robust against output-side renames, unlike the aggregate's own row type.
-            List<String> inputFields = agg.getInput().getRowType().getFieldNames();
-            return granularityKey(agg.getGroupSet().asList().stream().map(inputFields::get).collect(Collectors.toList()));
-        }
-        return NO_GROUPING_KEY;
-    }
-
-    /**
-     * Canonical granularity key: sorted, comma-joined group field names. Sorted because the
-     * plan emits group columns in schema order while the request walk accumulates them in
-     * nesting order — the two must produce the same key.
+     * Canonical granularity key: group field names in nesting order (outer bucket first),
+     * NUL-joined. Insertion uses the walker's {@link AggregationMetadata#getGroupByFieldNames()}
+     * and lookup uses the response walk's accumulated fields — both are built in nesting order,
+     * so the key matches by construction. Not sorted: sorting would erase nesting order, the
+     * one thing distinguishing sibling trees over the same field set (see class javadoc).
      */
     private static String granularityKey(List<String> groupFieldNames) {
-        return groupFieldNames.stream().sorted().collect(Collectors.joining(AGGREGATION_LEVEL_SEPARATOR));
+        return String.join(AGGREGATION_LEVEL_SEPARATOR, groupFieldNames);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -194,6 +194,11 @@ public final class AggregationResponseBuilder {
 
         Map<List<Object>, List<Object[]>> grouped = groupRowsByKeys(filteredRows, currentGroupColumns, colIndex);
 
+        Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
+        if (countIdx == null) {
+            throw new ConversionException("Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result");
+        }
+
         List<BucketEntry> buckets = new ArrayList<>();
         List<AggregationBuilder> subAggs = new ArrayList<>(translator.getSubAggregations(agg));
 
@@ -203,12 +208,6 @@ public final class AggregationResponseBuilder {
                 childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
             }
 
-            Integer countIdx = colIndex.get(AggregationMetadataBuilder.IMPLICIT_COUNT_NAME);
-            if (countIdx == null) {
-                throw new ConversionException(
-                    "Missing " + AggregationMetadataBuilder.IMPLICIT_COUNT_NAME + " column in aggregation result"
-                );
-            }
             Object[] firstRowInGroup = entry.getValue().get(0);
             long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -120,7 +120,7 @@ public final class AggregationResponseBuilder {
         AggregationBuilder agg,
         List<String> accumulatedGroupFields,
         Map<String, Object> parentKeyFilter
-    ) {
+    ) throws ConversionException {
 
         ExecutionResult result = granularityMap.get(granularityKey(accumulatedGroupFields));
 
@@ -138,19 +138,19 @@ public final class AggregationResponseBuilder {
         Integer colIdx = colIndex.get(agg.getName());
 
         if (colIdx == null) {
-            return buildEmptyMetric(translator, agg);
+            throw new ConversionException("Metric column '" + agg.getName() + "' not found in aggregation result columns");
         }
 
         Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
         Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
-        return translator.toInternalAggregation(agg.getName(), value);
+        return translator.toInternalAggregation(agg.getName(), value, AggregationTranslator.userMetadata(agg));
     }
 
     /**
      * Builds an empty metric aggregation with no computed value.
      */
     private static InternalAggregation buildEmptyMetric(MetricTranslator<AggregationBuilder> translator, AggregationBuilder agg) {
-        return translator.toInternalAggregation(agg.getName(), null);
+        return translator.toInternalAggregation(agg.getName(), null, AggregationTranslator.userMetadata(agg));
     }
 
     /**
@@ -248,6 +248,8 @@ public final class AggregationResponseBuilder {
         return null;
     }
 
+    // TODO: Avoid re-scanning the full row list on every recursion (here and in findMatchingRow).
+    // Index each granularity's rows by parent bucket key once, then look buckets up directly.
     /**
      * Filters rows to only those matching all filter criteria.
      * Ensures nested aggregations only process rows belonging to their parent bucket.

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -74,6 +74,8 @@ public final class AggregationResponseBuilder {
         }
     }
 
+    // TODO: Support pipeline aggregations. They post-process the assembled aggregation tree;
+    // currently they are ignored.
     /**
      * Builds InternalAggregations from the original aggregation builders.
      */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
@@ -8,38 +8,75 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Builds a {@link SearchResponse} from execution results.
+ * Handles conversion of flat execution results into OpenSearch response format.
  */
 public class SearchResponseBuilder {
 
     private SearchResponseBuilder() {}
 
     /**
-     * Builds a SearchResponse from the given results and timing.
+     * Builds a SearchResponse from execution results.
      *
-     * @param results execution results from the plan executor
-     * @param convertTimeNanos time spent in DSL-to-RelNode conversion, in nanoseconds
+     * @param results execution results from the query executor
+     * @param request the original search request
+     * @param registry aggregation registry for building aggregations
+     * @param tookInMillis total execution time in milliseconds
      * @return a SearchResponse
      */
-    // TODO: Analytics plugin should return execution metadata alongside Iterable<Object[]> rows:
-    // - executionTimeNanos: query execution time
-    // - totalDocCount: total matching documents for hits.total
-    // - terminatedEarly: whether execution was terminated early
-    // - timedOut: whether execution timed out
-    // - shardInfo: total/successful/skipped/failed shard counts
-    public static SearchResponse build(List<ExecutionResult> results, long convertTimeNanos) {
-        // TODO: populate HITS and AGGREGATION plan types from results
-        long tookInMillis = convertTimeNanos / 1_000_000;
-        SearchHits hits = SearchHits.empty(true);
-        SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 0);
-        return new SearchResponse(sections, null, 0, 0, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    public static SearchResponse build(
+        List<ExecutionResult> results,
+        SearchRequest request,
+        AggregationRegistry registry,
+        long tookInMillis
+    ) throws ConversionException {
+
+        SearchHits hits = buildHits(results);
+        InternalAggregations aggregations = buildAggregations(results, request, registry);
+
+        SearchResponseSections sections = new SearchResponseSections(hits, aggregations, null, false, null, null, 0);
+
+        // TODO: shard counts, timed_out, and engine-side took require execution metadata from
+        // the analytics plugin (returned alongside rows). Until then report a constant 1/1 —
+        // the analytics path has no per-shard fan-out to report.
+        return new SearchResponse(sections, null, 1, 1, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
+
+    private static SearchHits buildHits(List<ExecutionResult> results) {
+        // TODO: Build hits from HITS results
+        return SearchHits.empty(true);
+    }
+
+    private static InternalAggregations buildAggregations(
+        List<ExecutionResult> results,
+        SearchRequest request,
+        AggregationRegistry registry
+    ) throws ConversionException {
+
+        List<ExecutionResult> aggResults = results.stream()
+            .filter(r -> r.getType() == QueryPlans.Type.AGGREGATION)
+            .collect(Collectors.toList());
+
+        if (aggResults.isEmpty() || request.source() == null || request.source().aggregations() == null) {
+            return null;
+        }
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults);
+        return builder.build(new ArrayList<>(request.source().aggregations().getAggregatorFactories()));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
@@ -13,12 +13,17 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.pipeline.PipelineRegistry;
+import org.opensearch.dsl.aggregation.pipeline.PipelineTranslator;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +41,7 @@ public class SearchResponseBuilder {
      * @param results execution results from the query executor
      * @param request the original search request
      * @param registry aggregation registry for building aggregations
+     * @param pipelineRegistry pipeline translator registry for building pipeline results
      * @param tookInMillis total execution time in milliseconds
      * @return a SearchResponse
      */
@@ -43,11 +49,13 @@ public class SearchResponseBuilder {
         List<ExecutionResult> results,
         SearchRequest request,
         AggregationRegistry registry,
+        PipelineRegistry pipelineRegistry,
         long tookInMillis
     ) throws ConversionException {
 
         SearchHits hits = buildHits(results);
         InternalAggregations aggregations = buildAggregations(results, request, registry);
+        aggregations = appendPipelineResults(aggregations, results, request, pipelineRegistry);
 
         SearchResponseSections sections = new SearchResponseSections(hits, aggregations, null, false, null, null, 0);
 
@@ -78,5 +86,68 @@ public class SearchResponseBuilder {
 
         AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults);
         return builder.build(new ArrayList<>(request.source().aggregations().getAggregatorFactories()));
+    }
+
+    /**
+     * Appends sibling pipeline results to the aggregations. Each PIPELINE result carries one
+     * row with one column per pipeline aggregation; columns map back to their builders by
+     * name. An absent row or SQL NULL cell (empty sibling) maps to the translator's empty
+     * representation. Mirrors vanilla's reduce ordering: pipeline results follow regular
+     * aggregations.
+     */
+    private static InternalAggregations appendPipelineResults(
+        InternalAggregations aggregations,
+        List<ExecutionResult> results,
+        SearchRequest request,
+        PipelineRegistry pipelineRegistry
+    ) throws ConversionException {
+
+        List<ExecutionResult> pipelineResults = results.stream()
+            .filter(r -> r.getType() == QueryPlans.Type.PIPELINE)
+            .collect(Collectors.toList());
+
+        if (pipelineResults.isEmpty() || request.source() == null || request.source().aggregations() == null) {
+            return aggregations;
+        }
+
+        List<InternalAggregation> combined = new ArrayList<>();
+        if (aggregations != null) {
+            combined.addAll(aggregations.copyResults());
+        }
+        for (ExecutionResult result : pipelineResults) {
+            appendPipelineResult(combined, result, request, pipelineRegistry);
+        }
+        return InternalAggregations.from(combined);
+    }
+
+    private static void appendPipelineResult(
+        List<InternalAggregation> combined,
+        ExecutionResult result,
+        SearchRequest request,
+        PipelineRegistry pipelineRegistry
+    ) throws ConversionException {
+        Iterator<Object[]> rows = result.getRows().iterator();
+        Object[] row = rows.hasNext() ? rows.next() : null;
+        List<String> fieldNames = result.getFieldNames();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            PipelineAggregationBuilder pipeline = findPipelineBuilder(fieldNames.get(i), request);
+            PipelineTranslator<PipelineAggregationBuilder> translator = pipelineRegistry.get(pipeline.getClass());
+            if (translator == null) {
+                throw new ConversionException(
+                    "No pipeline translator registered for [" + pipeline.getName() + "] of type [" + pipeline.getWriteableName() + "]"
+                );
+            }
+            Object cell = row == null ? null : row[i];
+            combined.add(translator.toInternalAggregation(pipeline, cell));
+        }
+    }
+
+    private static PipelineAggregationBuilder findPipelineBuilder(String name, SearchRequest request) throws ConversionException {
+        for (PipelineAggregationBuilder pipeline : request.source().aggregations().getPipelineAggregatorFactories()) {
+            if (pipeline.getName().equals(name)) {
+                return pipeline;
+            }
+        }
+        throw new ConversionException("Pipeline result column [" + name + "] has no matching pipeline aggregation in the request");
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import java.util.Objects;
+
+/**
+ * Utility methods for comparing values.
+ */
+public final class ComparisonUtils {
+
+    private ComparisonUtils() {}
+
+    /**
+     * Compares two values for equality, coercing numeric types (the engine may box the same
+     * column differently across plans). Integral pairs compare as long to avoid precision
+     * loss; floating-point pairs via {@link Double#compare}. No cross-type string coercion —
+     * bucket keys are typed by the schema.
+     */
+    public static boolean valuesEqual(Object a, Object b) {
+        if (Objects.equals(a, b)) return true;
+
+        if (a instanceof Number na && b instanceof Number nb) {
+            if (isIntegral(na) && isIntegral(nb)) {
+                return na.longValue() == nb.longValue();
+            }
+            return Double.compare(na.doubleValue(), nb.doubleValue()) == 0;
+        }
+
+        return false;
+    }
+
+    private static boolean isIntegral(Number n) {
+        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -18,6 +18,7 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
@@ -123,6 +124,18 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals(3, terms.getBuckets().get(0).getDocCount());
         assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
         assertEquals(2, terms.getBuckets().get(1).getDocCount());
+    }
+
+    /** Legacy parity: docs with a missing field form no bucket — a SQL NULL group is dropped. */
+    public void testNullKeyBucketExcluded() {
+        List<BucketEntry> entries = new ArrayList<>();
+        entries.add(new BucketEntry(java.util.Collections.singletonList(null), 4L, InternalAggregations.EMPTY));
+        entries.add(new BucketEntry(List.of("BrandA"), 3L, InternalAggregations.EMPTY));
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
+
+        assertEquals(1, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
     }
 
     public void testToBucketAggregationEmptyBuckets() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -8,8 +8,12 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
+import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalOrder;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -103,7 +107,27 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         assertTrue(InternalOrder.isKeyAsc(compound.orderElements().get(1)));
     }
 
-    public void testToBucketAggregationNotYetImplemented() {
-        expectThrows(UnsupportedOperationException.class, () -> translator.toBucketAggregation(brandAgg, List.of()));
+    public void testToBucketAggregationBuildsStringTerms() {
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
+        );
+
+        InternalAggregation agg = translator.toBucketAggregation(brandAgg, entries);
+
+        assertTrue(agg instanceof StringTerms);
+        StringTerms terms = (StringTerms) agg;
+        assertEquals(brandAgg.getName(), terms.getName());
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals(3, terms.getBuckets().get(0).getDocCount());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals(2, terms.getBuckets().get(1).getDocCount());
+    }
+
+    public void testToBucketAggregationEmptyBuckets() {
+        InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
+        assertTrue(agg instanceof StringTerms);
+        assertTrue(((StringTerms) agg).getBuckets().isEmpty());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
@@ -16,6 +17,7 @@ import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
@@ -143,6 +145,88 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
         assertTrue(agg instanceof StringTerms);
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
+    }
+
+    public void testBucketsSortedByRequestedOrder() {
+        TermsAggregationBuilder aggKeyDesc = new TermsAggregationBuilder("by_brand").field("brand").order(BucketOrder.key(false));
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggKeyDesc, entries);
+
+        assertEquals("BrandC", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    public void testDefaultOrderSortsByCountDescThenKeyAsc() {
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandA"), 2, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(brandAgg, entries);
+
+        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
+        // tie on doc_count 2 broken by key asc
+        assertEquals("BrandA", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandC", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    public void testSizeTruncationReportsOtherDocCount() {
+        TermsAggregationBuilder aggSized = new TermsAggregationBuilder("by_brand").field("brand").size(2);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandD"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandC"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 3, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggSized, entries);
+
+        assertEquals(2, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandB", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals(3L, terms.getSumOfOtherDocCounts());
+    }
+
+    public void testMinDocCountExcludesBuckets() {
+        TermsAggregationBuilder aggMinCount = new TermsAggregationBuilder("by_brand").field("brand").minDocCount(3);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB"), 2, InternalAggregations.EMPTY)
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMinCount, entries);
+
+        assertEquals(1, terms.getBuckets().size());
+        assertEquals("BrandA", terms.getBuckets().get(0).getKeyAsString());
+        // min_doc_count drops are excluded entirely, not counted as "other"
+        assertEquals(0L, terms.getSumOfOtherDocCounts());
+    }
+
+    public void testMetricOrderSortsBySubAggregation() {
+        TermsAggregationBuilder aggMetricOrder = new TermsAggregationBuilder("by_brand").field("brand")
+            .order(BucketOrder.aggregation("avg_price", true));
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA"), 1, avgSubAgg(30.0)),
+            new BucketEntry(List.of("BrandB"), 1, avgSubAgg(10.0)),
+            new BucketEntry(List.of("BrandC"), 1, avgSubAgg(20.0))
+        );
+
+        StringTerms terms = (StringTerms) translator.toBucketAggregation(aggMetricOrder, entries);
+
+        assertEquals("BrandB", terms.getBuckets().get(0).getKeyAsString());
+        assertEquals("BrandC", terms.getBuckets().get(1).getKeyAsString());
+        assertEquals("BrandA", terms.getBuckets().get(2).getKeyAsString());
+    }
+
+    private static InternalAggregations avgSubAgg(double value) {
+        return InternalAggregations.from(List.of(new InternalAvg("avg_price", value, 1, DocValueFormat.RAW, null)));
     }
 
     /** User-supplied meta must be echoed back on the response aggregation, like classic search. */

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/TermsBucketTranslatorTests.java
@@ -20,6 +20,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class TermsBucketTranslatorTests extends OpenSearchTestCase {
 
@@ -142,5 +143,16 @@ public class TermsBucketTranslatorTests extends OpenSearchTestCase {
         InternalAggregation agg = translator.toBucketAggregation(brandAgg, List.of());
         assertTrue(agg instanceof StringTerms);
         assertTrue(((StringTerms) agg).getBuckets().isEmpty());
+    }
+
+    /** User-supplied meta must be echoed back on the response aggregation, like classic search. */
+    public void testMetadataEchoedInBucketAggregation() {
+        Map<String, Object> meta = Map.of("source", "dashboard");
+        TermsAggregationBuilder aggWithMeta = new TermsAggregationBuilder("by_brand").field("brand");
+        aggWithMeta.setMetadata(meta);
+
+        assertEquals(meta, translator.toBucketAggregation(aggWithMeta, List.of()).getMetadata());
+        // No meta on the request → none in the response
+        assertNull(translator.toBucketAggregation(brandAgg, List.of()).getMetadata());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
@@ -19,6 +19,8 @@ import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Map;
+
 public class MetricTranslatorTests extends OpenSearchTestCase {
 
     private final ConversionContext ctx = TestUtils.createContext();
@@ -69,5 +71,24 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
     public void testAggregateFieldName() {
         AvgMetricTranslator translator = new AvgMetricTranslator();
         assertEquals("avg_price", translator.getAggregateFieldName(new AvgAggregationBuilder("avg_price").field("price")));
+    }
+
+    /** User-supplied meta must be echoed back on the response aggregation, like classic search. */
+    public void testMetadataEchoedInInternalAggregation() {
+        Map<String, Object> meta = Map.of("owner", "pricing-team", "revision", 3);
+
+        assertEquals(meta, new AvgMetricTranslator().toInternalAggregation("a", 1.0, meta).getMetadata());
+        assertEquals(meta, new SumMetricTranslator().toInternalAggregation("s", 1.0, meta).getMetadata());
+        assertEquals(meta, new MinMetricTranslator().toInternalAggregation("mn", 1.0, meta).getMetadata());
+        assertEquals(meta, new MaxMetricTranslator().toInternalAggregation("mx", 1.0, meta).getMetadata());
+
+        // Echoed even when the metric has no value (empty result)
+        assertEquals(meta, new AvgMetricTranslator().toInternalAggregation("a", null, meta).getMetadata());
+    }
+
+    /** Requests without meta keep rendering without a meta section. */
+    public void testNullMetadataStaysNull() {
+        assertNull(new AvgMetricTranslator().toInternalAggregation("a", 1.0, null).getMetadata());
+        assertNull(new MaxMetricTranslator().toInternalAggregation("mx", null, null).getMetadata());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/pipeline/PipelineConversionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/pipeline/PipelineConversionTests.java
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.pipeline;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.converter.SearchSourceConverter;
+import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.InternalSimpleValue;
+import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Tests for pipeline aggregation conversion: buckets_path resolution and validation,
+ * PIPELINE plan composition, same-sibling merging, and result cell conversion.
+ */
+public class PipelineConversionTests extends OpenSearchTestCase {
+
+    private SearchSourceConverter converter;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+                return typeFactory.builder()
+                    .add("name", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("price", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true))
+                    .add("brand", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("rating", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true))
+                    .build();
+            }
+        });
+        converter = new SearchSourceConverter(schema);
+    }
+
+    private static TermsAggregationBuilder termsWithSum(String termsName, String sumName) {
+        return new TermsAggregationBuilder(termsName).field("brand").subAggregation(new SumAggregationBuilder(sumName).field("price"));
+    }
+
+    private QueryPlans convert(SearchSourceBuilder source) throws ConversionException {
+        return converter.convert(source, "test-index");
+    }
+
+    public void testAvgBucketProducesPipelinePlan() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>total"));
+
+        QueryPlans plans = convert(source);
+
+        assertEquals(2, plans.getAll().size());
+        List<QueryPlans.QueryPlan> pipelinePlans = plans.get(QueryPlans.Type.PIPELINE);
+        assertEquals(1, pipelinePlans.size());
+        assertEquals(List.of("avg_total"), pipelinePlans.get(0).relNode().getRowType().getFieldNames());
+        assertNull(pipelinePlans.get(0).aggregationMetadata());
+    }
+
+    public void testSameSiblingPipelinesShareOnePlan() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_docs", "by_brand>_count"));
+
+        QueryPlans plans = convert(source);
+
+        List<QueryPlans.QueryPlan> pipelinePlans = plans.get(QueryPlans.Type.PIPELINE);
+        assertEquals(1, pipelinePlans.size());
+        assertEquals(List.of("avg_total", "avg_docs"), pipelinePlans.get(0).relNode().getRowType().getFieldNames());
+    }
+
+    public void testDifferentSiblingsProduceSeparatePlans() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(
+                new TermsAggregationBuilder("by_name").field("name").subAggregation(new SumAggregationBuilder("sum2").field("price"))
+            )
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_sum2", "by_name>sum2"));
+
+        QueryPlans plans = convert(source);
+
+        assertEquals(2, plans.get(QueryPlans.Type.PIPELINE).size());
+    }
+
+    public void testUnsupportedPipelineTypeRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new MaxBucketPipelineAggregationBuilder("max_total", "by_brand>total"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("of type [max_bucket] is not supported"));
+    }
+
+    public void testMultiHopPathRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>nested>total"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("must be a single-level [sibling>metric] reference"));
+    }
+
+    public void testPropertyPathRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>total.value"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("unsupported property or key path"));
+    }
+
+    public void testUnknownSiblingRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "no_such_agg>total"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("references unknown aggregation [no_such_agg]"));
+    }
+
+    public void testUnknownMetricRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(termsWithSum("by_brand", "total"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>no_such_metric"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("metric [no_such_metric] not found under [by_brand]"));
+    }
+
+    public void testMetricSiblingRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new AvgAggregationBuilder("avg_price").field("price"))
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_avg", "avg_price>value"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("only [terms] siblings are supported"));
+    }
+
+    public void testBucketSubAggRejectedAsMetric() {
+        TermsAggregationBuilder sibling = new TermsAggregationBuilder("by_brand").field("brand")
+            .subAggregation(
+                new TermsAggregationBuilder("by_name").field("name").subAggregation(new SumAggregationBuilder("s").field("price"))
+            );
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(sibling)
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_x", "by_brand>by_name"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("must be a single-value metric aggregation"));
+    }
+
+    public void testNestedPipelineRejected() {
+        TermsAggregationBuilder sibling = termsWithSum("by_brand", "total").subAggregation(
+            new AvgBucketPipelineAggregationBuilder("nested_avg", "total")
+        );
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).aggregation(sibling);
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("[nested_avg] inside [by_brand] is not supported"));
+    }
+
+    public void testPipelineWithoutSiblingAggsRejected() {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new AvgBucketPipelineAggregationBuilder("avg_total", "by_brand>total"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> convert(source));
+        assertTrue(e.getMessage(), e.getMessage().contains("references unknown aggregation [by_brand]"));
+    }
+
+    public void testToInternalAggregationValue() {
+        AvgBucketTranslator translator = new AvgBucketTranslator();
+        AvgBucketPipelineAggregationBuilder builder = new AvgBucketPipelineAggregationBuilder("avg_total", "s>m");
+
+        InternalSimpleValue value = (InternalSimpleValue) translator.toInternalAggregation(builder, 416.5);
+
+        assertEquals("avg_total", value.getName());
+        assertEquals(416.5, value.value(), 0.0);
+    }
+
+    public void testToInternalAggregationNullCellIsNaN() {
+        AvgBucketTranslator translator = new AvgBucketTranslator();
+        AvgBucketPipelineAggregationBuilder builder = new AvgBucketPipelineAggregationBuilder("avg_total", "s>m");
+
+        InternalSimpleValue value = (InternalSimpleValue) translator.toInternalAggregation(builder, null);
+
+        assertTrue(Double.isNaN(value.value()));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -197,6 +198,8 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
                         fileName + ": Field names mismatch\n  Expected: " + tc.getMockResultFieldNames() + "\n  Actual:   " + actualFields
                     );
                 }
+
+                verifyAdditionalPlans(tc, plans, fileName, failures);
             } catch (Exception e) {
                 failures.add(fileName + ": " + e.getClass().getSimpleName() + " - " + e.getMessage());
             }
@@ -204,6 +207,46 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
 
         if (!failures.isEmpty()) {
             fail("Golden file RelNode generation failures:\n" + String.join("\n", failures));
+        }
+    }
+
+    /**
+     * Verifies each additional plan declared by the golden file: plan text and field
+     * names, matched positionally within the additional plan's type.
+     */
+    private static void verifyAdditionalPlans(GoldenTestCase tc, QueryPlans plans, String fileName, List<String> failures) {
+        if (tc.getAdditionalPlans() == null) {
+            return;
+        }
+        Map<QueryPlans.Type, Integer> nextIndexByType = new HashMap<>();
+        for (GoldenTestCase.AdditionalPlan additional : tc.getAdditionalPlans()) {
+            QueryPlans.Type type = QueryPlans.Type.valueOf(additional.getPlanType());
+            int index = nextIndexByType.merge(type, 1, Integer::sum) - 1;
+            List<QueryPlans.QueryPlan> typed = plans.get(type);
+            if (typed.size() <= index) {
+                failures.add(fileName + ": expected additional " + type + " plan #" + index + " but only " + typed.size() + " produced");
+                continue;
+            }
+            RelNode relNode = typed.get(index).relNode();
+            String actualPlan = relNode.explain().trim();
+            String expectedPlan = String.join("\n", additional.getExpectedRelNodePlan());
+            if (!expectedPlan.equals(actualPlan)) {
+                failures.add(
+                    fileName + ": additional " + type + " plan mismatch\n  Expected: " + expectedPlan + "\n  Actual:   " + actualPlan
+                );
+            }
+            List<String> actualFields = relNode.getRowType().getFieldNames();
+            if (!additional.getMockResultFieldNames().equals(actualFields)) {
+                failures.add(
+                    fileName
+                        + ": additional "
+                        + type
+                        + " field names mismatch\n  Expected: "
+                        + additional.getMockResultFieldNames()
+                        + "\n  Actual:   "
+                        + actualFields
+                );
+            }
         }
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
@@ -92,6 +92,21 @@ public class GoldenFileLoader {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Golden file " + filePath + " has invalid planType: " + testCase.getPlanType());
         }
+        if (testCase.getAdditionalPlans() != null) {
+            for (GoldenTestCase.AdditionalPlan additional : testCase.getAdditionalPlans()) {
+                requireNonNull(additional.getPlanType(), "additionalPlans.planType", filePath);
+                requireNonNull(additional.getExpectedRelNodePlan(), "additionalPlans.expectedRelNodePlan", filePath);
+                requireNonNull(additional.getMockResultFieldNames(), "additionalPlans.mockResultFieldNames", filePath);
+                requireNonNull(additional.getMockResultRows(), "additionalPlans.mockResultRows", filePath);
+                try {
+                    QueryPlans.Type.valueOf(additional.getPlanType());
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                        "Golden file " + filePath + " has invalid additionalPlans.planType: " + additional.getPlanType()
+                    );
+                }
+            }
+        }
     }
 
     private static void requireNonNull(Object value, String fieldName, Path filePath) {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
@@ -30,6 +30,52 @@ public class GoldenTestCase {
     private List<List<Object>> mockResultRows;
     private Map<String, Object> expectedOutputDsl;
     private String planType;
+    private List<AdditionalPlan> additionalPlans;
+
+    /**
+     * An additional plan the same request is expected to produce beyond the primary
+     * {@code planType} plan — e.g. the PIPELINE plan accompanying an AGGREGATION plan.
+     * Carries its own expected plan text, field names, and mock execution rows.
+     */
+    public static class AdditionalPlan {
+
+        private String planType;
+        private List<String> expectedRelNodePlan;
+        private List<String> mockResultFieldNames;
+        private List<List<Object>> mockResultRows;
+
+        public String getPlanType() {
+            return planType;
+        }
+
+        public void setPlanType(String planType) {
+            this.planType = planType;
+        }
+
+        public List<String> getExpectedRelNodePlan() {
+            return expectedRelNodePlan;
+        }
+
+        public void setExpectedRelNodePlan(List<String> expectedRelNodePlan) {
+            this.expectedRelNodePlan = expectedRelNodePlan;
+        }
+
+        public List<String> getMockResultFieldNames() {
+            return mockResultFieldNames;
+        }
+
+        public void setMockResultFieldNames(List<String> mockResultFieldNames) {
+            this.mockResultFieldNames = mockResultFieldNames;
+        }
+
+        public List<List<Object>> getMockResultRows() {
+            return mockResultRows;
+        }
+
+        public void setMockResultRows(List<List<Object>> mockResultRows) {
+            this.mockResultRows = mockResultRows;
+        }
+    }
 
     public String getTestName() {
         return testName;
@@ -101,6 +147,15 @@ public class GoldenTestCase {
 
     public void setPlanType(String planType) {
         this.planType = planType;
+    }
+
+    /** Returns additional expected plans, or null when the request produces only the primary plan. */
+    public List<AdditionalPlan> getAdditionalPlans() {
+        return additionalPlans;
+    }
+
+    public void setAdditionalPlans(List<AdditionalPlan> additionalPlans) {
+        this.additionalPlans = additionalPlans;
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AggregationResponseBuilderTests extends OpenSearchTestCase {
+
+    public void testBuildEmptyAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        InternalAggregations aggs = builder.build(List.of());
+        assertNotNull(aggs);
+        assertEquals(0, aggs.asList().size());
+    }
+
+    public void testBuildMetricWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("avg_price", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildBucketWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildMultipleAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg, termsAgg));
+        assertEquals(2, aggs.asList().size());
+    }
+
+    public void testBuildNestedAggregation() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand")
+            .subAggregation(new AvgAggregationBuilder("avg_price").field("price"));
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> MetricTranslator<T> createMetricTranslator(Class<T> aggClass) {
+        MetricTranslator<T> translator = mock(MetricTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+        when(translator.toInternalAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(inv.getArgument(0));
+            return agg;
+        });
+        return translator;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> BucketTranslator<T> createBucketTranslator(Class<T> aggClass, String fieldName) {
+        BucketTranslator<T> translator = mock(BucketTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+
+        GroupingInfo grouping = mock(GroupingInfo.class);
+        when(grouping.getFieldNames()).thenReturn(List.of(fieldName));
+        when(translator.getGrouping(any())).thenReturn(grouping);
+        when(translator.getSubAggregations(any())).thenReturn(List.of());
+
+        when(translator.toBucketAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(((AggregationBuilder) inv.getArgument(0)).getName());
+            return agg;
+        });
+        return translator;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -93,7 +93,7 @@ public class AggregationResponseBuilderTests extends OpenSearchTestCase {
     private <T extends AggregationBuilder> MetricTranslator<T> createMetricTranslator(Class<T> aggClass) {
         MetricTranslator<T> translator = mock(MetricTranslator.class);
         when(translator.getAggregationType()).thenReturn(aggClass);
-        when(translator.toInternalAggregation(any(), any())).thenAnswer(inv -> {
+        when(translator.toInternalAggregation(any(), any(), any())).thenAnswer(inv -> {
             InternalAggregation agg = mock(InternalAggregation.class);
             when(agg.getName()).thenReturn(inv.getArgument(0));
             return agg;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -17,12 +18,16 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
 import org.opensearch.dsl.golden.GoldenFileLoader;
 import org.opensearch.dsl.golden.GoldenTestCase;
 import org.opensearch.search.SearchModule;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -39,13 +44,161 @@ import java.util.stream.Collectors;
 
 public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
-    public void testBuildReturnsEmptyResponse() {
-        SearchResponse response = SearchResponseBuilder.build(List.of(), 42L * 1_000_000);
+    public void testBuildWithNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 42L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
         assertEquals(0, response.getHits().getHits().length);
         assertEquals(42L, response.getTook().millis());
+        assertNull(response.getAggregations());
+        assertEquals(1, response.getTotalShards());
+        assertEquals(1, response.getSuccessfulShards());
+    }
+
+    public void testBuildWithEmptyRequest() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 100L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertEquals(100L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testBuildWithNullSource() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 50L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertNull(response.getAggregations());
+        assertEquals(1, response.getTotalShards());
+    }
+
+    public void testBuildWithAggregationsButNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        source.aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        request.source(source);
+
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 75L);
+
+        assertNotNull(response);
+        assertEquals(75L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testShardCountsWithNoAggregations() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertEquals(1, response.getTotalShards());
+        assertEquals(1, response.getSuccessfulShards());
+        assertEquals(0, response.getSkippedShards());
+        assertEquals(0, response.getFailedShards());
+    }
+
+    public void testTimingPreserved() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response1 = SearchResponseBuilder.build(List.of(), request, registry, 0L);
+        assertEquals(0L, response1.getTook().millis());
+
+        SearchResponse response2 = SearchResponseBuilder.build(List.of(), request, registry, 999L);
+        assertEquals(999L, response2.getTook().millis());
+    }
+
+    public void testEmptyHitsAlwaysReturned() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertNotNull(response.getHits());
+        assertEquals(0, response.getHits().getHits().length);
+        assertNotNull(response.getHits().getTotalHits());
+    }
+
+    /**
+     * Regression: granularity keys must match even when the schema's column order opposes
+     * the request's nesting order (schema declares category before brand; request nests
+     * brand → category). Before key canonicalization this returned empty aggregations.
+     */
+    public void testNestedGroupFieldsWithOpposingSchemaOrder() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("category", "VARCHAR"); // lower column index than brand — the crux
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand")
+                    .field("brand")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_category")
+                            .field("category")
+                            .subAggregation(AggregationBuilders.avg("avg_price").field("price"))
+                    )
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, aggPlans.size());
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            if (fields.contains("avg_price")) {
+                // Group columns arrive in schema order (category first) despite brand-first nesting.
+                assertEquals(List.of("category", "brand", "avg_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "Cat1", "BrandA", 850.0, 2L }, new Object[] { "Cat2", "BrandA", 700.0, 1L })
+                    )
+                );
+            } else {
+                assertEquals(List.of("brand", "_count"), fields);
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
+            }
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertNotNull("by_brand must be present", byBrand);
+        assertEquals(1, byBrand.getBuckets().size());
+        assertEquals("BrandA", byBrand.getBuckets().get(0).getKeyAsString());
+        assertEquals(3L, byBrand.getBuckets().get(0).getDocCount());
+
+        StringTerms byCategory = byBrand.getBuckets().get(0).getAggregations().get("by_category");
+        assertNotNull("by_category must be present inside the brand bucket", byCategory);
+        assertEquals(2, byCategory.getBuckets().size());
+        assertEquals("Cat1", byCategory.getBuckets().get(0).getKeyAsString());
+        assertEquals(2L, byCategory.getBuckets().get(0).getDocCount());
+        InternalAvg avg1 = byCategory.getBuckets().get(0).getAggregations().get("avg_price");
+        assertEquals(850.0, avg1.getValue(), 0.0);
+        InternalAvg avg2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
+        assertEquals(700.0, avg2.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----
@@ -91,7 +244,14 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 ExecutionResult result = new ExecutionResult(matchingPlans.get(0), rows);
 
                 // Build and serialize SearchResponse
-                SearchResponse response = SearchResponseBuilder.build(List.of(result), 0L);
+                SearchRequest searchRequest = new SearchRequest(tc.getIndexName());
+                searchRequest.source(searchSource);
+                SearchResponse response = SearchResponseBuilder.build(
+                    List.of(result),
+                    searchRequest,
+                    converter.getAggregationRegistry(),
+                    0L
+                );
                 String responseJson = Strings.toString(MediaTypeRegistry.JSON, response);
 
                 Map<String, Object> actualOutput = XContentHelper.convertToMap(JsonXContent.jsonXContent, responseJson, false);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -19,6 +19,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.pipeline.PipelineRegistry;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.QueryPlans;
@@ -40,6 +41,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,7 +53,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         request.source(new SearchSourceBuilder());
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 42L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 42L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
@@ -66,7 +68,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest();
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 100L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 100L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
@@ -78,7 +80,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest();
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 50L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 50L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
@@ -94,7 +96,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 75L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 75L);
 
         assertNotNull(response);
         assertEquals(75L, response.getTook().millis());
@@ -106,7 +108,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         request.source(new SearchSourceBuilder());
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 10L);
 
         assertEquals(1, response.getTotalShards());
         assertEquals(1, response.getSuccessfulShards());
@@ -118,10 +120,10 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest();
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response1 = SearchResponseBuilder.build(List.of(), request, registry, 0L);
+        SearchResponse response1 = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 0L);
         assertEquals(0L, response1.getTook().millis());
 
-        SearchResponse response2 = SearchResponseBuilder.build(List.of(), request, registry, 999L);
+        SearchResponse response2 = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 999L);
         assertEquals(999L, response2.getTook().millis());
     }
 
@@ -129,7 +131,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest();
         AggregationRegistry registry = new AggregationRegistry();
 
-        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, PipelineRegistry.create(), 10L);
 
         assertNotNull(response.getHits());
         assertEquals(0, response.getHits().getHits().length);
@@ -184,7 +186,13 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
-        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+        SearchResponse response = SearchResponseBuilder.build(
+            results,
+            request,
+            converter.getAggregationRegistry(),
+            converter.getPipelineRegistry(),
+            1L
+        );
 
         StringTerms byBrand = response.getAggregations().get("by_brand");
         assertNotNull("by_brand must be present", byBrand);
@@ -275,7 +283,13 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
-        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+        SearchResponse response = SearchResponseBuilder.build(
+            results,
+            request,
+            converter.getAggregationRegistry(),
+            converter.getPipelineRegistry(),
+            1L
+        );
 
         // brand_first → BrandA → by_category → Cat1 (avg 850), Cat2 (avg 700)
         StringTerms brandFirst = response.getAggregations().get("brand_first");
@@ -320,7 +334,13 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
-        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+        SearchResponse response = SearchResponseBuilder.build(
+            results,
+            request,
+            converter.getAggregationRegistry(),
+            converter.getPipelineRegistry(),
+            1L
+        );
 
         StringTerms byBrand = response.getAggregations().get("by_brand");
         assertEquals(1, byBrand.getBuckets().size());
@@ -353,7 +373,7 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         expectThrows(
             ConversionException.class,
-            () -> SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L)
+            () -> SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), converter.getPipelineRegistry(), 1L)
         );
     }
 
@@ -402,7 +422,13 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
         SearchRequest request = new SearchRequest("products");
         request.source(source);
-        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+        SearchResponse response = SearchResponseBuilder.build(
+            results,
+            request,
+            converter.getAggregationRegistry(),
+            converter.getPipelineRegistry(),
+            1L
+        );
 
         StringTerms byBrand = response.getAggregations().get("by_brand");
         assertNotNull(byBrand);
@@ -454,15 +480,22 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
                 for (List<Object> row : tc.getMockResultRows()) {
                     rows.add(row.toArray());
                 }
-                ExecutionResult result = new ExecutionResult(matchingPlans.get(0), rows);
+                List<ExecutionResult> executionResults = new ArrayList<>();
+                executionResults.add(new ExecutionResult(matchingPlans.get(0), rows));
+                String additionalFailure = addAdditionalResults(tc, plans, executionResults);
+                if (additionalFailure != null) {
+                    failures.add(fileName + ": " + additionalFailure);
+                    continue;
+                }
 
                 // Build and serialize SearchResponse
                 SearchRequest searchRequest = new SearchRequest(tc.getIndexName());
                 searchRequest.source(searchSource);
                 SearchResponse response = SearchResponseBuilder.build(
-                    List.of(result),
+                    executionResults,
                     searchRequest,
                     converter.getAggregationRegistry(),
+                    converter.getPipelineRegistry(),
                     0L
                 );
                 String responseJson = Strings.toString(MediaTypeRegistry.JSON, response);
@@ -508,6 +541,31 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
     }
 
     // ---- Helpers ----
+
+    /**
+     * Builds ExecutionResults for the golden file's additional plans (matched positionally
+     * within each type). Returns a failure message, or null on success.
+     */
+    private static String addAdditionalResults(GoldenTestCase tc, QueryPlans plans, List<ExecutionResult> executionResults) {
+        if (tc.getAdditionalPlans() == null) {
+            return null;
+        }
+        Map<QueryPlans.Type, Integer> nextIndexByType = new HashMap<>();
+        for (GoldenTestCase.AdditionalPlan additional : tc.getAdditionalPlans()) {
+            QueryPlans.Type type = QueryPlans.Type.valueOf(additional.getPlanType());
+            int index = nextIndexByType.merge(type, 1, Integer::sum) - 1;
+            List<QueryPlans.QueryPlan> typed = plans.get(type);
+            if (typed.size() <= index) {
+                return "expected additional " + type + " plan #" + index + " but only " + typed.size() + " produced";
+            }
+            List<Object[]> additionalRows = new ArrayList<>();
+            for (List<Object> row : additional.getMockResultRows()) {
+                additionalRows.add(row.toArray());
+            }
+            executionResults.add(new ExecutionResult(typed.get(index), additionalRows));
+        }
+        return null;
+    }
 
     private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {
         String json;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -19,6 +19,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
@@ -297,6 +298,91 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         StringTerms byBrandCat2 = catFirst.getBuckets().get(1).getAggregations().get("by_brand");
         InternalSum sumCat2 = byBrandCat2.getBuckets().get(0).getAggregations().get("sum_price");
         assertEquals(700.0, sumCat2.getValue(), 0.0);
+    }
+
+    /** A result table missing a requested metric's column is a broken invariant — throw, don't render {@code "value": null}. */
+    public void testMissingMetricColumnThrows() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        // Results computed for a metric named "other"
+        SearchSourceBuilder executedSource = new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("other").field("price"));
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(executedSource, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            int columnCount = plan.relNode().getRowType().getFieldCount();
+            results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[columnCount])));
+        }
+
+        // Response requested for "avg_price" — same granularity, but no such column in the result
+        SearchRequest request = new SearchRequest("products");
+        request.source(new SearchSourceBuilder().size(0).aggregation(AggregationBuilders.avg("avg_price").field("price")));
+
+        expectThrows(
+            ConversionException.class,
+            () -> SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L)
+        );
+    }
+
+    /**
+     * User-supplied {@code meta} on an aggregation request must be echoed back verbatim on the
+     * corresponding response aggregation — classic search parity — for both bucket and metric
+     * aggregations, through the full plan/response round trip.
+     */
+    public void testUserMetaEchoedInAggregations() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        Map<String, Object> termsMeta = Map.of("source", "dashboard");
+        Map<String, Object> avgMeta = Map.of("owner", "pricing-team");
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("by_brand")
+                    .field("brand")
+                    .setMetadata(termsMeta)
+                    .subAggregation(AggregationBuilders.avg("avg_price").field("price").setMetadata(avgMeta))
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                if ("brand".equals(fields.get(i))) {
+                    row[i] = "BrandA";
+                } else if ("avg_price".equals(fields.get(i))) {
+                    row[i] = 850.0;
+                } else if ("_count".equals(fields.get(i))) {
+                    row[i] = 3L;
+                } else {
+                    fail("Unexpected column: " + fields.get(i));
+                }
+            }
+            results.add(new ExecutionResult(plan, List.<Object[]>of(row)));
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertNotNull(byBrand);
+        assertEquals(termsMeta, byBrand.getMetadata());
+
+        InternalAvg avg = byBrand.getBuckets().get(0).getAggregations().get("avg_price");
+        assertNotNull(avg);
+        assertEquals(avgMeta, avg.getMetadata());
+        assertEquals(850.0, avg.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -300,6 +300,35 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(700.0, sumCat2.getValue(), 0.0);
     }
 
+    /** Terms {@code size} truncates to the top-N buckets and reports the rest as sum_other_doc_count. */
+    public void testTermsSizeTruncation() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(AggregationBuilders.terms("by_brand").field("brand").size(1));
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : plans.get(QueryPlans.Type.AGGREGATION)) {
+            assertEquals(List.of("brand", "_count"), plan.relNode().getRowType().getFieldNames());
+            results.add(new ExecutionResult(plan, List.of(new Object[] { "BrandA", 3L }, new Object[] { "BrandB", 2L })));
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        StringTerms byBrand = response.getAggregations().get("by_brand");
+        assertEquals(1, byBrand.getBuckets().size());
+        assertEquals("BrandA", byBrand.getBuckets().get(0).getKeyAsString());
+        assertEquals(3L, byBrand.getBuckets().get(0).getDocCount());
+        assertEquals(2L, byBrand.getSumOfOtherDocCounts());
+    }
+
     /** A result table missing a requested metric's column is a broken invariant — throw, don't render {@code "value": null}. */
     public void testMissingMetricColumnThrows() throws Exception {
         Map<String, String> mapping = new java.util.LinkedHashMap<>();

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -28,6 +28,7 @@ import org.opensearch.search.SearchModule;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
+import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -199,6 +200,103 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
         assertEquals(850.0, avg1.getValue(), 0.0);
         InternalAvg avg2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
         assertEquals(700.0, avg2.getValue(), 0.0);
+    }
+
+    /**
+     * Regression: sibling aggregation trees over the same field SET but opposite nesting order
+     * (brand→category vs category→brand) produce two distinct plans and must resolve to two
+     * distinct results. Under the old order-insensitive (sorted) granularity keys, both deep
+     * plans collapsed onto one map slot: the second plan's result silently overwrote the
+     * first's, and the losing tree's metric came back empty ({@code "value": null}) beneath
+     * correct-looking buckets.
+     */
+    public void testReversedNestingSiblingTreesDoNotCollide() throws Exception {
+        Map<String, String> mapping = new java.util.LinkedHashMap<>();
+        mapping.put("brand", "VARCHAR");
+        mapping.put("category", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("products", mapping);
+
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                AggregationBuilders.terms("brand_first")
+                    .field("brand")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_category")
+                            .field("category")
+                            .subAggregation(AggregationBuilders.avg("avg_price").field("price"))
+                    )
+            )
+            .aggregation(
+                AggregationBuilders.terms("cat_first")
+                    .field("category")
+                    .subAggregation(
+                        AggregationBuilders.terms("by_brand")
+                            .field("brand")
+                            .subAggregation(AggregationBuilders.sum("sum_price").field("price"))
+                    )
+            );
+
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(source, "products");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(4, aggPlans.size());
+
+        // Data story: 3 docs — BrandA/Cat1/800, BrandA/Cat1/900, BrandA/Cat2/700.
+        List<ExecutionResult> results = new ArrayList<>();
+        for (QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> fields = plan.relNode().getRowType().getFieldNames();
+            if (fields.contains("avg_price")) {
+                // Both deep plans group by {brand, category} and emit columns in schema order —
+                // identical layouts, distinguished ONLY by the metadata's nesting order.
+                assertEquals(List.of("brand", "category", "avg_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "BrandA", "Cat1", 850.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                    )
+                );
+            } else if (fields.contains("sum_price")) {
+                assertEquals(List.of("brand", "category", "sum_price", "_count"), fields);
+                results.add(
+                    new ExecutionResult(
+                        plan,
+                        List.of(new Object[] { "BrandA", "Cat1", 1700.0, 2L }, new Object[] { "BrandA", "Cat2", 700.0, 1L })
+                    )
+                );
+            } else if (fields.equals(List.of("brand", "_count"))) {
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { "BrandA", 3L })));
+            } else {
+                assertEquals(List.of("category", "_count"), fields);
+                results.add(new ExecutionResult(plan, List.of(new Object[] { "Cat1", 2L }, new Object[] { "Cat2", 1L })));
+            }
+        }
+
+        SearchRequest request = new SearchRequest("products");
+        request.source(source);
+        SearchResponse response = SearchResponseBuilder.build(results, request, converter.getAggregationRegistry(), 1L);
+
+        // brand_first → BrandA → by_category → Cat1 (avg 850), Cat2 (avg 700)
+        StringTerms brandFirst = response.getAggregations().get("brand_first");
+        assertNotNull("brand_first must be present", brandFirst);
+        assertEquals(1, brandFirst.getBuckets().size());
+        StringTerms byCategory = brandFirst.getBuckets().get(0).getAggregations().get("by_category");
+        assertEquals(2, byCategory.getBuckets().size());
+        InternalAvg avgCat1 = byCategory.getBuckets().get(0).getAggregations().get("avg_price");
+        assertEquals("brand_first's metric must not be lost to the sibling tree", 850.0, avgCat1.getValue(), 0.0);
+        InternalAvg avgCat2 = byCategory.getBuckets().get(1).getAggregations().get("avg_price");
+        assertEquals(700.0, avgCat2.getValue(), 0.0);
+
+        // cat_first → Cat1 → by_brand → BrandA (sum 1700); Cat2 → by_brand → BrandA (sum 700)
+        StringTerms catFirst = response.getAggregations().get("cat_first");
+        assertNotNull("cat_first must be present", catFirst);
+        assertEquals(2, catFirst.getBuckets().size());
+        StringTerms byBrandCat1 = catFirst.getBuckets().get(0).getAggregations().get("by_brand");
+        InternalSum sumCat1 = byBrandCat1.getBuckets().get(0).getAggregations().get("sum_price");
+        assertEquals(1700.0, sumCat1.getValue(), 0.0);
+        StringTerms byBrandCat2 = catFirst.getBuckets().get(1).getAggregations().get("by_brand");
+        InternalSum sumCat2 = byBrandCat2.getBuckets().get(0).getAggregations().get("sum_price");
+        assertEquals(700.0, sumCat2.getValue(), 0.0);
     }
 
     // ---- Golden file driven SearchResponse generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ComparisonUtilsTests extends OpenSearchTestCase {
+
+    public void testBothNull() {
+        assertTrue(ComparisonUtils.valuesEqual(null, null));
+    }
+
+    public void testFirstNull() {
+        assertFalse(ComparisonUtils.valuesEqual(null, "value"));
+    }
+
+    public void testSecondNull() {
+        assertFalse(ComparisonUtils.valuesEqual("value", null));
+    }
+
+    public void testEqualStrings() {
+        assertTrue(ComparisonUtils.valuesEqual("test", "test"));
+    }
+
+    public void testDifferentValues() {
+        assertFalse(ComparisonUtils.valuesEqual("foo", "bar"));
+    }
+
+    public void testIntegerAndLong() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42L));
+    }
+
+    public void testIntegerAndDouble() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42.0));
+    }
+
+    public void testDoubleAndFloat() {
+        assertTrue(ComparisonUtils.valuesEqual(42.0, 42.0f));
+    }
+
+    public void testDifferentNumbers() {
+        assertFalse(ComparisonUtils.valuesEqual(42, 43));
+    }
+
+    public void testNumberAndStringAreNotEqual() {
+        // No cross-type stringification: bucket keys are schema-typed, "42" != 42.
+        assertFalse(ComparisonUtils.valuesEqual(42, "42"));
+    }
+
+    public void testLargeLongsBeyondDoublePrecision() {
+        // 2^53 + 1 vs 2^53: indistinguishable as doubles, distinct as longs.
+        assertFalse(ComparisonUtils.valuesEqual(9007199254740993L, 9007199254740992L));
+        assertTrue(ComparisonUtils.valuesEqual(9007199254740993L, 9007199254740993L));
+    }
+
+    public void testBooleanComparison() {
+        assertTrue(ComparisonUtils.valuesEqual(true, true));
+        assertFalse(ComparisonUtils.valuesEqual(true, false));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline.json
@@ -1,0 +1,103 @@
+{
+  "testName": "avg_bucket_pipeline",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "sales_by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "total_sales": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "avg_brand_sales": {
+        "avg_bucket": {
+          "buckets_path": "sales_by_brand>total_sales"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "total_sales", "_count"],
+  "mockResultRows": [
+    ["BrandA", 300, 2],
+    ["BrandB", 800, 2],
+    ["BrandC", 150, 2]
+  ],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_brand_sales=[AVG($1)])",
+        "  LogicalProject(brand=[$0], total_sales=[CAST($1):DOUBLE], _count=[$2])",
+        "    LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+        "      LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_brand_sales"],
+      "mockResultRows": [
+        [416.6666666666667]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "sales_by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "BrandA",
+            "doc_count": 2,
+            "total_sales": {
+              "value": 300.0
+            }
+          },
+          {
+            "key": "BrandB",
+            "doc_count": 2,
+            "total_sales": {
+              "value": 800.0
+            }
+          },
+          {
+            "key": "BrandC",
+            "doc_count": 2,
+            "total_sales": {
+              "value": 150.0
+            }
+          }
+        ]
+      },
+      "avg_brand_sales": {
+        "value": 416.6666666666667
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_count_path.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_count_path.json
@@ -1,0 +1,95 @@
+{
+  "testName": "avg_bucket_pipeline_count_path",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "sales_by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "total_sales": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "avg_brand_docs": {
+        "avg_bucket": {
+          "buckets_path": "sales_by_brand>_count"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "total_sales", "_count"],
+  "mockResultRows": [
+    ["BrandA", 300, 4],
+    ["BrandB", 800, 2]
+  ],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_brand_docs=[AVG($2)])",
+        "  LogicalProject(brand=[$0], total_sales=[$1], _count=[CAST($2):DOUBLE])",
+        "    LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+        "      LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_brand_docs"],
+      "mockResultRows": [
+        [3.0]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "sales_by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "BrandA",
+            "doc_count": 4,
+            "total_sales": {
+              "value": 300.0
+            }
+          },
+          {
+            "key": "BrandB",
+            "doc_count": 2,
+            "total_sales": {
+              "value": 800.0
+            }
+          }
+        ]
+      },
+      "avg_brand_docs": {
+        "value": 3.0
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_empty.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_empty.json
@@ -1,0 +1,77 @@
+{
+  "testName": "avg_bucket_pipeline_empty",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "sales_by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "total_sales": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "avg_brand_sales": {
+        "avg_bucket": {
+          "buckets_path": "sales_by_brand>total_sales"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "total_sales", "_count"],
+  "mockResultRows": [],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_brand_sales=[AVG($1)])",
+        "  LogicalProject(brand=[$0], total_sales=[CAST($1):DOUBLE], _count=[$2])",
+        "    LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+        "      LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_brand_sales"],
+      "mockResultRows": [
+        [null]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "sales_by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      },
+      "avg_brand_sales": {
+        "value": null
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_insert_zeros.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_insert_zeros.json
@@ -1,0 +1,96 @@
+{
+  "testName": "avg_bucket_pipeline_insert_zeros",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "sales_by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "avg_rating": {
+            "avg": {
+              "field": "rating"
+            }
+          }
+        }
+      },
+      "avg_brand_rating": {
+        "avg_bucket": {
+          "buckets_path": "sales_by_brand>avg_rating",
+          "gap_policy": "insert_zeros"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], avg_rating=[AVG($3)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "avg_rating", "_count"],
+  "mockResultRows": [
+    ["BrandA", 4.0, 2],
+    ["BrandB", null, 2]
+  ],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_brand_rating=[AVG($1)])",
+        "  LogicalProject(brand=[$0], avg_rating=[CAST(COALESCE($1, 0:DOUBLE)):DOUBLE], _count=[$2])",
+        "    LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+        "      LogicalAggregate(group=[{2}], avg_rating=[AVG($3)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_brand_rating"],
+      "mockResultRows": [
+        [2.0]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "sales_by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "BrandA",
+            "doc_count": 2,
+            "avg_rating": {
+              "value": 4.0
+            }
+          },
+          {
+            "key": "BrandB",
+            "doc_count": 2,
+            "avg_rating": {
+              "value": null
+            }
+          }
+        ]
+      },
+      "avg_brand_rating": {
+        "value": 2.0
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_sibling_order.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_sibling_order.json
@@ -1,0 +1,139 @@
+{
+  "testName": "avg_bucket_pipeline_sibling_order",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "top_brands": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "s1": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "brands_alpha": {
+        "terms": {
+          "field": "brand",
+          "size": 2,
+          "order": {
+            "_key": "asc"
+          }
+        },
+        "aggregations": {
+          "s2": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "avg_alpha": {
+        "avg_bucket": {
+          "buckets_path": "brands_alpha>s2"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$3], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], s1=[SUM($1)], s2=[SUM($1)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "s1", "s2", "_count"],
+  "mockResultRows": [
+    ["nike", 300, 300, 5],
+    ["zara", 200, 200, 3],
+    ["apple", 100, 100, 2]
+  ],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_alpha=[AVG($2)])",
+        "  LogicalProject(brand=[$0], s1=[$1], s2=[CAST($2):DOUBLE], _count=[$3])",
+        "    LogicalSort(sort0=[$0], dir0=[ASC], fetch=[2])",
+        "      LogicalAggregate(group=[{2}], s1=[SUM($1)], s2=[SUM($1)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_alpha"],
+      "mockResultRows": [
+        [200.0]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "top_brands": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "nike",
+            "doc_count": 5,
+            "s1": {
+              "value": 300.0
+            }
+          },
+          {
+            "key": "zara",
+            "doc_count": 3,
+            "s1": {
+              "value": 200.0
+            }
+          },
+          {
+            "key": "apple",
+            "doc_count": 2,
+            "s1": {
+              "value": 100.0
+            }
+          }
+        ]
+      },
+      "brands_alpha": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 3,
+        "buckets": [
+          {
+            "key": "apple",
+            "doc_count": 2,
+            "s2": {
+              "value": 100.0
+            }
+          },
+          {
+            "key": "nike",
+            "doc_count": 5,
+            "s2": {
+              "value": 300.0
+            }
+          }
+        ]
+      },
+      "avg_alpha": {
+        "value": 200.0
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_truncation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/avg_bucket_pipeline_truncation.json
@@ -1,0 +1,97 @@
+{
+  "testName": "avg_bucket_pipeline_truncation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "sales_by_brand": {
+        "terms": {
+          "field": "brand",
+          "size": 2
+        },
+        "aggregations": {
+          "total_sales": {
+            "sum": {
+              "field": "price"
+            }
+          }
+        }
+      },
+      "avg_brand_sales": {
+        "avg_bucket": {
+          "buckets_path": "sales_by_brand>total_sales"
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC])",
+    "  LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "total_sales", "_count"],
+  "mockResultRows": [
+    ["BrandB", 800, 5],
+    ["BrandA", 300, 3],
+    ["BrandC", 150, 1]
+  ],
+  "additionalPlans": [
+    {
+      "planType": "PIPELINE",
+      "expectedRelNodePlan": [
+        "LogicalAggregate(group=[{}], avg_brand_sales=[AVG($1)])",
+        "  LogicalProject(brand=[$0], total_sales=[CAST($1):DOUBLE], _count=[$2])",
+        "    LogicalSort(sort0=[$2], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[2])",
+        "      LogicalAggregate(group=[{2}], total_sales=[SUM($1)], _count=[COUNT()])",
+        "        LogicalTableScan(table=[[test-index]])"
+      ],
+      "mockResultFieldNames": ["avg_brand_sales"],
+      "mockResultRows": [
+        [550.0]
+      ]
+    }
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    },
+    "aggregations": {
+      "sales_by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 1,
+        "buckets": [
+          {
+            "key": "BrandB",
+            "doc_count": 5,
+            "total_sales": {
+              "value": 800.0
+            }
+          },
+          {
+            "key": "BrandA",
+            "doc_count": 3,
+            "total_sales": {
+              "value": 300.0
+            }
+          }
+        ]
+      },
+      "avg_brand_sales": {
+        "value": 550.0
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
@@ -44,6 +44,28 @@
       },
       "max_score": 0.0,
       "hits": []
+    },
+    "aggregations": {
+      "by_brand": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "BrandA",
+            "doc_count": 3,
+            "avg_price": {
+              "value": 850.0
+            }
+          },
+          {
+            "key": "BrandB",
+            "doc_count": 2,
+            "avg_price": {
+              "value": 1100.0
+            }
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Adds `avg_bucket` sibling pipeline aggregation support, computed engine-side. Supersedes #21201, following its plan-composition strategy.

Each sibling pipeline becomes a second plan wrapping the sibling's aggregate:

```
LogicalAggregate(group=[{}], avg_brand_sales=[AVG($1)])      -- one call per pipeline
  LogicalProject(..., total_sales=[CAST($1):DOUBLE], ...)    -- gap policy + widening
    LogicalSort(sort0=[$2], dir0=[DESC], fetch=[10])         -- sibling's own order + size
      <sibling aggregate>
```

The filter/sort/fetch shaping mirrors the sibling's *visible* buckets — vanilla runs sibling pipelines post-truncation, so the pipeline must aggregate what the response shows, not every group. Plans are tagged `QueryPlans.Type.PIPELINE`; the single result row maps back to pipelines by column name and renders via vanilla's `InternalSimpleValue` (empty sibling → `"value": null`).

Key semantics:

- `gap_policy: skip` = SQL `AVG`'s native NULL handling (excluded from numerator and denominator); `insert_zeros` = `COALESCE(metric, 0)`.
- Metric columns widen to DOUBLE so the engine's AVG decomposition divides in floating point.
- Pipelines targeting one sibling share one plan — one extra sibling computation regardless of pipeline count.
- Behavior change: previously pipelines were silently dropped; unsupported types, bad paths, and nested pipelines now fail at conversion with descriptive errors.

Scope: `avg_bucket` over root-level `terms` siblings, single-level `buckets_path` (metric or `_count`), both gap policies. Everything else is rejected explicitly; other `*_bucket` types are follow-ups reusing this machinery.

## Testing

- 14 unit tests (path validation, rejections, same-sibling merge, result conversion).
- 6 golden files, including truncation parity and same-field siblings with different orders; golden infra extended with optional `additionalPlans` for multi-plan scenarios.
- Verified end to end through Substrait/DataFusion on a live cluster: exact values for happy path, truncation, both gap policies, `_count`, empty sibling, and rejection.

## Related Issues

Supersedes #21201

---
