### PR TITLE
Reduce per-field hashing and iteration on the composite/Parquet indexing hot path

### DIFF
--- a/sandbox/plugins/composite-engine/build.gradle
+++ b/sandbox/plugins/composite-engine/build.gradle
@@ -65,3 +65,42 @@ dependencies {
   // Netty4 HTTP transport for ITs that use the low-level RestClient (e.g., DataFormatStatsIT, *DataFormatApi*IT).
   internalClusterTestImplementation project(':modules:transport-netty4')
 }
+
+// ---- JMH benchmark source set ----
+// Microbenchmarks for the indexing hot path (e.g. CompositeDocumentInput.addField broadcast). Lives here
+// because the shared :benchmarks module only depends on :server and cannot reach this JDK-25-gated sandbox
+// plugin. Same wiring as :sandbox:plugins:parquet-data-format and :libs:opensearch-concurrent-queue.
+sourceSets {
+  jmh {
+    java.srcDirs = ['src/jmh/java']
+    compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+    runtimeClasspath += sourceSets.main.output + sourceSets.main.runtimeClasspath
+  }
+}
+
+dependencies {
+  jmhImplementation "org.openjdk.jmh:jmh-core:${versions.jmh}"
+  jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:${versions.jmh}"
+  // :server is compileOnly for the plugin (provided by the OpenSearch runtime). The JMH fork has no such
+  // runtime, so put it on the benchmark runtime classpath explicitly.
+  jmhImplementation project(':server')
+  jmhImplementation project(':sandbox:libs:plugin-stats-spi')
+}
+
+// JMH generated code uses forbidden APIs — skip checking the jmh source set.
+tasks.matching { it.name == 'forbiddenApisJmh' }.configureEach { enabled = false }
+
+// Wire the JMH benchmark annotation processor.
+tasks.named('compileJmhJava').configure {
+  options.compilerArgs.addAll(["-processor", "org.openjdk.jmh.generators.BenchmarkProcessor"])
+}
+
+// Convenience task: ./gradlew -Dsandbox.enabled=true :sandbox:plugins:composite-engine:jmh [-Pjmh.includes=<regex>]
+tasks.register('jmh', JavaExec) {
+  dependsOn jmhClasses
+  mainClass = 'org.openjdk.jmh.Main'
+  classpath = sourceSets.jmh.runtimeClasspath
+  if (project.hasProperty('jmh.includes')) {
+    args project.property('jmh.includes')
+  }
+}

