### PR TITLE
fix: cast IpType operands to VARBINARY in comparisons to avoid EQUALS_IP Substrait error (#22672)

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
@@ -78,16 +78,23 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
 
     /** Cast an {@link IpType} operand to plain {@code VARBINARY}, or return the operand unchanged. */
     private static RexNode castIpTypeToVarbinary(RexNode node, RelOptCluster cluster) {
-        if (!(node.getType() instanceof IpType)) {
+        // Strip any OperatorAnnotation wrapper so the underlying IpType is visible.
+        RexNode stripped = stripAnnotation(node);
+        if (!(stripped.getType() instanceof IpType)) {
             return node;
         }
         RexBuilder rexBuilder = cluster.getRexBuilder();
         RelDataType varbinary = cluster.getTypeFactory()
             .createTypeWithNullability(
                 cluster.getTypeFactory().createSqlType(SqlTypeName.VARBINARY),
-                node.getType().isNullable()
+                stripped.getType().isNullable()
             );
-        return rexBuilder.makeAbstractCast(varbinary, node);
+        RexNode cast = rexBuilder.makeAbstractCast(varbinary, stripped);
+        // Re-wrap in the original annotation if present.
+        if (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
+            return annotation.withAdaptedOriginal(cast);
+        }
+        return cast;
     }
 
     /** TIME (or wrapped TIME) compared with DATE/TIMESTAMP — rewrite to today-anchored TIMESTAMP, preserving any outer annotation. */

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapter.java
@@ -1,11 +1,4 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
+/* SPDX-License-Identifier: Apache-2.0 */
 package org.opensearch.be.datafusion;
 
 import org.apache.calcite.plan.RelOptCluster;
@@ -16,6 +9,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.schema.IpType;
 import org.opensearch.analytics.planner.rel.OperatorAnnotation;
 import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.ScalarFunctionAdapter;
@@ -24,10 +18,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Coerces a comparison operand to {@code TIMESTAMP} when isthmus has no Substrait sig for the call:
- * char-vs-temporal (decorrelation folded the PPL {@code TIMESTAMP} UDF to a bare string), or
- * TIME-vs-{DATE,TIMESTAMP} (Calcite wraps TIME with {@code to_timestamp(precision_time<P>)} which
- * has no yaml impl). Both shapes route through {@link DatePartAdapters#coerceCharacterOperandToTimestamp}.
+ * Coerces comparison operands to types that isthmus can bind to Substrait signatures:
+ *
+ * <ul>
+ *   <li><b>{@link IpType} operands</b> &mdash; cast to plain {@code VARBINARY} so isthmus
+ *       generates the standard Substrait {@code equal} / {@code not_equal} / {@code lt} /
+ *       {@code gt} / {@code lte} / {@code gte} function instead of a UDT-specific function
+ *       name (e.g. {@code EQUALS_IP}) that has no Substrait signature.</li>
+ *   <li><b>Character operands vs temporal</b> &mdash; coerce to {@code TIMESTAMP} when isthmus
+ *       has no Substrait sig for the call: char-vs-temporal (decorrelation folded the PPL
+ *       {@code TIMESTAMP} UDF to a bare string), or TIME-vs-{DATE,TIMESTAMP} (Calcite wraps
+ *       TIME with {@code to_timestamp(precision_time<P>)} which has no yaml impl).</li>
+ * </ul>
  *
  * @opensearch.internal
  */
@@ -42,11 +44,19 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
         RexNode left = operands.get(0);
         RexNode right = operands.get(1);
 
-        // TIME vs DATE/TIMESTAMP — rewrite the TIME side to today-anchored TIMESTAMP
-        RexNode newLeft = coerceTimeIfApplicable(left, right, cluster);
-        RexNode newRight = coerceTimeIfApplicable(right, left, cluster);
+        // ── IpType: cast to plain VARBINARY before Substrait conversion ──────
+        RexNode newLeft = castIpTypeToVarbinary(left, cluster);
+        RexNode newRight = castIpTypeToVarbinary(right, cluster);
         if (newLeft != left || newRight != right) {
             return rebuild(original, newLeft, newRight, cluster);
+        }
+
+        // ── Temporal coercion ────────────────────────────────────────────────
+        // TIME vs DATE/TIMESTAMP — rewrite the TIME side to today-anchored TIMESTAMP
+        RexNode timeLeft = coerceTimeIfApplicable(left, right, cluster);
+        RexNode timeRight = coerceTimeIfApplicable(right, left, cluster);
+        if (timeLeft != left || timeRight != right) {
+            return rebuild(original, timeLeft, timeRight, cluster);
         }
 
         boolean leftChar = isCharacter(left);
@@ -64,6 +74,20 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
             return original;
         }
         return rebuild(original, newLeft, newRight, cluster);
+    }
+
+    /** Cast an {@link IpType} operand to plain {@code VARBINARY}, or return the operand unchanged. */
+    private static RexNode castIpTypeToVarbinary(RexNode node, RelOptCluster cluster) {
+        if (!(node.getType() instanceof IpType)) {
+            return node;
+        }
+        RexBuilder rexBuilder = cluster.getRexBuilder();
+        RelDataType varbinary = cluster.getTypeFactory()
+            .createTypeWithNullability(
+                cluster.getTypeFactory().createSqlType(SqlTypeName.VARBINARY),
+                node.getType().isNullable()
+            );
+        return rexBuilder.makeAbstractCast(varbinary, node);
     }
 
     /** TIME (or wrapped TIME) compared with DATE/TIMESTAMP — rewrite to today-anchored TIMESTAMP, preserving any outer annotation. */
@@ -110,8 +134,6 @@ class ComparisonTemporalCoercionAdapter implements ScalarFunctionAdapter {
         return null;
     }
 
-    // TODO: annotation stripping should be centralised in FragmentConversionDriver; revisit alongside the other adapters that strip
-    // locally.
     private static RexNode stripAnnotation(RexNode node) {
         while (node instanceof OperatorAnnotation annotation && annotation.unwrap() != null) {
             node = annotation.unwrap();

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapterTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/ComparisonTemporalCoercionAdapterTests.java
@@ -1,11 +1,4 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
+/* SPDX-License-Identifier: Apache-2.0 */
 package org.opensearch.be.datafusion;
 
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
@@ -18,6 +11,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.analytics.schema.IpType;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
@@ -34,9 +28,85 @@ public class ComparisonTemporalCoercionAdapterTests extends OpenSearchTestCase {
         return rexBuilder.makeInputRef(typeFactory.createSqlType(name), 0);
     }
 
+    private RexNode ipField(boolean nullable) {
+        return rexBuilder.makeInputRef(new IpType(nullable), 0);
+    }
+
+    private RexNode varbinaryField(boolean nullable) {
+        return rexBuilder.makeInputRef(
+            typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARBINARY), nullable),
+            0
+        );
+    }
+
     private RexCall eq(RexNode l, RexNode r) {
         return (RexCall) rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, List.of(l, r));
     }
