### PR TITLE
Lower frontend-private rel nodes before analytics planning

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -11,13 +11,17 @@ package org.opensearch.analytics.planner;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.plan.volcano.AbstractConverter;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.RelVisitor;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
@@ -125,6 +129,7 @@ public class PlannerImpl {
         RuleProfilingListener listener = context.isProfilingEnabled() ? new RuleProfilingListener() : null;
 
         RelNode modifiedRelNode = rawRelNode;
+        modifiedRelNode = lowerFrontendPrivateNodes(modifiedRelNode);
         modifiedRelNode = removeSubQueries(modifiedRelNode, listener);
         modifiedRelNode = extractLiteralAgg(modifiedRelNode, listener);
         modifiedRelNode = reduceExpressions(modifiedRelNode, listener);
@@ -166,6 +171,51 @@ public class PlannerImpl {
             LOGGER.info("Planner profile for raw RelNode is :\n{}", profile.format());
         }
         return modifiedRelNode;
+    }
+
+    /**
+     * Phase -1: lower frontend-private rel nodes into standard Calcite shapes.
+     *
+     * <p>The PPL frontend (unified-query library) plans some commands into rel classes that
+     * exist only in that library — e.g. {@code dedup} becomes a {@code LogicalDedup}. The
+     * marking phase covers the standard logical nodes and rejects anything else as an
+     * "unmarked child", so those nodes must be rewritten into standard shapes first. Rather
+     * than hard-linking this module against the frontend jar (a dependency inversion — the
+     * engine is frontend-agnostic), ask each foreign node itself via
+     * {@link RelNode#register(org.apache.calcite.plan.RelOptPlanner)}: custom rels register
+     * the library's own converter rules there (Calcite's standard extension hook; for
+     * LogicalDedup that's PPLDedupConvertRule, which lowers to ROW_NUMBER() OVER
+     * (PARTITION BY keys) + Filter — shapes the marking phase and backends already handle).
+     *
+     * <p>Standard Logical* nodes register optimization rules we don't want at this stage, so
+     * only nodes outside Calcite's namespace are asked. No foreign nodes → no HEP pass at all.
+     */
+    private static RelNode lowerFrontendPrivateNodes(RelNode input) {
+        List<RelOptRule> foreignRules = collectForeignNodeRules(input);
+        if (foreignRules.isEmpty()) {
+            return input;
+        }
+        HepProgramBuilder program = new HepProgramBuilder();
+        foreignRules.forEach(program::addRuleInstance);
+        HepPlanner hepPlanner = new HepPlanner(program.build());
+        hepPlanner.setRoot(input);
+        return hepPlanner.findBestExp();
+    }
+
+    /** Collects converter rules self-registered by non-Calcite rel nodes in the tree. */
+    private static List<RelOptRule> collectForeignNodeRules(RelNode input) {
+        // Throwaway planner used purely as a rule sink for RelNode.register().
+        HepPlanner ruleSink = new HepPlanner(new HepProgramBuilder().build());
+        new RelVisitor() {
+            @Override
+            public void visit(RelNode node, int ordinal, RelNode parent) {
+                if (node.getClass().getName().startsWith("org.apache.calcite.") == false) {
+                    node.register(ruleSink);
+                }
+                super.visit(node, ordinal, parent);
+            }
+        }.go(input);
+        return List.copyOf(ruleSink.getRules());
     }
 
     /**

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DedupCommandIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DedupCommandIT.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Self-contained integration test for PPL {@code dedup} on the analytics-engine route.
+ *
+ * <p>The frontend plans {@code dedup} into its library-private {@code LogicalDedup} rel;
+ * the planner's foreign-node lowering phase rewrites it (via the node's self-registered
+ * {@code PPLDedupConvertRule}) into ROW_NUMBER() OVER (PARTITION BY keys) + Filter before
+ * marking. Regression guard for the marking phase rejecting the raw node with
+ * "Project rule encountered unmarked child [LogicalDedup]" (#22671).
+ *
+ * <p>Calcs: 17 rows; {@code str0} has 3 distinct values, none null; {@code bool0} has
+ * true/false plus 7 null rows (nulls are dropped by dedup unless {@code keepempty=true}).
+ */
+public class DedupCommandIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    public void testDedupSingleKey() throws IOException {
+        // 3 distinct str0 values -> one row kept per value.
+        assertRowCount("source=" + DATASET.indexName + " | dedup str0 | fields str0", 3);
+    }
+
+    public void testDedupFollowedByStats() throws IOException {
+        // The originally-reported failing shape: dedup piped into an aggregation.
+        Map<String, Object> response = executePpl("source=" + DATASET.indexName + " | dedup str0 | stats count() as c");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertEquals(1, rows.size());
+        assertEquals(3, ((Number) rows.get(0).get(0)).intValue());
+    }
+
+    public void testDedupAllowedDuplication() throws IOException {
+        // dedup 2 keeps up to two rows per value: FURNITURE and OFFICE SUPPLIES and
+        // TECHNOLOGY all have >= 2 rows -> 6.
+        assertRowCount("source=" + DATASET.indexName + " | dedup 2 str0 | fields str0", 6);
+    }
+
+    public void testDedupMultipleKeys() throws IOException {
+        // Distinct (str0, bool0) pairs with both keys non-null: 3 str0 values x {true,false}
+        // present in the data minus combinations that never occur. Just assert it runs and
+        // returns between 3 and 6 rows (exact pairing depends on data), and no 500.
+        Map<String, Object> response = executePpl("source=" + DATASET.indexName + " | dedup str0, bool0 | fields str0, bool0");
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertTrue("expected 3..6 distinct non-null (str0,bool0) pairs, got " + rows.size(), rows.size() >= 3 && rows.size() <= 6);
+    }
+
+    public void testDedupNullKeyRowsDropped() throws IOException {
+        // bool0 is null in 7 of 17 rows; default dedup drops null-key rows -> 2 rows (true, false).
+        assertRowCount("source=" + DATASET.indexName + " | dedup bool0 | fields bool0", 2);
+    }
+
+    public void testDedupKeepEmpty() throws IOException {
+        // keepempty=true keeps the 7 null-key rows alongside one row per non-null value.
+        assertRowCount("source=" + DATASET.indexName + " | dedup bool0 keepempty=true | fields bool0", 9);
+    }
+
+    private void assertRowCount(String ppl, int expected) throws IOException {
+        Map<String, Object> response = executePpl(ppl);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) response.get("datarows");
+        assertNotNull("Response missing 'datarows' for query: " + ppl, rows);
+        assertEquals("Row count for query: " + ppl, expected, rows.size());
+    }
+}


