### PR TITLE
Lower arrow.flight.channel.outbound_buffer_threshold default

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
@@ -162,16 +162,16 @@ public class ServerConfig {
     );
 
     /**
-     * Per-stream outbound buffered-bytes threshold passed to gRPC's
-     * {@code setOnReadyThreshold}. {@code isReady()} flips false once the per-stream
-     * outbound buffer crosses this size; the producer parks on that signal. Set this
-     * strictly below {@code native.allocator.pool.flight.max} so the gate engages
-     * before the allocator runs out.
+     * Per-stream outbound buffered-bytes watermark passed to gRPC's {@code setOnReadyThreshold}.
+     * {@code isReady()} flips false once a stream's outbound buffer crosses this size, parking the producer.
+     * It bounds pipelining depth, not a single batch: gRPC accepts an over-watermark write in full, so a
+     * batch larger than this still passes and the producer parks afterward. Must stay strictly below
+     * {@code native.allocator.pool.flight.max} so the gate engages before the allocator runs out.
      */
     public static final Setting<ByteSizeValue> FLIGHT_OUTBOUND_BUFFER_THRESHOLD = Setting.byteSizeSetting(
         "arrow.flight.channel.outbound_buffer_threshold",
-        new ByteSizeValue(64, ByteSizeUnit.MB),
-        new ByteSizeValue(1, ByteSizeUnit.MB),
+        new ByteSizeValue(512, ByteSizeUnit.KB),
+        new ByteSizeValue(256, ByteSizeUnit.KB),
         new ByteSizeValue(2, ByteSizeUnit.GB),
         Setting.Property.NodeScope
     );

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/bootstrap/ServerConfigTests.java
@@ -88,7 +88,7 @@ public class ServerConfigTests extends OpenSearchTestCase {
         assertFalse(ServerConfig.ARROW_ENABLE_DEBUG_ALLOCATOR.get(defaultSettings));
         assertFalse(ServerConfig.ARROW_SSL_ENABLE.get(defaultSettings));
         assertEquals(TimeValue.timeValueSeconds(60), ServerConfig.FLIGHT_READY_TIMEOUT.get(defaultSettings));
-        assertEquals(64L * 1024 * 1024, ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(defaultSettings).getBytes());
+        assertEquals(512L * 1024, ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(defaultSettings).getBytes());
     }
 
     public void testBackpressureSettingsParse() {
@@ -137,7 +137,7 @@ public class ServerConfigTests extends OpenSearchTestCase {
 
     public void testOutboundBufferThresholdBounds() {
         Settings tooLow = Settings.builder()
-            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(512, ByteSizeUnit.KB))
+            .put(ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.getKey(), new ByteSizeValue(64, ByteSizeUnit.KB))
             .build();
         expectThrows(IllegalArgumentException.class, () -> ServerConfig.FLIGHT_OUTBOUND_BUFFER_THRESHOLD.get(tooLow));
 


### PR DESCRIPTION
The default (64mb) and minimum (1mb) for the per-stream outbound buffer watermark were larger than needed. The watermark bounds pipelining depth, not a single batch: gRPC accepts an over-watermark write in full, so a batch larger than it still passes and the producer parks afterward. A smaller watermark keeps per-stream outbound memory low and lets many streams share the Flight allocator pool concurrently.

Lower the default 64mb -> 512kb and the minimum 1mb -> 256kb, and clarify the setting javadoc. Update ServerConfigTests accordingly.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
