### PR TITLE
Re-register persistent task throttling keys to prevent cluster state restore failure

### DIFF
--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksClusterService.java
@@ -65,6 +65,9 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
 
+import static org.opensearch.cluster.service.ClusterManagerTask.CREATE_PERSISTENT_TASK;
+import static org.opensearch.cluster.service.ClusterManagerTask.FINISH_PERSISTENT_TASK;
+import static org.opensearch.cluster.service.ClusterManagerTask.REMOVE_PERSISTENT_TASK;
 import static org.opensearch.cluster.service.ClusterManagerTask.UPDATE_TASK_STATE;
 
 /**
@@ -110,6 +113,9 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             .addSettingsUpdateConsumer(CLUSTER_TASKS_ALLOCATION_RECHECK_INTERVAL_SETTING, this::setRecheckInterval);
 
         // Task is onboarded for throttling, it will get retried from associated TransportClusterManagerNodeAction.
+        clusterService.registerClusterManagerTask(CREATE_PERSISTENT_TASK, true);
+        clusterService.registerClusterManagerTask(FINISH_PERSISTENT_TASK, true);
+        clusterService.registerClusterManagerTask(REMOVE_PERSISTENT_TASK, true);
         updatePersistentTaskKey = clusterService.registerClusterManagerTask(UPDATE_TASK_STATE, true);
         this.updateTaskStateExecutor = new PersistentTaskUpdateExecutor();
     }


### PR DESCRIPTION



<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This re-registers the three keys so that settings validation passes during cluster state restoration. The actual batching still uses only the UPDATE_TASK_STATE key.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
