### PR TITLE
Add null check for FunctionFactorScorer

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -473,9 +473,21 @@ public class FunctionScoreQuery extends Query {
                     factorExplanation = functionsExplanations.get(0);
                 } else {
                     FunctionFactorScorer scorer = functionScorer(context);
-                    int actualDoc = scorer.iterator().advance(doc);
-                    assert (actualDoc == doc);
-                    double score = scorer.computeScore(doc, expl.getValue().floatValue());
+                    
+                        if (scorer == null) {
+                            return Explanation.noMatch(
+                                "No matching scorer for segment"
+                            );
+                        }
+                        
+                        int actualDoc = scorer.iterator().advance(doc);
+                        assert actualDoc == doc;
+                        
+                        double score = scorer.computeScore(
+                            doc,
+                            expl.getValue().floatValue()
+                        );
+                    
                     factorExplanation = Explanation.match(
                         (float) score,
                         "function score, score mode [" + scoreMode.toString().toLowerCase(Locale.ROOT) + "]",


### PR DESCRIPTION
Added null check for scorer before advancing document.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
