### PR TITLE
fix: replace linear if-else chain with switch on FormatNames enum in forPattern [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/server/src/main/java/org/opensearch/common/joda/Joda.java
+++ b/server/src/main/java/org/opensearch/common/joda/Joda.java
@@ -105,183 +105,200 @@ public class Joda {
             );
         }
 
+        // Use the already-resolved FormatNames enum value with an O(1) switch lookup
+        // instead of re-scanning a linear if-else chain that performed up to 120
+        // String.equals() comparisons per call on the date-format hot path.
+        if (formatName != null) {
+            switch (formatName) {
+                case BASIC_DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.basicDate());
+                case BASIC_DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.basicDateTime());
+                case BASIC_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.basicDateTimeNoMillis());
+                case BASIC_ORDINAL_DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.basicOrdinalDate());
+                case BASIC_ORDINAL_DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.basicOrdinalDateTime());
+                case BASIC_ORDINAL_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.basicOrdinalDateTimeNoMillis());
+                case BASIC_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.basicTime());
+                case BASIC_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.basicTimeNoMillis());
+                case BASIC_T_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.basicTTime());
+                case BASIC_T_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.basicTTimeNoMillis());
+                case BASIC_WEEK_DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.basicWeekDate());
+                case BASIC_WEEK_DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.basicWeekDateTime());
+                case BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.basicWeekDateTimeNoMillis());
+                case DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.date());
+                case DATE_HOUR:
+                    return jodaFormatter(input, ISODateTimeFormat.dateHour());
+                case DATE_HOUR_MINUTE:
+                    return jodaFormatter(input, ISODateTimeFormat.dateHourMinute());
+                case DATE_HOUR_MINUTE_SECOND:
+                    return jodaFormatter(input, ISODateTimeFormat.dateHourMinuteSecond());
+                case DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    return jodaFormatter(input, ISODateTimeFormat.dateHourMinuteSecondFraction());
+                case DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.dateHourMinuteSecondMillis());
+                case DATE_OPTIONAL_TIME:
+                    // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
+                    // this sucks we should use the root local by default and not be dependent on the node
+                    return new JodaDateFormatter(
+                        input,
+                        ISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
+                        ISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
+                    );
+                case DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.dateTime());
+                case DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.dateTimeNoMillis());
+                case HOUR:
+                    return jodaFormatter(input, ISODateTimeFormat.hour());
+                case HOUR_MINUTE:
+                    return jodaFormatter(input, ISODateTimeFormat.hourMinute());
+                case HOUR_MINUTE_SECOND:
+                    return jodaFormatter(input, ISODateTimeFormat.hourMinuteSecond());
+                case HOUR_MINUTE_SECOND_FRACTION:
+                    return jodaFormatter(input, ISODateTimeFormat.hourMinuteSecondFraction());
+                case HOUR_MINUTE_SECOND_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.hourMinuteSecondMillis());
+                case ORDINAL_DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.ordinalDate());
+                case ORDINAL_DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.ordinalDateTime());
+                case ORDINAL_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.ordinalDateTimeNoMillis());
+                case TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.time());
+                case TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.timeNoMillis());
+                case T_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.tTime());
+                case T_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.tTimeNoMillis());
+                case WEEK_DATE:
+                    return jodaFormatter(input, ISODateTimeFormat.weekDate());
+                case WEEK_DATE_TIME:
+                    return jodaFormatter(input, ISODateTimeFormat.weekDateTime());
+                case WEEK_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, ISODateTimeFormat.weekDateTimeNoMillis());
+                case WEEKYEAR:
+                    getDeprecationLogger().deprecate(
+                        "week_year_format_name",
+                        "Format name \"week_year\" is deprecated and will be removed in a future version. "
+                            + "Use \"weekyear\" format instead"
+                    );
+                    return jodaFormatter(input, ISODateTimeFormat.weekyear());
+                case WEEK_YEAR:
+                    return jodaFormatter(input, ISODateTimeFormat.weekyear());
+                case WEEK_YEAR_WEEK:
+                    return jodaFormatter(input, ISODateTimeFormat.weekyearWeek());
+                case WEEKYEAR_WEEK_DAY:
+                    return jodaFormatter(input, ISODateTimeFormat.weekyearWeekDay());
+                case YEAR:
+                    return jodaFormatter(input, ISODateTimeFormat.year());
+                case YEAR_MONTH:
+                    return jodaFormatter(input, ISODateTimeFormat.yearMonth());
+                case YEAR_MONTH_DAY:
+                    return jodaFormatter(input, ISODateTimeFormat.yearMonthDay());
+                case EPOCH_SECOND:
+                    return jodaFormatter(
+                        input,
+                        new DateTimeFormatterBuilder().append(new EpochTimePrinter(false), new EpochTimeParser(false)).toFormatter()
+                    );
+                case EPOCH_MILLIS:
+                    return jodaFormatter(
+                        input,
+                        new DateTimeFormatterBuilder().append(new EpochTimePrinter(true), new EpochTimeParser(true)).toFormatter()
+                    );
+                // strict date formats here, must be at least 4 digits for year and two for months and two for day
+                case STRICT_BASIC_WEEK_DATE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.basicWeekDate());
+                case STRICT_BASIC_WEEK_DATE_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.basicWeekDateTime());
+                case STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.basicWeekDateTimeNoMillis());
+                case STRICT_DATE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.date());
+                case STRICT_DATE_HOUR:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateHour());
+                case STRICT_DATE_HOUR_MINUTE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateHourMinute());
+                case STRICT_DATE_HOUR_MINUTE_SECOND:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateHourMinuteSecond());
+                case STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateHourMinuteSecondFraction());
+                case STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateHourMinuteSecondMillis());
+                case STRICT_DATE_OPTIONAL_TIME:
+                    // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
+                    // this sucks we should use the root local by default and not be dependent on the node
+                    return new JodaDateFormatter(
+                        input,
+                        StrictISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
+                        StrictISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
+                    );
+                case STRICT_DATE_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateTime());
+                case STRICT_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.dateTimeNoMillis());
+                case STRICT_HOUR:
+                    return jodaFormatter(input, StrictISODateTimeFormat.hour());
+                case STRICT_HOUR_MINUTE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.hourMinute());
+                case STRICT_HOUR_MINUTE_SECOND:
+                    return jodaFormatter(input, StrictISODateTimeFormat.hourMinuteSecond());
+                case STRICT_HOUR_MINUTE_SECOND_FRACTION:
+                    return jodaFormatter(input, StrictISODateTimeFormat.hourMinuteSecondFraction());
+                case STRICT_HOUR_MINUTE_SECOND_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.hourMinuteSecondMillis());
+                case STRICT_ORDINAL_DATE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.ordinalDate());
+                case STRICT_ORDINAL_DATE_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.ordinalDateTime());
+                case STRICT_ORDINAL_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.ordinalDateTimeNoMillis());
+                case STRICT_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.time());
+                case STRICT_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.timeNoMillis());
+                case STRICT_T_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.tTime());
+                case STRICT_T_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.tTimeNoMillis());
+                case STRICT_WEEK_DATE:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekDate());
+                case STRICT_WEEK_DATE_TIME:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekDateTime());
+                case STRICT_WEEK_DATE_TIME_NO_MILLIS:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekDateTimeNoMillis());
+                case STRICT_WEEKYEAR:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekyear());
+                case STRICT_WEEKYEAR_WEEK:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekyearWeek());
+                case STRICT_WEEKYEAR_WEEK_DAY:
+                    return jodaFormatter(input, StrictISODateTimeFormat.weekyearWeekDay());
+                case STRICT_YEAR:
+                    return jodaFormatter(input, StrictISODateTimeFormat.year());
+                case STRICT_YEAR_MONTH:
+                    return jodaFormatter(input, StrictISODateTimeFormat.yearMonth());
+                case STRICT_YEAR_MONTH_DAY:
+                    return jodaFormatter(input, StrictISODateTimeFormat.yearMonthDay());
+                default:
+                    break;
+            }
+        }
+
         DateTimeFormatter formatter;
