### PR TITLE
Normalize control characters in X-Request-Id and X-Opaque-Id before logging

### DIFF
--- a/server/src/main/java/org/opensearch/common/util/RequestUtils.java
+++ b/server/src/main/java/org/opensearch/common/util/RequestUtils.java
@@ -10,6 +10,8 @@ package org.opensearch.common.util;
 
 import org.opensearch.common.UUIDs;
 
+import java.util.regex.Pattern;
+
 /**
  * Common utility methods for request handling.
  *
@@ -18,6 +20,21 @@ import org.opensearch.common.UUIDs;
 public final class RequestUtils {
 
     private RequestUtils() {}
+
+    /** Matches ASCII control characters (0x00-0x1F and 0x7F). */
+    private static final Pattern CONTROL_CHARS = Pattern.compile("\\p{Cntrl}");
+
+    /**
+     * Removes control characters from a client-provided header value so it is safe to emit in
+     * single-line log output and response headers. A {@code null} input is returned unchanged;
+     * well-formed values (UUIDs, hexadecimal or alphanumeric identifiers) are unaffected.
+     */
+    public static String sanitizeHeaderValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return CONTROL_CHARS.matcher(value).replaceAll("");
+    }
 
     /**
      * Generates a new ID field for new documents.

--- a/server/src/main/java/org/opensearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/opensearch/http/DefaultRestChannel.java
@@ -40,6 +40,7 @@ import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.network.CloseableChannel;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.RequestUtils;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -147,12 +148,13 @@ class DefaultRestChannel extends AbstractRestChannel implements RestChannel {
 
             corsHandler.setCorsResponseHeaders(httpRequest, httpResponse);
 
-            opaque = request.header(X_OPAQUE_ID);
+            opaque = RequestUtils.sanitizeHeaderValue(request.header(X_OPAQUE_ID));
             if (opaque != null) {
                 setHeaderField(httpResponse, X_OPAQUE_ID, opaque);
             }
-            if (request.header(X_REQUEST_ID) != null) {
-                setHeaderField(httpResponse, X_REQUEST_ID, request.header(X_REQUEST_ID));
+            final String requestId = RequestUtils.sanitizeHeaderValue(request.header(X_REQUEST_ID));
+            if (requestId != null) {
+                setHeaderField(httpResponse, X_REQUEST_ID, requestId);
             }
 
             // Add all custom headers

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -440,10 +440,15 @@ public class RestController implements HttpServerTransport.Dispatcher {
                     );
                     return;
                 } else {
-                    threadContext.putHeader(name, String.join(",", distinctHeaderValues));
+                    String headerValue = String.join(",", distinctHeaderValues);
+                    // Normalize client-provided correlation headers so downstream log output stays single-line
+                    if (Task.X_REQUEST_ID.equals(name) || Task.X_OPAQUE_ID.equals(name)) {
+                        headerValue = RequestUtils.sanitizeHeaderValue(headerValue);
+                    }
+                    threadContext.putHeader(name, headerValue);
                     // Validate request-id header if present
-                    if (Task.X_REQUEST_ID.equals(restHeader.getName())) {
-                        RequestUtils.validateRequestId(distinctHeaderValues.getFirst(), requestIdMaxLength);
+                    if (Task.X_REQUEST_ID.equals(name)) {
+                        RequestUtils.validateRequestId(headerValue, requestIdMaxLength);
                     }
                 }
             }

--- a/server/src/test/java/org/opensearch/common/util/RequestUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/util/RequestUtilsTests.java
@@ -88,4 +88,31 @@ public class RequestUtilsTests extends OpenSearchTestCase {
         );
         assertEquals("X-Request-Id length [33] exceeds maximum allowed length [32]", exception.getMessage());
     }
+
+    public void testSanitizeHeaderValueNullReturnedUnchanged() {
+        assertNull(RequestUtils.sanitizeHeaderValue(null));
+    }
+
+    public void testSanitizeHeaderValueEmptyReturnedUnchanged() {
+        assertEquals("", RequestUtils.sanitizeHeaderValue(""));
+    }
+
+    public void testSanitizeHeaderValueWellFormedUnchanged() {
+        assertEquals("a1b2c3d4e5f67890abcdef1234567890", RequestUtils.sanitizeHeaderValue("a1b2c3d4e5f67890abcdef1234567890"));
+        assertEquals("a1b2c3d4-e5f6-7890-abcd-ef1234567890", RequestUtils.sanitizeHeaderValue("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+        assertEquals("my-trace-id-123", RequestUtils.sanitizeHeaderValue("my-trace-id-123"));
+    }
+
+    public void testSanitizeHeaderValueStripsControlCharacters() {
+        // Control characters (newline, carriage return, tab, NUL) are removed.
+        assertEquals("abcdef", RequestUtils.sanitizeHeaderValue("abc\r\ndef"));
+        assertEquals("tabbed", RequestUtils.sanitizeHeaderValue("tab\tbed"));
+        assertEquals("nul", RequestUtils.sanitizeHeaderValue("n\u0000ul"));
+        // Spaces (0x20) are not control characters and are preserved.
+        assertEquals("has space", RequestUtils.sanitizeHeaderValue("has space\n"));
+    }
+
+    public void testSanitizeHeaderValueControlCharactersOnlyBecomesEmpty() {
+        assertEquals("", RequestUtils.sanitizeHeaderValue("\n\r\t"));
+    }
 }

--- a/server/src/test/java/org/opensearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/opensearch/http/DefaultRestChannelTests.java
@@ -197,6 +197,34 @@ public class DefaultRestChannelTests extends OpenSearchTestCase {
         );
     }
 
+    public void testCorrelationHeadersStrippedOfControlCharacters() {
+        Settings settings = Settings.builder().build();
+        final TestHttpRequest httpRequest = new TestHttpRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");
+        httpRequest.getHeaders().put(Task.X_OPAQUE_ID, Collections.singletonList("opaque\r\nid"));
+        httpRequest.getHeaders().put(Task.X_REQUEST_ID, Collections.singletonList("request\tid"));
+        final RestRequest request = RestRequest.request(xContentRegistry(), httpRequest, httpChannel);
+        HttpHandlingSettings handlingSettings = HttpHandlingSettings.fromSettings(settings);
+
+        DefaultRestChannel channel = new DefaultRestChannel(
+            httpChannel,
+            httpRequest,
+            request,
+            bigArrays,
+            handlingSettings,
+            threadPool.getThreadContext(),
+            CorsHandler.fromSettings(settings),
+            null
+        );
+        channel.sendResponse(new TestRestResponse());
+
+        ArgumentCaptor<TestHttpResponse> responseCaptor = ArgumentCaptor.forClass(TestHttpResponse.class);
+        verify(httpChannel).sendResponse(responseCaptor.capture(), any());
+        Map<String, List<String>> headers = responseCaptor.getValue().headers();
+        // Control characters removed; remaining characters preserved
+        assertEquals("opaqueid", headers.get(Task.X_OPAQUE_ID).get(0));
+        assertEquals("requestid", headers.get(Task.X_REQUEST_ID).get(0));
+    }
+
     public void testCookiesSet() {
         Settings settings = Settings.builder().put(HttpTransportSettings.SETTING_HTTP_RESET_COOKIES.getKey(), true).build();
         final TestHttpRequest httpRequest = new TestHttpRequest(HttpRequest.HttpVersion.HTTP_1_1, RestRequest.Method.GET, "/");

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -56,6 +56,7 @@ import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.HttpStats;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.rest.action.admin.indices.RestCreateIndexAction;
+import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.client.NoOpNodeClient;
 import org.opensearch.test.rest.FakeRestRequest;
@@ -200,6 +201,23 @@ public class RestControllerTests extends OpenSearchTestCase {
         assertEquals("true", threadContext.getHeader("header.1"));
         assertEquals("true", threadContext.getHeader("header.2"));
         assertNull(threadContext.getHeader("header.3"));
+    }
+
+    public void testCorrelationHeadersStrippedOfControlCharacters() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        Set<RestHeaderDefinition> headers = new HashSet<>(
+            Arrays.asList(new RestHeaderDefinition(Task.X_OPAQUE_ID, false), new RestHeaderDefinition(Task.X_REQUEST_ID, false))
+        );
+        final RestController restController = new RestController(headers, null, null, circuitBreakerService, usageService);
+        Map<String, List<String>> restHeaders = new HashMap<>();
+        restHeaders.put(Task.X_OPAQUE_ID, Collections.singletonList("opaque\r\nid"));
+        restHeaders.put(Task.X_REQUEST_ID, Collections.singletonList("request\tid"));
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(restHeaders).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, false, RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        // Control characters removed from the stored header values; other characters preserved
+        assertEquals("opaqueid", threadContext.getHeader(Task.X_OPAQUE_ID));
+        assertEquals("requestid", threadContext.getHeader(Task.X_REQUEST_ID));
     }
 
     public void testRequestWithDisallowedMultiValuedHeader() {


### PR DESCRIPTION
### Description

The `X-Request-Id` and `X-Opaque-Id` request headers are client-provided and are written into the search slow logs (`SearchSlowLog`) and echoed back into HTTP responses. Today their values are used as-is. This change strips ASCII control characters from these values before they are used in log output, so that log records stay single-line and well-formed regardless of client input.

### What changed

- Added a shared `RequestUtils.sanitizeHeaderValue()` helper that removes ASCII control characters (`\p{Cntrl}`), leaving `null` and well-formed values (UUIDs, hex/alphanumeric identifiers) unchanged.
- Applied it centrally in `RestController` where correlation headers are copied into the `ThreadContext`, so every downstream consumer that reads them via `Task.getHeader(...)` (including `SearchSlowLog`) receives a normalized value.
- Applied it in `DefaultRestChannel`, where `X-Request-Id`/`X-Opaque-Id` are read directly off the request to echo into the response (this path bypasses the thread context).
- The JSON slow-log layout already escapes these values via `%enc{...}{JSON}`; this closes the gap for the text (`PatternLayout`) path and response headers.

### Why

Header values come directly from clients. Normalizing them keeps log files clean and reliably parseable for downstream tooling (log shippers, SIEM ingestion) and keeps a single logical request represented on a single log line.

### Related component

Search/Logging

### Check List

- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
