### PR TITLE
Fix ClassCastException in mixed rollup+raw avg aggregation reduce

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -38,6 +38,7 @@ import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptedMetricAggContexts;
+import org.opensearch.search.aggregations.AggregationExecutionException;
 import org.opensearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
@@ -99,8 +100,19 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         List<Object> aggregationObjects = new ArrayList<>();
         for (InternalAggregation aggregation : aggregations) {
-            InternalScriptedMetric mapReduceAggregation = (InternalScriptedMetric) aggregation;
-            aggregationObjects.addAll(mapReduceAggregation.aggregations);
+            if (aggregation instanceof InternalScriptedMetric mapReduceAggregation) {
+                aggregationObjects.addAll(mapReduceAggregation.aggregations);
+            } else if (aggregation instanceof InternalAvg avg) {
+                aggregationObjects.add(new ScriptedAvg(avg.getSum(), avg.getCount()));
+            } else {
+                throw new AggregationExecutionException(
+                    "aggregation ["
+                        + aggregation.getName()
+                        + "] of type ["
+                        + aggregation.getType()
+                        + "] cannot be reduced together with a scripted metric aggregation"
+                );
+            }
         }
         InternalScriptedMetric firstAggregation = ((InternalScriptedMetric) aggregations.get(0));
         List<Object> aggregation;

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -40,7 +40,10 @@ import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptModule;
 import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.Aggregation.CommonFields;
+import org.opensearch.search.aggregations.AggregationExecutionException;
+import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.opensearch.search.aggregations.ParsedAggregation;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
@@ -272,4 +275,90 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         }
         return new InternalScriptedMetric(name, aggregationsList, reduceScript, metadata);
     }
+
+    /**
+     * Reducing an {@link InternalScriptedMetric} together with an {@link InternalAvg} for the same
+     * aggregation name must not throw a {@code ClassCastException}. The {@link InternalAvg} is converted
+     * to a {@link ScriptedAvg} and blended into the final average.
+     */
+    public void testReduceAvgWithScriptedMetricDoesNotThrowAndBlends() {
+        Script reduceScript = new Script(ScriptType.INLINE, MockScriptEngine.NAME, REDUCE_SCRIPT_NAME, Collections.emptyMap());
+
+        // one input is an InternalScriptedMetric wrapping ScriptedAvg(sum, count)
+        InternalScriptedMetric scriptedMetric1 = new InternalScriptedMetric(
+            "avg_temp",
+            singletonList(new ScriptedAvg(41.0, 2)),
+            reduceScript,
+            null
+        );
+        InternalScriptedMetric scriptedMetric2 = new InternalScriptedMetric(
+            "avg_temp",
+            singletonList(new ScriptedAvg(241.0, 2)),
+            reduceScript,
+            null
+        );
+        // another input is a plain InternalAvg for the same aggregation name
+        InternalAvg internalAvg = new InternalAvg("avg_temp", 441.0, 2, DocValueFormat.RAW, null);
+
+        List<InternalAggregation> shards = new ArrayList<>();
+        shards.add(scriptedMetric1);
+        shards.add(scriptedMetric2);
+        shards.add(internalAvg);
+
+        InternalAggregation reduced = scriptedMetric1.reduce(
+            shards,
+            ReduceContext.forFinalReduction(null, avgBlendScriptService(), null, PipelineTree.EMPTY)
+        );
+
+        assertTrue(reduced instanceof InternalScriptedMetric);
+        // (41 + 241 + 441) / (2 + 2 + 2) = 723 / 6 = 120.5
+        assertEquals(120.5, (double) ((InternalScriptedMetric) reduced).aggregation(), 0.0);
+    }
+
+    /**
+     * Reducing an {@link InternalScriptedMetric} together with an unsupported aggregation type must fail
+     * fast with a clear error instead of silently dropping the aggregation from the result.
+     */
+    public void testReduceWithUnsupportedAggregationTypeThrows() {
+        Script reduceScript = new Script(ScriptType.INLINE, MockScriptEngine.NAME, REDUCE_SCRIPT_NAME, Collections.emptyMap());
+        InternalScriptedMetric scriptedMetric = new InternalScriptedMetric(
+            "agg",
+            singletonList(new ScriptedAvg(41.0, 2)),
+            reduceScript,
+            null
+        );
+        InternalMax max = new InternalMax("agg", 42.0, DocValueFormat.RAW, null);
+
+        List<InternalAggregation> shards = new ArrayList<>();
+        shards.add(scriptedMetric);
+        shards.add(max);
+
+        AggregationExecutionException e = expectThrows(
+            AggregationExecutionException.class,
+            () -> scriptedMetric.reduce(shards, ReduceContext.forFinalReduction(null, avgBlendScriptService(), null, PipelineTree.EMPTY))
+        );
+        assertTrue(e.getMessage().contains("[agg]"));
+        assertTrue(e.getMessage().contains("cannot be reduced together with a scripted metric aggregation"));
+    }
+
+    /**
+     * Script service whose reduce script blends {@link ScriptedAvg} states into a single average.
+     */
+    @SuppressWarnings("unchecked")
+    private ScriptService avgBlendScriptService() {
+        MockScriptEngine scriptEngine = new MockScriptEngine(MockScriptEngine.NAME, Collections.singletonMap(REDUCE_SCRIPT_NAME, script -> {
+            List<Object> states = (List<Object>) script.get("states");
+            double sum = 0;
+            long count = 0;
+            for (Object state : states) {
+                ScriptedAvg avg = (ScriptedAvg) state;
+                sum += avg.getSum();
+                count += avg.getCount();
+            }
+            return count == 0 ? 0.0 : sum / count;
+        }), Collections.emptyMap());
+        Map<String, ScriptEngine> engines = Collections.singletonMap(scriptEngine.getType(), scriptEngine);
+        return new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS);
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When an `avg` aggregation is executed across a **mix of rollup and raw indices** under the same aggregation name, the Index Management (ISM) rollup plugin rewrites `avg` on the rollup shards into a `scripted_metric` that emits `ScriptedAvg(sum, count)`, so those shards return an `InternalScriptedMetric`. The raw-index shards still return a plain `InternalAvg`.
  
 At coordinator reduce, `InternalScriptedMetric.reduce()` unconditionally cast every per-shard aggregation to `InternalScriptedMetric`, throwing:
  ```
  java.lang.ClassCastException: class org.opensearch.search.aggregations.metrics.InternalAvg cannot be cast to class org.opensearch.search.aggregations.metrics.InternalScriptedMetric
  ```
  which surfaces to the user as an HTTP 500 and fails the entire query.
  
  **Fix:** in the `reduce()` collection loop, handle the `InternalAvg` case by converting it into a `ScriptedAvg(sum, count)` — the same object the rollup combine step emits — so it is folded into the scripted-metric reduce script (`sum += a.getSum(); count += a.getCount(); return sum/count`) and the raw contribution is **blended** into the final average instead.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

  - Before: mixed rollup+raw avg search → HTTP 500 ClassCastException.
  - After: HTTP 200 with the correct blended average across all tiers.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
