### PR TITLE
Use slice() instead of clone() for multipart uploads in RemoteDirectory

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -436,7 +436,7 @@ public class RemoteDirectory extends Directory {
         assert ioContext != IOContext.READONCE : "Remote upload will fail with IoContext.READONCE";
         long expectedChecksum = calculateChecksumOfChecksum(from, src);
         long contentLength;
-        IndexInput indexInput = from.openInput(src, ioContext);
+        IndexInput indexInput = wrapWithLifecycleTracking(from.openInput(src, ioContext), src);
         try {
             contentLength = indexInput.length();
             boolean remoteIntegrityEnabled = false;
@@ -535,6 +535,69 @@ public class RemoteDirectory extends Directory {
         return (size, position) -> rateLimiter.apply(
             new OffsetRangeIndexInputStream(indexInput.slice("part@" + position, position, size), size, 0)
         );
+    }
+
+    /**
+     * Wraps the master {@link IndexInput} used for a multipart upload with lifecycle tracking that surfaces two
+     * classes of upload-path lifecycle bug:
+     *
+     * <ul>
+     *   <li><b>Double-close</b> — {@link #close()} being invoked more than once means two code paths are releasing
+     *       the same master input. The multipart upload defers the master close to the completion listener (fired
+     *       after publication completes); a second close indicates a leak or an errant close elsewhere.</li>
+     *   <li><b>Use-after-close</b> — a {@link #clone()} (which the part supplier reaches via {@code slice()}) attempted
+     *       after the master has been closed means the master was released before all parts finished, which must not
+     *       happen while parts are still being served.</li>
+     * </ul>
+     *
+     * <p>Both conditions are logged (not thrown) so a latent lifecycle bug is visible in logs without changing upload
+     * behavior. {@code clone()} delegates to the underlying input's {@code clone()} — <b>not</b> {@code super.clone()},
+     * which would inherit {@code Object.clone()} and produce a shallow {@link org.apache.lucene.store.FilterIndexInput}
+     * wrapper sharing the same delegate, causing a spurious double-close when that shallow copy is released. See PR
+     * #22309.
+     *
+     * @param rawIndexInput the freshly opened master {@link IndexInput}
+     * @param src           the source file name, for log context
+     * @return a tracking {@link IndexInput} that delegates to {@code rawIndexInput}
+     */
+    protected IndexInput wrapWithLifecycleTracking(IndexInput rawIndexInput, String src) {
+        final AtomicReference<Boolean> indexInputClosed = new AtomicReference<>(false);
+        return new org.apache.lucene.store.FilterIndexInput("tracked:" + src, rawIndexInput) {
+            @Override
+            public void close() throws IOException {
+                if (indexInputClosed.getAndSet(true)) {
+                    logger.warn(
+                        () -> new ParameterizedMessage(
+                            "IndexInput for [{}] closed a second time (double-close) on thread [{}]; "
+                                + "possible lifecycle bug in the upload path",
+                            src,
+                            Thread.currentThread().getName()
+                        )
+                    );
+                } else {
+                    logger.debug(() -> new ParameterizedMessage("IndexInput.close() for [{}]", src));
+                }
+                super.close();
+            }
+
+            @Override
+            public IndexInput clone() {
+                if (indexInputClosed.get()) {
+                    logger.warn(
+                        () -> new ParameterizedMessage(
+                            "IndexInput.slice()/clone() attempted on already-closed IndexInput for [{}] on thread [{}]; "
+                                + "the master was closed before all parts completed",
+                            src,
+                            Thread.currentThread().getName()
+                        )
+                    );
+                }
+                // Delegate to the underlying IndexInput's clone() — NOT super.clone(). FilterIndexInput inherits
+                // Object.clone(), which yields a shallow wrapper sharing the same 'in' field and double-closes it
+                // when released. slice() lands here via FilterIndexInput#slice -> clone of the sliced delegate.
+                return in.clone();
+            }
+        };
     }
 
     protected long calculateChecksumOfChecksum(Directory directory, String file) throws IOException {

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -446,15 +446,7 @@ public class RemoteDirectory extends Directory {
             lowPriorityUpload = lowPriorityUpload || contentLength > ByteSizeUnit.GB.toBytes(15);
             RemoteTransferContainer.OffsetRangeInputStreamSupplier offsetRangeInputStreamSupplier;
 
-            if (lowPriorityUpload) {
-                offsetRangeInputStreamSupplier = (size, position) -> lowPriorityUploadRateLimiter.apply(
-                    new OffsetRangeIndexInputStream(indexInput.clone(), size, position)
-                );
-            } else {
-                offsetRangeInputStreamSupplier = (size, position) -> uploadRateLimiter.apply(
-                    new OffsetRangeIndexInputStream(indexInput.clone(), size, position)
-                );
-            }
+            offsetRangeInputStreamSupplier = createOffsetRangeInputStreamSupplier(indexInput, lowPriorityUpload);
             RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
                 src,
                 remoteFileName,
@@ -514,6 +506,35 @@ public class RemoteDirectory extends Directory {
             indexInput.close();
             throw e;
         }
+    }
+
+    /**
+     * Builds the per-part {@link RemoteTransferContainer.OffsetRangeInputStreamSupplier} used to feed the multipart
+     * upload, applying the appropriate rate limiter for the upload priority.
+     *
+     * <p>Each part is backed by an independent {@link IndexInput#slice(String, long, long)} of the master input rather
+     * than a {@link IndexInput#clone()}. This is intentional and must not be changed back to {@code clone()}:
+     * {@code MemorySegmentIndexInput.clone()} shares the master's {@code MemorySegment[]} array by reference, so when
+     * any one part's stream closes, {@code Arrays.fill(segments, null)} corrupts the shared array and every subsequent
+     * {@code provideStream()} for the other parts fails with {@code AlreadyClosedException}. {@code slice()} allocates
+     * an independent array copy (via {@code ArrayUtil.copyOfSubArray} in {@code buildSlice}) for each non-full-range
+     * slice, so closing one part only nullifies its own private copy. No extra mmap is created — each slice is just a
+     * new Java object pointing into the already-mapped region. See PR #22309.
+     *
+     * <p>Because the slice already starts at {@code position}, the returned stream reads from offset {@code 0}.
+     *
+     * @param indexInput        the master {@link IndexInput} for the file being uploaded
+     * @param lowPriorityUpload whether to apply the low-priority rate limiter
+     * @return a supplier that produces an independent, rate-limited stream for each requested part
+     */
+    protected RemoteTransferContainer.OffsetRangeInputStreamSupplier createOffsetRangeInputStreamSupplier(
+        IndexInput indexInput,
+        boolean lowPriorityUpload
+    ) {
+        UnaryOperator<OffsetRangeInputStream> rateLimiter = lowPriorityUpload ? lowPriorityUploadRateLimiter : uploadRateLimiter;
+        return (size, position) -> rateLimiter.apply(
+            new OffsetRangeIndexInputStream(indexInput.slice("part@" + position, position, size), size, 0)
+        );
     }
 
     protected long calculateChecksumOfChecksum(Directory directory, String file) throws IOException {

--- a/server/src/main/java/org/opensearch/index/store/remote/DataFormatAwareRemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/DataFormatAwareRemoteDirectory.java
@@ -27,7 +27,6 @@ import org.opensearch.common.blobstore.exception.CorruptFileException;
 import org.opensearch.common.blobstore.stream.write.WriteContext;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.transfer.RemoteTransferContainer;
-import org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream;
 import org.opensearch.common.blobstore.transfer.stream.OffsetRangeInputStream;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.core.action.ActionListener;
@@ -77,8 +76,6 @@ public class DataFormatAwareRemoteDirectory extends RemoteDirectory {
 
     private static final String DEFAULT_FORMAT = "lucene";
 
-    private final UnaryOperator<OffsetRangeInputStream> uploadRateLimiter;
-    private final UnaryOperator<OffsetRangeInputStream> lowPriorityUploadRateLimiter;
     private final DownloadRateLimiterProvider downloadRateLimiterProvider;
 
     private final FormatBlobRouter formatBlobRouter;
@@ -108,8 +105,6 @@ public class DataFormatAwareRemoteDirectory extends RemoteDirectory {
             pendingDownloadMergedSegments
         );
         this.formatBlobRouter = new FormatBlobRouter(blobStore, baseBlobPath);
-        this.uploadRateLimiter = uploadRateLimiter;
-        this.lowPriorityUploadRateLimiter = lowPriorityUploadRateLimiter;
         this.downloadRateLimiterProvider = new DownloadRateLimiterProvider(downloadRateLimiter, lowPriorityDownloadRateLimiter);
         this.logger = logger;
 
@@ -434,21 +429,13 @@ public class DataFormatAwareRemoteDirectory extends RemoteDirectory {
             final boolean effectiveLowPriority = lowPriorityUpload || contentLength > ByteSizeUnit.GB.toBytes(15);
             lowPriorityUpload = effectiveLowPriority;
 
-            // Use slice() instead of clone() so each part gets its own independent
-            // MemorySegment[] array copy (via ArrayUtil.copyOfSubArray in buildSlice).
-            // clone() passes the master's segments[] array by reference to MultiSegmentImpl;
-            // when any clone closes, Arrays.fill(segments, null) corrupts the shared array,
-            // causing AlreadyClosedException on all subsequent provideStream() calls.
-            // slice() always allocates a new array for non-full-range slices, so each part's
-            // close only nullifies its own private copy. No extra mmap; just a new Java object
-            // pointing into the existing mapped region.
-            RemoteTransferContainer.OffsetRangeInputStreamSupplier supplier = effectiveLowPriority
-                ? (size, position) -> lowPriorityUploadRateLimiter.apply(
-                    new OffsetRangeIndexInputStream(indexInput.slice("part@" + position, position, size), size, 0)
-                )
-                : (size, position) -> uploadRateLimiter.apply(
-                    new OffsetRangeIndexInputStream(indexInput.slice("part@" + position, position, size), size, 0)
-                );
+            // Part streams are built by the shared base-class helper, which uses slice() (not clone())
+            // so each part gets its own independent MemorySegment[] array copy and closing one part
+            // cannot corrupt the others. See RemoteDirectory#createOffsetRangeInputStreamSupplier and PR #22309.
+            RemoteTransferContainer.OffsetRangeInputStreamSupplier supplier = createOffsetRangeInputStreamSupplier(
+                indexInput,
+                effectiveLowPriority
+            );
 
             RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
                 src,

--- a/server/src/main/java/org/opensearch/index/store/remote/DataFormatAwareRemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/DataFormatAwareRemoteDirectory.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 /**
@@ -375,52 +374,9 @@ public class DataFormatAwareRemoteDirectory extends RemoteDirectory {
         } else {
             expectedChecksum = calculateChecksumOfChecksum(from, src);
         }
-        final IndexInput rawIndexInput = from.openInput(src, ioContext);
-        // Wrap to detect double-close and already-closed slice attempts. These indicate
-        // lifecycle bugs — double-close means two code paths are releasing the same input,
-        // and an already-closed slice attempt means the master was closed before all parts
-        // completed (should not happen with the ref count in place).
-        final AtomicReference<Boolean> indexInputClosed = new AtomicReference<>(false);
-        final IndexInput indexInput = new org.apache.lucene.store.FilterIndexInput("tracked:" + src, rawIndexInput) {
-            @Override
-            public void close() throws IOException {
-                if (indexInputClosed.getAndSet(true)) {
-                    logger.warn(
-                        () -> new ParameterizedMessage(
-                            "IndexInput for [{}] closed a second time (double-close) on thread [{}]; "
-                                + "possible lifecycle bug in the upload path",
-                            src,
-                            Thread.currentThread().getName()
-                        )
-                    );
-                } else {
-                    logger.debug(() -> new ParameterizedMessage("IndexInput.close() for [{}]", src));
-                }
-                super.close();
-            }
-
-            @Override
-            public IndexInput clone() {
-                if (indexInputClosed.get()) {
-                    logger.warn(
-                        () -> new ParameterizedMessage(
-                            "IndexInput.slice() attempted on already-closed IndexInput for [{}] on thread [{}];"
-                                + " the master was closed before all parts completed",
-                            src,
-                            Thread.currentThread().getName()
-                        )
-                    );
-                }
-                // Delegate to the underlying IndexInput's clone() — NOT super.clone().
-                // FilterIndexInput inherits Object.clone() which produces a shallow wrapper
-                // copy sharing the same 'in' field; that causes double-close when the shallow
-                // copy is closed via OffsetRangeRefCount. The supplier now uses slice() rather
-                // than clone(), so this path is only reached by external callers (if any);
-                // those callers receive an untracked raw clone, which is intentional since
-                // the tracking wrapper is for the master lifecycle only.
-                return in.clone();
-            }
-        };
+        // Wrap the master input with the shared lifecycle tracking (double-close / use-after-close detection)
+        // from the base class. See RemoteDirectory#wrapWithLifecycleTracking and PR #22309.
+        final IndexInput indexInput = wrapWithLifecycleTracking(from.openInput(src, ioContext), src);
         try {
             long contentLength = indexInput.length();
             boolean remoteIntegrityEnabled = (targetContainer instanceof AsyncMultiStreamBlobContainer)

--- a/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
@@ -227,6 +227,54 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
         storeDirectory.close();
     }
 
+    /**
+     * The lifecycle-tracking wrapper (PR #22309, centralized in RemoteDirectory#wrapWithLifecycleTracking) must:
+     * transparently delegate reads and length; survive a double-close without throwing (it delegates close each
+     * time, but tracks and logs the second one as a lifecycle bug); and produce independent, still-readable clones.
+     */
+    public void testWrapWithLifecycleTracking() throws Exception {
+        String filename = "_wrap.bin";
+        byte[] payload = new byte[512];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+        Directory storeDirectory = new MMapDirectory(createTempDir());
+        try (IndexOutput out = storeDirectory.createOutput(filename, IOContext.DEFAULT)) {
+            out.writeBytes(payload, payload.length);
+            CodecUtil.writeFooter(out);
+        }
+        storeDirectory.sync(List.of(filename));
+        long fileLength = storeDirectory.fileLength(filename);
+
+        RemoteDirectory remoteDirectory = new RemoteDirectory(mock(AsyncMultiStreamBlobContainer.class));
+        IndexInput raw = storeDirectory.openInput(filename, IOContext.DEFAULT);
+        IndexInput tracked = remoteDirectory.wrapWithLifecycleTracking(raw, filename);
+
+        // Delegates length and reads.
+        assertEquals(fileLength, tracked.length());
+        byte[] head = new byte[payload.length];
+        tracked.readBytes(head, 0, head.length);
+        for (int i = 0; i < payload.length; i++) {
+            assertEquals("byte " + i, payload[i], head[i]);
+        }
+
+        // clone() yields an independent, readable input that seeks without disturbing the master.
+        IndexInput clone = tracked.clone();
+        clone.seek(0);
+        assertEquals(payload[0], clone.readByte());
+        clone.close();
+
+        // Master still usable after clone closes (slice()/clone() independence).
+        tracked.seek(0);
+        assertEquals(payload[0], tracked.readByte());
+
+        // Double-close must not throw (it is tracked and logged, not fatal).
+        tracked.close();
+        tracked.close();
+
+        storeDirectory.close();
+    }
+
     public void testCopyFromWithException() throws IOException, InterruptedException {
         AtomicReference<Boolean> postUploadInvoked = new AtomicReference<>(false);
         String filename = "_100.si";

--- a/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
@@ -13,13 +13,16 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.action.LatchedActionListener;
+import org.opensearch.common.StreamContext;
 import org.opensearch.common.blobstore.AsyncMultiStreamBlobContainer;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.stream.write.WriteContext;
 import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.common.io.InputStreamContainer;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
@@ -110,6 +113,117 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
         );
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
         assertTrue(postUploadInvoked.get());
+        storeDirectory.close();
+    }
+
+    /**
+     * Regression test for PR #22309 ported to the non-composite (Lucene-only) upload path in RemoteDirectory.
+     *
+     * <p>The multipart upload supplier must hand each part an <b>independent</b> IndexInput (via slice()), not a
+     * clone() that shares the master's MemorySegment[] array. With clone(), closing one part's stream runs
+     * Arrays.fill(segments, null) on the shared array, so the <i>next</i> part's provideStream() throws
+     * AlreadyClosedException inside the OffsetRangeIndexInputStream constructor (indexInput.seek()). The parts are
+     * therefore served interleaved — provideStream(i) then close(i) then provideStream(i+1) — which is how the
+     * async transfer manager consumes them and is what surfaces the corruption. Fails with clone(), passes with
+     * slice(). Ported from PR #22309's DataFormatAwareRemoteDirectory coverage.
+     */
+    public void testCopyFromMultiPartStreamsAreIndependent() throws Exception {
+        String filename = "_100.si";
+        // Build a real on-disk file large enough to split into several parts.
+        byte[] payload = new byte[65536];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+
+        // Use a real MMapDirectory with a small mmap chunk size so the file spans MULTIPLE segments,
+        // producing a MultiSegmentImpl-backed MemorySegmentIndexInput. That is the only shape where
+        // clone() shares the segments[] array by reference (MultiSegmentImpl), so closing one part
+        // corrupts the others via Arrays.fill(segments, null). A single-segment input clones to
+        // SingleSegmentImpl and would not reproduce the bug. maxChunkSize must be a power of two.
+        Directory storeDirectory = new MMapDirectory(createTempDir(), 4096L);
+        try (IndexOutput indexOutput = storeDirectory.createOutput(filename, IOContext.DEFAULT)) {
+            indexOutput.writeBytes(payload, payload.length);
+            CodecUtil.writeFooter(indexOutput);
+        }
+        storeDirectory.sync(List.of(filename));
+        long fileLength = storeDirectory.fileLength(filename);
+        byte[] fileBytes = new byte[(int) fileLength];
+        try (IndexInput verify = storeDirectory.openInput(filename, IOContext.DEFAULT)) {
+            verify.readBytes(fileBytes, 0, fileBytes.length);
+        }
+
+        // Capture the WriteContext and defer the completion listener, so the master IndexInput stays
+        // open while we serve part streams — mirroring how the async transfer manager consumes parts.
+        AtomicReference<WriteContext> capturedWriteContext = new AtomicReference<>();
+        AtomicReference<ActionListener<Void>> capturedListener = new AtomicReference<>();
+        CountDownLatch uploadInvoked = new CountDownLatch(1);
+        AsyncMultiStreamBlobContainer blobContainer = mock(AsyncMultiStreamBlobContainer.class);
+        when(blobContainer.remoteIntegrityCheckSupported()).thenReturn(false);
+        Mockito.doAnswer(invocation -> {
+            capturedWriteContext.set(invocation.getArgument(0));
+            capturedListener.set(invocation.getArgument(1));
+            uploadInvoked.countDown();
+            return null;
+        }).when(blobContainer).asyncBlobUpload(any(WriteContext.class), any());
+
+        CountDownLatch done = new CountDownLatch(1);
+        RemoteDirectory remoteDirectory = new RemoteDirectory(blobContainer);
+        remoteDirectory.copyFrom(
+            storeDirectory,
+            filename,
+            filename,
+            IOContext.DEFAULT,
+            () -> {},
+            new LatchedActionListener<>(ActionListener.wrap(r -> {}, e -> fail("upload failed: " + e)), done),
+            false,
+            null
+        );
+        assertTrue(uploadInvoked.await(10, TimeUnit.SECONDS));
+
+        // Split the file into 4 parts and serve them interleaved: provideStream(p) then close before
+        // provideStream(p+1). With clone(), closing part p corrupts the shared segments[] and the next
+        // provideStream() throws AlreadyClosedException; with slice() each part is independent.
+        long partSize = (fileLength + 3) / 4;
+        StreamContext streamContext = capturedWriteContext.get().getStreamProvider(partSize);
+        int numberOfParts = streamContext.getNumberOfParts();
+        assertTrue("expected multiple parts, got " + numberOfParts, numberOfParts > 1);
+
+        for (int p = 0; p < numberOfParts; p++) {
+            long offset = p * partSize;
+            long size = Math.min(partSize, fileLength - offset);
+            InputStreamContainer container;
+            try {
+                container = streamContext.provideStream(p);
+            } catch (org.apache.lucene.store.AlreadyClosedException e) {
+                throw new AssertionError(
+                    "provideStream("
+                        + p
+                        + ") threw AlreadyClosedException — a prior part's close() corrupted the "
+                        + "shared MemorySegment[] array. This is the clone() bug that slice() fixes (PR #22309).",
+                    e
+                );
+            }
+            assertEquals(size, container.getContentLength());
+            byte[] actual = new byte[(int) size];
+            InputStream in = container.getInputStream();
+            int read = 0;
+            while (read < actual.length) {
+                int n = in.read(actual, read, actual.length - read);
+                assertTrue("unexpected EOF on part " + p, n > 0);
+                read += n;
+            }
+            for (int i = 0; i < size; i++) {
+                assertEquals("mismatch part=" + p + " byte=" + i, fileBytes[(int) offset + i], actual[i]);
+            }
+            // Close this part before serving the next — this is what triggers the shared-array corruption
+            // under clone().
+            in.close();
+        }
+
+        // Complete the upload so the master IndexInput is closed via the completion listener.
+        capturedListener.get().onResponse(null);
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+
         storeDirectory.close();
     }
 


### PR DESCRIPTION
RemoteDirectory.uploadBlob (the non-composite, Lucene-only engine upload path used via RemoteSegmentStoreDirectory) fed each multipart chunk an indexInput.clone(). For a multi-segment MemorySegmentIndexInput, clone() shares the master's MemorySegment[] array by reference; when one part's stream closes, Arrays.fill(segments, null) corrupts the shared array and every subsequent provideStream() throws AlreadyClosedException.

This is the same defect fixed for DataFormatAwareRemoteDirectory in PR #22309, which left the base-class path untouched.

Fix it centrally: extract the part-stream construction into a shared protected helper RemoteDirectory#createOffsetRangeInputStreamSupplier that uses slice("part@"+position, position, size) so each part gets its own independent MemorySegment[] copy. Both RemoteDirectory and DataFormatAwareRemoteDirectory now call the single helper, so the slice-vs-clone decision lives in one place. Removed the now-redundant shadow rate-limiter fields from DataFormatAwareRemoteDirectory.

Adds a regression test that reproduces the corruption on a real multi-segment MMapDirectory (fails with clone(), passes with slice()).

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
