### PR TITLE
[Analytics Engine] Fix IP-field comparison 400 (Unable to convert call EQUALS_IP) on the DataFusion route

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -667,8 +667,13 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
                 SecondAdapter second = new SecondAdapter();
                 // Stateless cast adapter shared between CAST and SAFE_CAST registrations.
                 IpBinaryCastFunctionAdapter ipBinaryCast = new IpBinaryCastFunctionAdapter();
-                // Stateless adapter shared across the six comparison operators.
-                ComparisonTemporalCoercionAdapter comparisonTemporalCoercion = new ComparisonTemporalCoercionAdapter();
+                // Stateless adapter shared across the six comparison operators. Wrapped by
+                // IpComparisonNormalizationAdapter so PPL IP-comparison UDFs (EQUALS_IP etc.) over
+                // VARBINARY ip/binary fields are rewritten to native comparators before temporal
+                // coercion (and before Substrait conversion, which has no EQUALS_IP binding).
+                ScalarFunctionAdapter comparisonTemporalCoercion = new IpComparisonNormalizationAdapter(
+                    new ComparisonTemporalCoercionAdapter()
+                );
                 return Map.ofEntries(
                     Map.entry(ScalarFunction.ARRAY, new MakeArrayAdapter()),
                     Map.entry(ScalarFunction.ARRAY_JOIN, new ArrayToStringAdapter()),

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/IpComparisonNormalizationAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/IpComparisonNormalizationAdapter.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.analytics.spi.ScalarFunctionAdapter;
+
+import java.util.List;
+
+/**
+ * Normalizes the SQL plugin's PPL IP-comparison UDFs — {@code EQUALS_IP}, {@code NOT_EQUALS_IP},
+ * {@code LESS_IP}, {@code GREATER_IP}, {@code LTE_IP}, {@code GTE_IP} — back to their native
+ * Calcite comparators ({@link SqlStdOperatorTable#EQUALS} etc.) before Substrait conversion.
+ *
+ * <p>Why this is needed: {@code ip} (and {@code binary}) fields reach the analytics route typed as
+ * VARBINARY, so PPL {@code where ip_field = '1.2.3.4'} resolves to the {@code EQUALS_IP} user-defined
+ * function rather than a plain {@code =} (the UDF's {@code (IP_UDT, IP_UDT)} signature accepts a
+ * VARBINARY operand). {@code EQUALS_IP} is an SQL-plugin Enumerable-only UDF with no Substrait binding
+ * and no backend classpath presence, so isthmus rejects the call with
+ * {@code Unable to convert call EQUALS_IP(binary?, binary?)}. Swapping in the native comparator lets
+ * DataFusion run its byte-wise VARBINARY comparison — the same path a plain {@code =} takes — after
+ * {@link BinaryFunctionAdapter} has resolved the string literal into matching on-disk bytes (adapter
+ * recursion in {@code BackendPlanAdapter} runs operands bottom-up, so the literal is already
+ * VARBINARY by the time this parent adapter runs).
+ *
+ * <p>Detection is structural, not by operator identity: the backend cannot reference
+ * {@code PPLBuiltinOperators.EQUALS_IP} (it lives in the SQL plugin's {@code core} module, off the
+ * analytics backend classpath). A call qualifies when its operator carries a comparison
+ * {@link org.apache.calcite.sql.SqlKind} but is <em>not</em> the canonical {@code SqlStdOperatorTable}
+ * singleton for that kind, and both operands are VARBINARY. Plain numeric/string/temporal comparisons
+ * already use the standard operator, so they pass through untouched.
+ *
+ * <p>This adapter occupies the six comparison-operator slots that would otherwise hold
+ * {@link ComparisonTemporalCoercionAdapter}, so it delegates every call (rewritten or not) to a
+ * wrapped temporal-coercion instance to preserve that behavior. IP operands are never temporal, so
+ * the delegation is a no-op for the rewritten calls.
+ *
+ * @opensearch.internal
+ */
+class IpComparisonNormalizationAdapter implements ScalarFunctionAdapter {
+
+    private final ScalarFunctionAdapter delegate;
+
+    IpComparisonNormalizationAdapter(ScalarFunctionAdapter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public RexNode adapt(RexCall original, List<FieldStorageInfo> fieldStorage, RelOptCluster cluster) {
+        RexCall normalized = normalizeIpComparison(original, cluster);
+        return delegate.adapt(normalized, fieldStorage, cluster);
+    }
+
+    /** Rewrite an IP-comparison UDF call to its native comparator; return {@code original} otherwise. */
+    private static RexCall normalizeIpComparison(RexCall original, RelOptCluster cluster) {
+        if (original.getOperands().size() != 2) {
+            return original;
+        }
+        SqlOperator nativeOp = nativeComparator(original.getOperator());
+        if (nativeOp == null || original.getOperator() == nativeOp) {
+            return original;
+        }
+        if (!isVarbinary(original.getOperands().get(0)) || !isVarbinary(original.getOperands().get(1))) {
+            return original;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        // Preserve the original (BOOLEAN) result type so the plan schema is unchanged.
+        return (RexCall) rexBuilder.makeCall(original.getType(), nativeOp, original.getOperands());
+    }
+
+    /** The canonical {@code SqlStdOperatorTable} comparator for a comparison {@link org.apache.calcite.sql.SqlKind}, or null. */
+    private static SqlOperator nativeComparator(SqlOperator operator) {
+        return switch (operator.getKind()) {
+            case EQUALS -> SqlStdOperatorTable.EQUALS;
+            case NOT_EQUALS -> SqlStdOperatorTable.NOT_EQUALS;
+            case LESS_THAN -> SqlStdOperatorTable.LESS_THAN;
+            case LESS_THAN_OR_EQUAL -> SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
+            case GREATER_THAN -> SqlStdOperatorTable.GREATER_THAN;
+            case GREATER_THAN_OR_EQUAL -> SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
+            default -> null;
+        };
+    }
+
+    private static boolean isVarbinary(RexNode node) {
+        return node.getType().getSqlTypeName() == SqlTypeName.VARBINARY;
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/IpComparisonNormalizationAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/IpComparisonNormalizationAdapterTests.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link IpComparisonNormalizationAdapter}: PPL IP-comparison UDFs over VARBINARY
+ * operands are rewritten to native {@code SqlStdOperatorTable} comparators, native/non-VARBINARY
+ * comparisons pass through untouched, and the wrapped {@link ComparisonTemporalCoercionAdapter}
+ * is still invoked.
+ */
+public class IpComparisonNormalizationAdapterTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    private final RelOptCluster cluster = RelOptCluster.create(new VolcanoPlanner(), rexBuilder);
+    private final IpComparisonNormalizationAdapter adapter = new IpComparisonNormalizationAdapter(new ComparisonTemporalCoercionAdapter());
+
+    /**
+     * Stand-in for an SQL-plugin IP-comparison UDF (e.g. {@code EQUALS_IP}): a UDF-category operator
+     * carrying a comparison {@link SqlKind}, distinct from the {@code SqlStdOperatorTable} singleton.
+     */
+    private static SqlOperator ipCompareUdf(String name, SqlKind kind) {
+        return new SqlFunction(
+            name,
+            kind,
+            ReturnTypes.BOOLEAN_FORCE_NULLABLE,
+            null,
+            OperandTypes.ANY_ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION
+        );
+    }
+
+    private RexNode field(int index, SqlTypeName name) {
+        return rexBuilder.makeInputRef(typeFactory.createSqlType(name), index);
+    }
+
+    private RexCall call(SqlOperator op, RexNode left, RexNode right) {
+        RelDataType boolType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+        return (RexCall) rexBuilder.makeCall(boolType, op, List.of(left, right));
+    }
+
+    /** EQUALS_IP over two VARBINARY operands → native SqlStdOperatorTable.EQUALS, operands + type preserved. */
+    public void testEqualsIpOverVarbinaryRewritesToNativeEquals() {
+        RexNode left = field(0, SqlTypeName.VARBINARY);
+        RexNode right = field(1, SqlTypeName.VARBINARY);
+        RexCall original = call(ipCompareUdf("EQUALS_IP", SqlKind.EQUALS), left, right);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame(SqlStdOperatorTable.EQUALS, adapted.getOperator());
+        assertEquals(List.of(left, right), adapted.getOperands());
+        assertEquals("result type must be preserved", original.getType(), adapted.getType());
+    }
+
+    /** All six IP-comparison UDFs map to the matching native comparator. */
+    public void testAllSixIpComparatorsRewrite() {
+        assertRewritesTo("EQUALS_IP", SqlKind.EQUALS, SqlStdOperatorTable.EQUALS);
+        assertRewritesTo("NOT_EQUALS_IP", SqlKind.NOT_EQUALS, SqlStdOperatorTable.NOT_EQUALS);
+        assertRewritesTo("LESS_IP", SqlKind.LESS_THAN, SqlStdOperatorTable.LESS_THAN);
+        assertRewritesTo("LTE_IP", SqlKind.LESS_THAN_OR_EQUAL, SqlStdOperatorTable.LESS_THAN_OR_EQUAL);
+        assertRewritesTo("GREATER_IP", SqlKind.GREATER_THAN, SqlStdOperatorTable.GREATER_THAN);
+        assertRewritesTo("GTE_IP", SqlKind.GREATER_THAN_OR_EQUAL, SqlStdOperatorTable.GREATER_THAN_OR_EQUAL);
+    }
+
+    private void assertRewritesTo(String udfName, SqlKind kind, SqlOperator expectedNative) {
+        RexCall original = call(ipCompareUdf(udfName, kind), field(0, SqlTypeName.VARBINARY), field(1, SqlTypeName.VARBINARY));
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+        assertSame(udfName + " must rewrite to its native comparator", expectedNative, adapted.getOperator());
+    }
+
+    /** A plain native comparator over VARBINARY (the post-BinaryFunctionAdapter shape) is left as-is. */
+    public void testNativeEqualsOverVarbinaryPassesThrough() {
+        RexCall original = call(SqlStdOperatorTable.EQUALS, field(0, SqlTypeName.VARBINARY), field(1, SqlTypeName.VARBINARY));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+
+    /**
+     * The VARBINARY guard: a UDF-form comparison whose operands are not both VARBINARY is not
+     * rewritten (the IP-UDF path only ever produces VARBINARY operands on the analytics route).
+     */
+    public void testUdfComparisonWithNonVarbinaryOperandNotRewritten() {
+        RexCall original = call(ipCompareUdf("EQUALS_IP", SqlKind.EQUALS), field(0, SqlTypeName.VARBINARY), field(1, SqlTypeName.VARCHAR));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        // Operator preserved (not swapped to a native comparator).
+        assertSame(original.getOperator(), ((RexCall) adapted).getOperator());
+    }
+
+    /**
+     * Delegation is preserved: the wrapped {@link ComparisonTemporalCoercionAdapter} still coerces a
+     * char-vs-timestamp comparison (the shared comparison slots must keep their temporal behavior).
+     */
+    public void testTemporalCoercionStillDelegated() {
+        RexNode varchar = field(0, SqlTypeName.VARCHAR);
+        RexNode ts = field(1, SqlTypeName.TIMESTAMP);
+        RexCall original = call(SqlStdOperatorTable.EQUALS, varchar, ts);
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame("temporal coercion must still fire through the wrapper", original, adapted);
+        assertSame(SqlTypeName.TIMESTAMP, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame(ts, adapted.getOperands().get(1));
+    }
+
+    /** Numeric native comparison — neither rewritten nor temporally coerced; unchanged. */
+    public void testNumericComparisonPassesThrough() {
+        RexCall original = call(SqlStdOperatorTable.LESS_THAN, field(0, SqlTypeName.INTEGER), field(1, SqlTypeName.INTEGER));
+
+        RexNode adapted = adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+}


### PR DESCRIPTION
### Description

PPL equality/comparison predicates and projection expressions over `ip`-mapped (and `binary`-mapped) fields on the analytics-engine DataFusion route fail deterministically with HTTP 400:

```json
{
  "error": {
    "reason": "Invalid Query",
    "details": "Unable to convert call EQUALS_IP(binary?, binary?).",
    "type": "IllegalArgumentException"
  },
  "status": 400
}
```

This makes `ip`/`binary` `=`, `!=`, `<`, `>` filters and `if/case/count(eval(...))` project shapes over those fields unusable on the analytics route, and fails two `sandbox-check` CI tests on every run (`FieldTypeCoverageIT.testIpFilters`, `FieldTypeCoverageIT.testIpAndBinaryProjectExpressions`).

Resolves #22672.

#### Root cause

`ip` and `binary` fields reach the analytics route typed as `VARBINARY`. When the SQL plugin resolves a comparison such as `where ip_field = '1.2.3.4'`, its `PPLFuncImpTable` registers **two** operators per PPL comparator — the IP user-defined function (e.g. `EQUALS_IP`) first, then the standard Calcite comparator. Because the IP-UDF's `(IP_UDT, IP_UDT)` operand checker accepts a plain `VARBINARY` operand, the UDF overload wins, and the plan carries `EQUALS_IP(binary, binary)`.

`EQUALS_IP` (and its five siblings `NOT_EQUALS_IP`, `LESS_IP`, `GREATER_IP`, `LTE_IP`, `GTE_IP`) are SQL-plugin `ImplementorUDF`s with an Enumerable (codegen) implementation only. On the analytics route the RelNode is lowered to Substrait, and there is no Substrait binding and no backend adapter for these UDFs, so isthmus rejects the call with `Unable to convert call EQUALS_IP(binary?, binary?)`. The capability gate does not catch it earlier — the UDFs carry a comparison `SqlKind`, so `ScalarFunction.fromSqlOperatorWithFallback` resolves them to the standard `EQUALS`/`LESS_THAN`/... which the backend does support; the operator's true identity only surfaces at Substrait conversion.

This regressed when `ip`/`binary` gained their UDT representation (#21807): before that, `ip` was plain `VARBINARY`, the IP-UDF operand checker did not match, and the standard comparator was selected — the working path. #21807 shipped adapters for `CIDRMATCH` and the ip/binary→string casts but not for the six IP comparison UDFs.

#### Fix

A backend adapter (`IpComparisonNormalizationAdapter`) that normalizes an IP-comparison UDF call back to its native `SqlStdOperatorTable` comparator before Substrait conversion, when both operands are `VARBINARY`. DataFusion then runs its native byte-wise `VARBINARY` comparison — the same path a plain `=` takes — after `BinaryFunctionAdapter` has resolved the string literal into matching on-disk bytes (adapter recursion runs operands bottom-up, so the literal is already `VARBINARY` when this parent adapter runs). The BOOLEAN result type is preserved, so the plan schema is unchanged.

Detection is structural, not by operator identity: the analytics backend cannot reference `PPLBuiltinOperators.EQUALS_IP` (it lives in the SQL plugin's `core` module, off the backend classpath). A call qualifies when its operator carries a comparison `SqlKind` but is not the canonical `SqlStdOperatorTable` singleton for that kind, and both operands are `VARBINARY`. This mirrors `CidrMatchFunctionAdapter`, which already rewrites a UDF into native Calcite comparators over `VARBINARY`.

The adapter is registered in the six comparison-operator slots that previously held `ComparisonTemporalCoercionAdapter`, and wraps that adapter — every call (rewritten or not) is still delegated to it, so char↔temporal / TIME coercion on those slots is preserved unchanged (IP operands are never temporal, so the delegation is a no-op for the rewritten calls).

**Scope note.** Only the four direct comparators (`=`, `!=`, `<`, `>`) emit the IP UDFs. `in` and `between` over `ip`/`binary` already lower to native operators over `VARBINARY` (their literals go through the same `BINARY(varchar)` placeholder that `BinaryFunctionAdapter` resolves), and `cidrmatch` has its own adapter — those shapes were never broken. The failing test crashes at its first `=` assertion, before reaching them.

### Testing

| test | before | after |
|---|---|---|
| `IpComparisonNormalizationAdapterTests` (all 6 IP comparators → native op; native/non-VARBINARY passthrough; VARBINARY guard; type preserved; temporal coercion still delegated) | — | 6/6 pass |
| `ComparisonTemporalCoercionAdapterTests` (regression — behavior preserved through the wrapper) | 10/10 | 10/10 pass |
| `FieldTypeCoverageIT.testIpFilters` (`=`, `!=`, `>`, `<`, `in`, `between`, `cidrmatch`, AND-combination over `ip`) | 400 `Unable to convert call EQUALS_IP` | pass |
| `FieldTypeCoverageIT.testIpAndBinaryProjectExpressions` (`if`/`case`/`count(eval())` over `ip` `=` and `binary` `=`) | 400 `Unable to convert call EQUALS_IP` | pass |

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (adapter Javadoc + PR).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