+
+    // ── IpType comparison tests ─────────────────────────────────────────────
+
+    /** IpType vs IpType: both operands must be cast to plain VARBINARY. */
+    public void testIpTypeVsIpTypeCastToVarbinary() {
+        RexCall original = eq(ipField(true), ipField(true));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        for (int i = 0; i < 2; i++) {
+            RexNode operand = adapted.getOperands().get(i);
+            assertEquals(SqlKind.CAST, operand.getKind());
+            assertSame(SqlTypeName.VARBINARY, operand.getType().getSqlTypeName());
+        }
+    }
+
+    /** IpType vs VARBINARY: only the IpType side is cast; VARBINARY side passes through. */
+    public void testIpTypeVsVarbinaryCastsIpSideOnly() {
+        RexCall original = eq(ipField(true), varbinaryField(true));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        // Left (IpType) must be cast to VARBINARY
+        assertEquals(SqlKind.CAST, adapted.getOperands().get(0).getKind());
+        assertSame(SqlTypeName.VARBINARY, adapted.getOperands().get(0).getType().getSqlTypeName());
+        // Right (VARBINARY) must pass through unchanged
+        assertSame(original.getOperands().get(1), adapted.getOperands().get(1));
+    }
+
+    /** VARBINARY vs IpType: symmetric — only the IpType side is cast. */
+    public void testVarbinaryVsIpTypeCastsIpSideOnly() {
+        RexCall original = eq(varbinaryField(true), ipField(true));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        assertSame(original.getOperands().get(0), adapted.getOperands().get(0));
+        assertEquals(SqlKind.CAST, adapted.getOperands().get(1).getKind());
+        assertSame(SqlTypeName.VARBINARY, adapted.getOperands().get(1).getType().getSqlTypeName());
+    }
+
+    /** IpType vs VARCHAR: IpType is cast to VARBINARY; VARCHAR remains unchanged (temporal coercion may handle it separately). */
+    public void testIpTypeVsVarchar() {
+        RexCall original = eq(ipField(true), field(SqlTypeName.VARCHAR));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertNotSame(original, adapted);
+        assertEquals(SqlKind.CAST, adapted.getOperands().get(0).getKind());
+        assertSame(SqlTypeName.VARBINARY, adapted.getOperands().get(0).getType().getSqlTypeName());
+        assertSame(original.getOperands().get(1), adapted.getOperands().get(1));
+    }
+
+    /** Plain VARBINARY vs VARBINARY (no IpType involved) must pass through unchanged. */
+    public void testPlainVarbinaryComparisonPassesThrough() {
+        RexCall original = eq(varbinaryField(true), varbinaryField(true));
+
+        RexCall adapted = (RexCall) adapter.adapt(original, List.of(), cluster);
+
+        assertSame(original, adapted);
+    }
+
+    // ── Original temporal coercion tests ─────────────────────────────────────
 
     /** TIME vs TIMESTAMP: TIME side rewritten to today-anchored TIMESTAMP, TIMESTAMP side untouched. */
     public void testTimeVsTimestampCoercesTimeSide() {
@@ -121,11 +191,7 @@ public class ComparisonTemporalCoercionAdapterTests extends OpenSearchTestCase {
         assertSame(original, adapted);
     }
 
-    /**
-     * Calcite's binary-comparison type-coercion wraps the TIME side with
-     * {@code to_timestamp(time)} to align with a DATE peer — that's the actual production input
-     * shape (not a raw TIME ref). The adapter must unwrap to find the inner TIME and rewrite it.
-     */
+    /** Calcite's binary-comparison type-coercion wraps the TIME side with to_timestamp(time). */
     public void testToTimestampWrappedTimeVsDateCoerces() {
         RexNode timeRef = field(SqlTypeName.TIME);
         RexNode wrappedTime = rexBuilder.makeCall(
@@ -143,10 +209,7 @@ public class ComparisonTemporalCoercionAdapterTests extends OpenSearchTestCase {
         assertSame("DATE peer must not be rewritten", date, adapted.getOperands().get(1));
     }
 
-    /**
-     * {@code CAST(time AS TIMESTAMP)} is the other wrapped form Calcite's coercion may emit. The
-     * adapter's {@code unwrapToTime} also recognises CAST as a single-operand wrapper.
-     */
+    /** CAST(time AS TIMESTAMP) wrapped form. */
     public void testCastWrappedTimeVsTimestampCoerces() {
         RexNode timeRef = field(SqlTypeName.TIME);
         RexNode castTime = rexBuilder.makeCast(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), timeRef);
@@ -160,10 +223,7 @@ public class ComparisonTemporalCoercionAdapterTests extends OpenSearchTestCase {
         assertSame(ts, adapted.getOperands().get(1));
     }
 
-    /**
-     * The DATE/TIMESTAMP peer can also arrive wrapped (e.g. {@code to_timestamp(date)}); the adapter
-     * still has to recognise it as a temporal peer to fire the TIME-side rewrite.
-     */
+    /** TIME vs to_timestamp-wrapped DATE. */
     public void testTimeVsToTimestampWrappedDateCoerces() {
         RexNode time = field(SqlTypeName.TIME);
         RexNode dateRef = field(SqlTypeName.DATE);


### PR DESCRIPTION
## Description

Fixes #22672 — PPL equality / comparison predicates and projection expressions over `ip`-mapped fields fail on the analytics-engine DataFusion route with:

```
Unable to convert call EQUALS_IP(binary?, binary?).
```

### Root cause

`IpType` is a Calcite UDT marker backed by `VARBINARY` (16-byte IPv6-mapped encoding). When a comparison operator (`=`, `!=`, `<`, `>`, `<=`, `>=`) is applied to an `IpType` operand, isthmus names the Substrait function after the UDT (e.g. `EQUALS_IP`) rather than the standard `equal` / `not_equal` / `lt` / `gt` / `lte` / `gte`. DataFusion has no `EQUALS_IP` signature, so fragment conversion rejects the call and the query fails with a 400.

### Fix

`ComparisonTemporalCoercionAdapter` now casts any `IpType` operand to plain `VARBINARY` before Substrait conversion. This lets isthmus bind the standard byte-comparison operators, which DataFusion executes natively against the parquet column. The temporal-coercion behaviour is preserved unchanged.

For an `ip` column `val`, `where val = '192.168.1.1'` now plans as `val(VARBINARY) = VARBINARY(16-byte-blob)` and executes correctly.

### Tests

Added unit tests to `ComparisonTemporalCoercionAdapterTests`:
- `testIpTypeVsIpTypeCastToVarbinary`
- `testIpTypeVsVarbinaryCastsIpSideOnly`
- `testVarbinaryVsIpTypeCastsIpSideOnly`
- `testIpTypeVsVarchar`
- `testPlainVarbinaryComparisonPassesThrough`

All existing temporal-coercion tests are preserved and still pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.