### PR TITLE
[BUG] fix: set HTTP span status code for 4xx/5xx REST responses (#22663)

### DIFF
--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Span.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Span.java
@@ -75,6 +75,13 @@ public interface Span {
     void setError(Exception exception);
 
     /**
+     * Records error message in the span
+     *
+     * @param errorMessage error message to be recorded
+     */
+    void setError(String errorMessage);
+
+    /**
      * Adds an event in the span
      *
      * @param event name of the event

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpan.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpan.java
@@ -69,6 +69,11 @@ public class NoopSpan implements Span {
     }
 
     @Override
+    public void setError(String errorMessage) {
+
+    }
+
+    @Override
     public void addEvent(String event) {
 
     }

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelSpan.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelSpan.java
@@ -63,6 +63,13 @@ class OTelSpan extends AbstractSpan {
     }
 
     @Override
+    public void setError(String errorMessage) {
+        if (errorMessage != null) {
+            delegateSpan.setStatus(StatusCode.ERROR, errorMessage);
+        }
+    }
+
+    @Override
     public void addEvent(String event) {
         delegateSpan.addEvent(event);
     }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -111,6 +111,11 @@ public final class AttributeNames {
     public static final String REFRESH_POLICY = "refresh_policy";
 
     /**
+     * HTTP Response Status Code
+     */
+    public static final String HTTP_STATUS_CODE = "http.status_code";
+
+    /**
      * Search Response Total Hits
      */
     public static final String TOTAL_HITS = "total_hits";

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableRestChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableRestChannel.java
@@ -13,8 +13,10 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.StreamingRestChannel;
+import org.opensearch.telemetry.tracing.AttributeNames;
 import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
@@ -108,6 +110,11 @@ public class TraceableRestChannel<T extends RestChannel> implements RestChannel 
         try (SpanScope scope = tracer.withSpanInScope(span)) {
             delegate.sendResponse(response);
         } finally {
+            int statusCode = response.status().getStatus();
+            span.addAttribute(AttributeNames.HTTP_STATUS_CODE, (long) statusCode);
+            if (statusCode >= 500) {
+                span.setError("HTTP " + statusCode);
+            }
             span.endSpan();
         }
     }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableStreamingRestChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableStreamingRestChannel.java
@@ -10,7 +10,6 @@ package org.opensearch.telemetry.tracing.channels;
 
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.http.HttpChunk;
-import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.StreamingRestChannel;
 import org.opensearch.telemetry.tracing.AttributeNames;
 import org.opensearch.telemetry.tracing.Span;
@@ -48,20 +47,6 @@ class TraceableStreamingRestChannel extends TraceableRestChannel<StreamingRestCh
     }
 
     @Override
-    public void sendResponse(RestResponse response) {
-        try (SpanScope scope = tracer.withSpanInScope(span)) {
-            delegate.sendResponse(response);
-        } finally {
-            int statusCode = response.status().getStatus();
-            span.addAttribute(AttributeNames.HTTP_STATUS_CODE, (long) statusCode);
-            if (statusCode >= 500) {
-                span.setError("HTTP " + statusCode);
-            }
-            span.endSpan();
-        }
-    }
-
-    @Override
     public void sendChunk(HttpChunk chunk) {
         // Each chunk operation executes within the span scope for proper trace context propagation
         try (SpanScope ignored = tracer.withSpanInScope(span)) {
@@ -78,6 +63,11 @@ class TraceableStreamingRestChannel extends TraceableRestChannel<StreamingRestCh
     public void prepareResponse(RestStatus status, Map<String, List<String>> headers) {
         // Prepare response within span scope to ensure proper trace context
         try (SpanScope ignored = tracer.withSpanInScope(span)) {
+            int statusCode = status.getStatus();
+            span.addAttribute(AttributeNames.HTTP_STATUS_CODE, (long) statusCode);
+            if (statusCode >= 500) {
+                span.setError("HTTP " + statusCode);
+            }
             delegate.prepareResponse(status, headers);
         }
     }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableStreamingRestChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableStreamingRestChannel.java
@@ -10,7 +10,9 @@ package org.opensearch.telemetry.tracing.channels;
 
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.http.HttpChunk;
+import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.StreamingRestChannel;
+import org.opensearch.telemetry.tracing.AttributeNames;
 import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
@@ -43,6 +45,20 @@ class TraceableStreamingRestChannel extends TraceableRestChannel<StreamingRestCh
      */
     TraceableStreamingRestChannel(StreamingRestChannel delegate, Span span, Tracer tracer) {
         super(delegate, span, tracer);
+    }
+
+    @Override
+    public void sendResponse(RestResponse response) {
+        try (SpanScope scope = tracer.withSpanInScope(span)) {
+            delegate.sendResponse(response);
+        } finally {
+            int statusCode = response.status().getStatus();
+            span.addAttribute(AttributeNames.HTTP_STATUS_CODE, (long) statusCode);
+            if (statusCode >= 500) {
+                span.setError("HTTP " + statusCode);
+            }
+            span.endSpan();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description

Fixes #22663 — HTTP-layer SERVER/CLIENT tracing spans remain `status.code = 0` (UNSET) for 4xx/5xx REST responses, making it impossible for observability backends to detect failed requests from the root span.

### Root cause

`TraceableRestChannel.sendResponse()` and `TraceableStreamingRestChannel.prepareResponse()` did not check the HTTP response status code before ending the span. The `http.status_code` attribute was never set, and the span status was never set to ERROR for failed requests.

### Changes

1. **`Span.java`** — Added `setError(String errorMessage)` method to the interface for recording error status without requiring an `Exception` object.

2. **`NoopSpan.java`** — No-op implementation of the new `setError(String)` method.

3. **`OTelSpan.java`** — Implementation delegates to `delegateSpan.setStatus(StatusCode.ERROR, errorMessage)`.

4. **`AttributeNames.java`** — Added `HTTP_STATUS_CODE = "http.status_code"` constant.

5. **`TraceableRestChannel.java`** — In `sendResponse()`, adds `http.status_code` attribute and calls `setError("HTTP <code>")` when status >= 500.

6. **`TraceableStreamingRestChannel.java`** — In `prepareResponse()`, adds `http.status_code` attribute and calls `setError("HTTP <code>")` when status >= 500.

### Testing

- Verified that `http.status_code` attribute is set on every REST response span
- Verified that `status.code = ERROR` (2) is set for HTTP 5xx responses
- Non-streaming path: `sendResponse()` in `TraceableRestChannel`
- Streaming path: `prepareResponse()` in `TraceableStreamingRestChannel`
- Existing tests continue to pass (no behavioral change for successful responses)

### Related

- OTel HTTP semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
- Per OTel spec, server span status should be ERROR for HTTP 5xx responses