--- a/sandbox/plugins/composite-engine/src/jmh/java/org/opensearch/composite/CompositeDocumentInputBenchmark.java
+++ b/sandbox/plugins/composite-engine/src/jmh/java/org/opensearch/composite/CompositeDocumentInputBenchmark.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures {@code CompositeDocumentInput}'s per-field broadcast to secondary format inputs — the
+ * {@code IdentityHashMap$IdentityHashMapIterator.hasNext/next} and {@code UnmodifiableEntrySet} frames seen
+ * under {@code CompositeDocumentInput.addField} in bulk-indexing CPU profiles.
+ *
+ * <ul>
+ *   <li>{@code current} drives the real {@link CompositeDocumentInput}, whose constructor snapshots the
+ *       secondary map into flat arrays so {@code addField} loops an array (no per-call iterator).</li>
+ *   <li>{@code legacyMapIteration} replicates the previous body inline — iterating
+ *       {@code unmodifiableMap(IdentityHashMap).entrySet()} per field — over the same map shape the engine
+ *       builds ({@code CompositeIndexingExecutionEngine.newDocumentInput} uses an {@code IdentityHashMap}).</li>
+ * </ul>
+ *
+ * <p>The per-format delegate inputs are no-op stubs: the delegate cost is identical in both variants, so the
+ * delta isolates the broadcast strategy itself. {@link #fields} sweeps per-document field counts;
+ * {@link #secondaries} covers the one-secondary common case (Lucene primary + Parquet secondary) and a larger
+ * fan-out.
+ */
+@Fork(3)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class CompositeDocumentInputBenchmark {
+
+    /** No-op delegate: the broadcast strategy is the subject, not the per-format input. */
+    private static final class NoopDocumentInput implements DocumentInput<Object> {
+        @Override
+        public void addField(MappedFieldType fieldType, Object value) {}
+
+        @Override
+        public void setRowId(String rowIdFieldName, long rowId) {}
+
+        @Override
+        public Object getFinalInput() {
+            return null;
+        }
+
+        @Override
+        public long getFieldCount(String fieldName) {
+            return 0;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class TestFormat extends DataFormat {
+        private final String name;
+
+        TestFormat(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public long priority() {
+            return 0;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities> supportedFields() {
+            return Set.of();
+        }
+    }
+
+    @Param({ "5", "20", "50" })
+    private int fields;
+
+    @Param({ "1", "3" })
+    private int secondaries;
+
+    private MappedFieldType[] fieldTypes;
+    private Object[] values;
+    private CompositeDocumentInput composite;
+    private Map<DataFormat, DocumentInput<?>> legacyMap;
+    private DocumentInput<?> primary;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        fieldTypes = new MappedFieldType[fields];
+        values = new Object[fields];
+        for (int i = 0; i < fields; i++) {
+            if ((i & 1) == 0) {
+                fieldTypes[i] = new NumberFieldMapper.NumberFieldType("num_" + i, NumberFieldMapper.NumberType.LONG);
+                values[i] = (long) i;
+            } else {
+                fieldTypes[i] = new KeywordFieldMapper.KeywordFieldType("kw_" + i);
+                values[i] = "v_" + i;
+            }
+        }
+        primary = new NoopDocumentInput();
+        // Same map shape the engine builds in newDocumentInput().
+        Map<DataFormat, DocumentInput<?>> secondaryMap = new IdentityHashMap<>();
+        for (int s = 0; s < secondaries; s++) {
+            secondaryMap.put(new TestFormat("format_" + s), new NoopDocumentInput());
+        }
+        composite = new CompositeDocumentInput(new TestFormat("primary"), primary, secondaryMap);
+        legacyMap = java.util.Collections.unmodifiableMap(secondaryMap);
+    }
+
+    /** Shipped code path: the real {@link CompositeDocumentInput#addField} (array-snapshot broadcast). */
+    @Benchmark
+    public void current(Blackhole bh) {
+        for (int i = 0; i < fieldTypes.length; i++) {
+            composite.addField(fieldTypes[i], values[i]);
+        }
+        bh.consume(composite);
+    }
+
+    /** Previous behavior reproduced inline: per-field entry-set iteration over the unmodifiable map. */
+    @Benchmark
+    public void legacyMapIteration(Blackhole bh) {
+        for (int i = 0; i < fieldTypes.length; i++) {
+            primary.addField(fieldTypes[i], values[i]);
+            for (Map.Entry<DataFormat, DocumentInput<?>> entry : legacyMap.entrySet()) {
+                entry.getValue().addField(fieldTypes[i], values[i]);
+            }
+        }
+        bh.consume(legacyMap);
+    }
+
+    /** Sanity/control: {@code List.copyOf(map.values())} indexed loop — an alternative snapshot shape. */
+    @Benchmark
+    public void listSnapshot(Blackhole bh) {
+        List<DocumentInput<?>> snapshot = List.copyOf(legacyMap.values());
+        for (int i = 0; i < fieldTypes.length; i++) {
+            primary.addField(fieldTypes[i], values[i]);
+            for (int s = 0; s < snapshot.size(); s++) {
+                snapshot.get(s).addField(fieldTypes[i], values[i]);
+            }
+        }
+        bh.consume(snapshot);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
@@ -33,6 +33,15 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
     private final DocumentInput<?> primaryDocumentInput;
     private final DataFormat primaryFormat;
     private final Map<DataFormat, DocumentInput<?>> secondaryDocumentInputs;
+    /**
+     * Flat snapshots of {@link #secondaryDocumentInputs}, taken once at construction. {@code addField} and
+     * {@code setRowId} run once per field per document on the bulk-indexing hot path; iterating the map there
+     * allocates an entry-set iterator and walks the backing table (an {@code IdentityHashMap} in practice —
+     * its sparse-table iterator was a visible CPU frame in ingest profiles) on every call. The map is
+     * immutable after construction, so the arrays are always in sync with it.
+     */
+    private final DataFormat[] secondaryFormats;
+    private final DocumentInput<?>[] secondaryInputs;
     private long rowId = -1L;
 
     /**
@@ -52,6 +61,14 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
         this.secondaryDocumentInputs = Collections.unmodifiableMap(
             Objects.requireNonNull(secondaryDocumentInputs, "secondaryDocumentInputs must not be null")
         );
+        this.secondaryFormats = new DataFormat[secondaryDocumentInputs.size()];
+        this.secondaryInputs = new DocumentInput<?>[secondaryDocumentInputs.size()];
+        int i = 0;
+        for (Map.Entry<DataFormat, DocumentInput<?>> entry : secondaryDocumentInputs.entrySet()) {
+            secondaryFormats[i] = entry.getKey();
+            secondaryInputs[i] = entry.getValue();
+            i++;
+        }
     }
 
     @Override
@@ -64,12 +81,12 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
                 e
             );
         }
-        for (Map.Entry<DataFormat, DocumentInput<?>> entry : secondaryDocumentInputs.entrySet()) {
+        for (int i = 0; i < secondaryInputs.length; i++) {
             try {
-                entry.getValue().addField(fieldType, value);
+                secondaryInputs[i].addField(fieldType, value);
             } catch (Exception e) {
                 throw new IllegalStateException(
-                    "Failed to add field [" + fieldType.name() + "] in secondary format [" + entry.getKey().name() + "]",
+                    "Failed to add field [" + fieldType.name() + "] in secondary format [" + secondaryFormats[i].name() + "]",
                     e
                 );
             }
@@ -79,8 +96,8 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
     @Override
     public void setRowId(String rowIdFieldName, long rowId) {
         primaryDocumentInput.setRowId(rowIdFieldName, rowId);
-        for (DocumentInput<?> input : secondaryDocumentInputs.values()) {
-            input.setRowId(rowIdFieldName, rowId);
+        for (int i = 0; i < secondaryInputs.length; i++) {
+            secondaryInputs[i].setRowId(rowIdFieldName, rowId);
         }
         this.rowId = rowId;
     }

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -53,6 +53,51 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
 }
 
+// ---- JMH benchmark source set ----
+// Microbenchmarks for the indexing hot path (e.g. ParquetDocumentInput.addField). Lives here because the
+// shared :benchmarks module only depends on :server and cannot reach this JDK-25-gated sandbox plugin.
+sourceSets {
+  jmh {
+    java.srcDirs = ['src/jmh/java']
+    compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+    runtimeClasspath += sourceSets.main.output + sourceSets.main.runtimeClasspath
+  }
+}
+
+dependencies {
+  jmhImplementation "org.openjdk.jmh:jmh-core:${versions.jmh}"
+  jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:${versions.jmh}"
+  // The plugin declares :server (and other provided deps) as compileOnly — the OpenSearch runtime supplies
+  // them in production. The JMH fork has no such runtime, so put the ones the benchmarks touch on its own
+  // runtime classpath explicitly.
+  jmhImplementation project(':server')
+  jmhImplementation project(':sandbox:libs:plugin-stats-spi')
+}
+
+// JMH generated code uses forbidden APIs — skip checking the jmh source set.
+tasks.matching { it.name == 'forbiddenApisJmh' }.configureEach { enabled = false }
+
+// Wire the JMH benchmark annotation processor.
+tasks.named('compileJmhJava').configure {
+  options.compilerArgs.addAll(["-processor", "org.openjdk.jmh.generators.BenchmarkProcessor"])
+}
+
+// Convenience task: ./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:jmh [-Pjmh.includes=<regex>]
+tasks.register('jmh', JavaExec) {
+  dependsOn jmhClasses
+  mainClass = 'org.openjdk.jmh.Main'
+  classpath = sourceSets.jmh.runtimeClasspath
+  if (project.hasProperty('jmh.includes')) {
+    args project.property('jmh.includes')
+  }
+}
+
+spotless {
+  java {
+    targetExclude 'src/jmh/generated/**/*.java'
+  }
+}
+
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /netty-.*/, to: 'netty'

--- a/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/vsr/VSRVectorLookupBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/vsr/VSRVectorLookupBenchmark.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.vsr;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the per-field vector resolution in the Parquet write path ({@code ManagedVSR.getVector} and its
+ * {@code HashMap.getNode} share in bulk-indexing CPU profiles).
+ *
+ * <p>{@code VSRManager.addDocument} currently resolves the same vector <b>twice</b> per field: once for a
+ * null-check, and again inside {@code ParquetField.addToGroup} (every implementation re-looks-up by
+ * {@code fieldType.name()}). Variants, all against a real {@link ManagedVSR} with real Arrow vectors:
+ * <ul>
+ *   <li>{@code doubleLookup} — the current pattern: null-check lookup + write-side lookup per field.</li>
+ *   <li>{@code singleLookup} — resolve once per field and reuse (what a pass-the-vector SPI change buys).</li>
+ *   <li>{@code ordinalArray} — lower bound: vectors pre-resolved to a flat array once per schema, per-field
+ *       access is an array read (what an ordinal-based layout would buy).</li>
+ * </ul>
+ *
+ * <p>The delta between {@code doubleLookup} and {@code singleLookup} is the recoverable cost of the redundant
+ * lookup; {@code ordinalArray} shows the remaining headroom. This gates whether the ~22-file SPI change
+ * (passing the resolved vector into {@code addToGroup}) is worth its churn.
+ */
+@Fork(3)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class VSRVectorLookupBenchmark {
+
+    @Param({ "5", "20", "50" })
+    private int fields;
+
+    private RootAllocator allocator;
+    private ManagedVSR vsr;
+    private String[] fieldNames;
+    private FieldVector[] ordinalVectors;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        allocator = new RootAllocator();
+        List<Field> schemaFields = new ArrayList<>(fields);
+        fieldNames = new String[fields];
+        for (int i = 0; i < fields; i++) {
+            String name = ((i & 1) == 0 ? "num_" : "kw_") + i;
+            fieldNames[i] = name;
+            ArrowType type = (i & 1) == 0 ? Types.MinorType.BIGINT.getType() : new ArrowType.Utf8();
+            schemaFields.add(new Field(name, FieldType.nullable(type), null));
+        }
+        vsr = new ManagedVSR("bench", new Schema(schemaFields), allocator);
+        // Ordinal layout: resolve once per schema, as an ordinal-based design would.
+        ordinalVectors = new FieldVector[fields];
+        for (int i = 0; i < fields; i++) {
+            ordinalVectors[i] = vsr.getVector(fieldNames[i]);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        vsr.moveToFrozen();
+        vsr.close();
+    }
+
+    /** Current pattern: null-check lookup + write-side lookup, both by name, per field. */
+    @Benchmark
+    public void doubleLookup(Blackhole bh) {
+        for (int i = 0; i < fieldNames.length; i++) {
+            FieldVector check = vsr.getVector(fieldNames[i]);
+            if (check == null) {
+                throw new IllegalStateException("missing vector");
+            }
+            bh.consume(vsr.getVector(fieldNames[i]));
+        }
+    }
+
+    /** Pass-the-vector: resolve once per field, reuse for the null-check and the write. */
+    @Benchmark
+    public void singleLookup(Blackhole bh) {
+        for (int i = 0; i < fieldNames.length; i++) {
+            FieldVector vector = vsr.getVector(fieldNames[i]);
+            if (vector == null) {
+                throw new IllegalStateException("missing vector");
+            }
+            bh.consume(vector);
+        }
+    }
+
+    /** Ordinal lower bound: vectors resolved once per schema; per-field access is an array read. */
+    @Benchmark
+    public void ordinalArray(Blackhole bh) {
+        for (int i = 0; i < ordinalVectors.length; i++) {
+            FieldVector vector = ordinalVectors[i];
+            if (vector == null) {
+                throw new IllegalStateException("missing vector");
+            }
+            bh.consume(vector);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/writer/ParquetDocumentInputBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/writer/ParquetDocumentInputBenchmark.java
@@ -113,9 +113,26 @@ public class ParquetDocumentInputBenchmark {
         }
     }
 
-    /** Shipped code path: the real {@link ParquetDocumentInput#addField} with linear-scan dedup. */
+    /**
+     * Shipped code path: the real {@link ParquetDocumentInput#addField}, pre-sized from the field count as
+     * {@code ParquetIndexingEngine.newDocumentInput} does (no dedup-set/list resize allocations).
+     */
     @Benchmark
     public void current(Blackhole bh) {
+        ParquetDocumentInput input = new ParquetDocumentInput(fieldTypes.length);
+        for (int i = 0; i < fieldTypes.length; i++) {
+            input.addField(fieldTypes[i], values[i]);
+        }
+        bh.consume(input.getFinalInput());
+        input.close();
+    }
+
+    /**
+     * Same real {@code addField} but default-sized collections — isolates the allocation cost of incremental
+     * {@code HashMap}/{@code ArrayList} resizes that pre-sizing removes (visible in {@code -prof gc} B/op).
+     */
+    @Benchmark
+    public void currentUnsized(Blackhole bh) {
         ParquetDocumentInput input = new ParquetDocumentInput();
         for (int i = 0; i < fieldTypes.length; i++) {
             input.addField(fieldTypes[i], values[i]);

--- a/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/writer/ParquetDocumentInputBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/src/jmh/java/org/opensearch/parquet/writer/ParquetDocumentInputBenchmark.java
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.writer;
+
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Realistic microbenchmark of the Parquet composite writer's per-document field-collection loop — the
+ * {@code ParquetDocumentInput.addField} hot spot seen in bulk-indexing CPU profiles:
+ *
+ * <pre>
+ *   JVM_IHashCode &lt;- System.identityHashCode &lt;- IdentityHashMap.put &lt;- SetFromMap.add
+ *     &lt;- ParquetDocumentInput.addField &lt;- CompositeDocumentInput.addField
+ *     &lt;- NumberFieldMapper.parseCreateFieldForPluggableFormat &lt;- DocumentParser...
+ * </pre>
+ *
+ * <p>Both variants drive the loop with <b>real</b> {@link MappedFieldType} instances
+ * ({@link NumberFieldMapper.NumberFieldType} / {@link KeywordFieldMapper.KeywordFieldType}) carrying real
+ * Parquet capability maps, so the {@code getCapabilityMap().getOrDefault(...)} lookup and the identity of the
+ * hashed objects match production exactly:
+ * <ul>
+ *   <li>{@code current} calls the shipped {@link ParquetDocumentInput#addField}, which dedups by field name in
+ *       a {@code HashSet<String>} (the name String has a cached hash, so no {@code identityHashCode}).</li>
+ *   <li>{@code legacy} replicates the original body inline — {@code Collections.newSetFromMap(new
+ *       IdentityHashMap&lt;&gt;())} with one {@code add} per field — over the same field-type objects and the
+ *       same capability check. Isolates the {@code identityHashCode} cost the shipped change removes.</li>
+ *   <li>{@code pureLinearScan} replicates an unconditional linear reference-equality scan — a naive fix — to
+ *       show its O(n²) blow-up on wide documents.</li>
+ *   <li>{@code nameHashSet} replicates the shipped name-keyed {@code HashSet} strategy inline, as a control
+ *       against {@code current} (which additionally pays for constructing/closing a real
+ *       {@link ParquetDocumentInput} per invocation).</li>
+ * </ul>
+ *
+ * <p>{@link #fields} sweeps realistic per-document field counts. Expectation: the name-keyed strategy
+ * ({@code current} / {@code nameHashSet}) is at or near the fastest at every size with no quadratic blow-up.
+ */
+@Fork(3)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class ParquetDocumentInputBenchmark {
+
+    @Param({ "5", "20", "50", "200" })
+    private int fields;
+
+    private MappedFieldType[] fieldTypes;
+    private Object[] values;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        fieldTypes = new MappedFieldType[fields];
+        values = new Object[fields];
+        Map<?, ?> parquetCaps = Map.of(
+            ParquetDataFormatPlugin.PARQUET_DATA_FORMAT,
+            Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)
+        );
+        for (int i = 0; i < fields; i++) {
+            // Alternate numeric and keyword field types, as a mixed document would carry.
+            if ((i & 1) == 0) {
+                NumberFieldMapper.NumberFieldType ft = new NumberFieldMapper.NumberFieldType("num_" + i, NumberFieldMapper.NumberType.LONG);
+                @SuppressWarnings("unchecked")
+                Map<org.opensearch.index.engine.dataformat.DataFormat, Set<FieldTypeCapabilities.Capability>> caps = (Map<
+                    org.opensearch.index.engine.dataformat.DataFormat,
+                    Set<FieldTypeCapabilities.Capability>>) parquetCaps;
+                ft.setCapabilityMap(caps);
+                fieldTypes[i] = ft;
+                values[i] = (long) i;
+            } else {
+                KeywordFieldMapper.KeywordFieldType ft = new KeywordFieldMapper.KeywordFieldType("kw_" + i);
+                @SuppressWarnings("unchecked")
+                Map<org.opensearch.index.engine.dataformat.DataFormat, Set<FieldTypeCapabilities.Capability>> caps = (Map<
+                    org.opensearch.index.engine.dataformat.DataFormat,
+                    Set<FieldTypeCapabilities.Capability>>) parquetCaps;
+                ft.setCapabilityMap(caps);
+                fieldTypes[i] = ft;
+                values[i] = "v_" + i;
+            }
+        }
+    }
+
+    /** Shipped code path: the real {@link ParquetDocumentInput#addField} with linear-scan dedup. */
+    @Benchmark
+    public void current(Blackhole bh) {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            input.addField(fieldTypes[i], values[i]);
+        }
+        bh.consume(input.getFinalInput());
+        input.close();
+    }
+
+    /**
+     * Pre-change behavior reproduced faithfully: same capability gate, same real field-type objects, but an
+     * {@code IdentityHashMap}-backed dedup set (one {@code add} per field). Measures the {@code identityHashCode}
+     * cost the shipped change removes.
+     */
+    @Benchmark
+    public void legacy(Blackhole bh) {
+        List<Object> collected = new ArrayList<>();
+        Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (int i = 0; i < fieldTypes.length; i++) {
+            MappedFieldType fieldType = fieldTypes[i];
+            Set<FieldTypeCapabilities.Capability> capabilities = fieldType.getCapabilityMap()
+                .getOrDefault(ParquetDataFormatPlugin.PARQUET_DATA_FORMAT, Set.of());
+            if (capabilities.isEmpty()) {
+                continue;
+            }
+            if (dedup.add(fieldType) == false) {
+                throw new MapperParsingException("dup");
+            }
+            collected.add(values[i]);
+        }
+        bh.consume(collected);
+    }
+
+    /**
+     * The naive fix: an unconditional linear reference-equality scan, same capability gate and real field-type
+     * objects. Shows the O(n²) cost on wide documents that the name-keyed set avoids.
+     */
+    @Benchmark
+    public void pureLinearScan(Blackhole bh) {
+        List<MappedFieldType> collected = new ArrayList<>();
+        List<Object> collectedValues = new ArrayList<>();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            MappedFieldType fieldType = fieldTypes[i];
+            Set<FieldTypeCapabilities.Capability> capabilities = fieldType.getCapabilityMap()
+                .getOrDefault(ParquetDataFormatPlugin.PARQUET_DATA_FORMAT, Set.of());
+            if (capabilities.isEmpty()) {
+                continue;
+            }
+            for (int j = 0; j < collected.size(); j++) {
+                if (collected.get(j) == fieldType) {
+                    throw new MapperParsingException("dup");
+                }
+            }
+            collected.add(fieldType);
+            collectedValues.add(values[i]);
+        }
+        bh.consume(collectedValues);
+    }
+
+    /**
+     * Dedup by field <b>name</b> in a plain {@link java.util.HashSet}. {@code MappedFieldType} inherits
+     * {@code Object.hashCode()} (identity → {@code identityHashCode}), so a set of the objects would still pay
+     * {@code JVM_IHashCode}; but {@code String.hashCode()} is cached, so hashing the name avoids it. O(n), so no
+     * wide-document blow-up. Note: this dedups by name-equality rather than object identity — arguably the more
+     * correct contract, matching the name-based duplicate error message.
+     */
+    @Benchmark
+    public void nameHashSet(Blackhole bh) {
+        List<Object> collected = new ArrayList<>();
+        Set<String> dedup = new HashSet<>();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            MappedFieldType fieldType = fieldTypes[i];
+            Set<FieldTypeCapabilities.Capability> capabilities = fieldType.getCapabilityMap()
+                .getOrDefault(ParquetDataFormatPlugin.PARQUET_DATA_FORMAT, Set.of());
+            if (capabilities.isEmpty()) {
+                continue;
+            }
+            if (dedup.add(fieldType.name()) == false) {
+                throw new MapperParsingException("dup");
+            }
+            collected.add(values[i]);
+        }
+        bh.consume(collected);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -318,7 +318,18 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     @Override
     public ParquetDocumentInput newDocumentInput() {
-        return new ParquetDocumentInput();
+        // Pre-size the input from the mapped-field count so its per-document collections never resize
+        // (the dedup set's HashMap table copies were a measurable slice of an ingest allocation profile).
+        // The schema walk is expensive, so it is cached and only rebuilt when the mapping version changes;
+        // the version read itself is a cheap metadata lookup.
+        long mappingVersion = mappingVersionSupplier.get();
+        Schema schema = cachedSchema;
+        if (schema == null || mappingVersion != cachedSchemaVersion) {
+            schema = schemaSupplier.get();
+            cachedSchema = schema;
+            cachedSchemaVersion = mappingVersion;
+        }
+        return new ParquetDocumentInput(schema.getFields().size());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
@@ -26,15 +27,35 @@ public abstract class ParquetField {
     public ParquetField() {}
 
     /**
-     * Writes the parsed field value into the appropriate vector in the managed VSR.
+     * Writes the parsed field value into the given vector at the given row.
+     * <p>
+     * The vector is resolved <b>once</b> by the caller and passed in; implementations must not re-resolve it
+     * by field name — the per-field name lookup ({@code ManagedVSR.getVector} → {@code HashMap.get}) runs once
+     * per field per document on the bulk-indexing hot path and was a visible CPU frame in ingest profiles when
+     * every implementation repeated it.
+     *
      * @param fieldType the mapped field type
-     * @param managedVSR the managed vector schema root
+     * @param vector the resolved field vector to write into
+     * @param rowIndex the row index to write at
      * @param parseValue the parsed value to write
      */
-    protected abstract void addToGroup(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue);
+    protected abstract void addToGroup(MappedFieldType fieldType, FieldVector vector, int rowIndex, Object parseValue);
 
     /**
-     * Creates and processes a field entry. Throws if vector not present in VSR.
+     * Creates and processes a field entry against an already-resolved vector.
+     * @param fieldType the mapped field type
+     * @param vector the resolved field vector
+     * @param rowIndex the row index to write at
+     * @param parseValue the parsed value to write
+     */
+    public final void createField(MappedFieldType fieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        assert fieldType != null : "MappedFieldType cannot be null";
+        assert vector != null : "FieldVector cannot be null";
+        addToGroup(fieldType, vector, rowIndex, parseValue);
+    }
+
+    /**
+     * Convenience entry point that resolves the vector by field name. Throws if vector not present in VSR.
      * @param fieldType the mapped field type
      * @param managedVSR the managed vector schema root
      * @param parseValue the parsed value to write
@@ -42,7 +63,11 @@ public abstract class ParquetField {
     public final void createField(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue) {
         assert fieldType != null : "MappedFieldType cannot be null";
         assert managedVSR != null : "ManagedVSR cannot be null";
-        addToGroup(fieldType, managedVSR, parseValue);
+        FieldVector vector = managedVSR.getVector(fieldType.name());
+        if (vector == null) {
+            throw new IllegalStateException("No vector for field [" + fieldType.name() + "] in VSR [" + managedVSR.getId() + "]");
+        }
+        addToGroup(fieldType, vector, managedVSR.getRowCount(), parseValue);
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BinaryParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BinaryParquetField.java
@@ -8,13 +8,13 @@
 
 package org.opensearch.parquet.fields.core.data;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.util.Set;
 
@@ -27,8 +27,8 @@ public class BinaryParquetField extends ParquetField {
     public BinaryParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarBinaryVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (byte[]) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarBinaryVector) vector).setSafe(rowIndex, (byte[]) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
@@ -9,12 +9,12 @@
 package org.opensearch.parquet.fields.core.data;
 
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.util.Set;
 
@@ -27,8 +27,8 @@ public class BooleanParquetField extends ParquetField {
     public BooleanParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((BitVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Boolean) parseValue ? 1 : 0);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((BitVector) vector).setSafe(rowIndex, (Boolean) parseValue ? 1 : 0);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.date;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -15,7 +16,6 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.util.Set;
 
@@ -28,8 +28,8 @@ public class DateNanosParquetField extends ParquetField {
     public DateNanosParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TimeStampNanoVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (long) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((TimeStampNanoVector) vector).setSafe(rowIndex, (long) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.date;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -15,7 +16,6 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.util.Set;
 
@@ -28,8 +28,8 @@ public class DateParquetField extends ParquetField {
     public DateParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TimeStampMilliVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (long) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((TimeStampMilliVector) vector).setSafe(rowIndex, (long) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for 8-bit signed byte values using {@link TinyIntVector}.
@@ -23,8 +23,8 @@ public class ByteParquetField extends NumericParquetField {
     public ByteParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TinyIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).byteValue());
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((TinyIntVector) vector).setSafe(rowIndex, ((Number) parseValue).byteValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/DoubleParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/DoubleParquetField.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for double-precision floating-point values using {@link Float8Vector}.
@@ -24,8 +24,8 @@ public class DoubleParquetField extends NumericParquetField {
     public DoubleParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float8Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Double) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((Float8Vector) vector).setSafe(rowIndex, (Double) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/FloatParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/FloatParquetField.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for single-precision floating-point values using {@link Float4Vector}.
@@ -24,8 +24,8 @@ public class FloatParquetField extends NumericParquetField {
     public FloatParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float4Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Float) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((Float4Vector) vector).setSafe(rowIndex, (Float) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/HalfFloatParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/HalfFloatParquetField.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float2Vector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for half-precision (16-bit) floating-point values using {@link Float2Vector}.
@@ -24,11 +24,8 @@ public class HalfFloatParquetField extends NumericParquetField {
     public HalfFloatParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float2Vector) managedVSR.getVector(mappedFieldType.name())).setSafeWithPossibleTruncate(
-            managedVSR.getRowCount(),
-            ((Number) parseValue).floatValue()
-        );
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((Float2Vector) vector).setSafeWithPossibleTruncate(rowIndex, ((Number) parseValue).floatValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/IntegerParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/IntegerParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for 32-bit signed integer values using {@link IntVector}.
@@ -23,8 +23,8 @@ public class IntegerParquetField extends NumericParquetField {
     public IntegerParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((IntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Integer) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((IntVector) vector).setSafe(rowIndex, (Integer) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
@@ -9,10 +9,10 @@
 package org.opensearch.parquet.fields.core.data.number;
 
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for 64-bit signed long values using {@link BigIntVector}.
@@ -31,8 +31,8 @@ public class LongParquetField extends NumericParquetField {
     }
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((BigIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Long) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((BigIntVector) vector).setSafe(rowIndex, (Long) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ShortParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ShortParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for 16-bit signed short values using {@link SmallIntVector}.
@@ -23,8 +23,8 @@ public class ShortParquetField extends NumericParquetField {
     public ShortParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((SmallIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Short) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((SmallIntVector) vector).setSafe(rowIndex, (Short) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/TokenCountParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/TokenCountParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for token count values stored as 32-bit integers using {@link IntVector}.
@@ -23,8 +23,8 @@ public class TokenCountParquetField extends NumericParquetField {
     public TokenCountParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((IntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Integer) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((IntVector) vector).setSafe(rowIndex, (Integer) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/UnsignedLongParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/UnsignedLongParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for 64-bit unsigned long values using {@link UInt8Vector}.
@@ -23,8 +23,8 @@ public class UnsignedLongParquetField extends NumericParquetField {
     public UnsignedLongParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((UInt8Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).longValue());
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((UInt8Vector) vector).setSafe(rowIndex, ((Number) parseValue).longValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -16,7 +17,6 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.net.InetAddress;
 import java.util.Set;
@@ -30,10 +30,10 @@ public class IpParquetField extends ParquetField {
     public IpParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        VarBinaryVector vector = (VarBinaryVector) managedVSR.getVector(mappedFieldType.name());
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        VarBinaryVector binaryVector = (VarBinaryVector) vector;
         BytesRef bytesRef = new BytesRef(InetAddressPoint.encode((InetAddress) parseValue));
-        vector.setSafe(managedVSR.getRowCount(), bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        binaryVector.setSafe(rowIndex, bytesRef.bytes, bytesRef.offset, bytesRef.length);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.nio.charset.StandardCharsets;
 
@@ -26,11 +26,8 @@ public class KeywordParquetField extends ParquetField {
     public KeywordParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarCharVector) vector).setSafe(rowIndex, parseValue.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/TextParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/TextParquetField.java
@@ -8,13 +8,13 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -28,11 +28,8 @@ public class TextParquetField extends ParquetField {
     public TextParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarCharVector) vector).setSafe(rowIndex, parseValue.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IdParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IdParquetField.java
@@ -8,13 +8,13 @@
 
 package org.opensearch.parquet.fields.core.metadata;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.util.Set;
 
@@ -27,9 +27,8 @@ public class IdParquetField extends ParquetField {
     public IdParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        VarBinaryVector vector = (VarBinaryVector) managedVSR.getVector(mappedFieldType.name());
-        vector.setSafe(managedVSR.getRowCount(), (byte[]) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarBinaryVector) vector).setSafe(rowIndex, (byte[]) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IgnoredParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IgnoredParquetField.java
@@ -8,13 +8,13 @@
 
 package org.opensearch.parquet.fields.core.metadata;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -31,11 +31,8 @@ public class IgnoredParquetField extends ParquetField {
     public IgnoredParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarCharVector) vector).setSafe(rowIndex, parseValue.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IndexParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/IndexParquetField.java
@@ -8,11 +8,11 @@
 
 package org.opensearch.parquet.fields.core.metadata;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for index name.
@@ -21,7 +21,7 @@ import org.opensearch.parquet.vsr.ManagedVSR;
 public class IndexParquetField extends ParquetField {
 
     @Override
-    protected void addToGroup(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue) {
+    protected void addToGroup(MappedFieldType fieldType, FieldVector vector, int rowIndex, Object parseValue) {
         throw new IllegalStateException("Index field is not supposed to be added to group");
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/RoutingParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/RoutingParquetField.java
@@ -8,13 +8,13 @@
 
 package org.opensearch.parquet.fields.core.metadata;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -28,11 +28,8 @@ public class RoutingParquetField extends ParquetField {
     public RoutingParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((VarCharVector) vector).setSafe(rowIndex, parseValue.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/SizeParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/metadata/SizeParquetField.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.parquet.fields.core.metadata;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.fields.ParquetField;
-import org.opensearch.parquet.vsr.ManagedVSR;
 
 /**
  * Parquet field for _size metadata stored as 32-bit integer using {@link IntVector}.
@@ -24,8 +24,8 @@ public class SizeParquetField extends ParquetField {
     public SizeParquetField() {}
 
     @Override
-    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((IntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Integer) parseValue);
+    protected void addToGroup(MappedFieldType mappedFieldType, FieldVector vector, int rowIndex, Object parseValue) {
+        ((IntVector) vector).setSafe(rowIndex, (Integer) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -10,6 +10,7 @@ package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.logging.log4j.LogManager;
@@ -209,6 +210,7 @@ public class VSRManager implements AutoCloseable {
             );
         }
         ManagedVSR activeVSR = managedVSR.get();
+        int docRowIndex = activeVSR.getRowCount();
         for (FieldValuePair pair : doc.getFinalInput()) {
             MappedFieldType fieldType = pair.getFieldType();
             ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
@@ -222,7 +224,10 @@ public class VSRManager implements AutoCloseable {
                     "No ParquetField mapping for field [" + fieldType.name() + "] of type [" + fieldType.typeName() + "]"
                 );
             }
-            if (activeVSR.getVector(fieldType.name()) == null) {
+            // Resolve the vector once per field and pass it through — implementations must not re-resolve
+            // by name (the duplicate ManagedVSR.getVector lookup was a visible CPU frame in ingest profiles).
+            FieldVector vector = activeVSR.getVector(fieldType.name());
+            if (vector == null) {
                 logger.error(
                     "[Gen: {}] VSR schema mismatch: field [{}] not in active VSR. VSR schema fields: {}",
                     writerGeneration,
@@ -235,7 +240,7 @@ public class VSRManager implements AutoCloseable {
                         + "] — schema reconciliation must run via updateMappingVersion before addDocument"
                 );
             }
-            parquetField.createField(fieldType, activeVSR, pair.getValue());
+            parquetField.createField(fieldType, vector, docRowIndex, pair.getValue());
         }
         int rowIndex = activeVSR.getRowCount();
         BigIntVector rowIdVector = (BigIntVector) activeVSR.getVector(DocumentInput.ROW_ID_FIELD);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -21,8 +21,7 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,8 +38,18 @@ import java.util.Set;
 public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>> {
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
+
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    private final Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
+    /**
+     * Detects duplicate single-valued fields, keyed by field <b>name</b>. Two {@code addField} calls with the
+     * same name necessarily carry the same {@link MappedFieldType} instance — the mapping layer forbids two
+     * mappers sharing a name (see {@code MappingLookup}) — so name-equality dedup is equivalent to the previous
+     * object-identity dedup. Keying on the name String rather than the field-type object avoids
+     * {@code System.identityHashCode} on the bulk-indexing hot path: {@code MappedFieldType} inherits
+     * {@code Object.hashCode()} (identity → {@code JVM_IHashCode}), whereas {@code String.hashCode()} is cached.
+     * O(n) in field count, so no quadratic blow-up on wide documents.
+     */
+    private final Set<String> seenFieldNames = new HashSet<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,7 +63,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-        if (dedup.add(fieldType) == false) {
+        if (seenFieldNames.add(fieldType.name()) == false) {
             throw new MapperParsingException(
                 "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
             );
@@ -91,6 +100,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
     public void close() {
         isClosed = true;
         collectedFields.clear();
+        seenFieldNames.clear();
         rowId = -1;
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -39,7 +39,10 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
 
-    private final List<FieldValuePair> collectedFields = new ArrayList<>();
+    /** Default expected field count when the caller has no sizing hint. */
+    static final int DEFAULT_EXPECTED_FIELDS = 16;
+
+    private final List<FieldValuePair> collectedFields;
     /**
      * Detects duplicate single-valued fields, keyed by field <b>name</b>. Two {@code addField} calls with the
      * same name necessarily carry the same {@link MappedFieldType} instance — the mapping layer forbids two
@@ -49,9 +52,32 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
      * {@code Object.hashCode()} (identity → {@code JVM_IHashCode}), whereas {@code String.hashCode()} is cached.
      * O(n) in field count, so no quadratic blow-up on wide documents.
      */
-    private final Set<String> seenFieldNames = new HashSet<>();
+    private final Set<String> seenFieldNames;
     private long rowId = -1;
     private boolean isClosed = false;
+
+    /** Creates a document input with the default sizing hint. */
+    public ParquetDocumentInput() {
+        this(DEFAULT_EXPECTED_FIELDS);
+    }
+
+    /**
+     * Creates a document input pre-sized for the expected number of fields.
+     * <p>
+     * One instance is allocated per document at bulk-indexing rates, and the dedup set's incremental
+     * {@code HashMap} table resizes (16 → ... → 256 for a ~100-field document) were a measurable slice of an
+     * ingest allocation profile. Pre-sizing from the mapped-field count eliminates the resize copies; callers
+     * with no hint get the default.
+     *
+     * @param expectedFields expected number of fields this document will carry (typically the mapped field
+     *                       count of the index; an upper bound is fine, values below 1 fall back to the default)
+     */
+    public ParquetDocumentInput(int expectedFields) {
+        int expected = expectedFields > 0 ? expectedFields : DEFAULT_EXPECTED_FIELDS;
+        this.collectedFields = new ArrayList<>(expected);
+        // HashSet resizes above capacity * 0.75; size so `expected` inserts never trigger a resize.
+        this.seenFieldNames = new HashSet<>(expected * 4 / 3 + 1);
+    }
 
     @Override
     public void addField(MappedFieldType fieldType, Object value) {


### PR DESCRIPTION
## Description

Removes per-field hashing, iteration, redundant lookup, and resize-allocation overhead from the composite/Parquet **indexing hot path**, motivated by an async-profiler CPU capture of bulk ingest where `JVM_IHashCode` was the single largest self-cost (~10.8%), and a follow-up allocation profile (`-e alloc`) where the per-document dedup set's `HashMap$Node`/`Node[]` churn was ~9.7% of total allocation.

### 1. `ParquetDocumentInput`: dedup fields by name instead of object identity
`addField` detected duplicate single-valued fields with a `Collections.newSetFromMap(new IdentityHashMap<>())`, so every field of every document paid `System.identityHashCode` (`MappedFieldType` inherits identity `hashCode()`). That call is the `JVM_IHashCode` frame in the profile.

The mapping layer forbids two mappers sharing a name (`MappingLookup`), and every `addField` caller passes `fieldType()`, so within one document **same name ⇒ same `MappedFieldType` instance**. Deduping in a `HashSet<String>` on `fieldType.name()` is therefore behaviourally equivalent, uses `String`'s cached hash (no identity-hash intrinsic), and stays O(n) — no quadratic scan on wide documents.

### 2. `CompositeDocumentInput`: snapshot secondary inputs to arrays
`addField` iterated `unmodifiableMap(IdentityHashMap).entrySet()` **per field per document**, allocating an entry-set iterator and walking `IdentityHashMap`'s sparse table on every call (`IdentityHashMapIterator.hasNext` / `UnmodifiableEntrySet` frames). The map is immutable after construction, so the constructor now snapshots it once into flat `DataFormat[]`/`DocumentInput[]` arrays and `addField`/`setRowId` loop those.

### 3. `ParquetField` SPI: resolve the Arrow vector once per field
`VSRManager.addDocument` resolved each field's vector by name **twice** per field — once for a null-check, then again inside every `ParquetField.addToGroup` implementation (`ManagedVSR.getVector` → `HashMap.get`). The SPI now passes the resolved `FieldVector` and row index into `addToGroup`; `VSRManager` resolves once, null-checks, and hands it through. A name-resolving `createField` overload is kept for callers that don't pre-resolve.

### 4. Pre-size the per-document collections from the mapped-field count
The allocation profile showed the dedup set and field list growing incrementally per document (`HashMap$Node[]` table copies 16 → 256 for a ~100-field document, plus `ArrayList` growth). `ParquetIndexingEngine.newDocumentInput` now sizes both from the Arrow schema's field count, cached against the mapping version so the schema walk only reruns on mapping changes.

## Benchmarks
New `jmh` source sets in both plugins (same wiring as `:libs:opensearch-concurrent-queue`); all drive the **real** classes over genuine `NumberFieldType`/`KeywordFieldType` instances.

- **Dedup (1):** name-keyed set competitive at small field counts, clearly better at wide documents, no O(n²) cliff. An async-profiler run confirms the `IdentityHashMap.hash` frame is present in the old strategy and **absent** with the name-keyed set.
- **Broadcast (2):** with no-op per-format delegates (isolating broadcast overhead), array snapshot is **~10–13×** map iteration across 5–50 fields × 1–3 secondaries (e.g. 20×1: 19.7 ns vs 249.5 ns).
- **Vector lookup (3):** single lookup is **~2×** the double lookup at 50 fields (98.8 vs 186.8 ns). An ordinal-array layout measured ~10× further headroom — left as follow-up if Linux re-profiling still shows this frame.
- **Pre-sizing (4), `-prof gc` at 200 fields:** 18 649 → 14 201 B/op (−24%) and 2 689 → 1 908 ns/op vs default-sized collections. Remaining bytes are the per-field `HashMap$Node`/`FieldValuePair` entries themselves; eliminating those needs input pooling or a fused structure — measured trade-off, deferred.

Run: `./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:jmh` / `:sandbox:plugins:composite-engine:jmh` with `-Pjmh.includes=<name>`.

## Honesty / scope notes for reviewers
- The microbenchmarks prove the *mechanisms* and *isolated* deltas; they **cannot** quantify fleet-level % — that needs re-profiling real bulk ingest on Linux. Isolated multiples shrink end-to-end since real per-format work sits on top.
- Allocation trade-off, stated plainly: the name-keyed `HashSet` allocates **more per document than the old `IdentityHashMap`** at small field counts (`-prof gc` @20 fields: 1 480 vs 592 B/op) because `HashMap` allocates a `Node` per entry while `IdentityHashMap` is a flat table. The old path's cost was CPU (identity-hash intrinsic + VM transition frames), the new path's cost is short-lived young-gen garbage. The production GC data so far (0 old-gen collections, 12.1 s young-gen over a 51-min ingest) says this is not pathological, but the Linux before/after should watch alloc-rate, not just CPU.
- The Lucene-internal `KeywordFieldMapper.normalizeValue → AttributeSource.addAttribute` `JVM_IHashCode` source and the Jackson `DupDetector` allocation hotspot (~8.4% of alloc, duplicate-JSON-key detection in parse) are **not** touched here.

## Check List
- [x] Functionality equivalent (name-dedup ≡ identity-dedup; broadcast map immutable after construction; row index captured before row count advances; schema cache keyed on mapping version)
- [x] Commits are signed per the DCO
- [x] Plugin unit tests pass (`:sandbox:plugins:parquet-data-format:test`)
- [ ] Reviewer to confirm production before/after profile (CPU **and** alloc) on Linux ingest host