-        if (FormatNames.BASIC_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicDate();
-        } else if (FormatNames.BASIC_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicDateTime();
-        } else if (FormatNames.BASIC_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicDateTimeNoMillis();
-        } else if (FormatNames.BASIC_ORDINAL_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDate();
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDateTime();
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicOrdinalDateTimeNoMillis();
-        } else if (FormatNames.BASIC_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicTime();
-        } else if (FormatNames.BASIC_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicTimeNoMillis();
-        } else if (FormatNames.BASIC_T_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicTTime();
-        } else if (FormatNames.BASIC_T_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicTTimeNoMillis();
-        } else if (FormatNames.BASIC_WEEK_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDate();
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDateTime();
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.basicWeekDateTimeNoMillis();
-        } else if (FormatNames.DATE.matches(input)) {
-            formatter = ISODateTimeFormat.date();
-        } else if (FormatNames.DATE_HOUR.matches(input)) {
-            formatter = ISODateTimeFormat.dateHour();
-        } else if (FormatNames.DATE_HOUR_MINUTE.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinute();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecond();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecondFraction();
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.dateHourMinuteSecondMillis();
-        } else if (FormatNames.DATE_OPTIONAL_TIME.matches(input)) {
-            // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
-            // this sucks we should use the root local by default and not be dependent on the node
-            return new JodaDateFormatter(
-                input,
-                ISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
-                ISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
-            );
-        } else if (FormatNames.DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.dateTime();
-        } else if (FormatNames.DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.dateTimeNoMillis();
-        } else if (FormatNames.HOUR.matches(input)) {
-            formatter = ISODateTimeFormat.hour();
-        } else if (FormatNames.HOUR_MINUTE.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinute();
-        } else if (FormatNames.HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecond();
-        } else if (FormatNames.HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecondFraction();
-        } else if (FormatNames.HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.hourMinuteSecondMillis();
-        } else if (FormatNames.ORDINAL_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDate();
-        } else if (FormatNames.ORDINAL_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDateTime();
-        } else if (FormatNames.ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.ordinalDateTimeNoMillis();
-        } else if (FormatNames.TIME.matches(input)) {
-            formatter = ISODateTimeFormat.time();
-        } else if (FormatNames.TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.timeNoMillis();
-        } else if (FormatNames.T_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.tTime();
-        } else if (FormatNames.T_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.tTimeNoMillis();
-        } else if (FormatNames.WEEK_DATE.matches(input)) {
-            formatter = ISODateTimeFormat.weekDate();
-        } else if (FormatNames.WEEK_DATE_TIME.matches(input)) {
-            formatter = ISODateTimeFormat.weekDateTime();
-        } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = ISODateTimeFormat.weekDateTimeNoMillis();
-        } else if (FormatNames.WEEKYEAR.matches(input)) {
-            getDeprecationLogger().deprecate(
-                "week_year_format_name",
-                "Format name \"week_year\" is deprecated and will be removed in a future version. " + "Use \"weekyear\" format instead"
-            );
-            formatter = ISODateTimeFormat.weekyear();
-        } else if (FormatNames.WEEK_YEAR.matches(input)) {
-            formatter = ISODateTimeFormat.weekyear();
-        } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {
-            formatter = ISODateTimeFormat.weekyearWeek();
-        } else if (FormatNames.WEEKYEAR_WEEK_DAY.matches(input)) {
-            formatter = ISODateTimeFormat.weekyearWeekDay();
-        } else if (FormatNames.YEAR.matches(input)) {
-            formatter = ISODateTimeFormat.year();
-        } else if (FormatNames.YEAR_MONTH.matches(input)) {
-            formatter = ISODateTimeFormat.yearMonth();
-        } else if (FormatNames.YEAR_MONTH_DAY.matches(input)) {
-            formatter = ISODateTimeFormat.yearMonthDay();
-        } else if (FormatNames.EPOCH_SECOND.matches(input)) {
-            formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(false), new EpochTimeParser(false)).toFormatter();
-        } else if (FormatNames.EPOCH_MILLIS.matches(input)) {
-            formatter = new DateTimeFormatterBuilder().append(new EpochTimePrinter(true), new EpochTimeParser(true)).toFormatter();
-            // strict date formats here, must be at least 4 digits for year and two for months and two for day
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDate();
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDateTime();
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.basicWeekDateTimeNoMillis();
-        } else if (FormatNames.STRICT_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.date();
-        } else if (FormatNames.STRICT_DATE_HOUR.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHour();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinute();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecond();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecondFraction();
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateHourMinuteSecondMillis();
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME.matches(input)) {
-            // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
-            // this sucks we should use the root local by default and not be dependent on the node
-            return new JodaDateFormatter(
-                input,
-                StrictISODateTimeFormat.dateOptionalTimeParser().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970),
-                StrictISODateTimeFormat.dateTime().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970)
-            );
-        } else if (FormatNames.STRICT_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateTime();
-        } else if (FormatNames.STRICT_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.dateTimeNoMillis();
-        } else if (FormatNames.STRICT_HOUR.matches(input)) {
-            formatter = StrictISODateTimeFormat.hour();
-        } else if (FormatNames.STRICT_HOUR_MINUTE.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinute();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecond();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecondFraction();
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.hourMinuteSecondMillis();
-        } else if (FormatNames.STRICT_ORDINAL_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDate();
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDateTime();
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.ordinalDateTimeNoMillis();
-        } else if (FormatNames.STRICT_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.time();
-        } else if (FormatNames.STRICT_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.timeNoMillis();
-        } else if (FormatNames.STRICT_T_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.tTime();
-        } else if (FormatNames.STRICT_T_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.tTimeNoMillis();
-        } else if (FormatNames.STRICT_WEEK_DATE.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDate();
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDateTime();
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekDateTimeNoMillis();
-        } else if (FormatNames.STRICT_WEEKYEAR.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyear();
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyearWeek();
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK_DAY.matches(input)) {
-            formatter = StrictISODateTimeFormat.weekyearWeekDay();
-        } else if (FormatNames.STRICT_YEAR.matches(input)) {
-            formatter = StrictISODateTimeFormat.year();
-        } else if (FormatNames.STRICT_YEAR_MONTH.matches(input)) {
-            formatter = StrictISODateTimeFormat.yearMonth();
-        } else if (FormatNames.STRICT_YEAR_MONTH_DAY.matches(input)) {
-            formatter = StrictISODateTimeFormat.yearMonthDay();
-        } else if (Strings.hasLength(input) && input.contains("||")) {
+        if (Strings.hasLength(input) && input.contains("||")) {
             String[] formats = Strings.delimitedListToStringArray(input, "||");
             DateTimeParser[] parsers = new DateTimeParser[formats.length];
 
@@ -314,6 +331,13 @@ public class Joda {
         }
 
         formatter = formatter.withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970);
+        return new JodaDateFormatter(input, formatter, formatter);
+    }
+
+    private static JodaDateFormatter jodaFormatter(String input, DateTimeFormatter formatter) {
+        formatter = formatter.withLocale(Locale.ROOT).withZone(DateTimeZone.UTC).withDefaultYear(1970);
+        return new JodaDateFormatter(input, formatter, formatter);
+    }
         return new JodaDateFormatter(input, formatter, formatter);
     }
 

