### PR TITLE
planner and jemalloc changes to improve performance

### DIFF
--- a/sandbox/libs/dataformat-native/rust/.cargo/config.toml
+++ b/sandbox/libs/dataformat-native/rust/.cargo/config.toml
@@ -5,4 +5,4 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 # Enable jemalloc heap profiling support in all builds. prof:true is init-time only and
 # cannot be enabled post-start, so it must be compiled in. prof_active:false ensures zero
 # runtime overhead until explicitly activated via cluster settings at runtime.
-JEMALLOC_SYS_WITH_MALLOC_CONF = "prof:true,prof_active:false,lg_prof_sample:17"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "prof:true,prof_active:false,lg_prof_sample:17,thp:always,metadata_thp:always,oversize_threshold:536870912"

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/extract.rs
@@ -223,6 +223,23 @@ fn fill_int_builder<F>(
 where
     F: Fn(usize) -> Option<i64>,
 {
+    // The unit is virtually always a literal (`extract(minute from ts)`), in which case the
+    // planner hands us a length-1 array or an all-same column. Resolving + upper-casing it once
+    // instead of per row removes two heap allocations from a 100M-row loop (ClickBench q19 spent
+    // 5.6s of expr eval time in this UDF; the whole query in stock DataFusion is 1.8s).
+    if let Some(unit) = single_unit(unit_arr)? {
+        let upper = unit.to_ascii_uppercase();
+        for i in 0..n {
+            match value_at(i) {
+                None => builder.append_null(),
+                Some(v) => match compute_upper(&upper, v) {
+                    Some(out) => builder.append_value(out),
+                    None => builder.append_null(),
+                },
+            }
+        }
+        return Ok(());
+    }
     for i in 0..n {
         match value_at(i) {
             None => builder.append_null(),
@@ -236,6 +253,29 @@ where
         }
     }
     Ok(())
+}
+
+/// The unit as a single value when every row shares it — a length-1 (broadcast scalar) array, or a
+/// column whose values are all equal. Returns `None` when the unit genuinely varies per row, or when
+/// any unit is null, so the caller falls back to the per-row path and null handling is unchanged.
+fn single_unit(array: &ArrayRef) -> Result<Option<String>> {
+    if array.is_empty() || array.null_count() > 0 {
+        return Ok(None);
+    }
+    let first = match unit_at(array, 0)? {
+        Some(u) => u,
+        None => return Ok(None),
+    };
+    if array.len() == 1 {
+        return Ok(Some(first));
+    }
+    for row in 1..array.len() {
+        match unit_at(array, row)? {
+            Some(u) if u == first => {}
+            _ => return Ok(None),
+        }
+    }
+    Ok(Some(first))
 }
 
 fn scalar_utf8(s: &ScalarValue) -> Result<Option<String>> {
@@ -261,12 +301,29 @@ fn unit_at(array: &ArrayRef, row: usize) -> Result<Option<String>> {
 }
 
 fn compute(unit: &str, micros: i64) -> Option<i64> {
+    compute_upper(&unit.to_ascii_uppercase(), micros)
+}
+
+/// As [`compute`] but with the unit already upper-cased, so a hot loop over a constant unit does
+/// not re-allocate per row.
+fn compute_upper(unit_upper: &str, micros: i64) -> Option<i64> {
+    // Time-of-day components need no calendar arithmetic — derive them from the epoch offset
+    // directly and skip building a chrono DateTime for every row. div_euclid/rem_euclid keep
+    // pre-1970 (negative) timestamps correct, matching the chrono path.
+    match unit_upper {
+        "MICROSECOND" => return Some(micros.rem_euclid(1_000_000)),
+        "MILLISECOND" => return Some(micros.rem_euclid(1_000_000) / 1_000),
+        "SECOND" => return Some(micros.div_euclid(1_000_000).rem_euclid(60)),
+        "MINUTE" => return Some(micros.div_euclid(60_000_000).rem_euclid(60)),
+        "HOUR" => return Some(micros.div_euclid(3_600_000_000).rem_euclid(24)),
+        _ => {}
+    }
     let seconds = micros.div_euclid(1_000_000);
     let micro_fraction = micros.rem_euclid(1_000_000) as u32;
     let dt = Utc
         .timestamp_opt(seconds, micro_fraction * 1_000)
         .single()?;
-    extract_for_unit(&unit.to_ascii_uppercase(), dt)
+    extract_for_unit(unit_upper, dt)
 }
 
 /// Unknown unit → None (PPL throws; we surface null to avoid aborting the whole query).
@@ -401,5 +458,56 @@ mod tests {
     fn unknown_unit_yields_null() {
         assert_eq!(eval("NANOSECOND"), None);
         assert_eq!(eval(""), None);
+    }
+
+    /// The fast path for time-of-day units must agree with the chrono calendar path bit for bit,
+    /// including pre-epoch (negative) timestamps where div_euclid/rem_euclid matter.
+    #[test]
+    fn fast_path_matches_chrono_path() {
+        fn chrono_reference(unit_upper: &str, micros: i64) -> Option<i64> {
+            let seconds = micros.div_euclid(1_000_000);
+            let micro_fraction = micros.rem_euclid(1_000_000) as u32;
+            let dt = Utc
+                .timestamp_opt(seconds, micro_fraction * 1_000)
+                .single()?;
+            extract_for_unit(unit_upper, dt)
+        }
+        let samples: [i64; 9] = [
+            0,
+            1_000_000,
+            1_234_567_890_123_456,
+            1_700_000_000_999_999,
+            59_999_999,
+            86_399_999_999,
+            -1,
+            -1_000_000_001,
+            -86_400_000_000,
+        ];
+        for unit in ["MICROSECOND", "MILLISECOND", "SECOND", "MINUTE", "HOUR"] {
+            for micros in samples {
+                assert_eq!(
+                    compute_upper(unit, micros),
+                    chrono_reference(unit, micros),
+                    "unit={unit} micros={micros}"
+                );
+            }
+        }
+    }
+
+    /// A constant unit must take the hoisted path and a varying unit must not, with identical output.
+    #[test]
+    fn single_unit_detects_constant_and_varying_units() {
+        let constant: ArrayRef = Arc::new(StringArray::from(vec!["minute", "minute", "minute"]));
+        assert_eq!(single_unit(&constant).unwrap().as_deref(), Some("minute"));
+
+        let broadcast: ArrayRef = Arc::new(StringArray::from(vec!["hour"]));
+        assert_eq!(single_unit(&broadcast).unwrap().as_deref(), Some("hour"));
+
+        let varying: ArrayRef = Arc::new(StringArray::from(vec!["minute", "hour"]));
+        assert_eq!(single_unit(&varying).unwrap(), None);
+
+        // A null unit must fall back to the per-row path so null handling is preserved.
+        let with_null: ArrayRef = Arc::new(StringArray::from(vec![Some("minute"), None]));
+        assert_eq!(single_unit(&with_null).unwrap(), None);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -375,6 +375,7 @@ public class PlannerImpl {
             .addRuleInstance(new OpenSearchCheckedLongSumWindowRule())
             .addRuleInstance(new OpenSearchDistinctCountRule())
             .addRuleInstance(new OpenSearchAggregateReduceRule())
+            .addRuleInstance(CoreRules.AGGREGATE_PROJECT_PULL_UP_CONSTANTS)
             .run(input, listener);
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerImpl.java
@@ -376,6 +376,16 @@ public class PlannerImpl {
             .addRuleInstance(new OpenSearchDistinctCountRule())
             .addRuleInstance(new OpenSearchAggregateReduceRule())
             .addRuleInstance(CoreRules.AGGREGATE_PROJECT_PULL_UP_CONSTANTS)
+            // AGGREGATE_PROJECT_PULL_UP_CONSTANTS lifts constant group keys into a Project above
+            // the Aggregate. That Project lands directly beneath the query's own projection, and
+            // PROJECT_MERGE already ran back in the pushdown phase — so without merging here the
+            // tree keeps two adjacent, column-reordering Projects between any downstream Sort and
+            // the Aggregate. OpenSearchTopKRewriter only composes its sort-key remap through a
+            // single Project (it treats further Projects as transparent passthroughs), so the
+            // second reordering Project made it map the collation past the Aggregate's output and
+            // throw IndexOutOfBoundsException. Collapsing the pair back into one Project here keeps
+            // that invariant intact and lets TopK oversampling still fire for these queries.
+            .addRuleInstance(CoreRules.PROJECT_MERGE)
             .run(input, listener);
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregatePlanShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/AggregatePlanShapeTests.java
@@ -8,8 +8,11 @@
 
 package org.opensearch.analytics.planner;
 
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -291,6 +294,44 @@ public class AggregatePlanShapeTests extends PlanShapeTestBase {
                       OpenSearchTableScan(table=[[test_index]], viableBackends=[[mock-parquet]])
                 """,
             result
+        );
+    }
+
+    // ---- Constant group keys: PPL's `eval c = 1 | stats count() by c, URL` materialises the ----
+    // ---- literal into a Project column, so the aggregate groups on a column *reference* and ----
+    // ---- DataFusion can no longer tell it is constant. The literal then rides through the ----
+    // ---- hash-partitioning, group key and sort. AGGREGATE_PROJECT_PULL_UP_CONSTANTS drops it ----
+    // ---- from the group set and re-attaches it above. ClickBench q35: 3.07s -> see report. ----
+
+    public void testConstantGroupKeyIsPulledUp() {
+        RelOptTable table = mockTable("test_index", "status", "size");
+        RelNode scan = stubScan(table);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        // Project(const=1, status) — mirrors `eval const = 1 | stats count() by const, status`
+        LogicalProject project = LogicalProject.create(
+            scan,
+            List.of(),
+            List.of(rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE, intType), rexBuilder.makeInputRef(intType, 0)),
+            List.of("const", "status")
+        );
+        AggregateCall count = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            List.of(),
+            -1,
+            project,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "c"
+        );
+        RelNode agg = makeAggregate(project, ImmutableBitSet.of(0, 1), count);
+
+        RelNode result = runPlanner(agg, singleShardContext());
+
+        String plan = result.explain();
+        assertFalse("constant must not remain a group key:\n" + plan, plan.contains("group=[{0, 1}]"));
+        assertTrue(
+            "aggregate should group on the non-constant key only:\n" + plan,
+            plan.contains("group=[{0}]") || plan.contains("group=[{1}]")
         );
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RuleProfilingListenerTests.java
@@ -97,7 +97,10 @@ public class RuleProfilingListenerTests extends BasePlannerRulesTests {
                 Map.entry("OpenSearchAggregateSplitRule", 1L),
                 Map.entry("OpenSearchAggLiteralArgProjectSplitRule", 0L),
                 Map.entry("OpenSearchDistributionDeriveRule", 3L),
-                Map.entry("ExpandConversionRule", 5L)
+                Map.entry("ExpandConversionRule", 5L),
+                // Calcite built-in: attempted on the decomposed aggregate but produces nothing
+                // here (no constant group keys), so productions == 0.
+                Map.entry("AggregateProjectPullUpConstantsRule", 0L)
             )
         );
     }
@@ -107,27 +110,20 @@ public class RuleProfilingListenerTests extends BasePlannerRulesTests {
         runAndAssertRules(
             5,
             "SELECT l.CounterID, COUNT(*) AS cnt FROM hits l JOIN hits r ON l.CounterID = r.CounterID GROUP BY l.CounterID",
-            Map.of(
-                "ExtractLiteralAggRule",
-                0L,
-                "ReduceExpressionsRule(Project)",
-                0L,
-                "OpenSearchTableScanRule",
-                1L,
-                "OpenSearchProjectRule",
-                1L,
-                "OpenSearchJoinRule",
-                1L,
-                "OpenSearchAggregateRule",
-                1L,
-                "OpenSearchAggregateSplitRule",
-                1L,
-                "OpenSearchJoinSplitRule",
-                1L,
-                "OpenSearchAggLiteralArgProjectSplitRule",
-                0L,
-                "ExpandConversionRule",
-                2L
+            Map.ofEntries(
+                Map.entry("ExtractLiteralAggRule", 0L),
+                Map.entry("ReduceExpressionsRule(Project)", 0L),
+                Map.entry("OpenSearchTableScanRule", 1L),
+                Map.entry("OpenSearchProjectRule", 1L),
+                Map.entry("OpenSearchJoinRule", 1L),
+                Map.entry("OpenSearchAggregateRule", 1L),
+                Map.entry("OpenSearchAggregateSplitRule", 1L),
+                Map.entry("OpenSearchJoinSplitRule", 1L),
+                Map.entry("OpenSearchAggLiteralArgProjectSplitRule", 0L),
+                Map.entry("ExpandConversionRule", 2L),
+                // Calcite built-in: attempted on the decomposed aggregate but produces nothing
+                // here (no constant group keys), so productions == 0.
+                Map.entry("AggregateProjectPullUpConstantsRule", 0L)
             )
         );
     }

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q10.plan.yaml
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q10.plan.yaml
@@ -8,14 +8,13 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[$3], dc(UserID)=[$4], RegionID=[$0], viableBackends=[[datafusion]])
-            OpenSearchProject(RegionID=[$0], sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[SUM($2)], $f3=[SUM($3)], $f4=[SUM($4)], dc(UserID)=[APPROX_COUNT_DISTINCT($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchSort(sort0=[$2], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
-                    OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
-                      OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
-                        OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], RegionID=[$0], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[SUM($2)], $f3=[SUM($3)], $f4=[SUM($4)], dc(UserID)=[APPROX_COUNT_DISTINCT($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchSort(sort0=[$2], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
+                  OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
+                    OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
+                      OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$2], sort1=[$0], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
@@ -25,11 +24,10 @@ plans:
       [COORDINATOR_REDUCE chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[$3], dc(UserID)=[$4], RegionID=[$0], viableBackends=[[datafusion]])
-            OpenSearchProject(RegionID=[$0], sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[SUM($2)], $f3=[SUM($3)], $f4=[SUM($4)], dc(UserID)=[APPROX_COUNT_DISTINCT($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
+          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], RegionID=[$0], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[SUM($2)], $f3=[SUM($3)], $f4=[SUM($4)], dc(UserID)=[APPROX_COUNT_DISTINCT($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[RegionID@0 as RegionID, sum(<scrubbed>.AdvEngineID)[sum]@1 as sum(AdvEngineID), count(Int64(1))[count]@2 as c, sum(<scrubbed>.ResolutionWidth)[sum]@3 as $f3, count(<scrubbed>.ResolutionWidth)[count]@4 as $f4, approx_distinct(<scrubbed>.UserID)[hll_registers]@5 as dc(UserID)]
         SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST, RegionID@0 ASC], fetch=30
@@ -50,20 +48,18 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[$3], dc(UserID)=[$4], RegionID=[$0], viableBackends=[[datafusion]])
-            OpenSearchProject(RegionID=[$0], sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
-                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], RegionID=[$0], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
+                OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$1], sort1=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[$3], dc(UserID)=[$4], RegionID=[$0], viableBackends=[[datafusion]])
-            OpenSearchProject(RegionID=[$0], sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
-                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(sum(AdvEngineID)=[$1], c=[$2], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($3):DOUBLE), $4))], dc(UserID)=[$5], RegionID=[$0], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0}], sum(AdvEngineID)=[SUM($1)], c=[COUNT()], agg#2=[SUM($2)], agg#3=[COUNT($2)], dc(UserID)=[APPROX_COUNT_DISTINCT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(RegionID=[$65], AdvEngineID=[$0], ResolutionWidth=[$69], UserID=[$97], viableBackends=[[lucene, datafusion]])
+                OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     shard_physical_1seg: |
       RelabelExec: schema=Schema { fields: [Field { name: "sum(AdvEngineID)", data_type: Int64, nullable: true }, Field { name: "c", data_type: Int64 }, Field { name: "avg(ResolutionWidth)", data_type: Float64, nullable: true }, Field { name: "dc(UserID)", data_type: Int64, nullable: true }, Field { name: "RegionID", data_type: Int32, nullable: true }], metadata: {} }
         ProjectionExec: expr=[sum(<scrubbed>.AdvEngineID)@0 as sum(AdvEngineID), count(Int64(1))@1 as c, CASE WHEN count(<scrubbed>.ResolutionWidth) = Int64(0) THEN Float64(NULL) ELSE sum(<scrubbed>.ResolutionWidth) / count(<scrubbed>.ResolutionWidth) END@2 as avg(ResolutionWidth), approx_distinct(<scrubbed>.UserID)@3 as dc(UserID), RegionID@4 as RegionID]

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q31.plan.yaml
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q31.plan.yaml
@@ -8,15 +8,14 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(SearchEngineID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
-                    OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
-                      OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                        OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                          OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
+                  OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
+                    OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                      OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                        OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
@@ -27,11 +26,10 @@ plans:
       [COORDINATOR_REDUCE chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(SearchEngineID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[SearchEngineID@0 as SearchEngineID, ClientIP@1 as ClientIP, count(Int64(1))[count]@2 as c, sum(<scrubbed>.IsRefresh)[sum]@3 as sum(IsRefresh), sum(<scrubbed>.ResolutionWidth)[sum]@4 as $f4, count(<scrubbed>.ResolutionWidth)[count]@5 as $f5]
         SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST, SearchEngineID@0 ASC, ClientIP@1 ASC], fetch=30
@@ -66,22 +64,20 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(SearchEngineID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                    OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(SearchEngineID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                    OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], SearchEngineID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(SearchEngineID=[$73], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[count(Int64(1))@0 as c, sum(<scrubbed>.IsRefresh)@1 as sum(IsRefresh), CASE WHEN count(<scrubbed>.ResolutionWidth) = Int64(0) THEN Float64(NULL) ELSE sum(<scrubbed>.ResolutionWidth) / count(<scrubbed>.ResolutionWidth) END@2 as avg(ResolutionWidth), SearchEngineID@3 as SearchEngineID, ClientIP@4 as ClientIP]
         SortPreservingMergeExec: [count(Int64(1))@0 DESC NULLS LAST, SearchEngineID@3 ASC, ClientIP@4 ASC], fetch=10

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q32.plan.yaml
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q32.plan.yaml
@@ -8,15 +8,14 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchSort(sort0=[$2], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[datafusion]])
-                    OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
-                      OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                        OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                          OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchSort(sort0=[$2], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[datafusion]])
+                  OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
+                    OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                      OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                        OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$2], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[datafusion]])
@@ -27,11 +26,10 @@ plans:
       [COORDINATOR_REDUCE chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[WatchID@0 as WatchID, ClientIP@1 as ClientIP, count(Int64(1))[count]@2 as c, sum(<scrubbed>.IsRefresh)[sum]@3 as sum(IsRefresh), sum(<scrubbed>.ResolutionWidth)[sum]@4 as $f4, count(<scrubbed>.ResolutionWidth)[count]@5 as $f5]
         SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST], fetch=30
@@ -66,22 +64,20 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                    OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
-                  OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
-                    OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=6, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[datafusion]])
+                OpenSearchFilter(condition=[ANNOTATED_PREDICATE(id=0, backends=[datafusion], <>($74, ''))], viableBackends=[[datafusion]])
+                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[count(Int64(1))@0 as c, sum(<scrubbed>.IsRefresh)@1 as sum(IsRefresh), CASE WHEN count(<scrubbed>.ResolutionWidth) = Int64(0) THEN Float64(NULL) ELSE sum(<scrubbed>.ResolutionWidth) / count(<scrubbed>.ResolutionWidth) END@2 as avg(ResolutionWidth), WatchID@3 as WatchID, ClientIP@4 as ClientIP]
         SortPreservingMergeExec: [count(Int64(1))@0 DESC NULLS LAST], fetch=10

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q33.plan.yaml
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q33.plan.yaml
@@ -8,14 +8,13 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
-                    OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
-                      OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
-                        OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
+                  OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[PARTIAL], viableBackends=[[datafusion]])
+                    OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
+                      OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[30], viableBackends=[[datafusion]])
@@ -25,11 +24,10 @@ plans:
       [COORDINATOR_REDUCE chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
-                OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                  OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], sum(IsRefresh)=[SUM($3)], $f4=[SUM($4)], $f5=[SUM($5)], mode=[FINAL], viableBackends=[[datafusion]])
+              OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
+                OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[WatchID@0 as WatchID, ClientIP@1 as ClientIP, count(Int64(1))[count]@2 as c, sum(<scrubbed>.IsRefresh)[sum]@3 as sum(IsRefresh), sum(<scrubbed>.ResolutionWidth)[sum]@4 as $f4, count(<scrubbed>.ResolutionWidth)[count]@5 as $f5]
         SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST, WatchID@0 ASC, ClientIP@1 ASC], fetch=30
@@ -60,20 +58,18 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
-                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
+                OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], sort1=[$3], sort2=[$4], dir0=[DESC-nulls-last], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[$4], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
-            OpenSearchProject(WatchID=[$0], ClientIP=[$1], c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], viableBackends=[[datafusion]])
-              OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
-                OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
-                  OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$2], sum(IsRefresh)=[$3], avg(ResolutionWidth)=[ANNOTATED_PROJECT_EXPR(id=5, backends=[datafusion], /(ANNOTATED_PROJECT_EXPR(id=4, backends=[datafusion], CAST($4):DOUBLE), $5))], WatchID=[$0], ClientIP=[$1], viableBackends=[[datafusion]])
+            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], sum(IsRefresh)=[SUM($2)], agg#2=[SUM($3)], agg#3=[COUNT($3)], mode=[SINGLE], viableBackends=[[datafusion]])
+              OpenSearchProject(WatchID=[$98], ClientIP=[$6], IsRefresh=[$40], ResolutionWidth=[$69], viableBackends=[[lucene, datafusion]])
+                OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[count(Int64(1))@0 as c, sum(<scrubbed>.IsRefresh)@1 as sum(IsRefresh), CASE WHEN count(<scrubbed>.ResolutionWidth) = Int64(0) THEN Float64(NULL) ELSE sum(<scrubbed>.ResolutionWidth) / count(<scrubbed>.ResolutionWidth) END@2 as avg(ResolutionWidth), WatchID@3 as WatchID, ClientIP@4 as ClientIP]
         SortPreservingMergeExec: [count(Int64(1))@0 DESC NULLS LAST, WatchID@3 ASC, ClientIP@4 ASC], fetch=10

--- a/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q35.plan.yaml
+++ b/sandbox/qa/analytics-engine-rest/src/test/resources/planshape/clickbench/q35.plan.yaml
@@ -8,83 +8,83 @@ plans:
     post_cbo: |
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], const=[1], URL=[$1], viableBackends=[[lucene, datafusion]])
-            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], mode=[FINAL], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$1], const=[1], URL=[$0], viableBackends=[[lucene, datafusion]])
+            OpenSearchAggregate(group=[{0}], c=[SUM($1)], mode=[FINAL], viableBackends=[[lucene, datafusion]])
               OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
-                OpenSearchSort(sort0=[$2], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[lucene, datafusion]])
-                  OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], mode=[PARTIAL], viableBackends=[[lucene, datafusion]])
-                    OpenSearchProject(const=[1], URL=[$85], viableBackends=[[lucene, datafusion]])
+                OpenSearchSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[lucene, datafusion]])
+                  OpenSearchAggregate(group=[{0}], c=[COUNT()], mode=[PARTIAL], viableBackends=[[lucene, datafusion]])
+                    OpenSearchProject(URL=[$85], viableBackends=[[lucene, datafusion]])
                       OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
-      OpenSearchSort(sort0=[$2], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[lucene, datafusion]])
-        OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], mode=[PARTIAL], viableBackends=[[lucene, datafusion]])
-          OpenSearchProject(const=[1], URL=[$85], viableBackends=[[lucene, datafusion]])
+      OpenSearchSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[30], viableBackends=[[lucene, datafusion]])
+        OpenSearchAggregate(group=[{0}], c=[COUNT()], mode=[PARTIAL], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(URL=[$85], viableBackends=[[lucene, datafusion]])
             OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
       [COORDINATOR_REDUCE chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], const=[1], URL=[$1], viableBackends=[[lucene, datafusion]])
-            OpenSearchAggregate(group=[{0, 1}], c=[SUM($2)], mode=[FINAL], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$1], const=[1], URL=[$0], viableBackends=[[lucene, datafusion]])
+            OpenSearchAggregate(group=[{0}], c=[SUM($1)], mode=[FINAL], viableBackends=[[lucene, datafusion]])
               OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])
                 OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])
     shard_physical_1seg: |
-      ProjectionExec: expr=[Int32(1)@0 as const, URL@1 as URL, count(Int64(1))[count]@2 as c]
-        SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST], fetch=30
-          SortExec: TopK(fetch=30), expr=[count(Int64(1))@2 DESC NULLS LAST], preserve_partitioning=[true]
-            AggregateExec: mode=PartialReduce, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-              RepartitionExec: partitioning=Hash([Int32(1)@0, URL@1], 4), input_partitions=1
-                AggregateExec: mode=Partial, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                  DataSourceExec: file_groups={<scrubbed>}, projection=[1 as Int32(1), URL], file_type=parquet
+      ProjectionExec: expr=[URL@0 as URL, count(Int64(1))[count]@1 as c]
+        SortPreservingMergeExec: [count(Int64(1))@1 DESC NULLS LAST], fetch=30
+          SortExec: TopK(fetch=30), expr=[count(Int64(1))@1 DESC NULLS LAST], preserve_partitioning=[true]
+            AggregateExec: mode=PartialReduce, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+              RepartitionExec: partitioning=Hash([URL@0], 4), input_partitions=1
+                AggregateExec: mode=Partial, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                  DataSourceExec: file_groups={<scrubbed>}, projection=[URL], file_type=parquet
     shard_physical_nseg: |
-      ProjectionExec: expr=[Int32(1)@0 as const, URL@1 as URL, count(Int64(1))[count]@2 as c]
-        SortPreservingMergeExec: [count(Int64(1))@2 DESC NULLS LAST], fetch=30
-          SortExec: TopK(fetch=30), expr=[count(Int64(1))@2 DESC NULLS LAST], preserve_partitioning=[true]
-            AggregateExec: mode=PartialReduce, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-              RepartitionExec: partitioning=Hash([Int32(1)@0, URL@1], 4), input_partitions=2
-                AggregateExec: mode=Partial, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                  DataSourceExec: file_groups={<scrubbed>}, projection=[1 as Int32(1), URL], file_type=parquet
+      ProjectionExec: expr=[URL@0 as URL, count(Int64(1))[count]@1 as c]
+        SortPreservingMergeExec: [count(Int64(1))@1 DESC NULLS LAST], fetch=30
+          SortExec: TopK(fetch=30), expr=[count(Int64(1))@1 DESC NULLS LAST], preserve_partitioning=[true]
+            AggregateExec: mode=PartialReduce, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+              RepartitionExec: partitioning=Hash([URL@0], 4), input_partitions=2
+                AggregateExec: mode=Partial, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                  DataSourceExec: file_groups={<scrubbed>}, projection=[URL], file_type=parquet
     coord_physical: |
       ProjectionExec: expr=[sum(input-0.c)@0 as c, Int32(1)@1 as const, URL@2 as URL]
         SortPreservingMergeExec: [sum(input-0.c)@0 DESC NULLS LAST], fetch=10
           SortExec: TopK(fetch=10), expr=[sum(input-0.c)@0 DESC NULLS LAST], preserve_partitioning=[true]
-            ProjectionExec: expr=[sum(input-0.c)@2 as sum(input-0.c), 1 as Int32(1), URL@1 as URL]
-              AggregateExec: mode=FinalPartitioned, gby=[const@0 as const, URL@1 as URL], aggr=[sum(input-0.c)]
-                RepartitionExec: partitioning=Hash([const@0, URL@1], 4), input_partitions=4
-                  AggregateExec: mode=Partial, gby=[const@0 as const, URL@1 as URL], aggr=[sum(input-0.c)]
+            ProjectionExec: expr=[sum(input-0.c)@1 as sum(input-0.c), 1 as Int32(1), URL@0 as URL]
+              AggregateExec: mode=FinalPartitioned, gby=[URL@0 as URL], aggr=[sum(input-0.c)]
+                RepartitionExec: partitioning=Hash([URL@0], 4), input_partitions=4
+                  AggregateExec: mode=Partial, gby=[URL@0 as URL], aggr=[sum(input-0.c)]
                     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-                      StreamingTableExec: partition_sizes=1, projection=[const, URL, c]
+                      StreamingTableExec: partition_sizes=1, projection=[URL, c]
   prod1s:
     post_cbo: |
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], const=[1], URL=[$1], viableBackends=[[lucene, datafusion]])
-            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], mode=[SINGLE], viableBackends=[[lucene, datafusion]])
-              OpenSearchProject(const=[1], URL=[$85], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$1], const=[1], URL=[$0], viableBackends=[[lucene, datafusion]])
+            OpenSearchAggregate(group=[{0}], c=[COUNT()], mode=[SINGLE], viableBackends=[[lucene, datafusion]])
+              OpenSearchProject(URL=[$85], viableBackends=[[lucene, datafusion]])
                 OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     fragment: |
       [SHARD_FRAGMENT chosen_backend=datafusion tree_shape=NONE]
       OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10000], viableBackends=[[datafusion]])
         OpenSearchSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[10], viableBackends=[[datafusion]])
-          OpenSearchProject(c=[$2], const=[1], URL=[$1], viableBackends=[[lucene, datafusion]])
-            OpenSearchAggregate(group=[{0, 1}], c=[COUNT()], mode=[SINGLE], viableBackends=[[lucene, datafusion]])
-              OpenSearchProject(const=[1], URL=[$85], viableBackends=[[lucene, datafusion]])
+          OpenSearchProject(c=[$1], const=[1], URL=[$0], viableBackends=[[lucene, datafusion]])
+            OpenSearchAggregate(group=[{0}], c=[COUNT()], mode=[SINGLE], viableBackends=[[lucene, datafusion]])
+              OpenSearchProject(URL=[$85], viableBackends=[[lucene, datafusion]])
                 OpenSearchTableScan(table=[[<scrubbed>]], viableBackends=[[lucene, datafusion]])
     shard_physical_1seg: |
       ProjectionExec: expr=[count(Int64(1))@0 as c, Int32(1)@1 as const, URL@2 as URL]
         SortPreservingMergeExec: [count(Int64(1))@0 DESC NULLS LAST], fetch=10
           SortExec: TopK(fetch=10), expr=[count(Int64(1))@0 DESC NULLS LAST], preserve_partitioning=[true]
-            ProjectionExec: expr=[count(Int64(1))@2 as count(Int64(1)), 1 as Int32(1), URL@1 as URL]
-              AggregateExec: mode=FinalPartitioned, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                RepartitionExec: partitioning=Hash([Int32(1)@0, URL@1], 4), input_partitions=1
-                  AggregateExec: mode=Partial, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                    DataSourceExec: file_groups={<scrubbed>}, projection=[1 as Int32(1), URL], file_type=parquet
+            ProjectionExec: expr=[count(Int64(1))@1 as count(Int64(1)), 1 as Int32(1), URL@0 as URL]
+              AggregateExec: mode=FinalPartitioned, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                RepartitionExec: partitioning=Hash([URL@0], 4), input_partitions=1
+                  AggregateExec: mode=Partial, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                    DataSourceExec: file_groups={<scrubbed>}, projection=[URL], file_type=parquet
     shard_physical_nseg: |
       ProjectionExec: expr=[count(Int64(1))@0 as c, Int32(1)@1 as const, URL@2 as URL]
         SortPreservingMergeExec: [count(Int64(1))@0 DESC NULLS LAST], fetch=10
           SortExec: TopK(fetch=10), expr=[count(Int64(1))@0 DESC NULLS LAST], preserve_partitioning=[true]
-            ProjectionExec: expr=[count(Int64(1))@2 as count(Int64(1)), 1 as Int32(1), URL@1 as URL]
-              AggregateExec: mode=FinalPartitioned, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                RepartitionExec: partitioning=Hash([Int32(1)@0, URL@1], 4), input_partitions=2
-                  AggregateExec: mode=Partial, gby=[Int32(1)@0 as Int32(1), URL@1 as URL], aggr=[count(Int64(1))], ordering_mode=PartiallySorted([0])
-                    DataSourceExec: file_groups={<scrubbed>}, projection=[1 as Int32(1), URL], file_type=parquet
+            ProjectionExec: expr=[count(Int64(1))@1 as count(Int64(1)), 1 as Int32(1), URL@0 as URL]
+              AggregateExec: mode=FinalPartitioned, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                RepartitionExec: partitioning=Hash([URL@0], 4), input_partitions=2
+                  AggregateExec: mode=Partial, gby=[URL@0 as URL], aggr=[count(Int64(1))]
+                    DataSourceExec: file_groups={<scrubbed>}, projection=[URL], file_type=parquet


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

#### Jemalloc changes 

- THP -  The OS can use big 2MB memory pages instead of tiny 4KB ones, but only if the program asks. Our allocator never asked, so a 1GB hash table was managed as 260,000 tiny pages instead of 500 big ones. Made the change. [ thp:always,metadata_thp:always): system THP is madvise-only and jemalloc doesn't madvise by default, so q16's ~1.1 GB hash table faulted in as 4 K pages. q16 745 → 543 ms, after the config change and similar improvements in all heavy queries ]

- oversize_threshold — Whenever we freed a chunk of memory bigger than 8MB, jemalloc handed it straight back to the OS instead of keeping it for reuse. Some of the heavy queries such as group by URL in clickbench builds and frees a ~1GB hash table in big chunks, so every query gave that memory back and the next query had to ask the OS for it all over again — and the OS zeroes every page before handing it out. This cost ~0.1s per big query. Raised the cutoff to 512 MB so the memory just gets reused. This basically reduces OS page cache minor faults.

#### Planner changes

- Constant in group-by. The query groups by a column that's always the number 1. By the time DataFusion saw the plan, that "always 1" had been disguised as a normal column, so it hashed and sorted 100M copies of the number 1. Now we strip constants out of the grouping before handing the plan over. 
- extract(). Our date function, for every one of 100M rows, re-read the word "MINUTE" from a string, upper-cased it (two memory allocations per row), and built a full calendar date object just to get the minute. Now it reads "MINUTE" once and gets the minute value with integer division. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
