### PR TITLE
Fix 500 on PPL query over alias spanning mapping-less index

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -62,17 +62,19 @@ public class FieldStorageResolver {
         boolean luceneAvailable = LUCENE_FORMAT.equals(primaryFormat)
             || indexMetadata.getSettings().getAsList(SECONDARY_DATA_FORMATS_SETTING).contains(LUCENE_FORMAT);
 
+        // A mapping-less index (created empty, never written to) declares no fields — it
+        // contributes nothing to the field-storage union. Aliases and index patterns legitimately
+        // span such indices next to populated ones (schema-side resolution skips them the same
+        // way), so treat "no mapping" / "no properties" as an empty field set rather than an error.
+        // A query that references only such indices fails upstream at Calcite validation with
+        // "table not found" (the schema builder yields no row type), never reaching this resolver.
         MappingMetadata mapping = indexMetadata.mapping();
-        if (mapping == null) {
-            throw new IllegalStateException("No mapping found for index [" + indexName + "]");
-        }
-        Map<String, Object> properties = (Map<String, Object>) mapping.sourceAsMap().get("properties");
-        if (properties == null) {
-            throw new IllegalStateException("No properties in mapping for index [" + indexName + "]");
-        }
+        Map<String, Object> properties = mapping == null ? null : (Map<String, Object>) mapping.sourceAsMap().get("properties");
 
         this.fieldStorage = new HashMap<>();
-        populateFromProperties(properties, "", primaryFormat, luceneAvailable);
+        if (properties != null) {
+            populateFromProperties(properties, "", primaryFormat, luceneAvailable);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -89,6 +89,42 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
         assertEquals("alias", infos.get(2).getFieldName());
     }
 
+    public void testIndexWithoutMappingContributesNoFields() {
+        // An index created empty (no mapping, no data) declares no fields. It must construct
+        // cleanly — aliases legitimately span such indices next to populated ones — and resolving
+        // any field against it alone fails with the standard "not found" error.
+        FieldStorageResolver resolver = newMappinglessResolver();
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> resolver.resolve(List.of("name")));
+        assertTrue("expected 'not found' error, got: " + ex.getMessage(), ex.getMessage().contains("not found in field storage"));
+    }
+
+    public void testMergedResolverSkipsMappinglessIndex() {
+        // Alias over {empty index, populated index}: the union must equal the populated index's
+        // field set — the empty member contributes nothing and must not fail the merge.
+        FieldStorageResolver empty = newMappinglessResolver();
+        FieldStorageResolver populated = newResolver("parquet", Map.of("name", Map.of("type", "text"), "age", Map.of("type", "long")));
+
+        FieldStorageResolver merged = FieldStorageResolver.merged(List.of(empty, populated));
+        List<FieldStorageInfo> infos = merged.resolve(List.of("name", "age"));
+
+        assertEquals(2, infos.size());
+        assertEquals("name", infos.get(0).getFieldName());
+        assertEquals("age", infos.get(1).getFieldName());
+    }
+
+    private static FieldStorageResolver newMappinglessResolver() {
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getIndex()).thenReturn(new Index("empty_index", "uuid"));
+        when(indexMetadata.getSettings()).thenReturn(
+            Settings.builder()
+                .put("index.composite.primary_data_format", "parquet")
+                .putList("index.composite.secondary_data_formats", "lucene")
+                .build()
+        );
+        when(indexMetadata.mapping()).thenReturn(null);
+        return new FieldStorageResolver(indexMetadata);
+    }
+
     private static FieldStorageResolver newResolver(String primaryFormat, Map<String, Map<String, Object>> fieldMappings) {
         Map<String, Object> mappingSource = Map.of("properties", fieldMappings);
 

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AliasIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/AliasIT.java
@@ -126,6 +126,40 @@ public class AliasIT extends AnalyticsRestTestCase {
     }
 
     /**
+     * An alias spanning a mapping-less empty index (created with no mapping, never written to)
+     * and a populated index must serve queries from the populated member. The empty index
+     * declares no fields, so it contributes nothing to the schema union or field storage —
+     * regression guard for FieldStorageResolver throwing "No mapping found" on such members.
+     */
+    public void testAliasSpansMappinglessEmptyIndex() throws IOException {
+        String emptyIdx = "alias_mappingless_empty";
+        String dataIdx = "alias_mappingless_data";
+        String alias = "alias_mappingless";
+        // Create the empty member with NO mappings block — index exists but declares no fields.
+        Request create = new Request("PUT", "/" + emptyIdx);
+        create.setJsonEntity(
+            "{\"settings\":{\"index.pluggable.dataformat.enabled\":true,"
+                + "\"index.pluggable.dataformat\":\"composite\","
+                + "\"index.composite.primary_data_format\":\"parquet\","
+                + "\"index.composite.secondary_data_formats\":\"lucene\","
+                + "\"index.number_of_shards\":1,\"index.number_of_replicas\":0}}"
+        );
+        try {
+            client().performRequest(create);
+        } catch (ResponseException re) {
+            if (entityAsString(re.getResponse()).contains("resource_already_exists_exception") == false) {
+                throw re;
+            }
+        }
+        createIndexIfAbsent(dataIdx, "{\"properties\":{\"v\":{\"type\":\"long\"}}}");
+        bulk(dataIdx, "{\"v\":1}\n{\"v\":2}\n{\"v\":3}\n");
+        putAlias(alias, List.of(emptyIdx, dataIdx));
+
+        long count = singleCount("source=" + alias + " | stats count() as c");
+        assertEquals("mapping-less empty member contributes no rows", 3L, count);
+    }
+
+    /**
      * Filter aliases are rejected up-front — the planner can't honor the filter today
      * without weaving it into the Calcite plan, so silently dropping it would return more
      * rows than the user asked for. Better to error with a clear message.


### PR DESCRIPTION
### Description
An alias (or index pattern) spanning an index that was created empty and never written to — so it has **no mapping** — alongside a populated index caused analytics-engine PPL queries to fail with a 500:

```
source=my_alias | stats count()
→ 500 RuntimeException: internal problem at backend
```

The same query on a GENERAL-mode domain returns the populated index's count.

**Root cause:** three components in the analytics planning path read index mappings. `OpenSearchSchemaBuilder` and `IndexResolution.validateSchemaCompatibility` already skip a null mapping, but `FieldStorageResolver` threw `IllegalStateException("No mapping found for index")` when `CapabilityRegistry.resolveFieldStorage(List)`'s per-index loop reached the mapping-less backing index.

**Fix:** `FieldStorageResolver` now treats a null mapping / missing `properties` as an empty field set. The empty index contributes nothing to the merged field-storage union, matching the rest of the pipeline. A query targeting *only* mapping-less indices still fails cleanly upstream at Calcite validation with "table not found" (the schema builder yields no row type), so that error path is unchanged.

**Testing:**
- Unit: `FieldStorageResolverTests#testIndexWithoutMappingContributesNoFields`, `#testMergedResolverSkipsMappinglessIndex`
- Integration: `AliasIT#testAliasSpansMappinglessEmptyIndex` — creates the exact alias shape (empty index with no mappings + populated index) and asserts `stats count()` returns the populated index's doc count
- Verified end-to-end on version-matched 3.5 test domains: GENERAL returned 3, OPTIMIZED returned 500 before this fix

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).