### PR TITLE
[Backport 2.19] Reject out-of-range WLM node threshold updates at validation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
 - Prevent negative fielddata stats by guarding against stale removals after shard reallocation ([#21667](https://github.com/opensearch-project/OpenSearch/pull/21667))
 - Fix unbounded recursion in deserialization that can cause StackOverflowError ([#22404](https://github.com/opensearch-project/OpenSearch/pull/22404))
+- Reject out-of-range WLM node threshold updates at validation time ([#22678](https://github.com/opensearch-project/OpenSearch/pull/22678))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
@@ -14,6 +14,11 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 /**
  * Main class to declare Workload Management related settings
  */
@@ -93,6 +98,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_REJECTION_THRESHOLD,
+        NodeLevelThresholdValidator.forRejectionThreshold(
+            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -106,6 +116,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_REJECTION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_REJECTION_THRESHOLD,
+        NodeLevelThresholdValidator.forRejectionThreshold(
+            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -119,6 +134,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD,
+        NodeLevelThresholdValidator.forCancellationThreshold(
+            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_MEMORY_REJECTION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -132,6 +152,11 @@ public class WorkloadManagementSettings {
     public static final Setting<Double> NODE_LEVEL_CPU_CANCELLATION_THRESHOLD = Setting.doubleSetting(
         NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
         DEFAULT_NODE_LEVEL_CPU_CANCELLATION_THRESHOLD,
+        NodeLevelThresholdValidator.forCancellationThreshold(
+            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
+            () -> WorkloadManagementSettings.NODE_LEVEL_CPU_REJECTION_THRESHOLD
+        ),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -229,24 +254,12 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level memory based cancellation threshold
+     * Method to set the node level memory based cancellation threshold. This runs as the settings-update consumer at
+     * apply time; the value has already been checked by {@link NodeLevelThresholdValidator} during settings-update
+     * validation, so the setter only assigns.
      * @param nodeLevelMemoryCancellationThreshold sets the new node level memory based cancellation threshold
-     * @throws IllegalArgumentException if the value is &gt; 0.95 and cancellation &lt; rejection threshold
      */
     public void setNodeLevelMemoryCancellationThreshold(Double nodeLevelMemoryCancellationThreshold) {
-        if (Double.compare(nodeLevelMemoryCancellationThreshold, NODE_LEVEL_MEMORY_CANCELLATION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.95 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelMemoryRejectionThreshold,
-            nodeLevelMemoryCancellationThreshold,
-            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
-
         this.nodeLevelMemoryCancellationThreshold = nodeLevelMemoryCancellationThreshold;
     }
 
@@ -259,24 +272,11 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level cpu based cancellation threshold
+     * Method to set the node level cpu based cancellation threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelCpuCancellationThreshold sets the new node level cpu based cancellation threshold
-     * @throws IllegalArgumentException if the value is &gt; 0.95 and cancellation &lt; rejection threshold
      */
     public void setNodeLevelCpuCancellationThreshold(Double nodeLevelCpuCancellationThreshold) {
-        if (Double.compare(nodeLevelCpuCancellationThreshold, NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.95 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelCpuRejectionThreshold,
-            nodeLevelCpuCancellationThreshold,
-            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
-
         this.nodeLevelCpuCancellationThreshold = nodeLevelCpuCancellationThreshold;
     }
 
@@ -289,24 +289,11 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level memory based rejection threshold
+     * Method to set the node level memory based rejection threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelMemoryRejectionThreshold sets the new memory based rejection threshold
-     * @throws IllegalArgumentException if rejection &gt; 0.90 and rejection &lt; cancellation threshold
      */
     public void setNodeLevelMemoryRejectionThreshold(Double nodeLevelMemoryRejectionThreshold) {
-        if (Double.compare(nodeLevelMemoryRejectionThreshold, NODE_LEVEL_MEMORY_REJECTION_THRESHOLD_MAX_VALUE) > 0) {
-            throw new IllegalArgumentException(
-                NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.90 as it can result in a node drop"
-            );
-        }
-
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelMemoryRejectionThreshold,
-            nodeLevelMemoryCancellationThreshold,
-            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
-
         this.nodeLevelMemoryRejectionThreshold = nodeLevelMemoryRejectionThreshold;
     }
 
@@ -319,25 +306,39 @@ public class WorkloadManagementSettings {
     }
 
     /**
-     * Method to set the node level cpu based rejection threshold
+     * Method to set the node level cpu based rejection threshold. The value is validated by
+     * {@link NodeLevelThresholdValidator} at settings-update validation time; the setter only assigns.
      * @param nodeLevelCpuRejectionThreshold sets the new cpu based rejection threshold
-     * @throws IllegalArgumentException if rejection &gt; 0.90 and rejection &lt; cancellation threshold
      */
     public void setNodeLevelCpuRejectionThreshold(Double nodeLevelCpuRejectionThreshold) {
-        if (Double.compare(nodeLevelCpuRejectionThreshold, NODE_LEVEL_CPU_REJECTION_THRESHOLD_MAX_VALUE) > 0) {
+        this.nodeLevelCpuRejectionThreshold = nodeLevelCpuRejectionThreshold;
+    }
+
+    /**
+     * Method to validate that a threshold does not exceed its allowed maximum.
+     * @param thresholdValue the threshold value being set
+     * @param maxValue the maximum allowed value for this threshold
+     * @param thresholdSettingName name of the threshold setting
+     * @throws IllegalArgumentException if the value is greater than the allowed maximum
+     */
+    private static void ensureThresholdIsNotGreaterThanMax(Double thresholdValue, double maxValue, String thresholdSettingName) {
+        if (Double.compare(thresholdValue, maxValue) > 0) {
             throw new IllegalArgumentException(
-                NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME + " value cannot be greater than 0.90 as it can result in a node drop"
+                thresholdSettingName + " value cannot be greater than " + maxValue + " as it can result in a node drop"
             );
         }
+    }
 
-        ensureRejectionThresholdIsLessThanCancellation(
-            nodeLevelCpuRejectionThreshold,
-            nodeLevelCpuCancellationThreshold,
-            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
-            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME
-        );
-
-        this.nodeLevelCpuRejectionThreshold = nodeLevelCpuRejectionThreshold;
+    /**
+     * Method to validate that a threshold is not negative.
+     * @param thresholdValue the threshold value being set
+     * @param thresholdSettingName name of the threshold setting
+     * @throws IllegalArgumentException if the value is less than 0
+     */
+    private static void ensureThresholdIsNotNegative(Double thresholdValue, String thresholdSettingName) {
+        if (Double.compare(thresholdValue, 0.0) < 0) {
+            throw new IllegalArgumentException(thresholdSettingName + " value cannot be negative");
+        }
     }
 
     /**
@@ -348,7 +349,7 @@ public class WorkloadManagementSettings {
      * @param cancellationThresholdSettingName name of the cancellation threshold setting
      * @throws IllegalArgumentException if cancellation threshold is less than rejection threshold
      */
-    private void ensureRejectionThresholdIsLessThanCancellation(
+    private static void ensureRejectionThresholdIsLessThanCancellation(
         Double nodeLevelRejectionThreshold,
         Double nodeLevelCancellationThreshold,
         String rejectionThresholdSettingName,
@@ -358,6 +359,86 @@ public class WorkloadManagementSettings {
             throw new IllegalArgumentException(
                 cancellationThresholdSettingName + " value should not be less than " + rejectionThresholdSettingName
             );
+        }
+    }
+
+    /**
+     * Validator shared by all four node-level threshold settings. Enforced at settings-update validation time so that an
+     * invalid value is rejected before the new cluster state is published, rather than throwing while the state is applied
+     * (which would destabilize the cluster-manager).
+     * <p>
+     * It enforces two invariants: the value is within {@code [0, max]} (single-setting), and the rejection threshold does
+     * not exceed the cancellation threshold (cross-setting). The paired setting is supplied lazily via a {@link Supplier}
+     * because the four settings reference each other and are initialized in sequence; resolving it inside the method
+     * bodies (which only run at validation time) avoids a forward-reference to a not-yet-initialized field.
+     */
+    static final class NodeLevelThresholdValidator implements Setting.Validator<Double> {
+        private final String settingName;
+        private final double maxValue;
+        private final Supplier<Setting<Double>> pairedSetting;
+        private final boolean isCancellation;
+
+        private NodeLevelThresholdValidator(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> pairedSetting,
+            boolean isCancellation
+        ) {
+            this.settingName = settingName;
+            this.maxValue = maxValue;
+            this.pairedSetting = pairedSetting;
+            this.isCancellation = isCancellation;
+        }
+
+        /**
+         * Builds a validator for a cancellation threshold (the upper bound of the pair).
+         * @param settingName this cancellation setting's key
+         * @param maxValue the maximum allowed value for this cancellation threshold
+         * @param rejectionSetting supplier of the paired rejection setting
+         */
+        static NodeLevelThresholdValidator forCancellationThreshold(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> rejectionSetting
+        ) {
+            return new NodeLevelThresholdValidator(settingName, maxValue, rejectionSetting, true);
+        }
+
+        /**
+         * Builds a validator for a rejection threshold (the lower bound of the pair).
+         * @param settingName this rejection setting's key
+         * @param maxValue the maximum allowed value for this rejection threshold
+         * @param cancellationSetting supplier of the paired cancellation setting
+         */
+        static NodeLevelThresholdValidator forRejectionThreshold(
+            String settingName,
+            double maxValue,
+            Supplier<Setting<Double>> cancellationSetting
+        ) {
+            return new NodeLevelThresholdValidator(settingName, maxValue, cancellationSetting, false);
+        }
+
+        @Override
+        public void validate(Double value) {
+            ensureThresholdIsNotNegative(value, settingName);
+            ensureThresholdIsNotGreaterThanMax(value, maxValue, settingName);
+        }
+
+        @Override
+        public void validate(Double value, Map<Setting<?>, Object> settings) {
+            final String pairedName = pairedSetting.get().getKey();
+            final Double pairedValue = (Double) settings.get(pairedSetting.get());
+            // Substitute this setting's incoming value for its own side of the rejection <= cancellation comparison.
+            if (isCancellation) {
+                ensureRejectionThresholdIsLessThanCancellation(pairedValue, value, pairedName, settingName);
+            } else {
+                ensureRejectionThresholdIsLessThanCancellation(value, pairedValue, settingName, pairedName);
+            }
+        }
+
+        @Override
+        public Iterator<Setting<?>> settings() {
+            return List.<Setting<?>>of(pairedSetting.get()).iterator();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadManagementSettingsTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.wlm.WorkloadManagementSettings.NODE_CPU_CANCELLATIO
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME;
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME;
 import static org.opensearch.wlm.WorkloadManagementSettings.NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME;
+import static org.hamcrest.Matchers.containsString;
 
 public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
@@ -75,27 +76,30 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.cpu_rejection_threshold}
-     * When the value is set more than {@literal 0.9}
+     * When the value is set more than {@literal 0.9}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelCpuRejectionThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.8).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuRejectionThreshold(0.95));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.95).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.cpu_rejection_threshold}
-     * When the value is set more than {@code wlm.query_group.node.cpu_cancellation_threshold}
+     * When the value is set more than {@code wlm.query_group.node.cpu_cancellation_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelCpuRejectionThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection 0.85 > cancellation 0.8 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
             .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
             .build();
-        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuRejectionThreshold(0.85));
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -122,27 +126,30 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.cpu_cancellation_threshold}
-     * When the value is set more than {@literal 0.95}
+     * When the value is set more than {@literal 0.95}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelCpuCancellationThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuCancellationThreshold(0.96));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.96).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.cpu_cancellation_threshold}
-     * When the value is set less than {@code wlm.query_group.node.cpu_rejection_threshold}
+     * When the value is set less than {@code wlm.query_group.node.cpu_rejection_threshold}. The ordering invariant
+     * is enforced at settings-update validation time (not in the setter), so it is exercised here through the
+     * validation path.
      */
     public void testInvalidNodeLevelCpuCancellationThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
-            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
-            .build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelCpuCancellationThreshold(0.65));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // cancellation 0.65 < rejection 0.7 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.65)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -169,27 +176,30 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.memory_cancellation_threshold}
-     * When the value is set more than {@literal 0.95}
+     * When the value is set more than {@literal 0.95}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelMemoryCancellationThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryCancellationThreshold(0.96));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.96).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.memory_cancellation_threshold}
-     * When the value is set less than {@code wlm.query_group.node.memory_rejection_threshold}
+     * When the value is set less than {@code wlm.query_group.node.memory_rejection_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelMemoryCancellationThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
-            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
-            .build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryCancellationThreshold(0.65));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // cancellation 0.65 < rejection 0.7 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.65)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
     }
 
     /**
@@ -216,26 +226,253 @@ public class WorkloadManagementSettingsTests extends OpenSearchTestCase {
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.memory_rejection_threshold}
-     * When the value is set more than {@literal 0.9}
+     * When the value is set more than {@literal 0.9}. The max is enforced at settings-update validation time.
      */
     public void testInvalidNodeLevelMemoryRejectionThresholdCase1() {
-        Settings settings = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.9).build();
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryRejectionThreshold(0.92));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.92).build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
     }
 
     /**
      * Tests the invalid value for {@code wlm.query_group.node.memory_rejection_threshold}
-     * When the value is set more than {@code wlm.query_group.node.memory_cancellation_threshold}
+     * When the value is set more than {@code wlm.query_group.node.memory_cancellation_threshold}. The ordering
+     * invariant is enforced at settings-update validation time (not in the setter), so it is exercised here through
+     * the validation path.
      */
     public void testInvalidNodeLevelMemoryRejectionThresholdCase2() {
-        Settings settings = Settings.builder()
-            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.7)
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection 0.85 > cancellation 0.8 violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
             .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
             .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * Reproduces the production incident where a dynamic cluster settings update set
+     * {@code wlm.query_group.node.cpu_cancellation_threshold} above its maximum. Prior to the fix, the value passed
+     * the settings-update dry-run validation ({@link ClusterSettings#validateUpdate}) and was committed to cluster state,
+     * only to throw while the new state was being applied on every node. That apply-time failure destabilized the
+     * cluster-manager. This test asserts the update is instead rejected up-front at validation time.
+     */
+    public void testCpuCancellationThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        WorkloadManagementSettings workloadManagementSettings = new WorkloadManagementSettings(settings, cs);
-        assertThrows(IllegalArgumentException.class, () -> workloadManagementSettings.setNodeLevelMemoryRejectionThreshold(0.85));
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        // validateUpdate is the dry-run the cluster settings API runs before committing the new cluster state.
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+        assertThat(e.getMessage(), containsString(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+
+        // validate(...) is the other check the settings API applies to the final persistent/transient settings.
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> cs.validate(update, true));
+        assertThat(e2.getMessage(), containsString(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * A value at exactly the maximum must be accepted through the settings-update validation path.
+     */
+    public void testCpuCancellationThresholdAtMaxAcceptedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update);
+        assertEquals(
+            WorkloadManagementSettings.NODE_LEVEL_CPU_CANCELLATION_THRESHOLD_MAX_VALUE,
+            wlm.getNodeLevelCpuCancellationThreshold(),
+            1e-9
+        );
+    }
+
+    /**
+     * The same up-front rejection must hold for the memory cancellation threshold.
+     */
+    public void testMemoryCancellationThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder().put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+        assertThat(e.getMessage(), containsString(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * The rejection-vs-cancellation ordering invariant must also be enforced at settings-update validation time,
+     * not only via the setters.
+     */
+    public void testCpuCancellationBelowRejectionRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        // rejection (0.85) > cancellation (0.8) violates the invariant
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * The rejection-threshold max (0.90) must be enforced through the validation path for both cpu and memory, so a
+     * mis-wired rejection validator (wrong MAX constant / not attached) would be caught. The paired cancellation is
+     * raised to 0.95 in the same update so that the ordering invariant is satisfied and the rejection max is the sole
+     * trigger.
+     */
+    public void testRejectionThresholdAboveMaxRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        Settings cpu = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.95) // > 0.90 rejection max
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.95) // keeps rejection <= cancellation
+            .build();
+        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(cpu));
+        assertThat(e1.getMessage(), containsString(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME));
+
+        Settings memory = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.95)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.95)
+            .build();
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(memory));
+        assertThat(e2.getMessage(), containsString(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME));
+    }
+
+    /**
+     * The memory ordering violation must be rejected via the validation path (mirror of the cpu ordering test), so a
+     * regression swapping the memory validators' dependency setting or argument order is caught.
+     */
+    public void testMemoryCancellationBelowRejectionRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.85)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+    }
+
+    /**
+     * Boundary: rejection == cancellation is consistent (invariant is {@code rejection <= cancellation}) and must be
+     * accepted, so the ordering check is not wrongly strict.
+     */
+    public void testEqualRejectionAndCancellationAcceptedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.8)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.8)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.8, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        assertEquals(0.8, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * Lowering BOTH thresholds in a single update to a new, consistent state (rejection stays below cancellation) must
+     * succeed end-to-end. This guards against a regression where the ordering check ran in the apply-time setter against
+     * a stale sibling field: the cancellation consumer applied first would compare the new cancellation against the old
+     * (higher) rejection and throw while applying committed state, destabilizing the cluster-manager.
+     */
+    public void testLoweringBothCpuThresholdsTogetherIsAppliedCleanly() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs); // rejection=0.8, cancellation=0.9
+        Settings update = Settings.builder()
+            .put(NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME, 0.6)
+            .put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.7)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.6, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        assertEquals(0.7, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * Same as above for the memory pair.
+     */
+    public void testLoweringBothMemoryThresholdsTogetherIsAppliedCleanly() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+        Settings update = Settings.builder()
+            .put(NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME, 0.6)
+            .put(NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME, 0.7)
+            .build();
+
+        cs.validateUpdate(update);
+        cs.validate(update, true);
+        cs.applySettings(update); // must not throw
+
+        assertEquals(0.6, wlm.getNodeLevelMemoryRejectionThreshold(), 1e-9);
+        assertEquals(0.7, wlm.getNodeLevelMemoryCancellationThreshold(), 1e-9);
+    }
+
+    /**
+     * The setters run as the settings-update consumers at apply time and only assign; all bounds and ordering are
+     * enforced up front by {@code NodeLevelThresholdValidator} at validation time. This guards against reintroducing an
+     * apply-time throw in a setter (which, for the cross-setting ordering invariant, destabilized the cluster-manager).
+     */
+    public void testSettersOnlyAssignAndDoNotThrow() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        WorkloadManagementSettings wlm = new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        // Values that validation would reject (out of range, and cancellation < rejection) are still assigned by the
+        // raw setters without throwing, because the setters no longer validate.
+        wlm.setNodeLevelCpuCancellationThreshold(0.99);
+        assertEquals(0.99, wlm.getNodeLevelCpuCancellationThreshold(), 1e-9);
+        wlm.setNodeLevelCpuRejectionThreshold(-0.1);
+        assertEquals(-0.1, wlm.getNodeLevelCpuRejectionThreshold(), 1e-9);
+        wlm.setNodeLevelMemoryCancellationThreshold(0.1);
+        wlm.setNodeLevelMemoryRejectionThreshold(0.9); // rejection > cancellation; setter does not enforce ordering
+        assertEquals(0.9, wlm.getNodeLevelMemoryRejectionThreshold(), 1e-9);
+    }
+
+    /**
+     * A negative threshold is nonsensical and must be rejected at settings-update validation time by the validator's
+     * lower bound, for each of the four node threshold settings.
+     */
+    public void testNegativeNodeThresholdsRejectedAtSettingsUpdateValidation() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        new WorkloadManagementSettings(Settings.EMPTY, cs);
+
+        for (String key : new String[] {
+            NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_CPU_REJECTION_THRESHOLD_SETTING_NAME,
+            NODE_MEMORY_CANCELLATION_THRESHOLD_SETTING_NAME,
+            NODE_MEMORY_REJECTION_THRESHOLD_SETTING_NAME }) {
+            Settings update = Settings.builder().put(key, -0.1).build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> cs.validateUpdate(update));
+            assertThat(e.getMessage(), containsString(key));
+        }
+    }
+
+    /**
+     * A cluster that already carries an out-of-range value in persisted cluster state (as in the incident, where
+     * {@code 0.98} was committed before the fix) must be able to recover: on state recovery the invalid setting is
+     * archived rather than applied. This verifies the recovery/self-heal path enabled by the validator.
+     */
+    public void testOutOfRangeCpuCancellationThresholdIsArchivedOnRecovery() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        Settings poisoned = Settings.builder().put(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME, 0.98).build();
+
+        Settings archived = cs.archiveUnknownOrInvalidSettings(poisoned, e -> {}, (e, ex) -> {});
+
+        // The active (non-archived) key is dropped and preserved under the archived prefix for visibility.
+        assertNull(archived.get(NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
+        assertEquals("0.98", archived.get("archived." + NODE_CPU_CANCELLATION_THRESHOLD_SETTING_NAME));
     }
 }


### PR DESCRIPTION
### Description

Backport of #22649 to `2.19`.

Note: on `2.19` these settings use the `wlm.query_group.*` key prefix (they were renamed to `wlm.workload_group.*` in 3.x), so the backport preserves the `query_group` keys; the validation logic is otherwise identical to #22649.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