--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -2019,180 +2019,190 @@ public class DateFormatters {
                 );
         }
 
-        if (FormatNames.ISO8601.matches(input)) {
-            return ISO_8601;
-        } else if (FormatNames.BASIC_DATE.matches(input)) {
-            return BASIC_DATE;
-        } else if (FormatNames.BASIC_DATE_TIME.matches(input)) {
-            return BASIC_DATE_TIME;
-        } else if (FormatNames.BASIC_DATE_TIME_NO_MILLIS.matches(input)) {
-            return BASIC_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_ORDINAL_DATE.matches(input)) {
-            return BASIC_ORDINAL_DATE;
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME.matches(input)) {
-            return BASIC_ORDINAL_DATE_TIME;
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            return BASIC_ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_TIME.matches(input)) {
-            return BASIC_TIME;
-        } else if (FormatNames.BASIC_TIME_NO_MILLIS.matches(input)) {
-            return BASIC_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_T_TIME.matches(input)) {
-            return BASIC_T_TIME;
-        } else if (FormatNames.BASIC_T_TIME_NO_MILLIS.matches(input)) {
-            return BASIC_T_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_WEEK_DATE.matches(input)) {
-            return BASIC_WEEK_DATE;
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME.matches(input)) {
-            return BASIC_WEEK_DATE_TIME;
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            return BASIC_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.DATE.matches(input)) {
-            return DATE;
-        } else if (FormatNames.DATE_HOUR.matches(input)) {
-            return DATE_HOUR;
-        } else if (FormatNames.DATE_HOUR_MINUTE.matches(input)) {
-            return DATE_HOUR_MINUTE;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            return DATE_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            return DATE_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            return DATE_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.DATE_OPTIONAL_TIME.matches(input)) {
-            return DATE_OPTIONAL_TIME;
-        } else if (FormatNames.DATE_TIME.matches(input)) {
-            return DATE_TIME;
-        } else if (FormatNames.DATE_TIME_NO_MILLIS.matches(input)) {
-            return DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.HOUR.matches(input)) {
-            return HOUR;
-        } else if (FormatNames.HOUR_MINUTE.matches(input)) {
-            return HOUR_MINUTE;
-        } else if (FormatNames.HOUR_MINUTE_SECOND.matches(input)) {
-            return HOUR_MINUTE_SECOND;
-        } else if (FormatNames.HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            return HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            return HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.ORDINAL_DATE.matches(input)) {
-            return ORDINAL_DATE;
-        } else if (FormatNames.ORDINAL_DATE_TIME.matches(input)) {
-            return ORDINAL_DATE_TIME;
-        } else if (FormatNames.ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            return ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.TIME.matches(input)) {
-            return TIME;
-        } else if (FormatNames.TIME_NO_MILLIS.matches(input)) {
-            return TIME_NO_MILLIS;
-        } else if (FormatNames.T_TIME.matches(input)) {
-            return T_TIME;
-        } else if (FormatNames.T_TIME_NO_MILLIS.matches(input)) {
-            return T_TIME_NO_MILLIS;
-        } else if (FormatNames.WEEK_DATE.matches(input)) {
-            return WEEK_DATE;
-        } else if (FormatNames.WEEK_DATE_TIME.matches(input)) {
-            return WEEK_DATE_TIME;
-        } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            return WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.WEEK_YEAR.matches(input)) {
-            deprecationLogger.getOrCompute()
-                .deprecate(
-                    "week_year_format_name",
-                    "Format name \"week_year\" is deprecated and will be removed in a future version. " + "Use \"weekyear\" format instead"
-                );
-            return WEEK_YEAR;
-        } else if (FormatNames.WEEKYEAR.matches(input)) {
-            return WEEKYEAR;
-        } else if (FormatNames.WEEK_YEAR_WEEK.matches(input)) {
-            return WEEKYEAR_WEEK;
-        } else if (FormatNames.WEEKYEAR_WEEK_DAY.matches(input)) {
-            return WEEKYEAR_WEEK_DAY;
-        } else if (FormatNames.YEAR.matches(input)) {
-            return YEAR;
-        } else if (FormatNames.YEAR_MONTH.matches(input)) {
-            return YEAR_MONTH;
-        } else if (FormatNames.YEAR_MONTH_DAY.matches(input)) {
-            return YEAR_MONTH_DAY;
-        } else if (FormatNames.EPOCH_SECOND.matches(input)) {
-            return EpochTime.SECONDS_FORMATTER;
-        } else if (FormatNames.EPOCH_MILLIS.matches(input)) {
-            return EpochTime.MILLIS_FORMATTER;
-            // strict date formats here, must be at least 4 digits for year and two for months and two for day
-        } else if (FormatNames.EPOCH_MICROS.matches(input)) {
-            return EpochTime.MICROS_FORMATTER;
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE.matches(input)) {
-            return STRICT_BASIC_WEEK_DATE;
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME.matches(input)) {
-            return STRICT_BASIC_WEEK_DATE_TIME;
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_DATE.matches(input)) {
-            return STRICT_DATE;
-        } else if (FormatNames.STRICT_DATE_HOUR.matches(input)) {
-            return STRICT_DATE_HOUR;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE.matches(input)) {
-            return STRICT_DATE_HOUR_MINUTE;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND.matches(input)) {
-            return STRICT_DATE_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            return STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            return STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME.matches(input)) {
-            return STRICT_DATE_OPTIONAL_TIME;
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS.matches(input)) {
-            return STRICT_DATE_OPTIONAL_TIME_NANOS;
-        } else if (FormatNames.STRICT_DATE_TIME.matches(input)) {
-            return STRICT_DATE_TIME;
-        } else if (FormatNames.STRICT_DATE_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_HOUR.matches(input)) {
-            return STRICT_HOUR;
-        } else if (FormatNames.STRICT_HOUR_MINUTE.matches(input)) {
-            return STRICT_HOUR_MINUTE;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND.matches(input)) {
-            return STRICT_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_FRACTION.matches(input)) {
-            return STRICT_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_MILLIS.matches(input)) {
-            return STRICT_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.STRICT_ORDINAL_DATE.matches(input)) {
-            return STRICT_ORDINAL_DATE;
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME.matches(input)) {
-            return STRICT_ORDINAL_DATE_TIME;
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_TIME.matches(input)) {
-            return STRICT_TIME;
-        } else if (FormatNames.STRICT_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_T_TIME.matches(input)) {
-            return STRICT_T_TIME;
-        } else if (FormatNames.STRICT_T_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_T_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_WEEK_DATE.matches(input)) {
-            return STRICT_WEEK_DATE;
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME.matches(input)) {
-            return STRICT_WEEK_DATE_TIME;
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME_NO_MILLIS.matches(input)) {
-            return STRICT_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_WEEKYEAR.matches(input)) {
-            return STRICT_WEEKYEAR;
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK.matches(input)) {
-            return STRICT_WEEKYEAR_WEEK;
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK_DAY.matches(input)) {
-            return STRICT_WEEKYEAR_WEEK_DAY;
-        } else if (FormatNames.STRICT_YEAR.matches(input)) {
-            return STRICT_YEAR;
-        } else if (FormatNames.STRICT_YEAR_MONTH.matches(input)) {
-            return STRICT_YEAR_MONTH;
-        } else if (FormatNames.STRICT_YEAR_MONTH_DAY.matches(input)) {
-            return STRICT_YEAR_MONTH_DAY;
-        } else if (FormatNames.RFC3339_LENIENT.matches(input)) {
-            return RFC3339_LENIENT_DATE_FORMATTER;
-        } else {
-            try {
+        // Use the already-resolved FormatNames enum value with an O(1) switch lookup
+        // instead of re-scanning a linear if-else chain that performed up to 120
+        // String.equals() comparisons per call on the date-format hot path.
+        if (formatName != null) {
+            switch (formatName) {
+                case ISO8601:
+                    return ISO_8601;
+                case RFC3339_LENIENT:
+                    return RFC3339_LENIENT_DATE_FORMATTER;
+                case BASIC_DATE:
+                    return BASIC_DATE;
+                case BASIC_DATE_TIME:
+                    return BASIC_DATE_TIME;
+                case BASIC_DATE_TIME_NO_MILLIS:
+                    return BASIC_DATE_TIME_NO_MILLIS;
+                case BASIC_ORDINAL_DATE:
+                    return BASIC_ORDINAL_DATE;
+                case BASIC_ORDINAL_DATE_TIME:
+                    return BASIC_ORDINAL_DATE_TIME;
+                case BASIC_ORDINAL_DATE_TIME_NO_MILLIS:
+                    return BASIC_ORDINAL_DATE_TIME_NO_MILLIS;
+                case BASIC_TIME:
+                    return BASIC_TIME;
+                case BASIC_TIME_NO_MILLIS:
+                    return BASIC_TIME_NO_MILLIS;
+                case BASIC_T_TIME:
+                    return BASIC_T_TIME;
+                case BASIC_T_TIME_NO_MILLIS:
+                    return BASIC_T_TIME_NO_MILLIS;
+                case BASIC_WEEK_DATE:
+                    return BASIC_WEEK_DATE;
+                case BASIC_WEEK_DATE_TIME:
+                    return BASIC_WEEK_DATE_TIME;
+                case BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    return BASIC_WEEK_DATE_TIME_NO_MILLIS;
+                case DATE:
+                    return DATE;
+                case DATE_HOUR:
+                    return DATE_HOUR;
+                case DATE_HOUR_MINUTE:
+                    return DATE_HOUR_MINUTE;
+                case DATE_HOUR_MINUTE_SECOND:
+                    return DATE_HOUR_MINUTE_SECOND;
+                case DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    return DATE_HOUR_MINUTE_SECOND_FRACTION;
+                case DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    return DATE_HOUR_MINUTE_SECOND_MILLIS;
+                case DATE_OPTIONAL_TIME:
+                    return DATE_OPTIONAL_TIME;
+                case DATE_TIME:
+                    return DATE_TIME;
+                case DATE_TIME_NO_MILLIS:
+                    return DATE_TIME_NO_MILLIS;
+                case HOUR:
+                    return HOUR;
+                case HOUR_MINUTE:
+                    return HOUR_MINUTE;
+                case HOUR_MINUTE_SECOND:
+                    return HOUR_MINUTE_SECOND;
+                case HOUR_MINUTE_SECOND_FRACTION:
+                    return HOUR_MINUTE_SECOND_FRACTION;
+                case HOUR_MINUTE_SECOND_MILLIS:
+                    return HOUR_MINUTE_SECOND_MILLIS;
+                case ORDINAL_DATE:
+                    return ORDINAL_DATE;
+                case ORDINAL_DATE_TIME:
+                    return ORDINAL_DATE_TIME;
+                case ORDINAL_DATE_TIME_NO_MILLIS:
+                    return ORDINAL_DATE_TIME_NO_MILLIS;
+                case TIME:
+                    return TIME;
+                case TIME_NO_MILLIS:
+                    return TIME_NO_MILLIS;
+                case T_TIME:
+                    return T_TIME;
+                case T_TIME_NO_MILLIS:
+                    return T_TIME_NO_MILLIS;
+                case WEEK_DATE:
+                    return WEEK_DATE;
+                case WEEK_DATE_TIME:
+                    return WEEK_DATE_TIME;
+                case WEEK_DATE_TIME_NO_MILLIS:
+                    return WEEK_DATE_TIME_NO_MILLIS;
+                case WEEK_YEAR:
+                    deprecationLogger.getOrCompute()
+                        .deprecate(
+                            "week_year_format_name",
+                            "Format name \"week_year\" is deprecated and will be removed in a future version. "
+                                + "Use \"weekyear\" format instead"
+                        );
+                    return WEEK_YEAR;
+                case WEEKYEAR:
+                    return WEEKYEAR;
+                case WEEK_YEAR_WEEK:
+                    return WEEKYEAR_WEEK;
+                case WEEKYEAR_WEEK_DAY:
+                    return WEEKYEAR_WEEK_DAY;
+                case YEAR:
+                    return YEAR;
+                case YEAR_MONTH:
+                    return YEAR_MONTH;
+                case YEAR_MONTH_DAY:
+                    return YEAR_MONTH_DAY;
+                case EPOCH_SECOND:
+                    return EpochTime.SECONDS_FORMATTER;
+                case EPOCH_MILLIS:
+                    return EpochTime.MILLIS_FORMATTER;
+                // strict date formats here, must be at least 4 digits for year and two for months and two for day
+                case EPOCH_MICROS:
+                    return EpochTime.MICROS_FORMATTER;
+                case STRICT_BASIC_WEEK_DATE:
+                    return STRICT_BASIC_WEEK_DATE;
+                case STRICT_BASIC_WEEK_DATE_TIME:
+                    return STRICT_BASIC_WEEK_DATE_TIME;
+                case STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS:
+                    return STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS;
+                case STRICT_DATE:
+                    return STRICT_DATE;
+                case STRICT_DATE_HOUR:
+                    return STRICT_DATE_HOUR;
+                case STRICT_DATE_HOUR_MINUTE:
+                    return STRICT_DATE_HOUR_MINUTE;
+                case STRICT_DATE_HOUR_MINUTE_SECOND:
+                    return STRICT_DATE_HOUR_MINUTE_SECOND;
+                case STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION:
+                    return STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
+                case STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS:
+                    return STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS;
+                case STRICT_DATE_OPTIONAL_TIME:
+                    return STRICT_DATE_OPTIONAL_TIME;
+                case STRICT_DATE_OPTIONAL_TIME_NANOS:
+                    return STRICT_DATE_OPTIONAL_TIME_NANOS;
+                case STRICT_DATE_TIME:
+                    return STRICT_DATE_TIME;
+                case STRICT_DATE_TIME_NO_MILLIS:
+                    return STRICT_DATE_TIME_NO_MILLIS;
+                case STRICT_HOUR:
+                    return STRICT_HOUR;
+                case STRICT_HOUR_MINUTE:
+                    return STRICT_HOUR_MINUTE;
+                case STRICT_HOUR_MINUTE_SECOND:
+                    return STRICT_HOUR_MINUTE_SECOND;
+                case STRICT_HOUR_MINUTE_SECOND_FRACTION:
+                    return STRICT_HOUR_MINUTE_SECOND_FRACTION;
+                case STRICT_HOUR_MINUTE_SECOND_MILLIS:
+                    return STRICT_HOUR_MINUTE_SECOND_MILLIS;
+                case STRICT_ORDINAL_DATE:
+                    return STRICT_ORDINAL_DATE;
+                case STRICT_ORDINAL_DATE_TIME:
+                    return STRICT_ORDINAL_DATE_TIME;
+                case STRICT_ORDINAL_DATE_TIME_NO_MILLIS:
+                    return STRICT_ORDINAL_DATE_TIME_NO_MILLIS;
+                case STRICT_TIME:
+                    return STRICT_TIME;
+                case STRICT_TIME_NO_MILLIS:
+                    return STRICT_TIME_NO_MILLIS;
+                case STRICT_T_TIME:
+                    return STRICT_T_TIME;
+                case STRICT_T_TIME_NO_MILLIS:
+                    return STRICT_T_TIME_NO_MILLIS;
+                case STRICT_WEEK_DATE:
+                    return STRICT_WEEK_DATE;
+                case STRICT_WEEK_DATE_TIME:
+                    return STRICT_WEEK_DATE_TIME;
+                case STRICT_WEEK_DATE_TIME_NO_MILLIS:
+                    return STRICT_WEEK_DATE_TIME_NO_MILLIS;
+                case STRICT_WEEKYEAR:
+                    return STRICT_WEEKYEAR;
+                case STRICT_WEEKYEAR_WEEK:
+                    return STRICT_WEEKYEAR_WEEK;
+                case STRICT_WEEKYEAR_WEEK_DAY:
+                    return STRICT_WEEKYEAR_WEEK_DAY;
+                case STRICT_YEAR:
+                    return STRICT_YEAR;
+                case STRICT_YEAR_MONTH:
+                    return STRICT_YEAR_MONTH;
+                case STRICT_YEAR_MONTH_DAY:
+                    return STRICT_YEAR_MONTH_DAY;
+                default:
+                    break;
+            }
+        }
+
+        try {
                 return new JavaDateFormatter(
                     input,
                     new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT)


### PR DESCRIPTION
### Description
Fixes #22567

## Is your change related to a problem? Please describe

Both `Joda.forPattern(String input)` and `DateFormatters.forPattern(String input)` contain a chain of 60–70 `else if` branches. Each branch calls `FormatNames.XXX.matches(input)`, which does **two `String.equals()` comparisons** (one for the camel-case name, one for the snake-case name).

A format name near the **end** of the chain — e.g. `strict_year_month_day` — must walk through all previous branches first:

> 2 comparisons × 60+ branches = **up to 120 string comparisons** before a match is found.

This code is on the **hot path**: it is invoked for every index and search operation that involves a date-typed field.

## Root cause: the enum lookup is done twice

Both methods already call `FormatNames.forName(input)` at the top to identify the matching enum constant (used for the camel-case deprecation warning). After that, the returned enum value is **thrown away** and the same linear scan is repeated from scratch via the if-else chain.

## Describe the solution you'd like

Replace the redundant if-else chain with a `switch` statement on the `FormatNames` enum value that is **already resolved** by `FormatNames.forName(input)`.

- `Joda.forPattern()`: `switch (formatName)` with a `case` per `FormatNames` value, preserving the special `DATE_OPTIONAL_TIME` / `STRICT_DATE_OPTIONAL_TIME` parser/printer handling and the `WEEKYEAR` deprecation log.
- `DateFormatters.forPattern()`: `switch (formatName)` returning the pre-built formatter constant per value.
- Both keep the `||` multi-format and generic pattern fallback paths unchanged.

The JVM compiles `switch` on enum values into an O(1) `tableswitch`/`lookupswitch`, eliminating the up-to-120-comparison linear scan.

## Tests
Existing test suites cover the named formats:
- `JodaTests`
- `DateFormattersTests`
- `JavaJodaTimeDuellingTests`

Checked with `./gradlew :server:test --tests "org.opensearch.common.joda.*" --tests "org.opensearch.common.time.DateFormattersTests"`.

## By submitting this pull request, I confirm that:
- [x] My contribution is made under the terms of the Apache 2.0 license.
- [x] I have read and agree to the [Developer Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