### PR DESCRIPTION
### Description
PPL `dedup` followed by any pipe stage fails with a 500 on the analytics-engine route:

```
source=idx | dedup category | fields category
→ 500 RuntimeException: There was internal problem at backend
```

Server-side: `IllegalStateException: Project rule encountered unmarked child [LogicalDedup]` at `OpenSearchProjectRule.java:65`.

**Root cause:** the unified-query frontend plans `dedup` into its library-private `LogicalDedup` rel node. The engine's marking phase (`PlannerImpl.mark()`) only registers rules for the standard logical nodes (scan/filter/project/aggregate/join/sort/union/values), so the projection rule finds a raw `LogicalDedup` child and throws. The library already ships the needed lowering — `LogicalDedup.register()` self-registers `PPLDedupConvertRule`, which rewrites the node into `ROW_NUMBER() OVER (PARTITION BY keys)` + `Filter` (shapes the marking phase and the DataFusion backend, which declares ROW_NUMBER window capability, already execute) — but nothing on the analytics route ever ran that rule. The sandbox `test-ppl-frontend` shim isn't the place to run it either: the QA cluster (and real deployments) route `/_plugins/_ppl` through the opensearch-sql plugin, which hands its RelNode directly to `DefaultPlanExecutor`.

**Fix:** add a lowering phase at the top of `PlannerImpl.runAllOptimizations()` that walks the incoming tree, collects converter rules from any rel node outside the `org.apache.calcite` namespace via the standard `RelNode.register()` extension hook, and runs them in a single HEP pass.

Design notes:
- The engine stays decoupled from the frontend jar — no compile-time dependency on its rel classes; the node itself supplies its converter through Calcite's canonical extension point.
- Generalizes to other frontend-private nodes (the same library also defines e.g. `LogicalGraphLookup`).
- Plans containing no foreign nodes skip the phase entirely (no HEP pass constructed).

**Testing:**
- New `DedupCommandIT`: single/multi-key dedup, `dedup N` allowed-duplication, `keepempty=true`, null-key dropping, and the originally-failing `dedup | stats` shape — all pass.
- The 5 sandbox-check tests that failed on every CI run (including main) now pass: `ExtensiveCoveragePplIT`, `KubernetesLogsPplIT`, `MultiSourceJoinsPplIT`, `OtelLogsPplIT`, `TwoShardShapeIT`.
- analytics-engine unit tests + precommit pass.

### Related Issues
Resolves #22671

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).