### PR TITLE
Support multi-index DSL queries

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics;
 
 import org.apache.calcite.schema.SchemaPlus;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
 import org.opensearch.cluster.ClusterState;
 
@@ -40,6 +41,15 @@ public interface EngineContextProvider {
      */
     default QueryRequestContext getContext(ClusterState clusterState) {
         return new QueryRequestContext(clusterState, OpenSearchSchemaBuilder.buildSchema(clusterState));
+    }
+
+    /**
+     * Options-aware context: builds the schema with the supplied {@code IndicesOptions} so
+     * the lazy table-resolution closure honours the user's wildcard/state preferences.
+     * Default delegates to the 1-arg overload (lenientExpandOpen) for PPL/SQL compatibility.
+     */
+    default QueryRequestContext getContext(ClusterState clusterState, IndicesOptions indicesOptions) {
+        return getContext(clusterState);
     }
 
     QueryRequestContext getContext();

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
@@ -44,14 +44,11 @@ public interface EngineContextProvider {
     }
 
     /**
-     * Options-aware context: builds the schema with the supplied {@code IndicesOptions} so the lazy
-     * table-resolution closure honours the caller's wildcard and index-state preferences.
+     * Options-aware context: builds the schema with the supplied {@code IndicesOptions} so lazy
+     * table resolution honours the caller's wildcard and index-state preferences.
      *
-     * <p>Deliberately abstract rather than defaulted: a default that dropped the options would
-     * silently yield a {@code lenientExpandOpen} schema whose row type disagrees with the indices
-     * the planner targets — the exact mismatch this overload exists to remove. An implementation
-     * that cannot honour the options should pass {@code IndicesOptions.lenientExpandOpen()}
-     * explicitly so the choice is visible at the call site.
+     * <p>Abstract rather than defaulted: a default that dropped the options would yield a
+     * {@code lenientExpandOpen} schema whose row type disagrees with the planner's target indices.
      */
     QueryRequestContext getContext(ClusterState clusterState, IndicesOptions indicesOptions);
 

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/EngineContextProvider.java
@@ -44,13 +44,16 @@ public interface EngineContextProvider {
     }
 
     /**
-     * Options-aware context: builds the schema with the supplied {@code IndicesOptions} so
-     * the lazy table-resolution closure honours the user's wildcard/state preferences.
-     * Default delegates to the 1-arg overload (lenientExpandOpen) for PPL/SQL compatibility.
+     * Options-aware context: builds the schema with the supplied {@code IndicesOptions} so the lazy
+     * table-resolution closure honours the caller's wildcard and index-state preferences.
+     *
+     * <p>Deliberately abstract rather than defaulted: a default that dropped the options would
+     * silently yield a {@code lenientExpandOpen} schema whose row type disagrees with the indices
+     * the planner targets — the exact mismatch this overload exists to remove. An implementation
+     * that cannot honour the options should pass {@code IndicesOptions.lenientExpandOpen()}
+     * explicitly so the choice is visible at the call site.
      */
-    default QueryRequestContext getContext(ClusterState clusterState, IndicesOptions indicesOptions) {
-        return getContext(clusterState);
-    }
+    QueryRequestContext getContext(ClusterState clusterState, IndicesOptions indicesOptions);
 
     QueryRequestContext getContext();
 

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics;
 
 import org.apache.calcite.schema.SchemaPlus;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.tasks.Task;
 
@@ -28,13 +29,18 @@ import org.opensearch.tasks.Task;
  *
  * @opensearch.internal
  */
-public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask) {
+public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask,
+    IndicesOptions indicesOptions) {
+
+    public QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask) {
+        this(clusterState, schema, querySource, parentTask, IndicesOptions.lenientExpandOpen());
+    }
 
     public QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource) {
-        this(clusterState, schema, querySource, null);
+        this(clusterState, schema, querySource, null, IndicesOptions.lenientExpandOpen());
     }
 
     public QueryRequestContext(ClusterState clusterState, SchemaPlus schema) {
-        this(clusterState, schema, null, null);
+        this(clusterState, schema, null, null, IndicesOptions.lenientExpandOpen());
     }
 }

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -70,6 +70,15 @@ public class OpenSearchSchemaBuilder {
      * that drives lazy resolution of expressions.
      */
     public static SchemaPlus buildSchema(ClusterState clusterState, IndexNameExpressionResolver resolver) {
+        return buildSchema(clusterState, resolver, IndicesOptions.lenientExpandOpen());
+    }
+
+    /**
+     * Options-aware schema construction: resolves tables using the supplied {@code IndicesOptions}.
+     *
+     * @param options controls wildcard expansion and alias backing-index state filtering
+     */
+    public static SchemaPlus buildSchema(ClusterState clusterState, IndexNameExpressionResolver resolver, IndicesOptions options) {
         Schema lazySchema = new AbstractSchema() {
             // Truly lazy table map, mirroring sql-plugin's OpenSearchSchema pattern: no upfront
             // enumeration of cluster indices. get() registers on first lookup and caches under the
@@ -83,7 +92,7 @@ public class OpenSearchSchemaBuilder {
                 public Table get(Object key) {
                     String name = ((String) key).toLowerCase(java.util.Locale.ROOT);
                     if (!super.containsKey(name)) {
-                        Table resolved = resolveTable(clusterState, resolver, name);
+                        Table resolved = resolveTable(clusterState, resolver, name, options);
                         if (resolved != null) {
                             super.put(name, resolved);
                         }
@@ -111,7 +120,12 @@ public class OpenSearchSchemaBuilder {
      * is referenced.
      */
     @SuppressWarnings("unchecked")
-    private static Table resolveTable(ClusterState clusterState, IndexNameExpressionResolver resolver, String expression) {
+    private static Table resolveTable(
+        ClusterState clusterState,
+        IndexNameExpressionResolver resolver,
+        String expression,
+        IndicesOptions options
+    ) {
         // Short-circuit literal alias / data stream names so the resolver's lenientExpandOpen
         // (which does not include hidden backings) doesn't filter out data stream backings. The
         // alias / data-stream abstraction already carries the full backing list — use it directly.
@@ -121,7 +135,19 @@ public class OpenSearchSchemaBuilder {
         if (abstraction != null
             && (abstraction.getType() == org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS
                 || abstraction.getType() == org.opensearch.cluster.metadata.IndexAbstraction.Type.DATA_STREAM)) {
-            backing = abstraction.getIndices();
+            // WHY: IndexAbstraction.getIndices() returns ALL backings regardless of state.
+            // The schema's column set must never exceed the union of mappings of the indices
+            // the planner will actually target. IndexResolution.resolveAlias/resolveDataStream
+            // UNCONDITIONALLY filters to State.OPEN, so the schema must do the same —
+            // regardless of IndicesOptions. Without this, a closed backing's columns appear in
+            // the union row type even though no shard ever supplies them (phantom-column defect).
+            List<IndexMetadata> allBackings = abstraction.getIndices();
+            backing = new java.util.ArrayList<>(allBackings.size());
+            for (IndexMetadata idx : allBackings) {
+                if (idx.getState() == IndexMetadata.State.OPEN) {
+                    backing.add(idx);
+                }
+            }
         } else {
             String[] concrete;
             try {
@@ -131,12 +157,7 @@ public class OpenSearchSchemaBuilder {
                 // expand to its backings (the resolver normally excludes data streams from
                 // wildcard expansion otherwise). Literal data stream / alias names take the
                 // abstraction short-circuit above and skip the resolver entirely.
-                concrete = resolver.concreteIndexNames(
-                    clusterState,
-                    IndicesOptions.lenientExpandOpen(),
-                    true,
-                    Strings.splitStringByCommaToArray(expression)
-                );
+                concrete = resolver.concreteIndexNames(clusterState, options, true, Strings.splitStringByCommaToArray(expression));
             } catch (IndexNotFoundException e) {
                 return null;
             }

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -19,18 +19,21 @@ import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
-import org.opensearch.index.IndexNotFoundException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -90,7 +93,7 @@ public class OpenSearchSchemaBuilder {
             private final Map<String, Table> tableMap = new HashMap<>() {
                 @Override
                 public Table get(Object key) {
-                    String name = ((String) key).toLowerCase(java.util.Locale.ROOT);
+                    String name = ((String) key).toLowerCase(Locale.ROOT);
                     if (!super.containsKey(name)) {
                         Table resolved = resolveTable(clusterState, resolver, name, options);
                         if (resolved != null) {
@@ -129,39 +132,30 @@ public class OpenSearchSchemaBuilder {
         // Short-circuit literal alias / data stream names so the resolver's lenientExpandOpen
         // (which does not include hidden backings) doesn't filter out data stream backings. The
         // alias / data-stream abstraction already carries the full backing list — use it directly.
-        java.util.SortedMap<String, org.opensearch.cluster.metadata.IndexAbstraction> lookup = clusterState.metadata().getIndicesLookup();
-        org.opensearch.cluster.metadata.IndexAbstraction abstraction = lookup == null ? null : lookup.get(expression);
+        SortedMap<String, IndexAbstraction> lookup = clusterState.metadata().getIndicesLookup();
+        IndexAbstraction abstraction = lookup == null ? null : lookup.get(expression);
         List<IndexMetadata> backing;
         if (abstraction != null
-            && (abstraction.getType() == org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS
-                || abstraction.getType() == org.opensearch.cluster.metadata.IndexAbstraction.Type.DATA_STREAM)) {
-            // WHY: IndexAbstraction.getIndices() returns ALL backings regardless of state.
-            // The schema's column set must never exceed the union of mappings of the indices
-            // the planner will actually target. IndexResolution.resolveAlias/resolveDataStream
-            // UNCONDITIONALLY filters to State.OPEN, so the schema must do the same —
-            // regardless of IndicesOptions. Without this, a closed backing's columns appear in
-            // the union row type even though no shard ever supplies them (phantom-column defect).
+            && (abstraction.getType() == IndexAbstraction.Type.ALIAS || abstraction.getType() == IndexAbstraction.Type.DATA_STREAM)) {
+            // getIndices() returns all backings regardless of state, but IndexResolution filters
+            // aliases to State.OPEN unconditionally — the schema must match or closed backings add
+            // phantom columns that validate but never receive rows.
             List<IndexMetadata> allBackings = abstraction.getIndices();
-            backing = new java.util.ArrayList<>(allBackings.size());
+            backing = new ArrayList<>(allBackings.size());
             for (IndexMetadata idx : allBackings) {
                 if (idx.getState() == IndexMetadata.State.OPEN) {
                     backing.add(idx);
                 }
             }
         } else {
-            String[] concrete;
-            try {
-                // Comma-split first: concreteIndexNames treats each vararg as one expression, and
-                // splitting lets the resolver honor exclusions across tokens (e.g. "test*,-test1").
-                // includeDataStreams=true so wildcards / comma-lists that match a data stream NAME
-                // expand to its backings (the resolver normally excludes data streams from
-                // wildcard expansion otherwise). Literal data stream / alias names take the
-                // abstraction short-circuit above and skip the resolver entirely.
-                concrete = resolver.concreteIndexNames(clusterState, options, true, Strings.splitStringByCommaToArray(expression));
-            } catch (IndexNotFoundException e) {
-                return null;
-            }
-            backing = new java.util.ArrayList<>(concrete.length);
+            // Comma-split first: concreteIndexNames treats each vararg as one expression, and
+            // splitting lets the resolver honor exclusions across tokens (e.g. "test*,-test1").
+            // includeDataStreams=true so wildcards / comma-lists that match a data stream NAME
+            // expand to its backings (the resolver normally excludes data streams from
+            // wildcard expansion otherwise). Literal data stream / alias names take the
+            // abstraction short-circuit above and skip the resolver entirely.
+            String[] concrete = resolver.concreteIndexNames(clusterState, options, true, Strings.splitStringByCommaToArray(expression));
+            backing = new ArrayList<>(concrete.length);
             for (String name : concrete) {
                 IndexMetadata index = clusterState.metadata().index(name);
                 if (index != null) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/FilterDelegationForIndexFullConversionTests.java
@@ -59,7 +59,6 @@ import org.opensearch.analytics.spi.ShardScanWithDelegationInstructionNode;
 import org.opensearch.be.lucene.LuceneAnalyticsBackendPlugin;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.GroupShardsIterator;
@@ -68,7 +67,6 @@ import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -108,9 +106,6 @@ import static org.mockito.Mockito.when;
  * and preserved AND/OR/NOT boolean structure).
  */
 public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestCase {
-
-    /** Default resolver for DAGBuilder in tests; production injects core's resolver. */
-    private static final IndexNameExpressionResolver TEST_RESOLVER = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
 
     private static final SqlFunction MATCH_FUNCTION = new SqlFunction(
         "MATCH",
@@ -242,7 +237,7 @@ public class FilterDelegationForIndexFullConversionTests extends OpenSearchTestC
         }, condition);
 
         RelNode marked = PlannerImpl.runAllOptimizations(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/LuceneAnalyticsBackendPluginTests.java
@@ -58,7 +58,6 @@ import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.analytics.spi.ShardScanWithDelegationInstructionNode;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.GroupShardsIterator;
@@ -67,7 +66,6 @@ import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -94,9 +92,6 @@ import static org.mockito.Mockito.when;
  * {@link LuceneAnalyticsBackendPlugin} serializer, producing valid MatchQueryBuilder bytes.
  */
 public class LuceneAnalyticsBackendPluginTests extends OpenSearchTestCase {
-
-    /** Default resolver for DAGBuilder in tests; production injects core's resolver. */
-    private static final IndexNameExpressionResolver TEST_RESOLVER = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
 
     private static final SqlFunction MATCH_FUNCTION = new SqlFunction(
         "MATCH",
@@ -146,7 +141,7 @@ public class LuceneAnalyticsBackendPluginTests extends OpenSearchTestCase {
         }, condition);
 
         RelNode marked = PlannerImpl.runAllOptimizations(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         // Mirror DefaultPlanExecutor.executeInternal: forker → adapter → selector → convertor.
         // preferMetadataDriver=false drops the Lucene alternative and forces the DataFusion
         // peer; the surviving plan exercises the DF→Lucene filter delegation path, which is

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/PlanAlternativeSelectorTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/PlanAlternativeSelectorTests.java
@@ -64,7 +64,6 @@ import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.analytics.spi.ShardScanWithDelegationInstructionNode;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.GroupShardsIterator;
@@ -72,7 +71,6 @@ import org.opensearch.cluster.routing.OperationRouting;
 import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.index.Index;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -100,8 +98,6 @@ import static org.mockito.Mockito.when;
  * selection happens before conversion, mirroring {@code DefaultPlanExecutor.executeInternal}).
  */
 public class PlanAlternativeSelectorTests extends OpenSearchTestCase {
-
-    private static final IndexNameExpressionResolver TEST_RESOLVER = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
 
     private RelDataTypeFactory typeFactory;
     private RexBuilder rexBuilder;
@@ -289,7 +285,7 @@ public class PlanAlternativeSelectorTests extends OpenSearchTestCase {
 
         PlannerContext context = buildContext(fieldMappings, List.of(dfBackend, luceneBackend), preferMetadataDriver);
         RelNode marked = PlannerImpl.runAllOptimizations(plan, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
         PlanAlternativeSelector.selectAll(dag, context.getCapabilityRegistry(), preferMetadataDriver);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -15,6 +15,7 @@ import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.exec.AnalyticsFragmentSlowLog;
 import org.opensearch.analytics.exec.AnalyticsSearchService;
 import org.opensearch.analytics.exec.AnalyticsSearchSlowLog;
@@ -413,6 +414,12 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         public QueryRequestContext getContext(ClusterState clusterState) {
             SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState, indexNameExpressionResolver);
             return new QueryRequestContext(clusterState, schema);
+        }
+
+        @Override
+        public QueryRequestContext getContext(ClusterState clusterState, IndicesOptions indicesOptions) {
+            SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState, indexNameExpressionResolver, indicesOptions);
+            return new QueryRequestContext(clusterState, schema, null, null, indicesOptions);
         }
 
         @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -23,6 +23,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.TimeoutTaskCancellationUtility;
 import org.opensearch.analytics.AnalyticsPlugin;
 import org.opensearch.analytics.AnalyticsSettings;
@@ -395,6 +396,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
         // default 100 rows and broadcast loses the cost race against SINGLETON gather even
         // for tiny dimensions. See IndexRowCountFetcher's class javadoc for the full story.
         ToLongFunction<String> tableRowCounts = IndexRowCountFetcher.fetchFor(logicalFragment, client);
+        IndicesOptions planningOptions = queryCtx != null ? queryCtx.indicesOptions() : IndicesOptions.lenientExpandOpen();
         PlannerContext plannerContext = new PlannerContext(
             capabilityRegistry,
             planningState,
@@ -402,7 +404,8 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             false,
             preferMetadataDriver,
             perQuerySettings,
-            tableRowCounts
+            tableRowCounts,
+            planningOptions
         );
         plannerContext.setPlannerSettings(plannerSettings);
         // On the broadcast→shuffle retry, make BROADCAST ineligible so CBO falls back to
@@ -433,7 +436,7 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             );
         }
         final String fullPlan = profile ? RelOptUtil.toString(plan) : null;
-        QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);
+        QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService);
 
         // Dispatch resolution under the GENERAL post-CBO scheduler. The enforcement pass placed every
         // exchange (shuffle/broadcast) + pre-split any distributed aggregate; DAGBuilder cut at those and

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
@@ -94,6 +94,14 @@ public class AnalyticsQueryRequest extends ActionRequest implements IndicesReque
 
     @Override
     public IndicesOptions indicesOptions() {
+        // Honour the user's options from the carried QueryRequestContext so the security plugin
+        // resolves index expressions with the same semantics as the coordinator (ignore_unavailable,
+        // allow_no_indices, expand_wildcards). Falls back to strictExpandOpen() for the deserialized
+        // case where queryCtx is absent (local-dispatch-only, so the fallback covers only tests and
+        // hypothetical future wire paths).
+        if (queryCtx != null && queryCtx.indicesOptions() != null) {
+            return queryCtx.indicesOptions();
+        }
         return IndicesOptions.strictExpandOpen();
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequest.java
@@ -94,11 +94,8 @@ public class AnalyticsQueryRequest extends ActionRequest implements IndicesReque
 
     @Override
     public IndicesOptions indicesOptions() {
-        // Honour the user's options from the carried QueryRequestContext so the security plugin
-        // resolves index expressions with the same semantics as the coordinator (ignore_unavailable,
-        // allow_no_indices, expand_wildcards). Falls back to strictExpandOpen() for the deserialized
-        // case where queryCtx is absent (local-dispatch-only, so the fallback covers only tests and
-        // hypothetical future wire paths).
+        // Reuse the coordinator's options so the security plugin authorizes the same index set.
+        // Falls back to strictExpandOpen() when no context is attached.
         if (queryCtx != null && queryCtx.indicesOptions() != null) {
             return queryCtx.indicesOptions();
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
@@ -95,6 +95,22 @@ public final class IndexResolution {
      * resolved members.
      */
     public static IndexResolution resolve(String name, ClusterState clusterState, IndexNameExpressionResolver resolver) {
+        return resolve(name, clusterState, resolver, IndicesOptions.lenientExpandOpen());
+    }
+
+    /**
+     * Resolves {@code name} against the cluster state using the supplied {@code options} for
+     * wildcard and comma-expression resolution. Literal concrete indices and aliases are resolved
+     * directly (with filter-alias rejection and cross-member schema validation).
+     *
+     * @param options controls ignore_unavailable, allow_no_indices, and wildcard expansion semantics
+     */
+    public static IndexResolution resolve(
+        String name,
+        ClusterState clusterState,
+        IndexNameExpressionResolver resolver,
+        IndicesOptions options
+    ) {
         SortedMap<String, IndexAbstraction> lookup = clusterState.metadata().getIndicesLookup();
         IndexAbstraction abstraction = lookup == null ? null : lookup.get(name);
         if (abstraction != null) {
@@ -119,7 +135,7 @@ public final class IndexResolution {
                 // expand to its backings — the resolver excludes data streams from wildcard
                 // expansion otherwise. Literal data stream names take the abstraction short-circuit
                 // above (resolveDataStream) and skip the resolver entirely.
-                concrete = resolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpen(), true, expressions);
+                concrete = resolver.concreteIndexNames(clusterState, options, true, expressions);
             } catch (IndexNotFoundException e) {
                 throw new IllegalArgumentException("Index or alias [" + name + "] not found in cluster state", e);
             }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
@@ -99,11 +99,9 @@ public final class IndexResolution {
     }
 
     /**
-     * Resolves {@code name} against the cluster state using the supplied {@code options} for
-     * wildcard and comma-expression resolution. Literal concrete indices and aliases are resolved
-     * directly (with filter-alias rejection and cross-member schema validation).
+     * Resolves {@code name} to its concrete indices, using {@code options} for wildcard expansion.
      *
-     * @param options controls ignore_unavailable, allow_no_indices, and wildcard expansion semantics
+     * @param options controls wildcard expansion and missing-index handling
      */
     public static IndexResolution resolve(
         String name,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
@@ -35,8 +35,8 @@ import java.util.SortedMap;
  * every field present in any backing index has the same declared type in all others.
  *
  * <p>Aliases that declare a filter are rejected — the planner does not weave alias filters
- * into the query plan, so honoring such an alias would silently return more rows than the
- * user asked for. Data streams resolve to their backing indices like aliases do.
+ * into the query plan today, so honoring such an alias would silently return more rows than
+ * the user asked for. Data streams are likewise rejected for now.
  *
  * <p>Index expressions (comma lists, wildcards, exclusions, date-math) are resolved through the
  * cluster's {@link IndexNameExpressionResolver} and unioned, with the same schema-compatibility

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/IndexResolution.java
@@ -35,8 +35,8 @@ import java.util.SortedMap;
  * every field present in any backing index has the same declared type in all others.
  *
  * <p>Aliases that declare a filter are rejected — the planner does not weave alias filters
- * into the query plan today, so honoring such an alias would silently return more rows than
- * the user asked for. Data streams are likewise rejected for now.
+ * into the query plan, so honoring such an alias would silently return more rows than the
+ * user asked for. Data streams resolve to their backing indices like aliases do.
  *
  * <p>Index expressions (comma lists, wildcards, exclusions, date-math) are resolved through the
  * cluster's {@link IndexNameExpressionResolver} and unioned, with the same schema-compatibility

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.planner;
 
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
 import org.opensearch.analytics.settings.DelegationBlockList;
 import org.opensearch.analytics.settings.PlannerSettings;
@@ -47,6 +48,7 @@ public class PlannerContext {
     private final OpenSearchDistributionTraitDef distributionTraitDef;
     private final boolean profilingEnabled;
     private final boolean preferMetadataDriver;
+    private final IndicesOptions indicesOptions;
     private int annotationIdCounter;
     private RuleProfilingListener.PlannerProfile lastProfile;
     // Cluster settings the planner consults at planning time (oversampling factor + delegation
@@ -60,19 +62,46 @@ public class PlannerContext {
     private boolean broadcastEligible = true;
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState) {
-        this(capabilityRegistry, clusterState, null, false, true, Settings.EMPTY, DEFAULT_TABLE_ROW_COUNTS);
+        this(
+            capabilityRegistry,
+            clusterState,
+            null,
+            false,
+            true,
+            Settings.EMPTY,
+            DEFAULT_TABLE_ROW_COUNTS,
+            IndicesOptions.lenientExpandOpen()
+        );
     }
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState, boolean profilingEnabled) {
-        this(capabilityRegistry, clusterState, null, profilingEnabled, true, Settings.EMPTY, DEFAULT_TABLE_ROW_COUNTS);
+        this(
+            capabilityRegistry,
+            clusterState,
+            null,
+            profilingEnabled,
+            true,
+            Settings.EMPTY,
+            DEFAULT_TABLE_ROW_COUNTS,
+            IndicesOptions.lenientExpandOpen()
+        );
     }
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState, Settings settings) {
-        this(capabilityRegistry, clusterState, null, false, true, settings, DEFAULT_TABLE_ROW_COUNTS);
+        this(capabilityRegistry, clusterState, null, false, true, settings, DEFAULT_TABLE_ROW_COUNTS, IndicesOptions.lenientExpandOpen());
     }
 
     public PlannerContext(CapabilityRegistry capabilityRegistry, ClusterState clusterState, Settings settings, boolean profilingEnabled) {
-        this(capabilityRegistry, clusterState, null, profilingEnabled, true, settings, DEFAULT_TABLE_ROW_COUNTS);
+        this(
+            capabilityRegistry,
+            clusterState,
+            null,
+            profilingEnabled,
+            true,
+            settings,
+            DEFAULT_TABLE_ROW_COUNTS,
+            IndicesOptions.lenientExpandOpen()
+        );
     }
 
     public PlannerContext(
@@ -88,7 +117,8 @@ public class PlannerContext {
             profilingEnabled,
             true,
             Settings.EMPTY,
-            DEFAULT_TABLE_ROW_COUNTS
+            DEFAULT_TABLE_ROW_COUNTS,
+            IndicesOptions.lenientExpandOpen()
         );
     }
 
@@ -106,7 +136,8 @@ public class PlannerContext {
             profilingEnabled,
             preferMetadataDriver,
             Settings.EMPTY,
-            DEFAULT_TABLE_ROW_COUNTS
+            DEFAULT_TABLE_ROW_COUNTS,
+            IndicesOptions.lenientExpandOpen()
         );
     }
 
@@ -117,7 +148,7 @@ public class PlannerContext {
         ToLongFunction<String> tableRowCounts,
         boolean profilingEnabled
     ) {
-        this(capabilityRegistry, clusterState, null, profilingEnabled, true, settings, tableRowCounts);
+        this(capabilityRegistry, clusterState, null, profilingEnabled, true, settings, tableRowCounts, IndicesOptions.lenientExpandOpen());
     }
 
     public PlannerContext(
@@ -128,13 +159,23 @@ public class PlannerContext {
         @Nullable IndexNameExpressionResolver indexNameExpressionResolver,
         boolean profilingEnabled
     ) {
-        this(capabilityRegistry, clusterState, indexNameExpressionResolver, profilingEnabled, true, settings, tableRowCounts);
+        this(
+            capabilityRegistry,
+            clusterState,
+            indexNameExpressionResolver,
+            profilingEnabled,
+            true,
+            settings,
+            tableRowCounts,
+            IndicesOptions.lenientExpandOpen()
+        );
     }
 
     // Canonical constructor. Parameters that exist on upstream's PlannerContext
     // (indexNameExpressionResolver, profilingEnabled, preferMetadataDriver) come first, in
     // upstream's order; our feature-branch additions (settings, tableRowCounts) are appended last
     // so a future upstream merge that extends this constructor doesn't collide with our params.
+    // IndicesOptions is the final parameter — the per-query index resolution mode.
     public PlannerContext(
         CapabilityRegistry capabilityRegistry,
         ClusterState clusterState,
@@ -142,7 +183,8 @@ public class PlannerContext {
         boolean profilingEnabled,
         boolean preferMetadataDriver,
         Settings settings,
-        ToLongFunction<String> tableRowCounts
+        ToLongFunction<String> tableRowCounts,
+        IndicesOptions indicesOptions
     ) {
         this.capabilityRegistry = capabilityRegistry;
         this.clusterState = clusterState;
@@ -152,6 +194,7 @@ public class PlannerContext {
         this.distributionTraitDef = new OpenSearchDistributionTraitDef(this);
         this.profilingEnabled = profilingEnabled;
         this.preferMetadataDriver = preferMetadataDriver;
+        this.indicesOptions = indicesOptions;
         this.annotationIdCounter = 0;
     }
 
@@ -247,5 +290,10 @@ public class PlannerContext {
      */
     public boolean preferMetadataDriver() {
         return preferMetadataDriver;
+    }
+
+    /** Per-query index resolution options. Defaults to {@link IndicesOptions#lenientExpandOpen()}. */
+    public IndicesOptions getIndicesOptions() {
+        return indicesOptions;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/RelNodeUtils.java
@@ -76,7 +76,15 @@ public class RelNodeUtils {
         RelTraitSet newTraits = rebuildTraits(node, newCluster, distTraitDef);
 
         if (node instanceof OpenSearchTableScan scan) {
-            return new OpenSearchTableScan(newCluster, newTraits, scan.getTable(), scan.getViableBackends(), scan.getOutputFieldStorage());
+            return new OpenSearchTableScan(
+                newCluster,
+                newTraits,
+                scan.getTable(),
+                scan.getViableBackends(),
+                scan.getOutputFieldStorage(),
+                null,
+                scan.getCarriedResolution()
+            );
         } else if (node instanceof OpenSearchFilter filter) {
             return new OpenSearchFilter(newCluster, newTraits, newInputs.getFirst(), filter.getCondition(), filter.getViableBackends());
         } else if (node instanceof OpenSearchAggregate aggregate) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
@@ -25,7 +25,6 @@ import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
 import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.analytics.planner.rel.OpenSearchValues;
 import org.opensearch.analytics.spi.ExchangeSinkProvider;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 
 import java.util.ArrayList;
@@ -55,12 +54,7 @@ public class DAGBuilder {
 
     private DAGBuilder() {}
 
-    public static QueryDAG build(
-        RelNode cboOutput,
-        CapabilityRegistry registry,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver
-    ) {
+    public static QueryDAG build(RelNode cboOutput, CapabilityRegistry registry, ClusterService clusterService) {
         int[] counter = { 0 };
         List<Stage> childStages = new ArrayList<>();
 
@@ -69,16 +63,16 @@ public class DAGBuilder {
             // Root IS an ExchangeReducer — pure gather (no compute above the exchange).
             // Cut directly: child stage is the subtree below, root fragment is
             // ExchangeReducer → StageInputScan.
-            rootFragment = cutAtExchange(reducer, counter, childStages, registry, clusterService, indexNameExpressionResolver);
+            rootFragment = cutAtExchange(reducer, counter, childStages, registry, clusterService);
         } else if (cboOutput instanceof OpenSearchLateMaterialization lm) {
             // LM at root, no above-ops (e.g. `source = t | where ... | sort col | head N`):
             // promote the LM stage to rootStage and skip the synthetic post-LM stage that would
             // wrap a bare StageInputScan placeholder.
-            cutAtLateMaterialization(lm, counter, childStages, registry, clusterService, indexNameExpressionResolver);
+            cutAtLateMaterialization(lm, counter, childStages, registry, clusterService);
             assert childStages.size() == 1 : "cutAtLateMaterialization must add exactly one child (the LM stage)";
             return new QueryDAG(newQueryId(), childStages.getFirst());
         } else {
-            rootFragment = sever(cboOutput, counter, childStages, registry, clusterService, indexNameExpressionResolver);
+            rootFragment = sever(cboOutput, counter, childStages, registry, clusterService);
         }
 
         // Sink provider is needed whenever the root stage runs a backend plan locally —
@@ -100,9 +94,7 @@ public class DAGBuilder {
         // OpenSearchValues (literal-row source) and other coord-only leaves have no scan
         // and run as LOCAL_COMPUTE on the coordinator.
         boolean needsShardResolver = childStages.isEmpty() && RelNodeUtils.findNode(rootFragment, OpenSearchTableScan.class) != null;
-        TargetResolver rootTargetResolver = needsShardResolver
-            ? new ShardTargetResolver(rootFragment, clusterService, indexNameExpressionResolver)
-            : null;
+        TargetResolver rootTargetResolver = needsShardResolver ? new ShardTargetResolver(rootFragment, clusterService) : null;
 
         Stage rootStage = new Stage(counter[0]++, rootFragment, childStages, null, sinkProvider, rootTargetResolver);
         return new QueryDAG(newQueryId(), rootStage);
@@ -122,25 +114,22 @@ public class DAGBuilder {
         int[] counter,
         List<Stage> childStages,
         CapabilityRegistry registry,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        ClusterService clusterService
     ) {
         List<RelNode> newInputs = new ArrayList<>();
         List<RelNode> rawInputs = node.getInputs();
         for (int inputIndex = 0; inputIndex < rawInputs.size(); inputIndex++) {
             RelNode input = rawInputs.get(inputIndex);
             if (input instanceof OpenSearchExchangeReducer reducer) {
-                newInputs.add(cutAtExchange(reducer, counter, childStages, registry, clusterService, indexNameExpressionResolver));
+                newInputs.add(cutAtExchange(reducer, counter, childStages, registry, clusterService));
             } else if (input instanceof OpenSearchShuffleExchange shuffle) {
-                newInputs.add(
-                    cutShuffle(shuffle, counter, childStages, registry, clusterService, node, inputIndex, indexNameExpressionResolver)
-                );
+                newInputs.add(cutShuffle(shuffle, counter, childStages, registry, clusterService, node, inputIndex));
             } else if (input instanceof OpenSearchBroadcastExchange broadcast) {
-                newInputs.add(cutBroadcast(broadcast, counter, childStages, registry, clusterService, indexNameExpressionResolver));
+                newInputs.add(cutBroadcast(broadcast, counter, childStages, registry, clusterService));
             } else if (input instanceof OpenSearchLateMaterialization lm) {
-                newInputs.add(cutAtLateMaterialization(lm, counter, childStages, registry, clusterService, indexNameExpressionResolver));
+                newInputs.add(cutAtLateMaterialization(lm, counter, childStages, registry, clusterService));
             } else {
-                newInputs.add(sever(input, counter, childStages, registry, clusterService, indexNameExpressionResolver));
+                newInputs.add(sever(input, counter, childStages, registry, clusterService));
             }
         }
         if (node.getInputs().isEmpty()) return node;
@@ -184,12 +173,11 @@ public class DAGBuilder {
         int[] counter,
         List<Stage> parentChildStages,
         CapabilityRegistry registry,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        ClusterService clusterService
     ) {
         // 1. Reduce child — Sort+Limit reduce above shard scans. Multi-shard QTF only.
         List<Stage> reduceChildren = new ArrayList<>();
-        RelNode reduceFragment = sever(lm.getInput(), counter, reduceChildren, registry, clusterService, indexNameExpressionResolver);
+        RelNode reduceFragment = sever(lm.getInput(), counter, reduceChildren, registry, clusterService);
         if (reduceChildren.isEmpty()) {
             throw new IllegalStateException(
                 "QTF rewriter fired but the wrapper's input has no ExchangeReducer below it — "
@@ -269,14 +257,13 @@ public class DAGBuilder {
         int[] counter,
         List<Stage> parentChildStages,
         CapabilityRegistry registry,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        ClusterService clusterService
     ) {
         // Recurse into the child fragment with full sever() so any nested ExchangeReducers
         // (e.g. a Join below a top-level gather Reducer) are also cut into their own child
         // stages rather than being left intact inside the shard-local fragment.
         List<Stage> grandchildren = new ArrayList<>();
-        RelNode childFragment = sever(reducer.getInput(), counter, grandchildren, registry, clusterService, indexNameExpressionResolver);
+        RelNode childFragment = sever(reducer.getInput(), counter, grandchildren, registry, clusterService);
 
         int childStageId = counter[0]++;
         // Stage execution location is decided by the fragment's contents, not the grandchild
@@ -286,9 +273,7 @@ public class DAGBuilder {
         // fragment without a TableScan runs at the coordinator and consumes grandchildren via
         // an ExchangeSinkProvider.
         boolean fragmentHasShardScan = containsAnyInput(childFragment, OpenSearchTableScan.class);
-        TargetResolver targetResolver = fragmentHasShardScan
-            ? new ShardTargetResolver(childFragment, clusterService, indexNameExpressionResolver)
-            : null;
+        TargetResolver targetResolver = fragmentHasShardScan ? new ShardTargetResolver(childFragment, clusterService) : null;
         ExchangeSinkProvider childSinkProvider = null;
         if (!grandchildren.isEmpty() && !fragmentHasShardScan) {
             List<String> reduceViable = CapabilityResolutionUtils.filterByReduceCapability(registry, reducer.getViableBackends());
@@ -354,15 +339,14 @@ public class DAGBuilder {
         CapabilityRegistry registry,
         ClusterService clusterService,
         RelNode parent,
-        int parentInputIndex,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        int parentInputIndex
     ) {
         // Recurse into the shuffle's input with full sever() so any nested exchanges below the
         // shuffle (e.g. a partial-aggregate that itself reduces) are also cut into their own
         // stages. M2 today only composes shuffle over a shard scan, but the recursion makes the
         // cutter robust to future plan shapes.
         List<Stage> grandchildren = new ArrayList<>();
-        RelNode childFragment = sever(shuffle.getInput(), counter, grandchildren, registry, clusterService, indexNameExpressionResolver);
+        RelNode childFragment = sever(shuffle.getInput(), counter, grandchildren, registry, clusterService);
 
         int childStageId = counter[0]++;
         // Decide the producer's locality by whether its fragment has a shard scan — NOT by child-stage
@@ -375,9 +359,7 @@ public class DAGBuilder {
         // ("expected at least one child"). A fragment with no shard scan genuinely runs at the coordinator
         // and consumes its grandchildren via an ExchangeSinkProvider.
         boolean fragmentHasShardScan = containsAnyInput(childFragment, OpenSearchTableScan.class);
-        TargetResolver targetResolver = fragmentHasShardScan
-            ? new ShardTargetResolver(childFragment, clusterService, indexNameExpressionResolver)
-            : null;
+        TargetResolver targetResolver = fragmentHasShardScan ? new ShardTargetResolver(childFragment, clusterService) : null;
         ExchangeSinkProvider childSinkProvider = null;
         if (!grandchildren.isEmpty() && !fragmentHasShardScan) {
             List<String> reduceViable = CapabilityResolutionUtils.filterByReduceCapability(registry, shuffle.getViableBackends());
@@ -462,16 +444,13 @@ public class DAGBuilder {
         int[] counter,
         List<Stage> parentChildStages,
         CapabilityRegistry registry,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        ClusterService clusterService
     ) {
         List<Stage> grandchildren = new ArrayList<>();
-        RelNode childFragment = sever(broadcast.getInput(), counter, grandchildren, registry, clusterService, indexNameExpressionResolver);
+        RelNode childFragment = sever(broadcast.getInput(), counter, grandchildren, registry, clusterService);
 
         int childStageId = counter[0]++;
-        TargetResolver targetResolver = grandchildren.isEmpty()
-            ? new ShardTargetResolver(childFragment, clusterService, indexNameExpressionResolver)
-            : null;
+        TargetResolver targetResolver = grandchildren.isEmpty() ? new ShardTargetResolver(childFragment, clusterService) : null;
         ExchangeSinkProvider childSinkProvider = null;
         if (!grandchildren.isEmpty()) {
             List<String> reduceViable = CapabilityResolutionUtils.filterByReduceCapability(registry, broadcast.getViableBackends());

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
@@ -45,9 +45,9 @@ public class ShardTargetResolver extends TargetResolver {
 
     /**
      * Constructs a resolver that reads the carried {@link IndexResolution} from the fragment's
-     * {@link OpenSearchTableScan}. Fails loudly if the scan node does not carry a resolution —
-     * a silent fallback would mask a dropped field and reintroduce the options mismatch this
-     * change exists to remove.
+     * {@link OpenSearchTableScan}. Fails loudly if the scan carries no resolution — a silent
+     * fallback would re-resolve the index expression with different {@code IndicesOptions} and
+     * target a shard set that disagrees with the row type the plan was built against.
      */
     public ShardTargetResolver(RelNode fragment, ClusterService clusterService) {
         OpenSearchTableScan scan = RelNodeUtils.findNode(fragment, OpenSearchTableScan.class);
@@ -69,8 +69,8 @@ public class ShardTargetResolver extends TargetResolver {
 
     @Override
     public List<ExecutionTarget> resolve(ClusterState clusterState, @Nullable Object childManifest) {
-        // Use the carried resolution from planning — no re-resolution, eliminating the third
-        // independent resolution that would otherwise use different IndicesOptions.
+        // Reuse the planner's resolution rather than resolving again — a second resolution could
+        // use different IndicesOptions and yield a different shard set.
         IndexResolution resolution = carriedResolution;
         String[] concreteNames = resolution.concreteIndexNames().toArray(new String[0]);
         GroupShardsIterator<ShardIterator> shardIterators = clusterService.operationRouting()

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
@@ -12,9 +12,9 @@ import org.apache.calcite.rel.RelNode;
 import org.opensearch.action.search.TransportSearchAction;
 import org.opensearch.analytics.planner.IndexResolution;
 import org.opensearch.analytics.planner.RelNodeUtils;
+import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexAbstraction;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.GroupShardsIterator;
 import org.opensearch.cluster.routing.ShardIterator;
@@ -28,8 +28,9 @@ import java.util.SortedMap;
 
 /**
  * Resolves {@link ShardExecutionTarget}s for a DATA_NODE scan stage.
- * Extracts the index name from the fragment at construction time, then
- * resolves shard targets lazily when the Scheduler calls {@link #resolve}.
+ * Reads the pre-resolved {@link IndexResolution} carried on the fragment's
+ * {@link OpenSearchTableScan} node, then resolves shard targets lazily when
+ * the Scheduler calls {@link #resolve}.
  *
  * <p>Shard routing gives both the node and the shardId in one pass —
  * these are coupled and cannot be separated, hence a dedicated resolver
@@ -39,25 +40,38 @@ import java.util.SortedMap;
  */
 public class ShardTargetResolver extends TargetResolver {
 
-    private final String indexName;
+    private final IndexResolution carriedResolution;
     private final ClusterService clusterService;
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
-    public ShardTargetResolver(RelNode fragment, ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver) {
-        this.indexName = RelNodeUtils.findTableName(fragment);
-        this.clusterService = clusterService;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
-        if (this.indexName == null) {
+    /**
+     * Constructs a resolver that reads the carried {@link IndexResolution} from the fragment's
+     * {@link OpenSearchTableScan}. Fails loudly if the scan node does not carry a resolution —
+     * a silent fallback would mask a dropped field and reintroduce the options mismatch this
+     * change exists to remove.
+     */
+    public ShardTargetResolver(RelNode fragment, ClusterService clusterService) {
+        OpenSearchTableScan scan = RelNodeUtils.findNode(fragment, OpenSearchTableScan.class);
+        if (scan == null) {
             throw new IllegalArgumentException("ShardTargetResolver: no OpenSearchTableScan found in fragment");
         }
+        IndexResolution resolution = scan.getCarriedResolution();
+        if (resolution == null) {
+            throw new IllegalStateException(
+                "ShardTargetResolver: fragment's OpenSearchTableScan ["
+                    + scan.getTable().getQualifiedName()
+                    + "] does not carry a pre-resolved IndexResolution. "
+                    + "All scan nodes must carry their resolution from planning to avoid re-resolution with different IndicesOptions."
+            );
+        }
+        this.carriedResolution = resolution;
+        this.clusterService = clusterService;
     }
 
     @Override
     public List<ExecutionTarget> resolve(ClusterState clusterState, @Nullable Object childManifest) {
-        // Expand the table name (alias or concrete) to its concrete indices against the freshest
-        // cluster state. operationRouting().searchShards requires concrete names — aliases are
-        // not accepted there — so the expansion has to happen here, not at construction time.
-        IndexResolution resolution = IndexResolution.resolve(indexName, clusterState, indexNameExpressionResolver);
+        // Use the carried resolution from planning — no re-resolution, eliminating the third
+        // independent resolution that would otherwise use different IndicesOptions.
+        IndexResolution resolution = carriedResolution;
         String[] concreteNames = resolution.concreteIndexNames().toArray(new String[0]);
         GroupShardsIterator<ShardIterator> shardIterators = clusterService.operationRouting()
             .searchShards(clusterState, concreteNames, null, null);
@@ -68,7 +82,7 @@ public class ShardTargetResolver extends TargetResolver {
         long shardCountLimit = clusterService.getClusterSettings().get(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING);
         int shardCount = shardIterators.size();
         if (shardCount > shardCountLimit) {
-            String sourceType = describeIndexSource(indexName, clusterState);
+            String sourceType = describeIndexSource(resolution.requestedName(), clusterState);
             throw new IllegalArgumentException(
                 "Query via "
                     + sourceType

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
@@ -48,6 +48,8 @@ public class ShardTargetResolver extends TargetResolver {
      * Fails if absent — a silent fallback would re-resolve with different {@code IndicesOptions}.
      */
     public ShardTargetResolver(RelNode fragment, ClusterService clusterService) {
+        // Plural lookup: the scan may sit on a non-first join input a first-input-only walk cannot reach.
+        // First is safe: the only multi-scan shape is the collocated single-shard join, all scans same table and shard.
         List<OpenSearchTableScan> scans = RelNodeUtils.findNodes(fragment, OpenSearchTableScan.class);
         if (scans.isEmpty()) {
             throw new IllegalArgumentException("ShardTargetResolver: no OpenSearchTableScan found in fragment");

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
@@ -48,8 +48,8 @@ public class ShardTargetResolver extends TargetResolver {
      * Fails if absent — a silent fallback would re-resolve with different {@code IndicesOptions}.
      */
     public ShardTargetResolver(RelNode fragment, ClusterService clusterService) {
-        // Plural lookup: the scan may sit on a non-first join input a first-input-only walk cannot reach.
-        // First is safe: the only multi-scan shape is the collocated single-shard join, all scans same table and shard.
+        // Plural lookup: the scan may sit on a non-first join input a single-input walk misses.
+        // getFirst() is safe — the only multi-scan shape is the collocated single-shard join.
         List<OpenSearchTableScan> scans = RelNodeUtils.findNodes(fragment, OpenSearchTableScan.class);
         if (scans.isEmpty()) {
             throw new IllegalArgumentException("ShardTargetResolver: no OpenSearchTableScan found in fragment");

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/ShardTargetResolver.java
@@ -44,16 +44,15 @@ public class ShardTargetResolver extends TargetResolver {
     private final ClusterService clusterService;
 
     /**
-     * Constructs a resolver that reads the carried {@link IndexResolution} from the fragment's
-     * {@link OpenSearchTableScan}. Fails loudly if the scan carries no resolution — a silent
-     * fallback would re-resolve the index expression with different {@code IndicesOptions} and
-     * target a shard set that disagrees with the row type the plan was built against.
+     * Reads the carried {@link IndexResolution} from the fragment's {@link OpenSearchTableScan}.
+     * Fails if absent — a silent fallback would re-resolve with different {@code IndicesOptions}.
      */
     public ShardTargetResolver(RelNode fragment, ClusterService clusterService) {
-        OpenSearchTableScan scan = RelNodeUtils.findNode(fragment, OpenSearchTableScan.class);
-        if (scan == null) {
+        List<OpenSearchTableScan> scans = RelNodeUtils.findNodes(fragment, OpenSearchTableScan.class);
+        if (scans.isEmpty()) {
             throw new IllegalArgumentException("ShardTargetResolver: no OpenSearchTableScan found in fragment");
         }
+        OpenSearchTableScan scan = scans.getFirst();
         IndexResolution resolution = scan.getCarriedResolution();
         if (resolution == null) {
             throw new IllegalStateException(
@@ -69,8 +68,7 @@ public class ShardTargetResolver extends TargetResolver {
 
     @Override
     public List<ExecutionTarget> resolve(ClusterState clusterState, @Nullable Object childManifest) {
-        // Reuse the planner's resolution rather than resolving again — a second resolution could
-        // use different IndicesOptions and yield a different shard set.
+        // Reuse the planner's resolution — re-resolving could use different IndicesOptions.
         IndexResolution resolution = carriedResolution;
         String[] concreteNames = resolution.concreteIndexNames().toArray(new String[0]);
         GroupShardsIterator<ShardIterator> shardIterators = clusterService.operationRouting()

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
@@ -39,13 +39,9 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
      */
     private final RelDataType overrideRowType;
     /**
-     * The {@link IndexResolution} computed by the scan rule at planning time. Carrying it here
-     * lets shard targeting reuse the planner's resolution instead of resolving the index
-     * expression again with different {@code IndicesOptions}, which would yield a divergent
-     * shard set. Every copy path must propagate it; the shard-target resolver rejects a scan
-     * that arrives without one.
-     *
-     * <p>Null only on scans built outside the scan rule, which no shard stage consumes.
+     * Resolution from planning time. Carried so shard targeting reuses the same concrete index
+     * set rather than re-resolving with potentially different {@code IndicesOptions}.
+     * Null only on scans built outside the scan rule (which no shard stage consumes).
      */
     @Nullable
     private final IndexResolution carriedResolution;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
@@ -17,7 +17,9 @@ import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.opensearch.analytics.planner.IndexResolution;
 import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.common.Nullable;
 
 import java.util.List;
 
@@ -36,6 +38,14 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
      * appended. Null in the default case so {@link TableScan#deriveRowType()} drives.
      */
     private final RelDataType overrideRowType;
+    /**
+     * The {@link IndexResolution} computed by {@code OpenSearchTableScanRule} at planning time.
+     * Carrying it here eliminates a third independent re-resolution in {@code ShardTargetResolver}
+     * that would otherwise use different {@code IndicesOptions} and produce a divergent shard set.
+     * Null only for scans created before D4 (e.g. in {@code RelNodeUtils.copyToCluster} test paths).
+     */
+    @Nullable
+    private final IndexResolution carriedResolution;
 
     public OpenSearchTableScan(
         RelOptCluster cluster,
@@ -44,7 +54,7 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
         List<String> viableBackends,
         List<FieldStorageInfo> outputFieldStorage
     ) {
-        this(cluster, traitSet, table, viableBackends, outputFieldStorage, null);
+        this(cluster, traitSet, table, viableBackends, outputFieldStorage, null, null);
     }
 
     /**
@@ -61,10 +71,26 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
         List<FieldStorageInfo> outputFieldStorage,
         RelDataType overrideRowType
     ) {
+        this(cluster, traitSet, table, viableBackends, outputFieldStorage, overrideRowType, null);
+    }
+
+    /**
+     * Full constructor carrying an optional {@code IndexResolution} resolved by the scan rule.
+     */
+    public OpenSearchTableScan(
+        RelOptCluster cluster,
+        RelTraitSet traitSet,
+        RelOptTable table,
+        List<String> viableBackends,
+        List<FieldStorageInfo> outputFieldStorage,
+        RelDataType overrideRowType,
+        @Nullable IndexResolution carriedResolution
+    ) {
         super(cluster, traitSet, List.of(), table);
         this.viableBackends = viableBackends;
         this.outputFieldStorage = outputFieldStorage;
         this.overrideRowType = overrideRowType;
+        this.carriedResolution = carriedResolution;
     }
 
     @Override
@@ -93,12 +119,27 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
         int shardCount,
         OpenSearchDistributionTraitDef distTraitDef
     ) {
+        return create(cluster, table, viableBackends, outputFieldStorage, shardCount, distTraitDef, null);
+    }
+
+    /**
+     * Full factory carrying an optional {@link IndexResolution} from the scan rule.
+     */
+    public static OpenSearchTableScan create(
+        RelOptCluster cluster,
+        RelOptTable table,
+        List<String> viableBackends,
+        List<FieldStorageInfo> outputFieldStorage,
+        int shardCount,
+        OpenSearchDistributionTraitDef distTraitDef,
+        @Nullable IndexResolution carriedResolution
+    ) {
         int tableId = table.getQualifiedName().hashCode();
         OpenSearchDistribution distribution = shardCount == 1
             ? distTraitDef.shardSingleton(tableId, shardCount)
             : distTraitDef.shardRandom(tableId, shardCount);
         RelTraitSet traitSet = RelTraitSet.createEmpty().plus(OpenSearchConvention.INSTANCE).plus(distribution);
-        return new OpenSearchTableScan(cluster, traitSet, table, viableBackends, outputFieldStorage);
+        return new OpenSearchTableScan(cluster, traitSet, table, viableBackends, outputFieldStorage, null, carriedResolution);
     }
 
     @Override
@@ -111,9 +152,23 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
         return outputFieldStorage;
     }
 
+    /** The pre-resolved {@link IndexResolution} carried from planning, or null for legacy paths. */
+    @Nullable
+    public IndexResolution getCarriedResolution() {
+        return carriedResolution;
+    }
+
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-        return new OpenSearchTableScan(getCluster(), traitSet, getTable(), viableBackends, outputFieldStorage, overrideRowType);
+        return new OpenSearchTableScan(
+            getCluster(),
+            traitSet,
+            getTable(),
+            viableBackends,
+            outputFieldStorage,
+            overrideRowType,
+            carriedResolution
+        );
     }
 
     @Override
@@ -128,7 +183,15 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
 
     @Override
     public RelNode copyResolved(String backend, List<RelNode> children, List<OperatorAnnotation> resolvedAnnotations) {
-        return new OpenSearchTableScan(getCluster(), getTraitSet(), getTable(), List.of(backend), outputFieldStorage, overrideRowType);
+        return new OpenSearchTableScan(
+            getCluster(),
+            getTraitSet(),
+            getTable(),
+            List.of(backend),
+            outputFieldStorage,
+            overrideRowType,
+            carriedResolution
+        );
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
@@ -39,9 +39,9 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
      */
     private final RelDataType overrideRowType;
     /**
-     * Resolution from planning time. Carried so shard targeting reuses the same concrete index
-     * set rather than re-resolving with potentially different {@code IndicesOptions}.
-     * Null only on scans built outside the scan rule (which no shard stage consumes).
+     * Resolution from planning, carried so shard targeting reuses the same concrete indices
+     * rather than re-resolving with different {@code IndicesOptions}. Null only on scans built
+     * outside the scan rule, which no shard stage consumes.
      */
     @Nullable
     private final IndexResolution carriedResolution;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rel/OpenSearchTableScan.java
@@ -39,10 +39,13 @@ public class OpenSearchTableScan extends TableScan implements OpenSearchRelNode 
      */
     private final RelDataType overrideRowType;
     /**
-     * The {@link IndexResolution} computed by {@code OpenSearchTableScanRule} at planning time.
-     * Carrying it here eliminates a third independent re-resolution in {@code ShardTargetResolver}
-     * that would otherwise use different {@code IndicesOptions} and produce a divergent shard set.
-     * Null only for scans created before D4 (e.g. in {@code RelNodeUtils.copyToCluster} test paths).
+     * The {@link IndexResolution} computed by the scan rule at planning time. Carrying it here
+     * lets shard targeting reuse the planner's resolution instead of resolving the index
+     * expression again with different {@code IndicesOptions}, which would yield a divergent
+     * shard set. Every copy path must propagate it; the shard-target resolver rejects a scan
+     * that arrives without one.
+     *
+     * <p>Null only on scans built outside the scan rule, which no shard stage consumes.
      */
     @Nullable
     private final IndexResolution carriedResolution;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchLateMaterializationRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchLateMaterializationRewriter.java
@@ -494,7 +494,8 @@ public final class OpenSearchLateMaterializationRewriter {
             origScan.getTable(),
             origScan.getViableBackends(),
             newStorage,
-            rowTypeBuilder.build()
+            rowTypeBuilder.build(),
+            origScan.getCarriedResolution()
         );
         return new NarrowedScan(newScan, scanIdxRemap);
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTableScanRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchTableScanRule.java
@@ -61,7 +61,8 @@ public class OpenSearchTableScanRule extends RelOptRule {
         IndexResolution resolution = IndexResolution.resolve(
             tableName,
             context.getClusterState(),
-            context.getIndexNameExpressionResolver()
+            context.getIndexNameExpressionResolver(),
+            context.getIndicesOptions()
         );
         // Field storage is the union across all backing concrete indices. An index pattern or
         // alias can resolve to indices with differing field sets (e.g. test* where one index has
@@ -172,7 +173,8 @@ public class OpenSearchTableScanRule extends RelOptRule {
                 viableBackends,
                 fieldStorage,
                 resolution.totalShardCount(),
-                context.getDistributionTraitDef()
+                context.getDistributionTraitDef(),
+                resolution
             )
         );
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -34,6 +34,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.LinkedHashMap;
@@ -1142,5 +1143,48 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
             rowDefault.getFieldCount(),
             rowHidden.getFieldCount()
         );
+    }
+
+    // ===== C2: strict-options missing-index propagation tests =====
+
+    /**
+     * C2 regression: with STRICT {@link IndicesOptions} (ignore_unavailable=false) a MISSING
+     * concrete index name must PROPAGATE {@link IndexNotFoundException} out of the schema's lazy
+     * table lookup rather than being swallowed into a {@code null} table. Swallowing lets the
+     * schema layer ignore the IndicesOptions it was handed: a should-be-404 (missing index under
+     * ignore_unavailable=false) becomes a Calcite missing-table and surfaces to the client as a
+     * 400. Before the fix (a try/catch returning {@code null}) {@code getTable} returns null and
+     * this test FAILS; after the catch is deleted the exception propagates and it passes.
+     */
+    public void testStrictOptionsMissingIndexPropagatesIndexNotFound() throws Exception {
+        ClusterState clusterState = buildClusterState(Map.of("present_index", Map.of("name", "keyword")));
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState, resolver, IndicesOptions.strictExpandOpen());
+
+        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> schema.getTable("missing_index"));
+        assertTrue("IndexNotFoundException must name the missing index; got: " + e.getMessage(), e.getMessage().contains("missing_index"));
+    }
+
+    /**
+     * Companion to {@link #testStrictOptionsMissingIndexPropagatesIndexNotFound}, documenting why
+     * deleting the catch is safe: with {@link IndicesOptions#lenientExpandOpen()}
+     * (ignore_unavailable=true) a missing index resolves to zero concrete names —
+     * {@code concreteIndexNames} returns an empty array and never throws — so the lookup yields a
+     * {@code null} table WITHOUT throwing. The deleted catch therefore only ever fired under
+     * strict options, which is exactly the case where swallowing was wrong.
+     */
+    public void testLenientOptionsMissingIndexDoesNotThrow() throws Exception {
+        ClusterState clusterState = buildClusterState(Map.of("present_index", Map.of("name", "keyword")));
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState, resolver, IndicesOptions.lenientExpandOpen());
+
+        Table table = schema.getTable("missing_index");
+        assertNull("Missing index under lenient options must yield a null table, not throw", table);
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -21,6 +21,7 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.opensearch.Version;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.schema.BinaryType;
 import org.opensearch.analytics.schema.DateOnlyType;
 import org.opensearch.analytics.schema.IpType;
@@ -856,5 +857,230 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
             }
         }
         return sb.toString();
+    }
+
+    // ===== D2: options-aware schema construction tests =====
+
+    /**
+     * Regression guard: an alias backed by two OPEN indices still yields a unioned row type
+     * containing fields from both backings when using the new 3-arg buildSchema overload
+     * with lenientExpandOpen (the default).
+     */
+    public void testAliasOverTwoOpenBackingsYieldsUnionedRowType() throws Exception {
+        IndexMetadata a = IndexMetadata.builder("idx_a")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"field_a\":{\"type\":\"keyword\"}}}")
+            .putAlias(AliasMetadata.builder("my_alias").build())
+            .build();
+        IndexMetadata b = IndexMetadata.builder("idx_b")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"field_b\":{\"type\":\"long\"}}}")
+            .putAlias(AliasMetadata.builder("my_alias").build())
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(a, false).put(b, false).build())
+            .build();
+
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(state, resolver, IndicesOptions.lenientExpandOpen());
+
+        Table table = schema.getTable("my_alias");
+        assertNotNull("Alias over two OPEN backings must resolve", table);
+        RelDataType rowType = table.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(rowType, "field_a", SqlTypeName.VARCHAR);
+        assertFieldType(rowType, "field_b", SqlTypeName.BIGINT);
+    }
+
+    /**
+     * Phantom-column fix: an alias backed by one OPEN and one CLOSED index yields ONLY the
+     * open backing's columns when resolved with lenientExpandOpen (wildcard states = OPEN only).
+     */
+    public void testAliasOverOpenAndClosedBackingExcludesClosedColumns() throws Exception {
+        IndexMetadata open = IndexMetadata.builder("idx_open")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"open_field\":{\"type\":\"keyword\"}}}")
+            .putAlias(AliasMetadata.builder("mixed_alias").build())
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        IndexMetadata closed = IndexMetadata.builder("idx_closed")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"closed_field\":{\"type\":\"long\"}}}")
+            .putAlias(AliasMetadata.builder("mixed_alias").build())
+            .state(IndexMetadata.State.CLOSE)
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(open, false).put(closed, false).build())
+            .build();
+
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(state, resolver, IndicesOptions.lenientExpandOpen());
+
+        Table table = schema.getTable("mixed_alias");
+        assertNotNull("Alias must still resolve when at least one backing is open", table);
+        RelDataType rowType = table.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(rowType, "open_field", SqlTypeName.VARCHAR);
+        assertNull("Closed backing's column must NOT appear (phantom-column fix)", rowType.getField("closed_field", true, false));
+    }
+
+    /**
+     * Phantom-column invariant: even when IndicesOptions requests expandWildcardsClosed, the
+     * ALIAS short-circuit filters to State.OPEN unconditionally. A closed backing's fields must
+     * NOT appear in the row type because the planner (IndexResolution.resolveAlias) never
+     * targets closed indices — including them produces phantom columns that validate but
+     * null-fill at execution. The schema's column set must never exceed the union of mappings
+     * of the indices the planner will actually target.
+     */
+    public void testAliasWithExpandClosedOptionsStillExcludesClosedBacking() throws Exception {
+        IndexMetadata open = IndexMetadata.builder("idx_open")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"open_field\":{\"type\":\"keyword\"}}}")
+            .putAlias(AliasMetadata.builder("both_alias").build())
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        IndexMetadata closed = IndexMetadata.builder("idx_closed")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"closed_field\":{\"type\":\"long\"}}}")
+            .putAlias(AliasMetadata.builder("both_alias").build())
+            .state(IndexMetadata.State.CLOSE)
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(open, false).put(closed, false).build())
+            .build();
+
+        // Options that expand both open AND closed
+        IndicesOptions expandBoth = IndicesOptions.fromOptions(
+            true,  // ignoreUnavailable
+            true,  // allowNoIndices
+            true,  // expandWildcardsOpen
+            true   // expandWildcardsClosed
+        );
+
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(state, resolver, expandBoth);
+
+        Table table = schema.getTable("both_alias");
+        assertNotNull("Alias must resolve with expandBoth options", table);
+        RelDataType rowType = table.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(rowType, "open_field", SqlTypeName.VARCHAR);
+        assertNull(
+            "Closed backing's column must NOT appear even with expandWildcardsClosed (phantom-column invariant)",
+            rowType.getField("closed_field", true, false)
+        );
+    }
+
+    /**
+     * Wildcard with strict options (no ALLOW_NO_INDICES, no IGNORE_UNAVAILABLE) vs lenient:
+     * strict options pass through to the resolver and may produce different results. Here we
+     * verify that the options parameter IS actually threaded to the resolver's concreteIndexNames
+     * call by checking that expandWildcardsClosed=true includes a closed index in the wildcard
+     * resolution while lenientExpandOpen (open-only) does not.
+     */
+    public void testWildcardResolutionRespectsOptionsParameter() throws Exception {
+        IndexMetadata open = IndexMetadata.builder("wc_open")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"open_col\":{\"type\":\"keyword\"}}}")
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        IndexMetadata closed = IndexMetadata.builder("wc_closed")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"closed_col\":{\"type\":\"long\"}}}")
+            .state(IndexMetadata.State.CLOSE)
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(open, false).put(closed, false).build())
+            .build();
+
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+
+        // lenientExpandOpen — wildcard states = OPEN only
+        SchemaPlus schemaLenient = OpenSearchSchemaBuilder.buildSchema(state, resolver, IndicesOptions.lenientExpandOpen());
+        Table tableLenient = schemaLenient.getTable("wc*");
+        assertNotNull("wc* must resolve with lenient options", tableLenient);
+        RelDataType lenientRow = tableLenient.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(lenientRow, "open_col", SqlTypeName.VARCHAR);
+        assertNull("Closed index must NOT appear under lenient options", lenientRow.getField("closed_col", true, false));
+
+        // expandBoth — wildcard states = OPEN + CLOSED
+        IndicesOptions expandBoth = IndicesOptions.fromOptions(true, true, true, true);
+        SchemaPlus schemaBoth = OpenSearchSchemaBuilder.buildSchema(state, resolver, expandBoth);
+        Table tableBoth = schemaBoth.getTable("wc*");
+        assertNotNull("wc* must resolve with expandBoth options", tableBoth);
+        RelDataType bothRow = tableBoth.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(bothRow, "open_col", SqlTypeName.VARCHAR);
+        assertFieldType(bothRow, "closed_col", SqlTypeName.BIGINT);
+    }
+
+    /**
+     * Delegation regression guard: the 1-arg and 2-arg buildSchema overloads behave identically
+     * to the 3-arg overload with lenientExpandOpen, confirming correct delegation.
+     */
+    public void testOneArgAndTwoArgOverloadsDelegateLenient() throws Exception {
+        IndexMetadata open = IndexMetadata.builder("deleg_open")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"x\":{\"type\":\"keyword\"}}}")
+            .putAlias(AliasMetadata.builder("deleg_alias").build())
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        IndexMetadata closed = IndexMetadata.builder("deleg_closed")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"y\":{\"type\":\"long\"}}}")
+            .putAlias(AliasMetadata.builder("deleg_alias").build())
+            .state(IndexMetadata.State.CLOSE)
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(open, false).put(closed, false).build())
+            .build();
+
+        // 1-arg overload
+        SchemaPlus schema1 = OpenSearchSchemaBuilder.buildSchema(state);
+        Table table1 = schema1.getTable("deleg_alias");
+        assertNotNull("1-arg overload must resolve alias", table1);
+        RelDataType row1 = table1.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(row1, "x", SqlTypeName.VARCHAR);
+        assertNull("1-arg overload must exclude closed backing (lenient default)", row1.getField("y", true, false));
+
+        // 2-arg overload
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+        SchemaPlus schema2 = OpenSearchSchemaBuilder.buildSchema(state, resolver);
+        Table table2 = schema2.getTable("deleg_alias");
+        assertNotNull("2-arg overload must resolve alias", table2);
+        RelDataType row2 = table2.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(row2, "x", SqlTypeName.VARCHAR);
+        assertNull("2-arg overload must exclude closed backing (lenient default)", row2.getField("y", true, false));
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -1083,4 +1083,64 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
         assertFieldType(row2, "x", SqlTypeName.VARCHAR);
         assertNull("2-arg overload must exclude closed backing (lenient default)", row2.getField("y", true, false));
     }
+
+    /**
+     * Falsifiable pair proving expand_wildcards controls hidden-index inclusion: a wildcard
+     * resolved with default options (open, not hidden) excludes the hidden index's unique field,
+     * while the same wildcard resolved with expand_hidden=true includes it. If both assertions
+     * produce the same result, expand_wildcards is not being honoured.
+     */
+    public void testExpandWildcardsHiddenControlsHiddenIndexInclusion() throws Exception {
+        IndexMetadata visible = IndexMetadata.builder("hw_visible")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"visible_field\":{\"type\":\"keyword\"}}}")
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        IndexMetadata hidden = IndexMetadata.builder("hw_hidden")
+            .settings(settings(Version.CURRENT).put("index.hidden", true))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping("{\"properties\":{\"hidden_field\":{\"type\":\"long\"}}}")
+            .state(IndexMetadata.State.OPEN)
+            .build();
+        ClusterState state = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(visible, false).put(hidden, false).build())
+            .build();
+
+        org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver =
+            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(
+                new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY)
+            );
+
+        // Default options: open indices only, hidden NOT expanded
+        IndicesOptions defaultOpen = IndicesOptions.fromOptions(true, true, true, false, false);
+        SchemaPlus schemaDefault = OpenSearchSchemaBuilder.buildSchema(state, resolver, defaultOpen);
+        Table tableDefault = schemaDefault.getTable("hw_*");
+        // The wildcard must match the visible index but skip the hidden one
+        assertNotNull("hw_* must resolve with default options (visible index matches)", tableDefault);
+        RelDataType rowDefault = tableDefault.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(rowDefault, "visible_field", SqlTypeName.VARCHAR);
+        assertNull(
+            "Default options (hidden=false) must NOT include hidden index's field",
+            rowDefault.getField("hidden_field", true, false)
+        );
+
+        // Expand hidden: open + hidden
+        IndicesOptions withHidden = IndicesOptions.fromOptions(true, true, true, false, true);
+        SchemaPlus schemaHidden = OpenSearchSchemaBuilder.buildSchema(state, resolver, withHidden);
+        Table tableHidden = schemaHidden.getTable("hw_*");
+        assertNotNull("hw_* must resolve with hidden options", tableHidden);
+        RelDataType rowHidden = tableHidden.getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        assertFieldType(rowHidden, "visible_field", SqlTypeName.VARCHAR);
+        assertFieldType(rowHidden, "hidden_field", SqlTypeName.BIGINT);
+
+        // Falsifiability check: the two row types must differ
+        assertNotEquals(
+            "The two row types must differ — otherwise expand_wildcards is not controlling hidden-index inclusion",
+            rowDefault.getFieldCount(),
+            rowHidden.getFieldCount()
+        );
+    }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequestTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/action/AnalyticsQueryRequestTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.action;
+
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.analytics.QueryRequestContext;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AnalyticsQueryRequest}, focusing on IndicesOptions delegation.
+ */
+public class AnalyticsQueryRequestTests extends OpenSearchTestCase {
+
+    /**
+     * When a QueryRequestContext with custom IndicesOptions is present, indicesOptions()
+     * must return those options — not the hardcoded strictExpandOpen() default.
+     */
+    public void testIndicesOptionsReflectsQueryRequestContext() {
+        IndicesOptions customOptions = IndicesOptions.fromOptions(true, true, true, true);
+        ClusterState state = mock(ClusterState.class);
+        QueryRequestContext ctx = new QueryRequestContext(state, null, null, null, customOptions);
+
+        AnalyticsQueryRequest request = new AnalyticsQueryRequest(null, ctx, new String[] { "test-index" });
+
+        assertSame("indicesOptions() must return the QueryRequestContext's options when present", customOptions, request.indicesOptions());
+    }
+
+    /**
+     * When QueryRequestContext is null (deserialized case), indicesOptions() must fall back
+     * to strictExpandOpen() for backward compatibility.
+     */
+    public void testIndicesOptionsFallsBackToStrictExpandOpenWhenContextNull() {
+        AnalyticsQueryRequest request = new AnalyticsQueryRequest(null, null, new String[] { "test-index" });
+
+        assertEquals(
+            "indicesOptions() must fall back to strictExpandOpen() when queryCtx is null",
+            IndicesOptions.strictExpandOpen(),
+            request.indicesOptions()
+        );
+    }
+
+    /**
+     * When QueryRequestContext has null indicesOptions, fall back to strictExpandOpen().
+     */
+    public void testIndicesOptionsFallsBackWhenContextOptionsNull() {
+        ClusterState state = mock(ClusterState.class);
+        QueryRequestContext ctx = new QueryRequestContext(state, null, null, null, null);
+
+        AnalyticsQueryRequest request = new AnalyticsQueryRequest(null, ctx, new String[] { "test-index" });
+
+        assertEquals(
+            "indicesOptions() must fall back to strictExpandOpen() when context's options are null",
+            IndicesOptions.strictExpandOpen(),
+            request.indicesOptions()
+        );
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/MppStrategyObservationTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/MppStrategyObservationTests.java
@@ -178,7 +178,7 @@ public class MppStrategyObservationTests extends BasePlannerRulesTests {
                 /* shuffleAggregateEnabled */ true
             );
         }
-        return DAGBuilder.build(plan, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        return DAGBuilder.build(plan, context.getCapabilityRegistry(), mockClusterService());
     }
 
     private RelNode makeInnerEquiJoin(String leftIdx, String rightIdx) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/CascadeShuffleProbeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/CascadeShuffleProbeTests.java
@@ -748,7 +748,7 @@ public class CascadeShuffleProbeTests extends BasePlannerRulesTests {
         );
         // And the DAG still promotes two join worker tiers (the un-wireable agg-shuffle bug would have left
         // the PARTIAL stage consuming an un-promoted shuffle).
-        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         PlanAlternativeSelector.selectAll(dag, context.getCapabilityRegistry(), false);
         GeneralShuffleDAGRewriter.Structure structure = GeneralShuffleDAGRewriter.rewriteStructure(
@@ -985,7 +985,7 @@ public class CascadeShuffleProbeTests extends BasePlannerRulesTests {
             /* minRows */ 1L,
             /* shuffleAggregateEnabled */ true
         );
-        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         PlanAlternativeSelector.selectAll(dag, context.getCapabilityRegistry(), false);
         assertTrue("enforced DAG has a distributed join to promote", GeneralShuffleDAGRewriter.hasDistributedJoin(dag));
@@ -1062,7 +1062,7 @@ public class CascadeShuffleProbeTests extends BasePlannerRulesTests {
         RelNode logical = LogicalJoin.create(l, r, List.of(), cond, Set.of(), JoinRelType.INNER);
         RelNode cbo = runPlanner(logical, context);
         RelNode enforced = DistributionEnforcementPass.enforce(cbo, context.getDistributionTraitDef(), CLUSTER_DATA_NODES, 1L, true);
-        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         PlanAlternativeSelector.selectAll(dag, context.getCapabilityRegistry(), false);
 
@@ -1190,7 +1190,7 @@ public class CascadeShuffleProbeTests extends BasePlannerRulesTests {
 
         RelNode cbo = runPlanner(makeThreeWayJoin(context), context);
         RelNode enforced = DistributionEnforcementPass.enforce(cbo, context.getDistributionTraitDef(), CLUSTER_DATA_NODES, 1L, true);
-        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(enforced, context.getCapabilityRegistry(), mockClusterService());
 
         // Find the stage whose fragment contains an OpenSearchBroadcastScan AND a shard TableScan — the
         // broadcast-probe-that-is-also-a-shuffle-producer. There must be at least one (the enforced plan

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionIndicesOptionsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionIndicesOptionsTests.java
@@ -75,7 +75,7 @@ public class IndexResolutionIndicesOptionsTests extends OpenSearchTestCase {
         IndicesOptions custom = IndicesOptions.strictExpandOpen();
         ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().build()).build();
         CapabilityRegistry registry = null; // not needed for this test
-        PlannerContext ctx = new PlannerContext(registry, state, null, false, true, custom);
+        PlannerContext ctx = new PlannerContext(registry, state, null, false, true, Settings.EMPTY, s -> 0L, custom);
 
         assertSame(custom, ctx.getIndicesOptions());
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionIndicesOptionsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/IndexResolutionIndicesOptionsTests.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for the 4-arg {@link IndexResolution#resolve(String, ClusterState, IndexNameExpressionResolver, IndicesOptions)}
+ * overload and regression guard for the 3-arg overload delegating with lenientExpandOpen.
+ */
+public class IndexResolutionIndicesOptionsTests extends OpenSearchTestCase {
+
+    private static final IndexNameExpressionResolver RESOLVER = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
+
+    /**
+     * (a) 3-arg resolve still delegates to 4-arg with lenientExpandOpen — a nonexistent index
+     * in a comma-list is silently dropped (lenient semantics).
+     */
+    public void testThreeArgResolveDelegatesToFourArgWithLenientExpandOpen() {
+        ClusterState state = clusterStateOf(indexBuilder("bank", longField("age")));
+
+        // "bank,missing" with lenient options → should resolve to just "bank" (lenient drops missing)
+        IndexResolution result = IndexResolution.resolve("bank,missing", state, RESOLVER);
+
+        assertEquals(1, result.concreteIndices().size());
+        assertEquals("bank", result.concreteIndices().get(0).getIndex().getName());
+    }
+
+    /**
+     * (b) 4-arg overload with STRICT_EXPAND_OPEN throws on nonexistent index in a comma-list,
+     * unlike the lenient default.
+     */
+    public void testFourArgResolveWithStrictOptionsThrowsOnMissing() {
+        ClusterState state = clusterStateOf(indexBuilder("bank", longField("age")));
+
+        // strictExpandOpen forbids missing indices
+        IndicesOptions strict = IndicesOptions.strictExpandOpen();
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexResolution.resolve("bank,missing", state, RESOLVER, strict)
+        );
+        assertTrue("error must mention the expression: " + ex.getMessage(), ex.getMessage().contains("bank,missing"));
+    }
+
+    /**
+     * (b-2) 4-arg overload with lenient options behaves same as 3-arg — drops missing silently.
+     */
+    public void testFourArgResolveWithLenientOptionsDropsMissing() {
+        ClusterState state = clusterStateOf(indexBuilder("bank", longField("age")));
+
+        IndexResolution result = IndexResolution.resolve("bank,missing", state, RESOLVER, IndicesOptions.lenientExpandOpen());
+
+        assertEquals(1, result.concreteIndices().size());
+        assertEquals("bank", result.concreteIndices().get(0).getIndex().getName());
+    }
+
+    /**
+     * (c) PlannerContext carries IndicesOptions and the accessor returns what was set.
+     */
+    public void testPlannerContextCarriesIndicesOptions() {
+        IndicesOptions custom = IndicesOptions.strictExpandOpen();
+        ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().build()).build();
+        CapabilityRegistry registry = null; // not needed for this test
+        PlannerContext ctx = new PlannerContext(registry, state, null, false, true, custom);
+
+        assertSame(custom, ctx.getIndicesOptions());
+    }
+
+    /**
+     * (c-2) PlannerContext without IndicesOptions defaults to lenientExpandOpen.
+     */
+    public void testPlannerContextDefaultsToLenientExpandOpen() {
+        ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().build()).build();
+        PlannerContext ctx = new PlannerContext(null, state);
+
+        assertEquals(IndicesOptions.lenientExpandOpen(), ctx.getIndicesOptions());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private static IndexMetadata.Builder indexBuilder(String name, String mappingJson) {
+        try {
+            return IndexMetadata.builder(name)
+                .settings(
+                    Settings.builder()
+                        .put("index.version.created", org.opensearch.Version.CURRENT.id)
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .build()
+                )
+                .putMapping(mappingJson);
+        } catch (java.io.IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String longField(String name) {
+        return "{\"properties\":{\"" + name + "\":{\"type\":\"long\"}}}";
+    }
+
+    private static ClusterState clusterStateOf(IndexMetadata.Builder... indices) {
+        Metadata.Builder mb = Metadata.builder();
+        for (IndexMetadata.Builder b : indices) {
+            mb.put(b);
+        }
+        return ClusterState.builder(new ClusterName("test")).metadata(mb.build()).build();
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/RelNodeUtilsTests.java
@@ -9,6 +9,11 @@
 package org.opensearch.analytics.planner;
 
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.logical.LogicalFilter;
@@ -22,9 +27,24 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.analytics.planner.rel.OpenSearchDistributionTraitDef;
+import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
+import org.opensearch.analytics.spi.FieldStorageInfo;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.core.index.Index;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
 import static org.opensearch.analytics.planner.RelNodeUtils.MAX_EXTRACT_INDICES_DEPTH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link RelNodeUtils#extractIndices(RelNode)}.
@@ -217,6 +237,143 @@ public class RelNodeUtilsTests extends OpenSearchTestCase {
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
         schema.add(tableName, new MockTable());
         return RelBuilder.create(Frameworks.newConfigBuilder().defaultSchema(schema).build());
+    }
+
+    // ===== carriedResolution propagation tests =====
+    // These exist because dropping the field breaks shard targeting at execution time:
+    // ShardTargetResolver throws IllegalStateException when carriedResolution is null.
+
+    /**
+     * copyToCluster rebuilds every node in a new RelOptCluster; the resulting OpenSearchTableScan
+     * must carry the same IndexResolution instance as the original.
+     */
+    public void testCopyToClusterPreservesCarriedResolution() {
+        JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl();
+        RexBuilder rexBuilder = new RexBuilder(typeFactory);
+        RelOptCluster originalCluster = RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+        RelOptCluster newCluster = RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+
+        IndexResolution resolution = stubResolution("my_alias", List.of(mockIndexMetadata("idx_a", "uuid-a")));
+
+        RelDataType rowType = typeFactory.builder().add("v", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+        RelOptTable table = mock(RelOptTable.class);
+        when(table.getQualifiedName()).thenReturn(List.of("my_alias"));
+        when(table.getRowType()).thenReturn(rowType);
+
+        OpenSearchTableScan scan = new OpenSearchTableScan(
+            originalCluster,
+            originalCluster.traitSet(),
+            table,
+            List.of("datafusion"),
+            List.of(),
+            null,
+            resolution
+        );
+
+        OpenSearchDistributionTraitDef distTraitDef = mock(OpenSearchDistributionTraitDef.class);
+        RelNode copied = RelNodeUtils.copyToCluster(scan, newCluster, distTraitDef);
+
+        assertTrue("copyToCluster must return OpenSearchTableScan", copied instanceof OpenSearchTableScan);
+        OpenSearchTableScan copiedScan = (OpenSearchTableScan) copied;
+        assertSame("copyToCluster must preserve the carried IndexResolution instance", resolution, copiedScan.getCarriedResolution());
+        assertSame("copied scan must belong to the new cluster", newCluster, copiedScan.getCluster());
+    }
+
+    /**
+     * The QTF (late materialization) narrowed-scan path constructs a new OpenSearchTableScan
+     * with an overrideRowType and forwards origScan.getCarriedResolution(). This test verifies
+     * the 7-arg constructor (the path buildNarrowedScan uses) preserves the resolution when an
+     * override rowType is provided.
+     */
+    public void testNarrowedScanPreservesCarriedResolution() {
+        JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl();
+        RexBuilder rexBuilder = new RexBuilder(typeFactory);
+        RelOptCluster cluster = RelOptCluster.create(new HepPlanner(new HepProgramBuilder().build()), rexBuilder);
+
+        IndexResolution resolution = stubResolution(
+            "test_alias",
+            List.of(mockIndexMetadata("backing_a", "uuid-a"), mockIndexMetadata("backing_b", "uuid-b"))
+        );
+
+        RelDataType fullRowType = typeFactory.builder()
+            .add("col_a", typeFactory.createSqlType(SqlTypeName.INTEGER))
+            .add("col_b", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+            .build();
+        RelOptTable table = mock(RelOptTable.class);
+        when(table.getQualifiedName()).thenReturn(List.of("test_alias"));
+        when(table.getRowType()).thenReturn(fullRowType);
+
+        // Narrowed rowType — fewer columns, simulating the QTF narrowing that retains only
+        // sort/filter columns plus ___row_id.
+        RelDataType narrowedRowType = typeFactory.builder()
+            .add("col_a", typeFactory.createSqlType(SqlTypeName.INTEGER))
+            .add("___row_id", typeFactory.createSqlType(SqlTypeName.BIGINT))
+            .build();
+
+        List<FieldStorageInfo> narrowedStorage = List.of(
+            FieldStorageInfo.derivedColumn("col_a", SqlTypeName.INTEGER),
+            FieldStorageInfo.derivedColumn("___row_id", SqlTypeName.BIGINT)
+        );
+
+        OpenSearchTableScan narrowedScan = new OpenSearchTableScan(
+            cluster,
+            cluster.traitSet(),
+            table,
+            List.of("datafusion"),
+            narrowedStorage,
+            narrowedRowType,
+            resolution
+        );
+
+        assertSame(
+            "Narrowed scan (override rowType path) must preserve the carried IndexResolution",
+            resolution,
+            narrowedScan.getCarriedResolution()
+        );
+        assertEquals("Narrowed scan must use the override rowType", 2, narrowedScan.getRowType().getFieldCount());
+        assertEquals("___row_id", narrowedScan.getRowType().getFieldList().get(1).getName());
+    }
+
+    // ---- Helpers for carriedResolution tests ----
+
+    private IndexResolution stubResolution(String requestedName, List<IndexMetadata> indices) {
+        ClusterState state = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(state.metadata()).thenReturn(metadata);
+
+        if (indices.size() == 1) {
+            IndexMetadata imd = indices.get(0);
+            IndexAbstraction abstraction = mock(IndexAbstraction.class);
+            when(abstraction.getType()).thenReturn(IndexAbstraction.Type.CONCRETE_INDEX);
+            when(abstraction.getIndices()).thenReturn(List.of(imd));
+            when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+            TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
+            lookup.put(requestedName, abstraction);
+            when(metadata.getIndicesLookup()).thenReturn(lookup);
+        } else {
+            for (IndexMetadata imd : indices) {
+                when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+                AliasMetadata aliasMd = mock(AliasMetadata.class);
+                when(aliasMd.filteringRequired()).thenReturn(false);
+                when(imd.getAliases()).thenReturn(Map.of(requestedName, aliasMd));
+            }
+            IndexAbstraction aliasAbstraction = mock(IndexAbstraction.class);
+            when(aliasAbstraction.getType()).thenReturn(IndexAbstraction.Type.ALIAS);
+            when(aliasAbstraction.getIndices()).thenReturn(indices);
+            TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
+            lookup.put(requestedName, aliasAbstraction);
+            when(metadata.getIndicesLookup()).thenReturn(lookup);
+        }
+
+        return IndexResolution.resolve(requestedName, state);
+    }
+
+    private IndexMetadata mockIndexMetadata(String name, String uuid) {
+        IndexMetadata imd = mock(IndexMetadata.class);
+        when(imd.getIndex()).thenReturn(new Index(name, uuid));
+        when(imd.getNumberOfShards()).thenReturn(1);
+        when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+        return imd;
     }
 
     /** Minimal table implementation for RelBuilder schema registration. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortSpecExtractorTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/SortSpecExtractorTests.java
@@ -124,7 +124,7 @@ public class SortSpecExtractorTests extends PlanShapeTestBase {
     private SortSpec shardSortSpec(RelNode logicalPlan) {
         PlannerContext context = multiShardContext();
         RelNode planned = runPlanner(logicalPlan, context);
-        QueryDAG dag = DAGBuilder.build(planned, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(planned, context.getCapabilityRegistry(), mockClusterService());
         return leafStage(dag.rootStage()).getSortSpec();
     }
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/BackendPlanAdapterTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/BackendPlanAdapterTests.java
@@ -111,7 +111,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         RelNode marked = runPlanner(filter, context);
         LOGGER.debug("Marked:\n{}", RelOptUtil.toString(marked));
 
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -181,7 +181,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         RelNode marked = runPlanner(project, context);
         LOGGER.info("Marked project:\n{}", RelOptUtil.toString(marked));
 
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -224,7 +224,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(mockTable("test_index", "status", "size")), condition);
 
         RelNode marked = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -251,7 +251,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(mockTable("test_index", "status", "size")), condition);
 
         RelNode marked = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -292,7 +292,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(mockTable("test_index", "status", "size")), condition);
 
         RelNode marked = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -352,7 +352,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
 
         RelNode marked = runPlanner(join, context);
 
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 
@@ -389,7 +389,7 @@ public class BackendPlanAdapterTests extends BasePlannerRulesTests {
         RelNode join = LogicalJoin.create(leftScan, rightScan, List.of(), condition, Set.of(), JoinRelType.INNER);
 
         RelNode marked = runPlanner(join, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
@@ -58,7 +58,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(logicalPlan));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO RelNode:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("QueryDAG:\n{}", dag);
         return dag;
     }
@@ -137,7 +137,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
             customInfo
         );
 
-        QueryDAG dag = DAGBuilder.build(customReducer, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(customReducer, context.getCapabilityRegistry(), mockClusterService());
         Stage child = dag.rootStage().getChildStages().get(0);
         assertEquals(customInfo, child.getExchangeInfo());
     }
@@ -178,7 +178,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         );
         RelNode parsed = SqlPlannerTestFixture.parseSql(sql, state);
         RelNode cbo = PlannerImpl.runAllOptimizations(parsed, context);
-        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("QTF QueryDAG:\n{}", dag);
         return dag;
     }
@@ -331,7 +331,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
 
         // Build DAG + run conversion. The bug is that Stage 3 (root) gets a bare StageInputScan
         // and convertReduceNode trips on getInputs().getFirst().
-        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("QueryDAG:\n{}", dag);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
@@ -403,7 +403,7 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
         assertNotNull("QTF should fire", wrapper);
         assertNotSame("Outer Project should sit above the LM wrapper", wrapper, RelNodeUtils.unwrapHep(cbo));
 
-        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("QueryDAG:\n{}", dag);
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGShapeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGShapeTests.java
@@ -53,7 +53,7 @@ public class DAGShapeTests extends BasePlannerRulesTests {
         LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(logicalPlan));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO RelNode:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("QueryDAG:\n{}", dag);
         return dag;
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/FragmentConversionDriverTests.java
@@ -112,7 +112,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         var context = buildContext("parquet", shardCount, intFields(), List.of(df));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         LOGGER.info("QueryDAG after conversion:\n{}", dag);
@@ -370,7 +370,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         RelNode logical = buildUnionOverSortedAggArms();
         RelNode cboOutput = runPlanner(logical, context);
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
 
@@ -731,7 +731,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         LogicalFilter filter = LogicalFilter.create(stubScan(mockTable("test_index", fieldNames, fieldTypes)), condition);
         RelNode cboOutput = runPlanner(filter, context);
         LOGGER.info("Marked+CBO:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         return dag;
@@ -1002,7 +1002,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1062,7 +1062,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1123,7 +1123,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1175,7 +1175,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1228,7 +1228,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1293,7 +1293,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1384,7 +1384,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -1501,7 +1501,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
         LogicalAggregate aggregate = makeAggregate(where, ImmutableBitSet.of(0), countStarCall(where));
         LogicalFilter having = LogicalFilter.create(aggregate, makeEquals(1, SqlTypeName.BIGINT, 1));
         RelNode cboOutput = runPlanner(having, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         return leafStage(dag).getPlanAlternatives().getFirst();
@@ -2021,7 +2021,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             makeFullTextCall(MATCH_PHRASE_FUNCTION, 0, "hello world")
         );
         RelNode marked = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(marked, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -2067,7 +2067,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();
@@ -2114,7 +2114,7 @@ public class FragmentConversionDriverTests extends BasePlannerRulesTests {
             condition
         );
         RelNode cboOutput = runPlanner(filter, context);
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         StagePlan plan = leafStage(dag).getPlanAlternatives().getFirst();

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/JoinPipelineEndToEndTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/JoinPipelineEndToEndTests.java
@@ -66,7 +66,7 @@ public class JoinPipelineEndToEndTests extends BasePlannerRulesTests {
         LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(logicalPlan));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO RelNode:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         BackendPlanAdapter.adaptAll(dag, context.getCapabilityRegistry());
         LOGGER.info("Adapted QueryDAG:\n{}", dag);

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/PlanForkerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/PlanForkerTests.java
@@ -80,7 +80,7 @@ public class PlanForkerTests extends BasePlannerRulesTests {
         LOGGER.info("Input RelNode:\n{}", RelOptUtil.toString(logicalPlan));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO RelNode:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         LOGGER.info("QueryDAG after forking:\n{}", dag);
         return dag;
@@ -331,7 +331,7 @@ public class PlanForkerTests extends BasePlannerRulesTests {
         var context = buildContextWithExplicitStorage(shardCount, duplicatedIntFields(), List.of(unionCapableDf, luceneScan));
         RelNode cboOutput = runPlanner(logicalPlan, context);
         LOGGER.info("Marked+CBO RelNode:\n{}", RelOptUtil.toString(cboOutput));
-        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cboOutput, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         return dag;
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/ShardTargetResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/ShardTargetResolverTests.java
@@ -11,21 +11,19 @@ package org.opensearch.analytics.planner.dag;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.action.search.TransportSearchAction;
-import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.analytics.planner.IndexResolution;
+import org.opensearch.analytics.planner.rel.OpenSearchTableScan;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -52,10 +50,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Pins the freshness contract of {@link ShardTargetResolver#resolve}: each call must re-resolve
- * the index name against the supplied {@link ClusterState}, never a snapshot taken at
- * construction time. A regression that caches concrete indices upfront would dispatch to stale
- * shards when an alias gets re-pointed mid-query.
+ * Pins the freshness contract of {@link ShardTargetResolver#resolve}: each call must use the
+ * supplied {@link ClusterState} for shard routing, even though the carried {@link IndexResolution}
+ * (set at planning time) determines which concrete indices are targeted. A regression that
+ * caches shard routing upfront would dispatch to stale shards when the routing table changes.
  */
 public class ShardTargetResolverTests extends OpenSearchTestCase {
 
@@ -71,32 +69,17 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
     }
 
     /**
-     * Two cluster states with the same alias pointing to different concrete indices. The first
-     * resolve() must produce shards on node-a; the second must produce shards on node-b. If the
-     * resolver cached state at construction, both calls would return the same targets.
+     * Two cluster states with the same concrete indices routed to different nodes. The first
+     * resolve() must produce shards on node-a; the second must produce shards on node-b. The
+     * carried resolution fixes the concrete indices but shard routing is re-evaluated against
+     * the cluster state passed to each resolve() call.
      */
     public void testResolveReRunsAgainstPassedClusterState() {
-        // Two distinct mocked cluster states. The alias expression is the same; the resolver is
-        // configured to map it to a different concrete index per cluster-state object identity.
+        // The carried resolution is fixed — same concrete index for both calls.
+        IndexResolution resolution = stubResolution("my_alias", "idx_a");
+
         ClusterState stateA = mock(ClusterState.class);
         ClusterState stateB = mock(ClusterState.class);
-        Metadata metaA = mock(Metadata.class);
-        Metadata metaB = mock(Metadata.class);
-        when(stateA.metadata()).thenReturn(metaA);
-        when(stateB.metadata()).thenReturn(metaB);
-        // Empty getIndicesLookup() forces IndexResolution.resolve to fall through to the resolver
-        // path (no literal alias match), which is the path under test.
-        when(metaA.getIndicesLookup()).thenReturn(new TreeMap<>());
-        when(metaB.getIndicesLookup()).thenReturn(new TreeMap<>());
-        // After the resolver returns concrete names, IndexResolution.resolve looks each up via
-        // metadata().index(...). Return a mapping-less IndexMetadata so schema-compat validation
-        // no-ops (it skips indices whose mapping() returns null).
-        IndexMetadata imdA = mock(IndexMetadata.class);
-        IndexMetadata imdB = mock(IndexMetadata.class);
-        when(imdA.getIndex()).thenReturn(new Index("idx_a", "uuid-a"));
-        when(imdB.getIndex()).thenReturn(new Index("idx_b", "uuid-b"));
-        when(metaA.index("idx_a")).thenReturn(imdA);
-        when(metaB.index("idx_b")).thenReturn(imdB);
         DiscoveryNodes nodesA = mock(DiscoveryNodes.class);
         DiscoveryNodes nodesB = mock(DiscoveryNodes.class);
         when(stateA.nodes()).thenReturn(nodesA);
@@ -109,26 +92,8 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
         when(nodesA.get("node-a")).thenReturn(nodeA);
         when(nodesB.get("node-b")).thenReturn(nodeB);
 
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(
-            resolver.concreteIndexNames(
-                eq(stateA),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "idx_a" });
-        when(
-            resolver.concreteIndexNames(
-                eq(stateB),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "idx_b" });
-
         ShardId shardA = new ShardId(new Index("idx_a", "uuid-a"), 0);
-        ShardId shardB = new ShardId(new Index("idx_b", "uuid-b"), 0);
+        ShardId shardB = new ShardId(new Index("idx_a", "uuid-a"), 0);
         ShardRouting routingA = mock(ShardRouting.class);
         ShardRouting routingB = mock(ShardRouting.class);
         when(routingA.currentNodeId()).thenReturn("node-a");
@@ -148,21 +113,21 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
         when(routing.searchShards(eq(stateA), eq(new String[] { "idx_a" }), any(), any())).thenReturn(
             new GroupShardsIterator<>(List.of(iterA))
         );
-        when(routing.searchShards(eq(stateB), eq(new String[] { "idx_b" }), any(), any())).thenReturn(
+        when(routing.searchShards(eq(stateB), eq(new String[] { "idx_a" }), any(), any())).thenReturn(
             new GroupShardsIterator<>(List.of(iterB))
         );
 
-        RelNode fragment = stubScanForAlias("my_alias");
-        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(fragment, clusterService, resolver);
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
 
-        // First resolve hits state A → shard on node-a / idx_a.
+        // First resolve hits state A → shard on node-a.
         List<ExecutionTarget> targetsA = resolverUnderTest.resolve(stateA, null);
         assertEquals(1, targetsA.size());
         assertSame("first resolve must surface state-A's node", nodeA, targetsA.get(0).node());
         assertEquals("first resolve must surface state-A's shard", shardA, ((ShardExecutionTarget) targetsA.get(0)).shardId());
 
-        // Second resolve hits state B → shard on node-b / idx_b. If the resolver cached state,
-        // this assertion fails (targets would still be on node-a / idx_a).
+        // Second resolve hits state B → shard on node-b. If the resolver cached routing state,
+        // this assertion fails (targets would still be on node-a).
         List<ExecutionTarget> targetsB = resolverUnderTest.resolve(stateB, null);
         assertEquals(1, targetsB.size());
         assertSame("second resolve must surface state-B's node", nodeB, targetsB.get(0).node());
@@ -176,31 +141,22 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
     public void testResolveRejectsAliasExceedingMaxShardsPerQuery() {
         int limit = 3;
 
+        // Build a carried resolution for an alias with 2 backing indices.
+        IndexMetadata imdA = mockIndexMetadata("idx_a", "uuid-a");
+        IndexMetadata imdB = mockIndexMetadata("idx_b", "uuid-b");
+        IndexResolution resolution = stubResolution("my_alias", List.of(imdA, imdB));
+
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
 
-        // Set up alias in the indices lookup so IndexResolution takes the alias path.
-        IndexMetadata imdA = mock(IndexMetadata.class);
-        IndexMetadata imdB = mock(IndexMetadata.class);
-        when(imdA.getIndex()).thenReturn(new Index("idx_a", "uuid-a"));
-        when(imdB.getIndex()).thenReturn(new Index("idx_b", "uuid-b"));
-        when(imdA.getState()).thenReturn(IndexMetadata.State.OPEN);
-        when(imdB.getState()).thenReturn(IndexMetadata.State.OPEN);
-        AliasMetadata aliasMd = mock(AliasMetadata.class);
-        when(aliasMd.filteringRequired()).thenReturn(false);
-        when(imdA.getAliases()).thenReturn(Map.of("my_alias", aliasMd));
-        when(imdB.getAliases()).thenReturn(Map.of("my_alias", aliasMd));
-
+        // describeIndexSource looks up the alias in the indices lookup
         IndexAbstraction aliasAbstraction = mock(IndexAbstraction.class);
         when(aliasAbstraction.getType()).thenReturn(IndexAbstraction.Type.ALIAS);
-        when(aliasAbstraction.getIndices()).thenReturn(List.of(imdA, imdB));
         TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
         lookup.put("my_alias", aliasAbstraction);
         when(metadata.getIndicesLookup()).thenReturn(lookup);
 
-        when(metadata.index("idx_a")).thenReturn(imdA);
-        when(metadata.index("idx_b")).thenReturn(imdB);
         DiscoveryNodes nodes = mock(DiscoveryNodes.class);
         when(clusterState.nodes()).thenReturn(nodes);
 
@@ -211,25 +167,15 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             DiscoveryNode node = mock(DiscoveryNode.class);
             when(node.getId()).thenReturn("node-" + i);
             when(nodes.get("node-" + i)).thenReturn(node);
-            ShardRouting routing = mock(ShardRouting.class);
-            when(routing.currentNodeId()).thenReturn("node-" + i);
+            ShardRouting shardRouting = mock(ShardRouting.class);
+            when(shardRouting.currentNodeId()).thenReturn("node-" + i);
             String idx = i < 3 ? "idx_a" : "idx_b";
             String uuid = i < 3 ? "uuid-a" : "uuid-b";
-            when(routing.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i % 3));
+            when(shardRouting.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i % 3));
             ShardIterator iter = mock(ShardIterator.class);
-            when(iter.nextOrNull()).thenReturn(routing);
+            when(iter.nextOrNull()).thenReturn(shardRouting);
             iterators.add(iter);
         }
-
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(
-            resolver.concreteIndexNames(
-                eq(clusterState),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "idx_a", "idx_b" });
 
         ClusterService clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), limit).build();
@@ -241,8 +187,8 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             new GroupShardsIterator<>(iterators)
         );
 
-        RelNode fragment = stubScanForAlias("my_alias");
-        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(fragment, clusterService, resolver);
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
 
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> resolverUnderTest.resolve(clusterState, null));
         assertTrue(ex.getMessage().contains("alias [my_alias]"));
@@ -261,13 +207,21 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
         int shardCount = 5;
         int limit = 3;
 
+        // Carried resolution with a single concrete index.
+        IndexMetadata imd = mockIndexMetadata("big_index", "uuid-big");
+        IndexResolution resolution = stubResolution("big_index", List.of(imd));
+
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.getIndicesLookup()).thenReturn(new TreeMap<>());
-        IndexMetadata imd = mock(IndexMetadata.class);
-        when(imd.getIndex()).thenReturn(new Index("big_index", "uuid-big"));
-        when(metadata.index("big_index")).thenReturn(imd);
+
+        // describeIndexSource looks up the index name in the indices lookup
+        IndexAbstraction indexAbstraction = mock(IndexAbstraction.class);
+        when(indexAbstraction.getType()).thenReturn(IndexAbstraction.Type.CONCRETE_INDEX);
+        TreeMap<String, IndexAbstraction> indexLookup = new TreeMap<>();
+        indexLookup.put("big_index", indexAbstraction);
+        when(metadata.getIndicesLookup()).thenReturn(indexLookup);
+
         DiscoveryNodes nodes = mock(DiscoveryNodes.class);
         when(clusterState.nodes()).thenReturn(nodes);
 
@@ -276,23 +230,13 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             DiscoveryNode node = mock(DiscoveryNode.class);
             when(node.getId()).thenReturn("node-" + i);
             when(nodes.get("node-" + i)).thenReturn(node);
-            ShardRouting routing = mock(ShardRouting.class);
-            when(routing.currentNodeId()).thenReturn("node-" + i);
-            when(routing.shardId()).thenReturn(new ShardId(new Index("big_index", "uuid-big"), i));
+            ShardRouting shardRouting = mock(ShardRouting.class);
+            when(shardRouting.currentNodeId()).thenReturn("node-" + i);
+            when(shardRouting.shardId()).thenReturn(new ShardId(new Index("big_index", "uuid-big"), i));
             ShardIterator iter = mock(ShardIterator.class);
-            when(iter.nextOrNull()).thenReturn(routing);
+            when(iter.nextOrNull()).thenReturn(shardRouting);
             iterators.add(iter);
         }
-
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(
-            resolver.concreteIndexNames(
-                eq(clusterState),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "big_index" });
 
         ClusterService clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), limit).build();
@@ -304,8 +248,8 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             new GroupShardsIterator<>(iterators)
         );
 
-        RelNode fragment = stubScanForAlias("big_index");
-        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(fragment, clusterService, resolver);
+        OpenSearchTableScan scan = createScanWithResolution("big_index", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
 
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> resolverUnderTest.resolve(clusterState, null));
         assertTrue(ex.getMessage(), ex.getMessage().contains("big_index"));
@@ -321,13 +265,14 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
     public void testResolveIsUnlimitedByDefault() {
         int shardCount = 5;
 
+        // Carried resolution with a single concrete index.
+        IndexMetadata imd = mockIndexMetadata("big_index", "uuid-big");
+        IndexResolution resolution = stubResolution("big_index", List.of(imd));
+
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
         when(metadata.getIndicesLookup()).thenReturn(new TreeMap<>());
-        IndexMetadata imd = mock(IndexMetadata.class);
-        when(imd.getIndex()).thenReturn(new Index("big_index", "uuid-big"));
-        when(metadata.index("big_index")).thenReturn(imd);
         DiscoveryNodes nodes = mock(DiscoveryNodes.class);
         when(clusterState.nodes()).thenReturn(nodes);
 
@@ -344,16 +289,6 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             iterators.add(iter);
         }
 
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(
-            resolver.concreteIndexNames(
-                eq(clusterState),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "big_index" });
-
         ClusterService clusterService = mock(ClusterService.class);
         // Settings.EMPTY — the setting is registered but never set, so its default applies.
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING));
@@ -364,8 +299,8 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             new GroupShardsIterator<>(iterators)
         );
 
-        RelNode fragment = stubScanForAlias("big_index");
-        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(fragment, clusterService, resolver);
+        OpenSearchTableScan scan = createScanWithResolution("big_index", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
 
         List<ExecutionTarget> targets = resolverUnderTest.resolve(clusterState, null);
         assertEquals("an unconfigured limit rejects nothing", shardCount, targets.size());
@@ -378,30 +313,21 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
     public void testResolveSucceedsAtExactLimitForAlias() {
         int limit = 3;
 
+        // Carried resolution with two backing indices for the alias.
+        IndexMetadata imdA = mockIndexMetadata("idx_a", "uuid-a");
+        IndexMetadata imdB = mockIndexMetadata("idx_b", "uuid-b");
+        IndexResolution resolution = stubResolution("my_alias", List.of(imdA, imdB));
+
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         when(clusterState.metadata()).thenReturn(metadata);
 
-        IndexMetadata imdA = mock(IndexMetadata.class);
-        IndexMetadata imdB = mock(IndexMetadata.class);
-        when(imdA.getIndex()).thenReturn(new Index("idx_a", "uuid-a"));
-        when(imdB.getIndex()).thenReturn(new Index("idx_b", "uuid-b"));
-        when(imdA.getState()).thenReturn(IndexMetadata.State.OPEN);
-        when(imdB.getState()).thenReturn(IndexMetadata.State.OPEN);
-        AliasMetadata aliasMd = mock(AliasMetadata.class);
-        when(aliasMd.filteringRequired()).thenReturn(false);
-        when(imdA.getAliases()).thenReturn(Map.of("my_alias", aliasMd));
-        when(imdB.getAliases()).thenReturn(Map.of("my_alias", aliasMd));
-
         IndexAbstraction aliasAbstraction = mock(IndexAbstraction.class);
         when(aliasAbstraction.getType()).thenReturn(IndexAbstraction.Type.ALIAS);
-        when(aliasAbstraction.getIndices()).thenReturn(List.of(imdA, imdB));
         TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
         lookup.put("my_alias", aliasAbstraction);
         when(metadata.getIndicesLookup()).thenReturn(lookup);
 
-        when(metadata.index("idx_a")).thenReturn(imdA);
-        when(metadata.index("idx_b")).thenReturn(imdB);
         DiscoveryNodes nodes = mock(DiscoveryNodes.class);
         when(clusterState.nodes()).thenReturn(nodes);
 
@@ -411,25 +337,15 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             DiscoveryNode node = mock(DiscoveryNode.class);
             when(node.getId()).thenReturn("node-" + i);
             when(nodes.get("node-" + i)).thenReturn(node);
-            ShardRouting routing = mock(ShardRouting.class);
-            when(routing.currentNodeId()).thenReturn("node-" + i);
+            ShardRouting shardRouting = mock(ShardRouting.class);
+            when(shardRouting.currentNodeId()).thenReturn("node-" + i);
             String idx = i < 2 ? "idx_a" : "idx_b";
             String uuid = i < 2 ? "uuid-a" : "uuid-b";
-            when(routing.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i % 2));
+            when(shardRouting.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i % 2));
             ShardIterator iter = mock(ShardIterator.class);
-            when(iter.nextOrNull()).thenReturn(routing);
+            when(iter.nextOrNull()).thenReturn(shardRouting);
             iterators.add(iter);
         }
-
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(
-            resolver.concreteIndexNames(
-                eq(clusterState),
-                any(IndicesOptions.class),
-                org.mockito.ArgumentMatchers.anyBoolean(),
-                any(String[].class)
-            )
-        ).thenReturn(new String[] { "idx_a", "idx_b" });
 
         ClusterService clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), limit).build();
@@ -441,24 +357,240 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
             new GroupShardsIterator<>(iterators)
         );
 
-        RelNode fragment = stubScanForAlias("my_alias");
-        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(fragment, clusterService, resolver);
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
 
         List<ExecutionTarget> targets = resolverUnderTest.resolve(clusterState, null);
         assertEquals(limit, targets.size());
     }
 
-    /** Minimal table scan referencing {@code aliasName} so {@code findTableName} surfaces it. */
-    private TableScan stubScanForAlias(String aliasName) {
+    // ========== Helpers ==========
+
+    /** Creates an {@link OpenSearchTableScan} carrying a pre-resolved {@link IndexResolution}. */
+    private OpenSearchTableScan createScanWithResolution(String tableName, IndexResolution resolution) {
         RelDataType rowType = typeFactory.builder().add("v", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
         RelOptTable table = mock(RelOptTable.class);
-        when(table.getQualifiedName()).thenReturn(List.of(aliasName));
+        when(table.getQualifiedName()).thenReturn(List.of(tableName));
         when(table.getRowType()).thenReturn(rowType);
-        return new TableScan(cluster, cluster.traitSet(), List.of(), table) {
-            @Override
-            public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-                return this;
+        return new OpenSearchTableScan(cluster, cluster.traitSet(), table, List.of("datafusion"), List.of(), null, resolution);
+    }
+
+    /** Builds an {@link IndexResolution} for a single concrete index via the literal-name path. */
+    private IndexResolution stubResolution(String requestedName, String concreteName) {
+        return stubResolution(requestedName, List.of(mockIndexMetadata(concreteName, concreteName + "-uuid")));
+    }
+
+    /** Builds an {@link IndexResolution} via a mock cluster state that resolves to the given indices. */
+    private IndexResolution stubResolution(String requestedName, List<IndexMetadata> indices) {
+        ClusterState state = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(state.metadata()).thenReturn(metadata);
+
+        if (indices.size() == 1) {
+            // Single concrete index path
+            IndexMetadata imd = indices.get(0);
+            IndexAbstraction abstraction = mock(IndexAbstraction.class);
+            when(abstraction.getType()).thenReturn(IndexAbstraction.Type.CONCRETE_INDEX);
+            when(abstraction.getIndices()).thenReturn(List.of(imd));
+            when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+            TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
+            lookup.put(requestedName, abstraction);
+            when(metadata.getIndicesLookup()).thenReturn(lookup);
+        } else {
+            // Alias path
+            for (IndexMetadata imd : indices) {
+                when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+                AliasMetadata aliasMd = mock(AliasMetadata.class);
+                when(aliasMd.filteringRequired()).thenReturn(false);
+                when(imd.getAliases()).thenReturn(Map.of(requestedName, aliasMd));
             }
-        };
+            IndexAbstraction aliasAbstraction = mock(IndexAbstraction.class);
+            when(aliasAbstraction.getType()).thenReturn(IndexAbstraction.Type.ALIAS);
+            when(aliasAbstraction.getIndices()).thenReturn(indices);
+            TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
+            lookup.put(requestedName, aliasAbstraction);
+            when(metadata.getIndicesLookup()).thenReturn(lookup);
+        }
+
+        return IndexResolution.resolve(requestedName, state);
+    }
+
+    private IndexMetadata mockIndexMetadata(String name, String uuid) {
+        IndexMetadata imd = mock(IndexMetadata.class);
+        when(imd.getIndex()).thenReturn(new Index(name, uuid));
+        when(imd.getNumberOfShards()).thenReturn(1);
+        when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+        return imd;
+    }
+
+    private IndexMetadata mockIndexMetadata(String name, String uuid, int shardCount) {
+        IndexMetadata imd = mock(IndexMetadata.class);
+        when(imd.getIndex()).thenReturn(new Index(name, uuid));
+        when(imd.getNumberOfShards()).thenReturn(shardCount);
+        when(imd.getState()).thenReturn(IndexMetadata.State.OPEN);
+        return imd;
+    }
+
+    /** Creates an {@link OpenSearchTableScan} without a carried resolution (backward-compat null case). */
+    private OpenSearchTableScan createScanWithoutResolution(String tableName) {
+        RelDataType rowType = typeFactory.builder().add("v", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+        RelOptTable table = mock(RelOptTable.class);
+        when(table.getQualifiedName()).thenReturn(List.of(tableName));
+        when(table.getRowType()).thenReturn(rowType);
+        return new OpenSearchTableScan(cluster, cluster.traitSet(), table, List.of("datafusion"), List.of());
+    }
+
+    // ========== D4: carried IndexResolution on OpenSearchTableScan ==========
+
+    /**
+     * The standard copy(traitSet, inputs) path preserves the carried IndexResolution.
+     */
+    public void testCopyPreservesCarriedResolution() {
+        IndexResolution resolution = stubResolution(
+            "my_alias",
+            List.of(mockIndexMetadata("idx_a", "idx_a-uuid"), mockIndexMetadata("idx_b", "idx_b-uuid"))
+        );
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+
+        RelNode copied = scan.copy(scan.getTraitSet(), List.of());
+        assertTrue("copy must return OpenSearchTableScan", copied instanceof OpenSearchTableScan);
+        OpenSearchTableScan copiedScan = (OpenSearchTableScan) copied;
+        assertSame("copy(traitSet,inputs) must preserve carried IndexResolution", resolution, copiedScan.getCarriedResolution());
+    }
+
+    /**
+     * The copyResolved(backend, children, annotations) path preserves the carried IndexResolution.
+     */
+    public void testCopyResolvedPreservesCarriedResolution() {
+        IndexResolution resolution = stubResolution(
+            "my_alias",
+            List.of(mockIndexMetadata("idx_a", "idx_a-uuid"), mockIndexMetadata("idx_b", "idx_b-uuid"))
+        );
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+
+        RelNode copied = scan.copyResolved("datafusion", List.of(), List.of());
+        assertTrue("copyResolved must return OpenSearchTableScan", copied instanceof OpenSearchTableScan);
+        OpenSearchTableScan copiedScan = (OpenSearchTableScan) copied;
+        assertSame("copyResolved must preserve carried IndexResolution", resolution, copiedScan.getCarriedResolution());
+    }
+
+    /**
+     * stripAnnotations returns this — the field is trivially preserved.
+     */
+    public void testStripAnnotationsPreservesCarriedResolution() {
+        IndexResolution resolution = stubResolution("my_alias", List.of(mockIndexMetadata("idx_a", "idx_a-uuid")));
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+
+        RelNode stripped = scan.stripAnnotations(List.of());
+        assertSame("stripAnnotations returns this, so resolution is preserved", scan, stripped);
+        assertSame(resolution, ((OpenSearchTableScan) stripped).getCarriedResolution());
+    }
+
+    /**
+     * Regression guard: a multi-index alias carried through planning produces the same
+     * shard targets as it did when re-resolving.
+     */
+    public void testResolveFromCarriedResolutionProducesSameTargets() {
+        IndexMetadata imdA = mockIndexMetadata("idx_a", "uuid-a", 2);
+        IndexMetadata imdB = mockIndexMetadata("idx_b", "uuid-b", 1);
+        IndexResolution resolution = stubResolution("my_alias", List.of(imdA, imdB));
+        OpenSearchTableScan scan = createScanWithResolution("my_alias", resolution);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(clusterState.nodes()).thenReturn(nodes);
+
+        List<ShardIterator> iterators = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            DiscoveryNode node = mock(DiscoveryNode.class);
+            when(node.getId()).thenReturn("node-" + i);
+            when(nodes.get("node-" + i)).thenReturn(node);
+            ShardRouting routing = mock(ShardRouting.class);
+            when(routing.currentNodeId()).thenReturn("node-" + i);
+            String idx = i < 2 ? "idx_a" : "idx_b";
+            String uuid = i < 2 ? "uuid-a" : "uuid-b";
+            when(routing.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i < 2 ? i : 0));
+            ShardIterator iter = mock(ShardIterator.class);
+            when(iter.nextOrNull()).thenReturn(routing);
+            iterators.add(iter);
+        }
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        OperationRouting opRouting = mock(OperationRouting.class);
+        when(clusterService.operationRouting()).thenReturn(opRouting);
+        when(opRouting.searchShards(eq(clusterState), eq(new String[] { "idx_a", "idx_b" }), any(), any())).thenReturn(
+            new GroupShardsIterator<>(iterators)
+        );
+
+        ShardTargetResolver resolver = new ShardTargetResolver(scan, clusterService);
+
+        List<ExecutionTarget> targets = resolver.resolve(clusterState, null);
+        assertEquals("Should produce 3 shard targets from the carried resolution", 3, targets.size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals("node-" + i, targets.get(i).node().getId());
+        }
+    }
+
+    /**
+     * When the fragment's scan node carries no IndexResolution (null), ShardTargetResolver
+     * must throw IllegalStateException.
+     */
+    public void testThrowsIllegalStateExceptionWhenNoCarriedResolution() {
+        OpenSearchTableScan scan = createScanWithoutResolution("my_alias");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> new ShardTargetResolver(scan, clusterService));
+        assertTrue(
+            "Exception message should name the fragment shape",
+            ex.getMessage().contains("OpenSearchTableScan") || ex.getMessage().contains("IndexResolution")
+        );
+    }
+
+    /**
+     * The resolution carried through planning reflects strict IndicesOptions — proving the
+     * third re-resolution is genuinely gone.
+     */
+    public void testCarriedResolutionReflectsStrictOptions() {
+        IndexMetadata openIdx = mockIndexMetadata("open_idx", "uuid-open", 1);
+        IndexResolution strictResolution = stubResolution("test*", List.of(openIdx));
+
+        OpenSearchTableScan scan = createScanWithResolution("test*", strictResolution);
+
+        assertNotNull("Carried resolution must be non-null", scan.getCarriedResolution());
+        assertEquals("test*", scan.getCarriedResolution().requestedName());
+        assertEquals(1, scan.getCarriedResolution().concreteIndices().size());
+        assertEquals("open_idx", scan.getCarriedResolution().concreteIndices().get(0).getIndex().getName());
+
+        ClusterState clusterState = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(clusterState.nodes()).thenReturn(nodes);
+        DiscoveryNode node = mock(DiscoveryNode.class);
+        when(node.getId()).thenReturn("node-0");
+        when(nodes.get("node-0")).thenReturn(node);
+
+        ShardRouting routing = mock(ShardRouting.class);
+        when(routing.currentNodeId()).thenReturn("node-0");
+        when(routing.shardId()).thenReturn(new ShardId(new Index("open_idx", "uuid-open"), 0));
+        ShardIterator iter = mock(ShardIterator.class);
+        when(iter.nextOrNull()).thenReturn(routing);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Set.of(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        OperationRouting opRouting = mock(OperationRouting.class);
+        when(clusterService.operationRouting()).thenReturn(opRouting);
+        when(opRouting.searchShards(eq(clusterState), eq(new String[] { "open_idx" }), any(), any())).thenReturn(
+            new GroupShardsIterator<>(List.of(iter))
+        );
+
+        ShardTargetResolver resolver = new ShardTargetResolver(scan, clusterService);
+        List<ExecutionTarget> targets = resolver.resolve(clusterState, null);
+        assertEquals(1, targets.size());
+        assertEquals("node-0", targets.get(0).node().getId());
     }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/ShardTargetResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/ShardTargetResolverTests.java
@@ -593,4 +593,70 @@ public class ShardTargetResolverTests extends OpenSearchTestCase {
         assertEquals(1, targets.size());
         assertEquals("node-0", targets.get(0).node().getId());
     }
+
+    /**
+     * When the requested name is an index pattern (wildcard or comma-list) that does not appear
+     * in the cluster metadata's indices lookup, describeIndexSource classifies it as
+     * "index pattern [name]". The rejection message must surface this wording so operators can
+     * identify which expression caused the limit to be hit.
+     */
+    public void testResolveRejectsIndexPatternExceedingMaxShardsWithPatternWording() {
+        int limit = 2;
+
+        // A wildcard pattern resolves to two backing indices but the pattern itself is not
+        // in the metadata indices lookup — so describeIndexSource falls through to "index pattern".
+        IndexMetadata imdA = mockIndexMetadata("logs-2024-01", "uuid-a");
+        IndexMetadata imdB = mockIndexMetadata("logs-2024-02", "uuid-b");
+        IndexResolution resolution = stubResolution("logs-*", List.of(imdA, imdB));
+
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(clusterState.metadata()).thenReturn(metadata);
+
+        // The pattern "logs-*" is NOT in the lookup — exercising the fallback path.
+        TreeMap<String, IndexAbstraction> lookup = new TreeMap<>();
+        when(metadata.getIndicesLookup()).thenReturn(lookup);
+
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(clusterState.nodes()).thenReturn(nodes);
+
+        // 4 shards total across the two indices — exceeds limit of 2.
+        int shardCount = 4;
+        List<ShardIterator> iterators = new ArrayList<>();
+        for (int i = 0; i < shardCount; i++) {
+            DiscoveryNode node = mock(DiscoveryNode.class);
+            when(node.getId()).thenReturn("node-" + i);
+            when(nodes.get("node-" + i)).thenReturn(node);
+            ShardRouting shardRouting = mock(ShardRouting.class);
+            when(shardRouting.currentNodeId()).thenReturn("node-" + i);
+            String idx = i < 2 ? "logs-2024-01" : "logs-2024-02";
+            String uuid = i < 2 ? "uuid-a" : "uuid-b";
+            when(shardRouting.shardId()).thenReturn(new ShardId(new Index(idx, uuid), i % 2));
+            ShardIterator iter = mock(ShardIterator.class);
+            when(iter.nextOrNull()).thenReturn(shardRouting);
+            iterators.add(iter);
+        }
+
+        ClusterService clusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), limit).build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        OperationRouting opRouting = mock(OperationRouting.class);
+        when(clusterService.operationRouting()).thenReturn(opRouting);
+        when(opRouting.searchShards(eq(clusterState), eq(new String[] { "logs-2024-01", "logs-2024-02" }), any(), any())).thenReturn(
+            new GroupShardsIterator<>(iterators)
+        );
+
+        OpenSearchTableScan scan = createScanWithResolution("logs-*", resolution);
+        ShardTargetResolver resolverUnderTest = new ShardTargetResolver(scan, clusterService);
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> resolverUnderTest.resolve(clusterState, null));
+        assertTrue(
+            "Message must use 'index pattern' wording for wildcard patterns, got: " + ex.getMessage(),
+            ex.getMessage().contains("index pattern [logs-*]")
+        );
+        assertTrue("Message must state shard count", ex.getMessage().contains("[" + shardCount + "] shards"));
+        assertTrue("Message must state the limit", ex.getMessage().contains("[" + limit + "]"));
+        assertTrue("Message must name the setting", ex.getMessage().contains("action.search.shard_count.limit"));
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -17,6 +17,7 @@ import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
@@ -54,16 +55,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ThreadPool threadPool;
 
-    /**
-     * Guice-injected constructor — receives analytics engine dependencies.
-     *
-     * @param transportService transport service
-     * @param actionFilters action filters
-     * @param contextProvider analytics engine context providing schema and operator table
-     * @param executor analytics engine plan executor
-     * @param clusterService cluster service for resolving index aliases
-     * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
-     */
+    /** Guice-injected constructor — receives analytics engine dependencies. */
     @Inject
     public TransportDslExecuteAction(
         TransportService transportService,
@@ -112,32 +104,13 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                     return;
                 }
 
-                // Pass the user's raw index expression to the converter so alias identity
-                // reaches the engine. The engine's IndexResolution.resolveAlias fires its own
-                // filtered-alias rejection natively when it sees an alias name.
-                //
-                // Coordinator-level guard: reject any request whose expressions involve a
-                // filtering alias. The engine's alias branch (IndexResolution.resolveAlias)
-                // only fires for a single literal alias name; comma-lists and wildcards
-                // bypass it because clusterState.metadata().getIndicesLookup().get(expression)
-                // returns null for multi-valued or wildcard strings, falling through to the
-                // concrete-names branch where aliasMd.filteringRequired() is never consulted.
-                // Example: 'al_filt*' resolves to concrete indices without applying the alias
-                // filter, silently leaking documents the filter is meant to hide.
-                rejectFilteringAliases(state, request.indices(), concreteIndices);
+                // Coordinator-level guard — see rejectFilteringAliases Javadoc for rationale.
+                rejectFilteringAliases(state, request.indices(), concreteIndices, request.indicesOptions());
                 String expression = String.join(",", indices);
 
-                // Build a QueryRequestContext bound to the SAME ClusterState snapshot the
-                // coordinator resolved against. This ensures the engine plans against the
-                // validated state — not a later snapshot from clusterService.state().
-                //
-                // The request's IndicesOptions are supplied twice on purpose, because two
-                // consumers read them at different points and neither can reach the other's
-                // copy. Passing them to getContext bakes them into the schema's lazy
-                // table-resolution closure, which fixes the row type; putting them on the
-                // context lets the planner resolve the concrete index set with the same flags,
-                // and lets the security layer authorize the expression with them. Supply only
-                // one and the schema and the plan can disagree on which indices exist.
+                // IndicesOptions are supplied to both getContext and QueryRequestContext because
+                // schema resolution and planner resolution read them independently — supplying
+                // only one lets the schema and plan disagree on which indices exist.
                 queryCtx = new QueryRequestContext(
                     state,
                     contextProvider.getContext(state, request.indicesOptions()).schema(),
@@ -174,29 +147,25 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
 
     // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via
     // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
-    // so this plugin doesn't need its own resolution logic. The QueryRequestContext now threads
-    // IndicesOptions and ClusterState to the engine, partially satisfying this — full delegation
-    // requires the engine to handle 404 semantics (IndexNotFoundException) that today rely on
-    // the coordinator's concreteIndices call above.
+    // so this plugin doesn't need its own resolution logic.
 
     /**
      * Rejects any request whose index expressions involve a filtering alias.
      *
-     * <p>This guard cannot be delegated to the engine's {@code IndexResolution.resolveAlias}
-     * because that code path only fires when the <em>entire</em> expression string resolves
-     * to a single literal alias name via {@code clusterState.metadata().getIndicesLookup().get(expression)}.
-     * Comma-lists (e.g. {@code "al_filtered,mi_open_b"}) and wildcards (e.g. {@code "al_filt*"})
-     * cause that lookup to return null, so resolution falls through to the concrete-names branch
-     * where {@code aliasMd.filteringRequired()} is never consulted — silently returning
-     * unfiltered data that the alias filter should have hidden.
+     * <p>Required because the engine's {@code IndexResolution.resolveAlias} only checks filters
+     * for single literal alias names; comma-lists and wildcards bypass that check.
      *
-     * @param state the ClusterState snapshot already captured in doExecute
-     * @param requestIndices the raw index expressions from the request
-     * @param concreteIndices the resolved concrete indices
+     * @param indicesOptions forwarded to expression resolution so hidden aliases are visible
+     *                       when the request expands hidden wildcards
      * @throws IllegalArgumentException if a filtering alias is detected
      */
-    private void rejectFilteringAliases(ClusterState state, String[] requestIndices, Index[] concreteIndices) {
-        Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, requestIndices);
+    private void rejectFilteringAliases(
+        ClusterState state,
+        String[] requestIndices,
+        Index[] concreteIndices,
+        IndicesOptions indicesOptions
+    ) {
+        Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, indicesOptions, requestIndices);
         for (Index concreteIndex : concreteIndices) {
             String[] filteringAliases = indexNameExpressionResolver.filteringAliases(state, concreteIndex.getName(), resolvedExpressions);
             if (filteringAliases != null && filteringAliases.length > 0) {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -55,7 +55,16 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ThreadPool threadPool;
 
-    /** Guice-injected constructor — receives analytics engine dependencies. */
+    /**
+     * Guice-injected constructor — receives analytics engine dependencies.
+     *
+     * @param transportService transport service
+     * @param actionFilters action filters
+     * @param contextProvider analytics engine context providing schema and operator table
+     * @param executor analytics engine plan executor
+     * @param clusterService cluster service for resolving index aliases
+     * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
+     */
     @Inject
     public TransportDslExecuteAction(
         TransportService transportService,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -18,6 +18,7 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
+import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -33,10 +34,6 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
-
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
@@ -88,16 +85,19 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             final QueryPlans plans;
             final long convertTime;
+            final QueryRequestContext queryCtx;
             try {
                 String[] indices = request.indices();
                 if (indices == null || indices.length == 0) {
                     throw new IllegalArgumentException("DSL execution requires at least one index expression, but none was specified");
                 }
 
-                // Pre-resolve index expressions using the request's IndicesOptions so that
-                // ignore_unavailable, allow_no_indices and expand_wildcards are honoured.
-                // This also throws IndexNotFoundException (HTTP 404) for a missing concrete index
-                // under default options, matching vanilla SearchRequest behaviour.
+                // Pre-resolve index expressions to enforce HTTP semantics: IndexNotFoundException
+                // (HTTP 404) for a missing concrete index under default options, and the
+                // zero-resolution empty-response branch for wildcards matching nothing. Without
+                // this call, a missing index would surface as HTTP 400 ("Index not found in
+                // schema") because OpenSearchSchemaBuilder.resolveTable catches
+                // IndexNotFoundException and returns null.
                 final ClusterState state = clusterService.state();
                 Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
 
@@ -110,18 +110,24 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                     return;
                 }
 
-                // The analytics engine's own filtered-alias check (IndexResolution.resolveAlias)
-                // is unreachable once expressions are pre-resolved to concrete index names, so we
-                // must reject filtering aliases here at the coordinator level.
-                rejectFilteringAliases(state, request.indices(), concreteIndices);
+                // Pass the user's raw index expression to the converter so alias identity
+                // reaches the engine. The engine's IndexResolution.resolveAlias fires its own
+                // filtered-alias rejection natively when it sees an alias name.
+                String expression = String.join(",", indices);
 
-                // Join already-concrete index names with commas. Passing resolved names
-                // neutralises the schema layer's hardcoded IndicesOptions.lenientExpandOpen()
-                // because there is nothing left to expand — the names are already concrete.
-                String expression = Arrays.stream(concreteIndices).map(Index::getName).collect(Collectors.joining(","));
+                // Build a QueryRequestContext bound to the SAME ClusterState snapshot the
+                // coordinator resolved against. This ensures the engine plans against the
+                // validated state — not a later snapshot from clusterService.state().
+                queryCtx = new QueryRequestContext(
+                    state,
+                    contextProvider.getContext(state, request.indicesOptions()).schema(),
+                    null,
+                    null,
+                    request.indicesOptions()
+                );
 
                 long convertStart = System.nanoTime();
-                SearchSourceConverter converter = new SearchSourceConverter(contextProvider.getContext().schema());
+                SearchSourceConverter converter = new SearchSourceConverter(queryCtx.schema());
                 plans = converter.convert(request.source(), expression);
                 convertTime = System.nanoTime() - convertStart;
             } catch (Exception e) {
@@ -129,7 +135,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 listener.onFailure(e);
                 return;
             }
-            planExecutor.execute(plans, ActionListener.wrap(results -> {
+            planExecutor.execute(plans, queryCtx, ActionListener.wrap(results -> {
                 final SearchResponse response;
                 try {
                     response = SearchResponseBuilder.build(results, convertTime);
@@ -148,28 +154,10 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
 
     // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via
     // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
-    // so this plugin doesn't need its own resolution logic.
-
-    /**
-     * Rejects any request whose index expressions involve a filtering alias.
-     *
-     * @throws IllegalArgumentException if a filtering alias is detected
-     */
-    private void rejectFilteringAliases(ClusterState state, String[] requestIndices, Index[] concreteIndices) {
-        Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, requestIndices);
-        for (Index concreteIndex : concreteIndices) {
-            String[] filteringAliases = indexNameExpressionResolver.filteringAliases(state, concreteIndex.getName(), resolvedExpressions);
-            if (filteringAliases != null && filteringAliases.length > 0) {
-                throw new IllegalArgumentException(
-                    "Alias ["
-                        + filteringAliases[0]
-                        + "] declares a filter on index ["
-                        + concreteIndex.getName()
-                        + "]; filter aliases are not yet supported by analytics queries"
-                );
-            }
-        }
-    }
+    // so this plugin doesn't need its own resolution logic. The QueryRequestContext now threads
+    // IndicesOptions and ClusterState to the engine, partially satisfying this — full delegation
+    // requires the engine to handle 404 semantics (IndexNotFoundException) that today rely on
+    // the coordinator's concreteIndices call above.
 
     /** Builds an empty SearchResponse with zero hits and zero shards. */
     private static SearchResponse emptySearchResponse() {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -19,6 +19,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -34,6 +35,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -96,7 +98,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 // ignore_unavailable, allow_no_indices and expand_wildcards are honoured.
                 // This also throws IndexNotFoundException (HTTP 404) for a missing concrete index
                 // under default options, matching vanilla SearchRequest behaviour.
-                Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterService.state(), request);
+                final ClusterState state = clusterService.state();
+                Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
 
                 if (concreteIndices.length == 0) {
                     // Zero concrete indices without an exception means the resolver accepted it
@@ -106,6 +109,11 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                     listener.onResponse(emptySearchResponse());
                     return;
                 }
+
+                // The analytics engine's own filtered-alias check (IndexResolution.resolveAlias)
+                // is unreachable once expressions are pre-resolved to concrete index names, so we
+                // must reject filtering aliases here at the coordinator level.
+                rejectFilteringAliases(state, request.indices(), concreteIndices);
 
                 // Join already-concrete index names with commas. Passing resolved names
                 // neutralises the schema layer's hardcoded IndicesOptions.lenientExpandOpen()
@@ -141,6 +149,27 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via
     // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
     // so this plugin doesn't need its own resolution logic.
+
+    /**
+     * Rejects any request whose index expressions involve a filtering alias.
+     *
+     * @throws IllegalArgumentException if a filtering alias is detected
+     */
+    private void rejectFilteringAliases(ClusterState state, String[] requestIndices, Index[] concreteIndices) {
+        Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, requestIndices);
+        for (Index concreteIndex : concreteIndices) {
+            String[] filteringAliases = indexNameExpressionResolver.filteringAliases(state, concreteIndex.getName(), resolvedExpressions);
+            if (filteringAliases != null && filteringAliases.length > 0) {
+                throw new IllegalArgumentException(
+                    "Alias ["
+                        + filteringAliases[0]
+                        + "] declares a filter on index ["
+                        + concreteIndex.getName()
+                        + "]; filter aliases are not yet supported by analytics queries"
+                );
+            }
+        }
+    }
 
     /** Builds an empty SearchResponse with zero hits and zero shards. */
     private static SearchResponse emptySearchResponse() {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -130,6 +130,14 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 // Build a QueryRequestContext bound to the SAME ClusterState snapshot the
                 // coordinator resolved against. This ensures the engine plans against the
                 // validated state — not a later snapshot from clusterService.state().
+                //
+                // The request's IndicesOptions are supplied twice on purpose, because two
+                // consumers read them at different points and neither can reach the other's
+                // copy. Passing them to getContext bakes them into the schema's lazy
+                // table-resolution closure, which fixes the row type; putting them on the
+                // context lets the planner resolve the concrete index set with the same flags,
+                // and lets the security layer authorize the expression with them. Supply only
+                // one and the schema and the plan can disagree on which indices exist.
                 queryCtx = new QueryRequestContext(
                     state,
                     contextProvider.getContext(state, request.indicesOptions()).schema(),

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -95,20 +95,15 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                     throw new IllegalArgumentException("DSL execution requires at least one index expression, but none was specified");
                 }
 
-                // Pre-resolve index expressions to enforce HTTP semantics: IndexNotFoundException
-                // (HTTP 404) for a missing concrete index under default options, and the
-                // zero-resolution empty-response branch for wildcards matching nothing. Without
-                // this call, a missing index would surface as HTTP 400 ("Index not found in
-                // schema") because OpenSearchSchemaBuilder.resolveTable catches
+                // Pre-resolve to enforce HTTP semantics: without this a missing index surfaces as
+                // 400 instead of 404, because OpenSearchSchemaBuilder.resolveTable swallows
                 // IndexNotFoundException and returns null.
                 final ClusterState state = clusterService.state();
                 Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
 
                 if (concreteIndices.length == 0) {
-                    // Zero concrete indices without an exception means the resolver accepted it
-                    // (allow_no_indices=true, the default). Return an empty successful response
-                    // rather than an error — this matches vanilla search behaviour for wildcards
-                    // and patterns that match nothing.
+                    // Resolver accepted it (allow_no_indices=true) — return an empty response,
+                    // matching vanilla search for wildcards that match nothing.
                     listener.onResponse(emptySearchResponse());
                     return;
                 }
@@ -117,9 +112,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 rejectFilteringAliases(state, request.indices(), concreteIndices, request.indicesOptions());
                 String expression = String.join(",", indices);
 
-                // IndicesOptions are supplied to both getContext and QueryRequestContext because
-                // schema resolution and planner resolution read them independently — supplying
-                // only one lets the schema and plan disagree on which indices exist.
+                // Options go to both getContext and QueryRequestContext: schema and planner read
+                // them independently, and supplying one lets them disagree on which indices exist.
                 queryCtx = new QueryRequestContext(
                     state,
                     contextProvider.getContext(state, request.indicesOptions()).schema(),
@@ -159,13 +153,12 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     // so this plugin doesn't need its own resolution logic.
 
     /**
-     * Rejects any request whose index expressions involve a filtering alias.
+     * Rejects a request whose expressions resolve to a filtering alias.
      *
-     * <p>Required because the engine's {@code IndexResolution.resolveAlias} only checks filters
-     * for single literal alias names; comma-lists and wildcards bypass that check.
+     * <p>The engine's {@code IndexResolution.resolveAlias} only checks filters for single literal
+     * alias names, so comma-lists and wildcards bypass it — this guard covers them.
      *
-     * @param indicesOptions forwarded to expression resolution so hidden aliases are visible
-     *                       when the request expands hidden wildcards
+     * @param indicesOptions forwarded so hidden filtered aliases are visible under hidden-wildcard expansion
      * @throws IllegalArgumentException if a filtering alias is detected
      */
     private void rejectFilteringAliases(

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -35,6 +35,8 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Set;
+
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
  * executes them via the analytics engine, and builds a SearchResponse.
@@ -113,6 +115,16 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 // Pass the user's raw index expression to the converter so alias identity
                 // reaches the engine. The engine's IndexResolution.resolveAlias fires its own
                 // filtered-alias rejection natively when it sees an alias name.
+                //
+                // Coordinator-level guard: reject any request whose expressions involve a
+                // filtering alias. The engine's alias branch (IndexResolution.resolveAlias)
+                // only fires for a single literal alias name; comma-lists and wildcards
+                // bypass it because clusterState.metadata().getIndicesLookup().get(expression)
+                // returns null for multi-valued or wildcard strings, falling through to the
+                // concrete-names branch where aliasMd.filteringRequired() is never consulted.
+                // Example: 'al_filt*' resolves to concrete indices without applying the alias
+                // filter, silently leaking documents the filter is meant to hide.
+                rejectFilteringAliases(state, request.indices(), concreteIndices);
                 String expression = String.join(",", indices);
 
                 // Build a QueryRequestContext bound to the SAME ClusterState snapshot the
@@ -158,6 +170,38 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     // IndicesOptions and ClusterState to the engine, partially satisfying this — full delegation
     // requires the engine to handle 404 semantics (IndexNotFoundException) that today rely on
     // the coordinator's concreteIndices call above.
+
+    /**
+     * Rejects any request whose index expressions involve a filtering alias.
+     *
+     * <p>This guard cannot be delegated to the engine's {@code IndexResolution.resolveAlias}
+     * because that code path only fires when the <em>entire</em> expression string resolves
+     * to a single literal alias name via {@code clusterState.metadata().getIndicesLookup().get(expression)}.
+     * Comma-lists (e.g. {@code "al_filtered,mi_open_b"}) and wildcards (e.g. {@code "al_filt*"})
+     * cause that lookup to return null, so resolution falls through to the concrete-names branch
+     * where {@code aliasMd.filteringRequired()} is never consulted — silently returning
+     * unfiltered data that the alias filter should have hidden.
+     *
+     * @param state the ClusterState snapshot already captured in doExecute
+     * @param requestIndices the raw index expressions from the request
+     * @param concreteIndices the resolved concrete indices
+     * @throws IllegalArgumentException if a filtering alias is detected
+     */
+    private void rejectFilteringAliases(ClusterState state, String[] requestIndices, Index[] concreteIndices) {
+        Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, requestIndices);
+        for (Index concreteIndex : concreteIndices) {
+            String[] filteringAliases = indexNameExpressionResolver.filteringAliases(state, concreteIndex.getName(), resolvedExpressions);
+            if (filteringAliases != null && filteringAliases.length > 0) {
+                throw new IllegalArgumentException(
+                    "Alias ["
+                        + filteringAliases[0]
+                        + "] declares a filter on index ["
+                        + concreteIndex.getName()
+                        + "]; filter aliases are not yet supported by analytics queries"
+                );
+            }
+        }
+    }
 
     /** Builds an empty SearchResponse with zero hits and zero shards. */
     private static SearchResponse emptySearchResponse() {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.analytics.EngineContextProvider;
@@ -26,9 +28,13 @@ import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.result.SearchResponseBuilder;
+import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
@@ -81,10 +87,34 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             final QueryPlans plans;
             final long convertTime;
             try {
-                String indexName = resolveToSingleIndex(request);
+                String[] indices = request.indices();
+                if (indices == null || indices.length == 0) {
+                    throw new IllegalArgumentException("DSL execution requires at least one index expression, but none was specified");
+                }
+
+                // Pre-resolve index expressions using the request's IndicesOptions so that
+                // ignore_unavailable, allow_no_indices and expand_wildcards are honoured.
+                // This also throws IndexNotFoundException (HTTP 404) for a missing concrete index
+                // under default options, matching vanilla SearchRequest behaviour.
+                Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterService.state(), request);
+
+                if (concreteIndices.length == 0) {
+                    // Zero concrete indices without an exception means the resolver accepted it
+                    // (allow_no_indices=true, the default). Return an empty successful response
+                    // rather than an error — this matches vanilla search behaviour for wildcards
+                    // and patterns that match nothing.
+                    listener.onResponse(emptySearchResponse());
+                    return;
+                }
+
+                // Join already-concrete index names with commas. Passing resolved names
+                // neutralises the schema layer's hardcoded IndicesOptions.lenientExpandOpen()
+                // because there is nothing left to expand — the names are already concrete.
+                String expression = Arrays.stream(concreteIndices).map(Index::getName).collect(Collectors.joining(","));
+
                 long convertStart = System.nanoTime();
                 SearchSourceConverter converter = new SearchSourceConverter(contextProvider.getContext().schema());
-                plans = converter.convert(request.source(), indexName);
+                plans = converter.convert(request.source(), expression);
                 convertTime = System.nanoTime() - convertStart;
             } catch (Exception e) {
                 logger.error("DSL conversion failed", e);
@@ -111,17 +141,11 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via
     // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
     // so this plugin doesn't need its own resolution logic.
-    /**
-     * Resolves the request's indices (which may be aliases or wildcards) to a single concrete index.
-     * Throws if the resolution yields zero or more than one concrete index.
-     */
-    private String resolveToSingleIndex(SearchRequest request) {
-        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterService.state(), request);
-        if (concreteIndices.length != 1) {
-            throw new IllegalArgumentException(
-                "DSL execution currently supports exactly one concrete index, but resolved to " + concreteIndices.length + " indices"
-            );
-        }
-        return concreteIndices[0].getName();
+
+    /** Builds an empty SearchResponse with zero hits and zero shards. */
+    private static SearchResponse emptySearchResponse() {
+        SearchHits hits = SearchHits.empty(true);
+        SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 0);
+        return new SearchResponse(sections, null, 0, 0, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -11,6 +11,7 @@ package org.opensearch.dsl.executor;
 import org.apache.calcite.rel.RelNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.dsl.result.ExecutionResult;
@@ -48,18 +49,20 @@ public class DslQueryPlanExecutor {
      * {@code onFailure} with that error and remaining plans do not run.
      *
      * @param plans    the query plans to execute
+     * @param queryCtx per-query context carrying IndicesOptions and the coordinator's ClusterState
      * @param listener receives the ordered list of results on success, or the first failure
      */
-    public void execute(QueryPlans plans, ActionListener<List<ExecutionResult>> listener) {
+    public void execute(QueryPlans plans, QueryRequestContext queryCtx, ActionListener<List<ExecutionResult>> listener) {
         List<QueryPlans.QueryPlan> queryPlans = plans.getAll();
         List<ExecutionResult> results = new ArrayList<>(queryPlans.size());
-        executeNext(queryPlans, 0, results, listener);
+        executeNext(queryPlans, 0, results, queryCtx, listener);
     }
 
     private void executeNext(
         List<QueryPlans.QueryPlan> queryPlans,
         int index,
         List<ExecutionResult> results,
+        QueryRequestContext queryCtx,
         ActionListener<List<ExecutionResult>> outer
     ) {
         if (index >= queryPlans.size()) {
@@ -69,11 +72,10 @@ public class DslQueryPlanExecutor {
         QueryPlans.QueryPlan plan = queryPlans.get(index);
         RelNode relNode = plan.relNode();
         logPlan(relNode);
-        // TODO: context param is null, may carry execution hints
-        executor.execute(relNode, null, ActionListener.wrap(rows -> {
+        executor.execute(relNode, queryCtx, ActionListener.wrap(rows -> {
             logRows(rows);
             results.add(new ExecutionResult(plan, rows));
-            executeNext(queryPlans, index + 1, results, outer);
+            executeNext(queryPlans, index + 1, results, queryCtx, outer);
         }, outer::onFailure));
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -33,6 +33,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -689,6 +691,308 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertNotNull(listener.response.get());
     }
 
+    // --- Coordinator-side filtered-alias rejection tests (rejectFilteringAliases guard) ---
+
+    /** Literal filtered alias name is rejected at coordinator (E1 case). */
+    public void testFilteredAliasLiteralIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("mi_open_a", "uuid-a") });
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_filtered");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_filtered");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** Wildcard 'al_*' matching a filtered alias is rejected at coordinator (E2 case). */
+    public void testWildcardMatchingFilteredAliasIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("mi_open_a", "uuid-a"), new Index("mi_open_b", "uuid-b") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_filtered");
+        resolvedExprs.add("al_open");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+        when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_*");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** Comma-list 'mi_open_b,al_filtered' is rejected at coordinator (E3 case). */
+    public void testCommaListWithFilteredAliasSecondIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("mi_open_b", "uuid-b"), new Index("mi_open_a", "uuid-a") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("mi_open_b");
+        resolvedExprs.add("al_filtered");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "mi_open_b", "al_filtered");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** Reversed comma-list 'al_filtered,mi_open_b' is rejected at coordinator (E3b case). */
+    public void testReversedCommaListWithFilteredAliasFirstIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("mi_open_a", "uuid-a"), new Index("mi_open_b", "uuid-b") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_filtered");
+        resolvedExprs.add("mi_open_b");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+        when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_filtered", "mi_open_b");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** Prefix wildcard 'al_filt*' matching filtered alias is rejected at coordinator (E5 case). */
+    public void testPrefixWildcardMatchingFilteredAliasIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("mi_open_a", "uuid-a") });
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_filtered");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_filt*");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** Duplicated alias 'al_filtered,al_filtered' is rejected at coordinator (E6 case). */
+    public void testDuplicatedFilteredAliasIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("mi_open_a", "uuid-a") });
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_filtered");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_filtered", "al_filtered");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [al_filtered] declares a filter on index [mi_open_a]; filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** A non-filtered alias (al_open) passes through and succeeds — the guard must not block it. */
+    public void testNonFilteredAliasIsNotRejectedByGuard() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "al_open");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("mi_open_b", "uuid-b") });
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("al_open");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        // No filtering aliases for this alias
+        when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
+
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "al_open");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
     // --- Helper methods ---
 
     private TestListener executeWith(TransportDslExecuteAction action, String... indices) {
@@ -707,6 +1011,9 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
+        // Stub the filtering-alias guard: no filtering aliases by default
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(Collections.emptySet());
+        when(resolver.filteringAliases(any(), any(String.class), any())).thenReturn(null);
 
         return new TransportDslExecuteAction(
             mock(TransportService.class),

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -17,6 +17,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.cluster.ClusterState;
@@ -63,17 +64,40 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertTrue(listener.failure.get().getMessage().contains("nonexistent-index"));
     }
 
-    public void testDoExecuteRejectsMultipleConcreteIndices() {
-        TransportDslExecuteAction action = createAction(new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+    // Two Index objects sharing the same name but different UUIDs can arise after a reindex or
+    // shrink operation. The comma-join must still produce a resolvable schema table name.
+    public void testDoExecuteAcceptsMultipleConcreteIndices() {
+        // Schema entry is keyed by the comma-joined string that the converter receives.
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "test-index,test-index");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("test-index", "uuid-a"), new Index("test-index", "uuid-b") }
+        );
+
+        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            () -> ctx,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
 
         TestListener listener = executeWith(action, "multi-alias");
 
-        assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(listener.failure.get() instanceof IllegalArgumentException);
-        assertTrue(listener.failure.get().getMessage().contains("exactly one concrete index"));
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull("Expected a response for multiple resolved indices", listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
     }
 
+    // Updated to assert new contract: IndexNotFoundException propagates from resolver
     public void testDoExecuteFailsWhenIndexNotInClusterState() {
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
@@ -98,8 +122,193 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertTrue(listener.failure.get() instanceof IndexNotFoundException);
     }
 
-    private TestListener executeWith(TransportDslExecuteAction action, String index) {
-        SearchRequest request = new SearchRequest(index);
+    // --- New tests for the pre-resolve design ---
+
+    /** Two existing indices resolve and the converter receives both concrete names comma-joined. */
+    public void testMultipleConcreteIndicesPassedAsCommaListToConverter() {
+        // Schema entry keyed by the comma-joined string proves the transport action
+        // passes the resolved names as "index-a,index-b" to the converter.
+        // In production the analytics schema's lazy resolution handles comma-split internally.
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "index-a,index-b");
+
+        TransportDslExecuteAction action = createActionWithSchema(schema, new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+
+        TestListener listener = executeWith(action, "index-a", "index-b");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    /** An alias resolves to concrete backing index names, not the alias name itself. */
+    public void testAliasResolvesToConcreteBackingIndexNames() {
+        // Schema has the concrete backing index, not the alias
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "concrete-backing-index");
+
+        TransportDslExecuteAction action = createActionWithSchema(schema, new Index("concrete-backing-index", "uuid-backing"));
+
+        // Request uses alias name, but resolver returns concrete name
+        TestListener listener = executeWith(action, "my-alias");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    /** Wildcard matching nothing responds successfully with empty SearchResponse; converter never invoked. */
+    public void testWildcardMatchingNothingReturnsEmptyResponse() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        // Zero concrete indices — wildcard matched nothing but allow_no_indices=true (default)
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[0]);
+
+        // Use a failing executor to prove the converter is never invoked
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> {
+                throw new AssertionError("converter should not be invoked");
+            },
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "zzz_no_match_*");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull("Expected an empty SearchResponse", listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+        assertEquals(0, listener.response.get().getHits().getTotalHits().value());
+        assertEquals(0, listener.response.get().getTotalShards());
+    }
+
+    /** allow_no_indices=false with wildcard matching nothing fails with IndexNotFoundException. */
+    public void testAllowNoIndicesFalseWithNoMatchFails() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("zzz_no_match_*"));
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        SearchRequest request = new SearchRequest("zzz_no_match_*");
+        request.source(new SearchSourceBuilder());
+        request.indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IndexNotFoundException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IndexNotFoundException
+        );
+    }
+
+    /** A nonexistent concrete index under default options fails with IndexNotFoundException. */
+    public void testNonexistentConcreteIndexFailsWithIndexNotFound() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("totally_fake_index"));
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "totally_fake_index");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IndexNotFoundException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IndexNotFoundException
+        );
+    }
+
+    /** ignore_unavailable=true with one existing + one missing resolves to only the existing one. */
+    public void testIgnoreUnavailableTrueResolvesOnlyExistingIndex() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "existing-index");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        // Resolver with ignore_unavailable=true returns only the existing index
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("existing-index", "uuid-exists") }
+        );
+
+        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            () -> ctx,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        SearchRequest request = new SearchRequest("existing-index", "missing-index");
+        request.source(new SearchSourceBuilder());
+        request.indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    /** null or empty request.indices() fails with IllegalArgumentException. */
+    public void testNullOrEmptyIndicesThrowsIllegalArgument() {
+        TransportDslExecuteAction action = createAction(new Index("test-index", "uuid"));
+
+        // Test with empty indices
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+    }
+
+    // --- Helper methods ---
+
+    private TestListener executeWith(TransportDslExecuteAction action, String... indices) {
+        SearchRequest request = new SearchRequest(indices);
         request.source(new SearchSourceBuilder());
 
         TestListener listener = new TestListener();
@@ -125,6 +334,25 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         );
     }
 
+    private TransportDslExecuteAction createActionWithSchema(SchemaPlus schema, Index... resolvedIndices) {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
+
+        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        return new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            () -> ctx,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+    }
+
     private EngineContextProvider buildEngineContext() {
         QueryRequestContext ctx = new QueryRequestContext(null, buildSchema());
         return () -> ctx;
@@ -139,6 +367,15 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             }
         });
         return schema;
+    }
+
+    private static void addTable(SchemaPlus schema, String name) {
+        schema.add(name, new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory tf) {
+                return tf.builder().add("name", SqlTypeName.VARCHAR).add("price", SqlTypeName.INTEGER).build();
+            }
+        });
     }
 
     private static ThreadPool mockThreadPool() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -33,8 +33,6 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,6 +54,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     }
 
     public void testDoExecuteFailsWhenIndexNotInSchema() {
+        // Schema has "test-index" but the converter receives the raw expression "nonexistent-index"
         TransportDslExecuteAction action = createAction(new Index("nonexistent-index", "uuid"));
 
         TestListener listener = executeWith(action, "nonexistent-index");
@@ -67,25 +66,26 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     }
 
     // Two Index objects sharing the same name but different UUIDs can arise after a reindex or
-    // shrink operation. The comma-join must still produce a resolvable schema table name.
+    // shrink operation. The raw expression is passed to the converter (not concrete names).
     public void testDoExecuteAcceptsMultipleConcreteIndices() {
-        // Schema entry is keyed by the comma-joined string that the converter receives.
+        // Schema entry is keyed by the raw expression that the user sent.
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
-        addTable(schema, "test-index,test-index");
+        addTable(schema, "multi-alias");
 
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
             new Index[] { new Index("test-index", "uuid-a"), new Index("test-index", "uuid-b") }
         );
 
-        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            () -> ctx,
+            mockContextProvider(ctx),
             (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
@@ -102,7 +102,8 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     // Updated to assert new contract: IndexNotFoundException propagates from resolver
     public void testDoExecuteFailsWhenIndexNotInClusterState() {
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("bogus-index"));
@@ -124,35 +125,76 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertTrue(listener.failure.get() instanceof IndexNotFoundException);
     }
 
-    // --- New tests for the pre-resolve design ---
+    // --- Tests for the raw-expression-to-converter contract ---
 
-    /** Two existing indices resolve and the converter receives both concrete names comma-joined. */
-    public void testMultipleConcreteIndicesPassedAsCommaListToConverter() {
-        // Schema entry keyed by the comma-joined string proves the transport action
-        // passes the resolved names as "index-a,index-b" to the converter.
-        // In production the analytics schema's lazy resolution handles comma-split internally.
+    /**
+     * When the user sends an alias name, the converter receives the alias name (raw expression),
+     * NOT the backing index names. This lets the engine's alias-branch guardrails fire natively.
+     */
+    public void testAliasRawExpressionReachesConverter() {
+        // Schema has the alias name as a table — this is what the engine's schema builder
+        // produces when IndicesOptions + alias identity are threaded correctly.
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
-        addTable(schema, "index-a,index-b");
+        addTable(schema, "my-alias");
 
-        TransportDslExecuteAction action = createActionWithSchema(schema, new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
-        TestListener listener = executeWith(action, "index-a", "index-b");
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        // Resolver returns the backing concrete index, but the converter should NOT see it
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("concrete-backing-index", "uuid-backing") }
+        );
 
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        // Request uses alias name
+        TestListener listener = executeWith(action, "my-alias");
+
+        // If the raw expression reaches the converter, it finds "my-alias" in the schema and succeeds.
+        // If concrete names were passed, it would look for "concrete-backing-index" and fail.
         assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
         assertNotNull(listener.response.get());
         assertEquals(200, listener.response.get().status().getStatus());
     }
 
-    /** An alias resolves to concrete backing index names, not the alias name itself. */
-    public void testAliasResolvesToConcreteBackingIndexNames() {
-        // Schema has the concrete backing index, not the alias
+    /** Multiple raw index expressions are joined by commas and reach the converter. */
+    public void testMultipleRawExpressionsJoinedByComma() {
+        // Schema entry keyed by the comma-joined RAW expressions
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
-        addTable(schema, "concrete-backing-index");
+        addTable(schema, "index-a,index-b");
 
-        TransportDslExecuteAction action = createActionWithSchema(schema, new Index("concrete-backing-index", "uuid-backing"));
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
-        // Request uses alias name, but resolver returns concrete name
-        TestListener listener = executeWith(action, "my-alias");
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b") }
+        );
+
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "index-a", "index-b");
 
         assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
         assertNotNull(listener.response.get());
@@ -162,7 +204,8 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     /** Wildcard matching nothing responds successfully with empty SearchResponse; converter never invoked. */
     public void testWildcardMatchingNothingReturnsEmptyResponse() {
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         // Zero concrete indices — wildcard matched nothing but allow_no_indices=true (default)
@@ -193,7 +236,8 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     /** allow_no_indices=false with wildcard matching nothing fails with IndexNotFoundException. */
     public void testAllowNoIndicesFalseWithNoMatchFails() {
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("zzz_no_match_*"));
@@ -226,7 +270,8 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     /** A nonexistent concrete index under default options fails with IndexNotFoundException. */
     public void testNonexistentConcreteIndexFailsWithIndexNotFound() {
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("totally_fake_index"));
@@ -253,11 +298,13 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
     /** ignore_unavailable=true with one existing + one missing resolves to only the existing one. */
     public void testIgnoreUnavailableTrueResolvesOnlyExistingIndex() {
+        // Schema has the raw expression that will be passed to the converter
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
-        addTable(schema, "existing-index");
+        addTable(schema, "existing-index,missing-index");
 
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         // Resolver with ignore_unavailable=true returns only the existing index
@@ -265,11 +312,11 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             new Index[] { new Index("existing-index", "uuid-exists") }
         );
 
-        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            () -> ctx,
+            mockContextProvider(ctx),
             (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
@@ -307,10 +354,24 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         );
     }
 
-    // --- Filtered-alias rejection tests ---
+    // --- Filtered-alias rejection tests (engine-side path) ---
 
-    /** A filtered alias over two backing indices is rejected with IllegalArgumentException. */
-    public void testFilteredAliasOverTwoBackingIndicesIsRejected() {
+    /**
+     * A filtered alias name reaches the converter as the raw expression.
+     * Engine-side rejection (via IndexResolution.resolveAlias) cannot be asserted from this
+     * unit test module because it requires a real OpenSearchSchemaBuilder + IndexResolution
+     * wiring. This test verifies that the raw alias name is what gets passed to the converter
+     * (not concrete backing indices), which is the prerequisite for engine guardrails to fire.
+     *
+     * Integration test DslQueryExecutorIT should cover end-to-end filtered-alias rejection.
+     */
+    public void testFilteredAliasNameReachesConverterAsRawExpression() {
+        // Schema has the alias name — converter will find it and succeed.
+        // In production the engine's IndexResolution.resolveAlias would reject it,
+        // but that happens inside the engine, not at the coordinator level.
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "filtered-alias");
+
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
         when(clusterService.state()).thenReturn(state);
@@ -320,19 +381,12 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             new Index[] { new Index("backing-1", "uuid-1"), new Index("backing-2", "uuid-2") }
         );
 
-        Set<String> resolvedExprs = new HashSet<>();
-        resolvedExprs.add("filtered-alias");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
-
-        // First backing index has a filtering alias
-        when(resolver.filteringAliases(state, "backing-1", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
-        when(resolver.filteringAliases(state, "backing-2", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
-
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            buildEngineContext(),
-            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
             mockThreadPool()
@@ -340,25 +394,21 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         TestListener listener = executeWith(action, "filtered-alias");
 
-        assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(
-            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
-            listener.failure.get() instanceof IllegalArgumentException
-        );
-        assertTrue(
-            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
-            listener.failure.get()
-                .getMessage()
-                .contains(
-                    "Alias [filtered-alias] declares a filter on index [backing-1]; "
-                        + "filter aliases are not yet supported by analytics queries"
-                )
-        );
+        // The alias name reaches the converter (schema has "filtered-alias" entry), so it succeeds
+        // at the coordinator. Engine-side rejection happens deeper in IndexResolution.resolveAlias.
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
     }
 
-    /** A filtered alias over a single backing index is also rejected (pre-existing hole). */
-    public void testFilteredAliasOverOneBackingIndexIsRejected() {
+    /**
+     * A single-backing filtered alias also passes the raw alias name to the converter.
+     * Same principle: engine-side rejection is tested at integration level.
+     */
+    public void testSingleBackingFilteredAliasNameReachesConverter() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "single-filtered-alias");
+
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
         when(clusterService.state()).thenReturn(state);
@@ -368,17 +418,12 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             new Index[] { new Index("single-backing", "uuid-single") }
         );
 
-        Set<String> resolvedExprs = new HashSet<>();
-        resolvedExprs.add("single-filtered-alias");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
-
-        when(resolver.filteringAliases(state, "single-backing", resolvedExprs)).thenReturn(new String[] { "single-filtered-alias" });
-
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            buildEngineContext(),
-            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
             mockThreadPool()
@@ -386,27 +431,15 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         TestListener listener = executeWith(action, "single-filtered-alias");
 
-        assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(
-            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
-            listener.failure.get() instanceof IllegalArgumentException
-        );
-        assertTrue(
-            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
-            listener.failure.get()
-                .getMessage()
-                .contains(
-                    "Alias [single-filtered-alias] declares a filter on index [single-backing]; "
-                        + "filter aliases are not yet supported by analytics queries"
-                )
-        );
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
     }
 
-    /** A non-filtered alias over two backing indices succeeds and passes both concrete names to the converter. */
-    public void testNonFilteredAliasOverTwoBackingIndicesSucceeds() {
+    /** A non-filtered alias passes the raw alias name to the converter and succeeds. */
+    public void testNonFilteredAliasPassesRawNameToConverter() {
         SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
-        addTable(schema, "nf-backing-1,nf-backing-2");
+        addTable(schema, "non-filtered-alias");
 
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
@@ -417,19 +450,11 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             new Index[] { new Index("nf-backing-1", "uuid-nf1"), new Index("nf-backing-2", "uuid-nf2") }
         );
 
-        Set<String> resolvedExprs = new HashSet<>();
-        resolvedExprs.add("non-filtered-alias");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
-
-        // No filtering aliases on either backing index
-        when(resolver.filteringAliases(state, "nf-backing-1", resolvedExprs)).thenReturn(null);
-        when(resolver.filteringAliases(state, "nf-backing-2", resolvedExprs)).thenReturn(null);
-
-        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            () -> ctx,
+            mockContextProvider(ctx),
             (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
@@ -457,18 +482,11 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             new Index[] { new Index("plain-concrete", "uuid-plain") }
         );
 
-        Set<String> resolvedExprs = new HashSet<>();
-        resolvedExprs.add("plain-concrete");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
-
-        // filteringAliases returns null for a concrete index (no alias in play)
-        when(resolver.filteringAliases(state, "plain-concrete", resolvedExprs)).thenReturn(null);
-
-        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            () -> ctx,
+            mockContextProvider(ctx),
             (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
@@ -482,8 +500,11 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertEquals(200, listener.response.get().status().getStatus());
     }
 
-    /** A wildcard expression that expands to a filtered alias name is also rejected. */
-    public void testWildcardMatchingFilteredAliasIsRejected() {
+    /** A wildcard expression is passed as the raw expression to the converter. */
+    public void testWildcardExpressionPassedAsRawToConverter() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "filtered-*");
+
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
         when(clusterService.state()).thenReturn(state);
@@ -491,42 +512,181 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("wc-backing", "uuid-wc") });
 
-        // resolveExpressions expands wildcard "filtered-*" to the alias name "filtered-alias"
-        Set<String> resolvedExprs = new HashSet<>();
-        resolvedExprs.add("filtered-alias");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
-
-        // filteringAliases detects the alias
-        when(resolver.filteringAliases(state, "wc-backing", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
-
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
         TransportDslExecuteAction action = new TransportDslExecuteAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
-            buildEngineContext(),
-            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
             mockThreadPool()
         );
 
-        // User specifies wildcard "filtered-*" which resolves to "filtered-alias"
+        // User specifies wildcard "filtered-*"
         TestListener listener = executeWith(action, "filtered-*");
 
-        assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(
-            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
-            listener.failure.get() instanceof IllegalArgumentException
+        // The raw wildcard expression reaches the converter — schema has "filtered-*" entry
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    // --- D5: QueryRequestContext carries IndicesOptions and ClusterState ---
+
+    /** The QueryRequestContext handed to the engine carries the request's IndicesOptions and the captured ClusterState. */
+    public void testQueryRequestContextCarriesIndicesOptionsAndClusterState() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "ctx-test-index");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("ctx-test-index", "uuid-ctx") });
+
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        // Capture what the engine executor actually receives
+        AtomicReference<QueryRequestContext> capturedContext = new AtomicReference<>();
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> {
+                capturedContext.set(execCtx);
+                l.onResponse(Collections.emptyList());
+            },
+            clusterService,
+            resolver,
+            mockThreadPool()
         );
-        assertTrue(
-            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+
+        IndicesOptions customOptions = IndicesOptions.fromOptions(true, false, true, true);
+        SearchRequest request = new SearchRequest("ctx-test-index");
+        request.source(new SearchSourceBuilder());
+        request.indicesOptions(customOptions);
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+
+        // Verify the context passed to the engine
+        assertNotNull("QueryRequestContext should be passed to engine executor", capturedContext.get());
+        assertSame("ClusterState must be the same snapshot captured at coordinator", state, capturedContext.get().clusterState());
+        assertSame("IndicesOptions must match the request's options", customOptions, capturedContext.get().indicesOptions());
+    }
+
+    /** Default IndicesOptions are threaded when not explicitly set on the request. */
+    public void testDefaultIndicesOptionsAreThreadedToEngine() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "default-opts-index");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("default-opts-index", "uuid-default") }
+        );
+
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        AtomicReference<QueryRequestContext> capturedContext = new AtomicReference<>();
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> {
+                capturedContext.set(execCtx);
+                l.onResponse(Collections.emptyList());
+            },
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        // SearchRequest default IndicesOptions
+        SearchRequest request = new SearchRequest("default-opts-index");
+        request.source(new SearchSourceBuilder());
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(capturedContext.get());
+        assertSame(
+            "IndicesOptions should be the request's default options",
+            request.indicesOptions(),
+            capturedContext.get().indicesOptions()
+        );
+        assertSame("ClusterState should be the captured state", state, capturedContext.get().clusterState());
+    }
+
+    // --- D6: Schema built with request's IndicesOptions ---
+
+    /**
+     * The schema handed to the converter must be built with the request's IndicesOptions, not
+     * the default lenientExpandOpen(). This verifies that
+     * {@link EngineContextProvider#getContext(ClusterState, IndicesOptions)} is called with the
+     * request's options and that the resulting schema drives conversion.
+     */
+    public void testSchemaBuiltWithRequestIndicesOptions() {
+        // Two schemas: one "default" and one "custom". The custom schema has a table
+        // that only appears when the right options are used.
+        SchemaPlus defaultSchema = CalciteSchema.createRootSchema(true).plus();
+        addTable(defaultSchema, "default-table");
+
+        SchemaPlus customSchema = CalciteSchema.createRootSchema(true).plus();
+        addTable(customSchema, "custom-options-table");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("custom-options-table", "uuid-custom") }
+        );
+
+        IndicesOptions customOptions = IndicesOptions.fromOptions(true, true, true, true);
+
+        // Set up the context provider to return different schemas depending on whether
+        // the options-aware overload is called
+        QueryRequestContext defaultCtx = new QueryRequestContext(state, defaultSchema);
+        QueryRequestContext customCtx = new QueryRequestContext(state, customSchema, null, null, customOptions);
+
+        EngineContextProvider provider = mock(EngineContextProvider.class);
+        when(provider.getContext(any(ClusterState.class))).thenReturn(defaultCtx);
+        when(provider.getContext(any(ClusterState.class), any(IndicesOptions.class))).thenReturn(customCtx);
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            provider,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        SearchRequest request = new SearchRequest("custom-options-table");
+        request.source(new SearchSourceBuilder());
+        request.indicesOptions(customOptions);
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        // If the action uses the options-aware overload, the converter gets the custom schema
+        // which has "custom-options-table" — and succeeds. If it uses the default overload,
+        // the converter gets the default schema which doesn't have "custom-options-table" and fails.
+        assertNull(
+            "Expected no failure — schema must be built with request's IndicesOptions, but got: " + listener.failure.get(),
             listener.failure.get()
-                .getMessage()
-                .contains(
-                    "Alias [filtered-alias] declares a filter on index [wc-backing]; "
-                        + "filter aliases are not yet supported by analytics queries"
-                )
         );
+        assertNotNull(listener.response.get());
     }
 
     // --- Helper methods ---
@@ -542,7 +702,8 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
     private TransportDslExecuteAction createAction(Index... resolvedIndices) {
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
@@ -558,28 +719,19 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         );
     }
 
-    private TransportDslExecuteAction createActionWithSchema(SchemaPlus schema, Index... resolvedIndices) {
-        ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
-
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
-
-        QueryRequestContext ctx = new QueryRequestContext(null, schema);
-        return new TransportDslExecuteAction(
-            mock(TransportService.class),
-            new ActionFilters(Collections.emptySet()),
-            () -> ctx,
-            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
-            clusterService,
-            resolver,
-            mockThreadPool()
-        );
+    private EngineContextProvider buildEngineContext() {
+        SchemaPlus schema = buildSchema();
+        ClusterState state = mock(ClusterState.class);
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+        return mockContextProvider(ctx);
     }
 
-    private EngineContextProvider buildEngineContext() {
-        QueryRequestContext ctx = new QueryRequestContext(null, buildSchema());
-        return () -> ctx;
+    private EngineContextProvider mockContextProvider(QueryRequestContext ctx) {
+        EngineContextProvider provider = mock(EngineContextProvider.class);
+        when(provider.getContext()).thenReturn(ctx);
+        when(provider.getContext(any(ClusterState.class))).thenReturn(ctx);
+        when(provider.getContext(any(ClusterState.class), any(IndicesOptions.class))).thenReturn(ctx);
+        return provider;
     }
 
     private SchemaPlus buildSchema() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -704,7 +704,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_filtered");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
 
         TransportDslExecuteAction action = new TransportDslExecuteAction(
@@ -749,7 +749,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_filtered");
         resolvedExprs.add("al_open");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
         when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
 
@@ -795,7 +795,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("mi_open_b");
         resolvedExprs.add("al_filtered");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
 
@@ -841,7 +841,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_filtered");
         resolvedExprs.add("mi_open_b");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
         when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
 
@@ -884,7 +884,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_filtered");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
 
         TransportDslExecuteAction action = new TransportDslExecuteAction(
@@ -926,7 +926,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_filtered");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         when(resolver.filteringAliases(state, "mi_open_a", resolvedExprs)).thenReturn(new String[] { "al_filtered" });
 
         TransportDslExecuteAction action = new TransportDslExecuteAction(
@@ -971,7 +971,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
 
         Set<String> resolvedExprs = new HashSet<>();
         resolvedExprs.add("al_open");
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(resolvedExprs);
         // No filtering aliases for this alias
         when(resolver.filteringAliases(state, "mi_open_b", resolvedExprs)).thenReturn(null);
 
@@ -993,6 +993,75 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertEquals(200, listener.response.get().status().getStatus());
     }
 
+    /**
+     * A hidden filtered alias must be rejected by the coordinator guard when
+     * {@code expand_wildcards=open,hidden} is set. Before the fix, the guard called
+     * {@code resolveExpressions(state, requestIndices)} which hardcodes
+     * {@code IndicesOptions.lenientExpandOpen()} — excluding hidden abstractions from
+     * the resolved set. This let the alias slip through undetected.
+     */
+    public void testHiddenFilteredAliasIsRejectedWhenExpandWildcardsIncludesHidden() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        // The wildcard "hid_al*" expands (with hidden=true) to the hidden alias "hid_al_filtered",
+        // which backs "concrete_data_index". The index name does NOT match the wildcard.
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("concrete_data_index", "uuid-data") }
+        );
+
+        // The options-aware overload (3-arg) resolves the hidden alias correctly.
+        Set<String> hiddenResolved = new HashSet<>();
+        hiddenResolved.add("hid_al_filtered");
+        when(resolver.resolveExpressions(any(ClusterState.class), any(IndicesOptions.class), any(String[].class))).thenReturn(
+            hiddenResolved
+        );
+
+        // filteringAliases detects the alias when it appears in the resolved set.
+        when(resolver.filteringAliases(state, "concrete_data_index", hiddenResolved)).thenReturn(new String[] { "hid_al_filtered" });
+
+        // Schema includes the wildcard expression so execution succeeds if guard doesn't throw
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "hid_al*");
+        QueryRequestContext ctx = new QueryRequestContext(state, schema);
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            mockContextProvider(ctx),
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        // Request with expand_wildcards=open,hidden
+        SearchRequest request = new SearchRequest("hid_al*");
+        request.source(new SearchSourceBuilder());
+        request.indicesOptions(IndicesOptions.fromOptions(true, true, true, false, true));
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+
+        assertNull("Guard should have rejected the request but it succeeded: response=" + listener.response.get(), listener.response.get());
+        assertNotNull("Expected IllegalArgumentException for hidden filtered alias but guard passed", listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [hid_al_filtered] declares a filter on index [concrete_data_index];"
+                        + " filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
     // --- Helper methods ---
 
     private TestListener executeWith(TransportDslExecuteAction action, String... indices) {
@@ -1012,7 +1081,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
         when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
         // Stub the filtering-alias guard: no filtering aliases by default
-        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(Collections.emptySet());
+        when(resolver.resolveExpressions(any(), any(IndicesOptions.class), any(String[].class))).thenReturn(Collections.emptySet());
         when(resolver.filteringAliases(any(), any(String.class), any())).thenReturn(null);
 
         return new TransportDslExecuteAction(

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -33,6 +33,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -302,6 +304,228 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         assertTrue(
             "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
             listener.failure.get() instanceof IllegalArgumentException
+        );
+    }
+
+    // --- Filtered-alias rejection tests ---
+
+    /** A filtered alias over two backing indices is rejected with IllegalArgumentException. */
+    public void testFilteredAliasOverTwoBackingIndicesIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("backing-1", "uuid-1"), new Index("backing-2", "uuid-2") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("filtered-alias");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+
+        // First backing index has a filtering alias
+        when(resolver.filteringAliases(state, "backing-1", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
+        when(resolver.filteringAliases(state, "backing-2", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "filtered-alias");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [filtered-alias] declares a filter on index [backing-1]; "
+                        + "filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** A filtered alias over a single backing index is also rejected (pre-existing hole). */
+    public void testFilteredAliasOverOneBackingIndexIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("single-backing", "uuid-single") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("single-filtered-alias");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+
+        when(resolver.filteringAliases(state, "single-backing", resolvedExprs)).thenReturn(new String[] { "single-filtered-alias" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "single-filtered-alias");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [single-filtered-alias] declares a filter on index [single-backing]; "
+                        + "filter aliases are not yet supported by analytics queries"
+                )
+        );
+    }
+
+    /** A non-filtered alias over two backing indices succeeds and passes both concrete names to the converter. */
+    public void testNonFilteredAliasOverTwoBackingIndicesSucceeds() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "nf-backing-1,nf-backing-2");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("nf-backing-1", "uuid-nf1"), new Index("nf-backing-2", "uuid-nf2") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("non-filtered-alias");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+
+        // No filtering aliases on either backing index
+        when(resolver.filteringAliases(state, "nf-backing-1", resolvedExprs)).thenReturn(null);
+        when(resolver.filteringAliases(state, "nf-backing-2", resolvedExprs)).thenReturn(null);
+
+        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            () -> ctx,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "non-filtered-alias");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    /** A plain concrete index (no alias involvement) still succeeds. */
+    public void testPlainConcreteIndexStillSucceeds() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        addTable(schema, "plain-concrete");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(
+            new Index[] { new Index("plain-concrete", "uuid-plain") }
+        );
+
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("plain-concrete");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+
+        // filteringAliases returns null for a concrete index (no alias in play)
+        when(resolver.filteringAliases(state, "plain-concrete", resolvedExprs)).thenReturn(null);
+
+        QueryRequestContext ctx = new QueryRequestContext(null, schema);
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            () -> ctx,
+            (plan, execCtx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "plain-concrete");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    /** A wildcard expression that expands to a filtered alias name is also rejected. */
+    public void testWildcardMatchingFilteredAliasIsRejected() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(new Index[] { new Index("wc-backing", "uuid-wc") });
+
+        // resolveExpressions expands wildcard "filtered-*" to the alias name "filtered-alias"
+        Set<String> resolvedExprs = new HashSet<>();
+        resolvedExprs.add("filtered-alias");
+        when(resolver.resolveExpressions(any(), any(String[].class))).thenReturn(resolvedExprs);
+
+        // filteringAliases detects the alias
+        when(resolver.filteringAliases(state, "wc-backing", resolvedExprs)).thenReturn(new String[] { "filtered-alias" });
+
+        TransportDslExecuteAction action = new TransportDslExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            resolver,
+            mockThreadPool()
+        );
+
+        // User specifies wildcard "filtered-*" which resolves to "filtered-alias"
+        TestListener listener = executeWith(action, "filtered-*");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(
+            "Expected IllegalArgumentException but got: " + listener.failure.get().getClass(),
+            listener.failure.get() instanceof IllegalArgumentException
+        );
+        assertTrue(
+            "Expected message about filter alias but got: " + listener.failure.get().getMessage(),
+            listener.failure.get()
+                .getMessage()
+                .contains(
+                    "Alias [filtered-alias] declares a filter on index [wc-backing]; "
+                        + "filter aliases are not yet supported by analytics queries"
+                )
         );
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
@@ -10,6 +10,7 @@ package org.opensearch.dsl.executor;
 
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.test.OpenSearchTestCase;
@@ -33,7 +34,7 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
         QueryPlans plans = new QueryPlans.Builder().add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan)).build();
 
         PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
-        executor.execute(plans, future);
+        executor.execute(plans, null, future);
         List<ExecutionResult> results = future.actionGet();
 
         assertEquals(1, results.size());
@@ -65,6 +66,24 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
             ),
             result.getFieldNames()
         );
+    }
+
+    public void testExecutePassesQueryRequestContextToEngine() {
+        List<Object[]> expectedRows = List.<Object[]>of(new Object[] { "laptop", 1200 });
+        QueryRequestContext queryCtx = new QueryRequestContext(null, null);
+
+        java.util.concurrent.atomic.AtomicReference<QueryRequestContext> captured = new java.util.concurrent.atomic.AtomicReference<>();
+        DslQueryPlanExecutor executor = new DslQueryPlanExecutor((plan, ctx, listener) -> {
+            captured.set(ctx);
+            listener.onResponse(expectedRows);
+        });
+        QueryPlans plans = new QueryPlans.Builder().add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan)).build();
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor.execute(plans, queryCtx, future);
+        future.actionGet();
+
+        assertSame("QueryRequestContext must be forwarded to engine executor", queryCtx, captured.get());
     }
 
     // TODO: add test with multiple plans (HITS + AGGREGATION) to verify iteration order

--- a/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
+++ b/sandbox/qa/analytics-engine-coordinator/src/internalClusterTest/java/org/opensearch/be/datafusion/QtfSubstraitDumpIT.java
@@ -49,13 +49,11 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.GroupShardsIterator;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.routing.OperationRouting;
 import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -96,7 +94,6 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
     private static final Logger LOGGER = LogManager.getLogger(QtfSubstraitDumpIT.class);
 
     private static final String INDEX = "hits";
-    private static final IndexNameExpressionResolver TEST_RESOLVER = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
 
     public void testDumpQtfPipeline() throws Exception {
         String sql = "SELECT URL, EventDate FROM hits WHERE CounterID = 5 ORDER BY EventDate LIMIT 10";
@@ -136,7 +133,7 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
         RelNode cbo = PlannerImpl.runAllOptimizations(parsed, context);
         LOGGER.info("[QTF-DUMP] post-CBO+QTF RelNode:\n{}", RelOptUtil.toString(cbo));
 
-        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService());
         LOGGER.info("[QTF-DUMP] QueryDAG (pre-conversion):\n{}", dag);
 
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
@@ -211,7 +208,7 @@ public class QtfSubstraitDumpIT extends OpenSearchTestCase {
 
         RelNode parsed = parseSql(sql, clusterState);
         RelNode cbo = PlannerImpl.runAllOptimizations(parsed, context);
-        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService());
         PlanForker.forkAll(dag, context.getCapabilityRegistry());
         FragmentConversionDriver.convertAll(dag, context.getCapabilityRegistry());
         return dag;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -612,7 +612,15 @@ public class IndexNameExpressionResolver {
      * Resolve an array of expressions to the set of indices and aliases that these expressions match.
      */
     public Set<String> resolveExpressions(ClusterState state, String... expressions) {
-        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), true, false, true, isSystemIndexAccessAllowed());
+        return resolveExpressions(state, IndicesOptions.lenientExpandOpen(), expressions);
+    }
+
+    /**
+     * Resolve an array of expressions to the set of indices and aliases that these expressions match,
+     * using the supplied {@link IndicesOptions} to control wildcard expansion and hidden-alias visibility.
+     */
+    public Set<String> resolveExpressions(ClusterState state, IndicesOptions options, String... expressions) {
+        Context context = new Context(state, options, true, false, true, isSystemIndexAccessAllowed());
         List<String> resolvedExpressions = Arrays.asList(expressions);
         for (ExpressionResolver expressionResolver : expressionResolvers) {
             resolvedExpressions = expressionResolver.resolve(context, resolvedExpressions);

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2704,4 +2704,23 @@ public class IndexNameExpressionResolverTests extends OpenSearchTestCase {
             .map(i -> i.getName())
             .collect(Collectors.toList());
     }
+
+    /**
+     * Empirical check: when the options-aware resolveExpressions overload is called with strict
+     * (non-lenient) options on an expression naming a missing index, does it throw?
+     */
+    public void testResolveExpressionsWithStrictOptionsThrowsForMissingIndex() {
+        Metadata.Builder mdBuilder = Metadata.builder().put(indexBuilder("existing-index").state(State.OPEN));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
+
+        // Default SearchRequest options: ignore_unavailable=false, allow_no_indices=true, expand open only
+        IndicesOptions strictOpts = IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled();
+
+        // A concrete missing index name should throw IndexNotFoundException
+        IndexNotFoundException ex = expectThrows(
+            IndexNotFoundException.class,
+            () -> indexNameExpressionResolver.resolveExpressions(state, strictOpts, "nonexistent-index")
+        );
+        assertTrue(ex.getMessage().contains("nonexistent-index"));
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

The DSL `_search` path previously accepted exactly one concrete index and rejected anything resolving to more with HTTP 400. This change removes that restriction, threads the request's `IndicesOptions` through schema construction, planning and shard targeting, and keeps a coordinator-side guard that rejects filtered aliases. Behaviour now aligns with vanilla `_search` for index-expression handling.

#### Why

The single-index gate `resolveToSingleIndex()` was the only barrier. It was introduced by PR #20916 when the analytics engine had no multi-index support, and was made obsolete by PR #21822 which added that support, but the gate was never cleaned up.

The engine's schema layer, planner and shard fan-out already handle multi-index resolution end to end, and the PPL suites exercise those paths daily across aliases, wildcards and comma-lists. Data nodes null-fill columns absent from a given shard, and the reduce path is index-agnostic.

#### What changed

| Area | Description |
|---|---|
| Gate removal and pre-resolution in `TransportDslExecuteAction` | Resolves the expression with `indexNameExpressionResolver.concreteIndices(state, request)` using the request's own options, and returns an empty HTTP 200 response when the resolution is legitimately empty. |
| Options-aware schema construction | The request's `IndicesOptions` reach the schema's lazy table-resolution closure, so the row type is built from the same index set the plan will target. |
| Planner resolution carries forward | `OpenSearchTableScan` carries the `IndexResolution` computed by the scan rule, so shard targeting reuses it instead of resolving the expression a third time with different options. |
| Coordinator-side filtered-alias guard | Rejects any expression resolving to a filtered alias with HTTP 400 at the coordinator; this is a permanent part of the design rather than a temporary gap. |
| Phantom-column fix | The alias short-circuit filters backing indices to OPEN state unconditionally. |

**Why the options are supplied twice at the coordinator:**

`request.indicesOptions()` is passed both into the context provider, so the schema's lazy resolution closure captures it and fixes the row type, and onto `QueryRequestContext`, so the planner resolves the concrete index set with the same flags and the security layer authorizes the expression with them. Neither consumer can reach the other's copy, because Calcite's lazy table lookup has a fixed signature and must capture at construction while the planner resolves later and independently. Supply only one and the schema and the plan can disagree about which indices exist.

**Resolution sites:**

The expression was previously resolved three times independently. Shard targeting no longer resolves at all. The two remaining sites are schema construction and planner resolution — both now driven by the same `IndicesOptions`.

#### Supported index expression forms

| Expression form | Status |
|---|---|
| Single concrete index | Supported |
| Comma-separated list (`idx_a,idx_b`) | Supported |
| Wildcard (`mi_*`) | Supported |
| Alias over multiple backing indices | Supported |
| Exclusion pattern (`mi_*,-idx_b`) | Supported |
| Date-math (`<logs-{now/d}>`) | Supported |
| Data stream | Supported |

Data streams resolve to their backing indices the same way aliases do, and an end-to-end run confirmed a data stream returns its documents.

#### IndicesOptions behaviour

Vanilla `_search` defaults: `ignore_unavailable=false`, `allow_no_indices=true`, `expand_wildcards=open`.

Source: `SearchRequest.DEFAULT_INDICES_OPTIONS` = `strictExpandOpenAndForbidClosedIgnoreThrottled`.

| Option | Before this change | After this change | Vanilla `_search` |
|---|---|---|---|
| `ignore_unavailable` | Ignored — single-index guard ran first | Honoured during pre-resolution; missing indices silently dropped when `true` | Honoured; missing indices dropped when `true` |
| `allow_no_indices` | Ignored | Honoured; empty resolution returns HTTP 200 empty response when `true`, throws `IndexNotFoundException` when `false` | Honoured identically |
| `expand_wildcards` | Ignored | Honoured during pre-resolution (`open`, `closed`, `hidden`, `none`, `all`) | Honoured identically |

#### Behaviour changes users will observe

| Scenario | Before | After |
|---|---|---|
| Wildcard matching no index (e.g. `nonexist_*`) | HTTP 400: `Index not found in schema: nonexist_*` | HTTP 200 with empty response (matching vanilla) |
| Nonexistent concrete index | HTTP 400: single-index guard or schema error | HTTP 404: `no such index [X]` via `IndexNotFoundException` (matching vanilla) |
| Multiple concrete indices (`idx_a,idx_b`) | HTTP 400: `DSL execution currently supports exactly one concrete index, but resolved to 2 indices` | Executes query across both indices |
| Closed index named explicitly | HTTP 400: single-index guard | HTTP 400: `Index [X] is closed` |
| Any expression that resolves to a filtered alias | HTTP 400 — a single literal alias name was rejected by the engine; other forms were rejected by the single-index gate | HTTP 400, in more forms than before, because the coordinator guard covers comma-list, wildcard and duplicate forms that previously slipped past |
| Single-index query exceeding shard-count limit | Exempt from limit | Now rejected. Upstream PR #22530 replaced the plugin-local limit with `action.search.shard_count.limit` and dropped the single-index exemption. The default is unlimited, so this is inert unless an operator sets the limit. |

#### Rejected by design

**Filtered aliases**

The rejection is a permanent part of the design. The engine's `IndexResolution` consults `filteringRequired()` only when the expression is a single literal alias name that hits an exact key lookup; comma-lists, wildcards and duplicate forms fall through to the expression resolver where the filter is never consulted, so removing the coordinator guard would let those forms return unfiltered rows.

This was caught by an end-to-end run after the guard had been removed, not by unit tests or code review.

**Cross-index field-type conflicts**

Rejected with:

> `Alias [X] resolves to indices with incompatible field types: [f] is [t1] in [i1] but [t2] in [i2]`

Compatibility is judged on the mapped Calcite type — `text` and `keyword` both map to `VARCHAR` and unify, while `long` and `keyword` do not.

#### Known divergences from vanilla `_search`

| # | Divergence | Reasoning |
|---|---|---|
| a | A field absent from the union schema returns HTTP 500 (`ConversionException` from `ConversionContext.makeFieldRef`, mapped to 500 by `ExceptionsHelper.status()` because it is not an `OpenSearchException`); vanilla returns 200 with zero hits (via `MatchNoneQueryBuilder`); PPL returns 400 | Verified on HEAD `3a2b5370faf`: the converter throws before `FieldStorageResolver` is reached, so the 400 path added by PR #22452 is unreachable for this case. Pre-existing behaviour, not introduced by this change. |
| b | No gate rejects a non-pluggable-dataformat index; fails at planning with `No backend can scan all requested fields on table [X]` | Identical to the PPL path |
| c | Cross-index type-conflict validation covers only top-level `properties`; nested object leaf conflicts are not caught on the coordinator | Schema resolution iterates top-level `properties` only |
| d | Wildcards match alias names as well as index names | Standard `IndexNameExpressionResolver` behaviour; may surprise test authors |
| e | `hits` array is always empty; aggregations are the observation channel | `SearchResponseBuilder.build()` is still stubbed for hit construction |
| f | The shard-count limit is enforced before the can-match pre-filter prunes shards, so a request over the limit is rejected even when pruning would have brought it under | This is upstream's ordering, not introduced here, but it is newly reachable because this change is what makes multi-index fan-out possible |
| g | PPL and SQL still resolve with `lenientExpandOpen()` and are unaffected | This change is scoped to the DSL path only |

#### Testing

**Unit tests:**

885 in `analytics-engine` and 163 in `dsl-query-executor`, 0 failures; plus 33 integration tests in `analytics-engine-rest`, 0 failures.

Coverage themes:

- Index-expression forms reaching the converter as resolved names.
- Each `IndicesOptions` flag including a falsifiable `expand_wildcards=hidden` pair.
- Filtered-alias rejection across literal, comma-list, wildcard and duplicate forms.
- Carried-resolution propagation through the copy paths, which converts a latent runtime failure into a build failure.
- Shard-count-limit message wording for the alias, index-pattern and data-stream forms.

**End-to-end:**

A 52-row matrix, 49 passing, covering every expression form and options combination, re-run after the final fix.

The matrix was executed on a combined branch that also carries the aggregation-response work from PR #22561, because on this branch alone the `hits` array is still stubbed empty, so aggregations are the only observation channel.

#### Notes for reviewers

- The branch was rebased onto `upstream/main`. Resolving a conflict with upstream PR #22530 meant adopting upstream's `action.search.shard_count.limit` in place of the plugin-local setting, while keeping the carried-resolution design.
- The diff touches one upstream test file, `SortSpecExtractorTests.java`, solely because `DAGBuilder.build` lost its `IndexNameExpressionResolver` parameter, going from four arguments to three.

### Related Issues

Resolves #[Issue number to be closed when this PR is merged]
<!-- Replace with the tracking issue number, or delete this section if none. -->

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. (Not applicable — the `_search` request and response shapes are unchanged; only the range of accepted index expressions widens.)
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. (Not applicable — the affected code is a sandbox plugin whose behaviour is not yet publicly documented.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
