### PR TITLE
Add cluster.blocks.read.auto_release setting to control read block auto-release

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -494,14 +494,19 @@ public class DiskThresholdMonitor {
     }
 
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
-        final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
-            Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
-            false
-        )
-            .map(Map.Entry::getKey)
-            .filter(index -> indicesToBlockRead.contains(index) == false)
-            .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
-            .collect(Collectors.toSet());
+        final Set<String> indicesToReleaseReadBlock;
+        if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {
+            indicesToReleaseReadBlock = StreamSupport.stream(
+                Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
+                false
+            )
+                .map(Map.Entry::getKey)
+                .filter(index -> indicesToBlockRead.contains(index) == false)
+                .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+                .collect(Collectors.toSet());
+        } else {
+            indicesToReleaseReadBlock = new HashSet<>();
+        }
 
         if (indicesToReleaseReadBlock.isEmpty() == false) {
             updateIndicesReadBlock(indicesToReleaseReadBlock, listener, false);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -114,6 +114,12 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> CLUSTER_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+        "cluster.blocks.read.auto_release",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     private volatile String lowWatermarkRaw;
     private volatile String highWatermarkRaw;
@@ -123,6 +129,7 @@ public class DiskThresholdSettings {
     private volatile ByteSizeValue freeBytesThresholdHigh;
     private volatile boolean includeRelocations;
     private volatile boolean createIndexBlockAutoReleaseEnabled;
+    private volatile boolean readBlockAutoReleaseEnabled;
     private volatile boolean enabled;
     private volatile boolean warmThresholdEnabled;
     private volatile TimeValue rerouteInterval;
@@ -153,6 +160,7 @@ public class DiskThresholdSettings {
         this.enabled = CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.warmThresholdEnabled = CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.createIndexBlockAutoReleaseEnabled = CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE.get(settings);
+        this.readBlockAutoReleaseEnabled = CLUSTER_READ_BLOCK_AUTO_RELEASE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING, this::setLowWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING, this::setHighWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING, this::setFloodStage);
@@ -164,6 +172,7 @@ public class DiskThresholdSettings {
             this::setWarmThresholdEnabled
         );
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE, this::setCreateIndexBlockAutoReleaseEnabled);
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_READ_BLOCK_AUTO_RELEASE, this::setReadBlockAutoReleaseEnabled);
     }
 
     /**
@@ -365,6 +374,10 @@ public class DiskThresholdSettings {
         this.createIndexBlockAutoReleaseEnabled = createIndexBlockAutoReleaseEnabled;
     }
 
+    private void setReadBlockAutoReleaseEnabled(boolean readBlockAutoReleaseEnabled) {
+        this.readBlockAutoReleaseEnabled = readBlockAutoReleaseEnabled;
+    }
+
     /**
      * Gets the raw (uninterpreted) low watermark value as found in the settings.
      */
@@ -421,6 +434,10 @@ public class DiskThresholdSettings {
 
     public boolean isCreateIndexBlockAutoReleaseEnabled() {
         return createIndexBlockAutoReleaseEnabled;
+    }
+
+    public boolean isReadBlockAutoReleaseEnabled() {
+        return readBlockAutoReleaseEnabled;
     }
 
     String describeLowThreshold() {


### PR DESCRIPTION
### Description

The `DiskThresholdMonitor.handleReadBlocks()` unconditionally auto-releases `index.blocks.read` blocks on all indices, even when manually set by users. This can cause unexpected behavior where users set a read block for maintenance or security reasons, only to have it silently removed by the monitor.

### Changes

- Added a new cluster setting `cluster.blocks.read.auto_release` (default: true, to preserve existing behavior)
- When set to `false`, the DiskThresholdMonitor will no longer auto-release `index.blocks.read` blocks
- This is analogous to the existing `cluster.blocks.create_index.auto_release` setting

### Files changed

- `server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java` — added `CLUSTER_READ_BLOCK_AUTO_RELEASE` setting definition, field, getter, setter, and dynamic update consumer
- `server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java` — gated the auto-release logic with `isReadBlockAutoReleaseEnabled()`

### Testing

- Default behavior is unchanged (setting defaults to `true`)
- When set to `false`, only the auto-release is skipped; the read block APPLICATION (when the system detects high disk usage) still works normally

### Related issue

Closes #20539