### PR TITLE
fix(wlm): Skip rejection for MONITOR mode workload groups

### DIFF
--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
@@ -272,8 +272,9 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
             .findFirst();
 
         if (optionalWorkloadGroup.isPresent()
-            && (optionalWorkloadGroup.get().getResiliencyMode() == MutableWorkloadGroupFragment.ResiliencyMode.SOFT
-                && !nodeDuressTrackers.isNodeInDuress())) return;
+            && (optionalWorkloadGroup.get().getResiliencyMode() == MutableWorkloadGroupFragment.ResiliencyMode.MONITOR
+                || (optionalWorkloadGroup.get().getResiliencyMode() == MutableWorkloadGroupFragment.ResiliencyMode.SOFT
+                    && !nodeDuressTrackers.isNodeInDuress()))) return;
 
         optionalWorkloadGroup.ifPresent(workloadGroup -> {
             boolean reject = false;

--- a/server/src/test/java/org/opensearch/wlm/WorkloadGroupServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadGroupServiceTests.java
@@ -268,6 +268,35 @@ public class WorkloadGroupServiceTests extends OpenSearchTestCase {
         verify(spyState, never()).getResourceState();
     }
 
+    public void testRejectIfNeeded_whenWorkloadGroupIsMonitorMode() {
+        Set<WorkloadGroup> activeWorkloadGroups = getActiveWorkloadGroups(
+            "testWorkloadGroup",
+            WORKLOAD_GROUP_ID,
+            MutableWorkloadGroupFragment.ResiliencyMode.MONITOR,
+            Map.of(ResourceType.CPU, 0.10)
+        );
+        mockWorkloadGroupStateMap = new HashMap<>();
+        WorkloadGroupState spyState = spy(new WorkloadGroupState());
+        mockWorkloadGroupStateMap.put(WORKLOAD_GROUP_ID, spyState);
+
+        mockWorkloadGroupsStateAccessor = new WorkloadGroupsStateAccessor(mockWorkloadGroupStateMap);
+
+        workloadGroupService = new WorkloadGroupService(
+            mockCancellationService,
+            mockClusterService,
+            mockThreadPool,
+            mockWorkloadManagementSettings,
+            mockNodeDuressTrackers,
+            mockWorkloadGroupsStateAccessor,
+            activeWorkloadGroups,
+            new HashSet<>()
+        );
+        workloadGroupService.rejectIfNeeded(WORKLOAD_GROUP_ID);
+
+        // MONITOR mode should never reject - verify no resource state access for rejection
+        verify(spyState, never()).getResourceState();
+    }
+
     public void testRejectIfNeeded_whenWorkloadGroupIsEnforcedMode_andNotBreaching() {
         WorkloadGroup testWorkloadGroup = getWorkloadGroup(
             "testWorkloadGroup",


### PR DESCRIPTION
### Description
  
  `WorkloadGroupService.rejectIfNeeded` incorrectly rejects requests for workload groups with `resiliency_mode: monitor`. MONITOR mode is
  documented as observe-only — it should never reject or cancel requests.
  
  The bug occurs because the resiliency mode exemption in `rejectIfNeeded` only checks for `SOFT` mode (which skips rejection when the node is
  not in duress). `MONITOR` falls through to the same rejection path as `ENFORCED`.
  
  **Fix:** Add a `MONITOR` mode check alongside the existing `SOFT` mode exemption so that monitor-mode groups bypass the rejection path
  entirely.
  
  ### Related Issues
  
  Resolves #22616
  
  ### Check List
  - [x] Functionality includes testing.
  - [ ] API changes companion pull request
  [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
  - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on
  following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
