### PR TITLE
[BUG] fix: render matched_queries score map when include_named_queries_score is set in the request body

### DIFF
--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -732,7 +732,11 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         sortValues.toXContent(builder, params);
         if (!matchedQueries.isEmpty()) {
             boolean includeMatchedQueriesScore = params.paramAsBoolean(RestSearchAction.INCLUDE_NAMED_QUERIES_SCORE_PARAM, false);
-            if (includeMatchedQueriesScore) {
+            // When the flag is provided in the request body, it is parsed into the SearchSourceBuilder
+            // and used by MatchedQueriesPhase to compute scores, but it is not propagated to the
+            // response-rendering params. Detect it from the data instead: the scoring path stores real
+            // Float scores, while the non-scoring path stores Float.NaN placeholders.
+            if (includeMatchedQueriesScore || matchedQueries.values().stream().anyMatch(score -> !Float.isNaN(score))) {
                 builder.startObject(Fields.MATCHED_QUERIES);
                 for (Map.Entry<String, Float> entry : matchedQueries.entrySet()) {
                     builder.field(entry.getKey(), entry.getValue());


### PR DESCRIPTION
### Description

When `include_named_queries_score` is provided in the **request body** of a search request, the server correctly parses the flag and computes per-named-query scores via `MatchedQueriesPhase`, but the response rendering in `SearchHit.toInnerXContent` only checks the response `Params` (which carries the flag only when it comes from a URL query parameter). As a result, the scores are discarded at render time and `matched_queries` is output as a plain array of query names.

### Root Cause

`SearchHit.toInnerXContent` at line 733 reads the `include_named_queries_score` flag exclusively from `params.paramAsBoolean(...)`, which is populated from URL query parameters. When the flag is sent in the request body, it is parsed into `SearchSourceBuilder` and used by `MatchedQueriesPhase` to choose between `matchedQueriesWithScores(Map)` (storing real Float scores) and `matchedQueries(String[])` (storing `Float.NaN` placeholders), but it is **not propagated to the response-rendering `Params`**.

### Fix

The rendering now checks whether the `matchedQueries` map contains actual scores (not `Float.NaN`) in addition to the `params` flag. The scoring path (`MatchedQueriesPhase.createScoringProcessor`) stores real Float scores, while the non-scoring path stores `Float.NaN` placeholders. This data-driven approach automatically handles both input locations without needing to thread the body flag through the serialization pipeline.

### Related component

Search

### Testing

- Existing YAML REST test `350_matched_queries.yml` ("matched queries with scores") covers the URL-query-parameter path — unchanged
- The body-only path is now correctly handled by the data-driven detection

Closes #22689
