### PR TITLE
Default index to false for doc-values-backed fields on pluggable data format indices

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -127,8 +127,24 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         );
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
+        /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructor that receives index settings, so builders created
+         * for internal field types — derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        private boolean pluggableDataFormat;
+
         public Builder(String name, Settings settings) {
             this(name, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
+            if (Mapper.isPluggableDataFormatEnabled(settings)) {
+                // Pluggable data formats serve numeric queries from the doc-values column and write
+                // no BKD points, so the field is not point-searchable. Default `index` to false; an
+                // explicit `index: true` overwrites this during parameter parsing and is rejected in
+                // build().
+                this.pluggableDataFormat = true;
+                this.indexed.setValue(false);
+            }
         }
 
         public Builder(String name, boolean ignoreMalformedByDefault, boolean coerceByDefault) {
@@ -159,6 +175,19 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public ScaledFloatFieldMapper build(BuilderContext context) {
+            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
+            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
+            // pluggable data format index cannot be honoured — no BKD points are written — and would
+            // route queries to a point branch that matches nothing.
+            if (pluggableDataFormat && indexed.getValue()) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + name
+                        + "] of type ["
+                        + CONTENT_TYPE
+                        + "] cannot set [index] to true on an index using a pluggable data format"
+                );
+            }
             ScaledFloatFieldType type = new ScaledFloatFieldType(
                 buildFullName(context),
                 indexed.getValue(),

--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -90,7 +90,7 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
 
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
+        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, () -> pluggableDataFormat == false);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
@@ -127,24 +127,9 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         );
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
-        /**
-         * True when this builder defaulted {@code index} to false because the index uses a pluggable
-         * data format. Only set by the constructor that receives index settings, so builders created
-         * for internal field types — derived fields, which evaluate queries against an in-memory
-         * index of their own rather than the pluggable storage — are unaffected.
-         */
-        private boolean pluggableDataFormat;
-
         public Builder(String name, Settings settings) {
             this(name, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
-            if (Mapper.isPluggableDataFormatEnabled(settings)) {
-                // Pluggable data formats serve numeric queries from the doc-values column and write
-                // no BKD points, so the field is not point-searchable. Default `index` to false; an
-                // explicit `index: true` overwrites this during parameter parsing and is rejected in
-                // build().
-                this.pluggableDataFormat = true;
-                this.indexed.setValue(false);
-            }
+            this.pluggableDataFormat = Mapper.isPluggableDataFormatEnabled(settings);
         }
 
         public Builder(String name, boolean ignoreMalformedByDefault, boolean coerceByDefault) {
@@ -175,19 +160,6 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public ScaledFloatFieldMapper build(BuilderContext context) {
-            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
-            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
-            // pluggable data format index cannot be honoured — no BKD points are written — and would
-            // route queries to a point branch that matches nothing.
-            if (pluggableDataFormat && indexed.getValue()) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + name
-                        + "] of type ["
-                        + CONTENT_TYPE
-                        + "] cannot set [index] to true on an index using a pluggable data format"
-                );
-            }
             ScaledFloatFieldType type = new ScaledFloatFieldType(
                 buildFullName(context),
                 indexed.getValue(),
@@ -442,7 +414,7 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.isPluggableDataFormat());
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
         this.stored = builder.stored.getValue();

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -605,4 +605,58 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             assertTrue("Pluggable path should capture field '" + fieldName + "'", pluggableHasField);
         }
     }
+
+    private static Settings pluggableSettings() {
+        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+    }
+
+    /**
+     * On a pluggable-dataformat index no BKD points are written for scaled_float fields, so
+     * {@code index} defaults to false and the field reports itself as not searchable — routing
+     * queries to the doc-values column instead of an empty point index.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** An explicit {@code index: false} is accepted on a pluggable-dataformat index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatAcceptsExplicitIndexFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /**
+     * An explicit {@code index: true} cannot be honoured on a pluggable-dataformat index — no point
+     * index is written — so the mapping is rejected rather than silently producing a field whose
+     * queries match nothing.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrue() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("index", true);
+            }))
+        );
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
+    public void testNonPluggableDataFormatKeepsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertTrue(mapperService.fieldType("field").isSearchable());
+
+        MapperService explicit = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", true);
+        }));
+        assertTrue(explicit.fieldType("field").isSearchable());
+    }
 }

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -52,6 +52,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
@@ -59,7 +60,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 
 public class ScaledFloatFieldMapperTests extends MapperTestCase {
@@ -68,7 +68,7 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return singletonList(new MapperExtrasModulePlugin());
+        return List.of(new MapperExtrasModulePlugin(), new MockDocValuesDataFormatPlugin());
     }
 
     @Override
@@ -607,7 +607,10 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
     }
 
     private static Settings pluggableSettings() {
-        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", MockDocValuesDataFormatPlugin.FORMAT_NAME)
+            .build();
     }
 
     /**
@@ -645,7 +648,7 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
                 b.field("index", true);
             }))
         );
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
@@ -689,6 +692,6 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             b.field("index", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 }

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -659,4 +659,36 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
         }));
         assertTrue(explicit.fieldType("field").isSearchable());
     }
+
+    /**
+     * A field added by a later mapping update also defaults to not-indexed, and the update leaves the
+     * value of the already-mapped field unchanged.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateDefaultsNewFieldToNotIndexed() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+
+        merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.endObject();
+        }));
+
+        assertFalse("newly added field should default to not-indexed", mapperService.fieldType("field2").isSearchable());
+        assertFalse("existing field's value should be preserved across the update", mapperService.fieldType("field").isSearchable());
+    }
+
+    /** A mapping update that sets index:true on a new field is rejected on a pluggable data format index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateRejectsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.field("index", true);
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldCapabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldCapabilityIT.java
@@ -749,24 +749,21 @@ public class CompositeFieldCapabilityIT extends AbstractCompositeEngineIT {
         // Verify doc was indexed
         assertDocCount(indexName, 1);
 
-        // Attempt to update mapping with an unsupported field type (geo_point).
-        // The cluster-manager accepts the mapping update, but the data node fails
-        // when trying to apply it (capability assignment fails for geo_point).
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
-            .setSource("{\"properties\":{\"unsupported_geo\":{\"type\":\"geo_point\"}}}", MediaTypeRegistry.JSON)
-            .get();
+        // A mapping update adding an unsupported field type (geo_point) is now rejected up front
+        // by the cluster-manager during capability validation, so the mapping is never published
+        // and the shard is not left in an unrecoverable state.
+        expectThrows(
+            MapperParsingException.class,
+            () -> client().admin()
+                .indices()
+                .preparePutMapping(indexName)
+                .setSource("{\"properties\":{\"unsupported_geo\":{\"type\":\"geo_point\"}}}", MediaTypeRegistry.JSON)
+                .get()
+        );
 
-        // The shard should become unhealthy as the mapping update fails on the data node.
-        // Wait for the cluster to detect the failure.
-        assertBusy(() -> {
-            String health = client().admin().cluster().prepareHealth(indexName).get().getStatus().name();
-            assertTrue(
-                "Index should be RED or YELLOW after unsupported mapping update, got: " + health,
-                health.equals("RED") || health.equals("YELLOW")
-            );
-        });
+        // The index remains healthy and the original data is intact.
+        ensureGreen(indexName);
+        assertDocCount(indexName, 1);
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldConfigRandomizedIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldConfigRandomizedIT.java
@@ -81,22 +81,22 @@ public class CompositeFieldConfigRandomizedIT extends AbstractCompositeEngineIT 
         startCluster();
         String indexName = "test-randomized-field-config";
 
-        // Randomly decide index=true/false for keyword and numeric fields
+        // Randomly decide index=true/false for keyword fields — keyword keeps FULL_TEXT_SEARCH,
+        // so it can be indexed on a pluggable data format index.
         boolean kw1Indexed = randomBoolean();
         boolean kw2Indexed = randomBoolean();
         boolean kw3Indexed = randomBoolean();
-        boolean longIndexed = randomBoolean();
-        boolean doubleIndexed = randomBoolean();
 
-        // Text fields always need index=true
+        // Numeric fields cannot request POINT_RANGE on a pluggable data format index — neither the
+        // parquet primary nor the lucene secondary backs it — so index=true is rejected. They are
+        // therefore always index=false (columnar/doc-values only). Text fields always need index=true.
         logger.info(
             "Random config: f_keyword_1.index={}, f_keyword_2.index={}, f_keyword_3.index={}, "
-                + "f_long.index={}, f_double.index={}, f_text_1.index=true, f_text_2.index=true, f_match_only_text.index=true",
+                + "f_long.index=false, f_double.index=false, f_text_1.index=true, f_text_2.index=true, "
+                + "f_match_only_text.index=true",
             kw1Indexed,
             kw2Indexed,
-            kw3Indexed,
-            longIndexed,
-            doubleIndexed
+            kw3Indexed
         );
 
         String mapping = "{\n"
@@ -113,12 +113,8 @@ public class CompositeFieldConfigRandomizedIT extends AbstractCompositeEngineIT 
             + "    \"f_text_1\": { \"type\": \"text\" },\n"
             + "    \"f_text_2\": { \"type\": \"text\" },\n"
             + "    \"f_match_only_text\": { \"type\": \"match_only_text\" },\n"
-            + "    \"f_long\": { \"type\": \"long\", \"index\": "
-            + longIndexed
-            + ", \"doc_values\": true },\n"
-            + "    \"f_double\": { \"type\": \"double\", \"index\": "
-            + doubleIndexed
-            + ", \"doc_values\": true }\n"
+            + "    \"f_long\": { \"type\": \"long\", \"index\": false, \"doc_values\": true },\n"
+            + "    \"f_double\": { \"type\": \"double\", \"index\": false, \"doc_values\": true }\n"
             + "  }\n"
             + "}";
 
@@ -202,13 +198,9 @@ public class CompositeFieldConfigRandomizedIT extends AbstractCompositeEngineIT 
         assertFieldInLucene(luceneFields, "f_keyword_2", kw2Indexed);
         assertFieldInLucene(luceneFields, "f_keyword_3", kw3Indexed);
 
-        // Numeric fields with index=false should NOT appear in lucene FieldInfos
-        if (!longIndexed) {
-            assertFalse("f_long with index=false should NOT be in lucene", luceneFields.contains("f_long"));
-        }
-        if (!doubleIndexed) {
-            assertFalse("f_double with index=false should NOT be in lucene", luceneFields.contains("f_double"));
-        }
+        // Numeric fields are index=false, so they must NOT appear in lucene FieldInfos
+        assertFalse("f_long with index=false should NOT be in lucene", luceneFields.contains("f_long"));
+        assertFalse("f_double with index=false should NOT be in lucene", luceneFields.contains("f_double"));
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
@@ -38,8 +38,6 @@ public class BooleanParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // No FULL_TEXT_SEARCH: the pluggable data format writes no inverted-index terms for boolean
-        // fields, so a mapping that requests search (index:true) is rejected via the capability path.
         return Set.of(FieldTypeCapabilities.Capability.BLOOM_FILTER, FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
@@ -38,11 +38,9 @@ public class BooleanParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        return Set.of(
-            FieldTypeCapabilities.Capability.BLOOM_FILTER,
-            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
-            FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH // This can be supported directly via stats
-        );
+        // No FULL_TEXT_SEARCH: the pluggable data format writes no inverted-index terms for boolean
+        // fields, so a mapping that requests search (index:true) is rejected via the capability path.
+        return Set.of(FieldTypeCapabilities.Capability.BLOOM_FILTER, FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
@@ -44,8 +44,6 @@ public class DateNanosParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // No POINT_RANGE: the pluggable data format writes no BKD points for date_nanos fields, so a
-        // mapping that requests search (index:true) is rejected via the capability path.
         return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
@@ -44,10 +44,8 @@ public class DateNanosParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        return Set.of(
-            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
-            FieldTypeCapabilities.Capability.BLOOM_FILTER,
-            FieldTypeCapabilities.Capability.POINT_RANGE
-        );
+        // No POINT_RANGE: the pluggable data format writes no BKD points for date_nanos fields, so a
+        // mapping that requests search (index:true) is rejected via the capability path.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
@@ -44,8 +44,6 @@ public class DateParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // No POINT_RANGE: the pluggable data format writes no BKD points for date fields, so a mapping
-        // that requests search (index:true) is rejected via the capability path.
         return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
@@ -44,10 +44,8 @@ public class DateParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        return Set.of(
-            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
-            FieldTypeCapabilities.Capability.BLOOM_FILTER,
-            FieldTypeCapabilities.Capability.POINT_RANGE
-        );
+        // No POINT_RANGE: the pluggable data format writes no BKD points for date fields, so a mapping
+        // that requests search (index:true) is rejected via the capability path.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
@@ -20,9 +20,6 @@ public abstract class NumericParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // No POINT_RANGE: the pluggable data format writes no BKD points for numeric fields, so the
-        // field is not point-searchable. A mapping that requests search on a numeric field (index:true)
-        // therefore cannot be covered by any configured format and is rejected via the capability path.
         return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
@@ -20,10 +20,9 @@ public abstract class NumericParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        return Set.of(
-            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
-            FieldTypeCapabilities.Capability.BLOOM_FILTER,
-            FieldTypeCapabilities.Capability.POINT_RANGE
-        );
+        // No POINT_RANGE: the pluggable data format writes no BKD points for numeric fields, so the
+        // field is not point-searchable. A mapping that requests search on a numeric field (index:true)
+        // therefore cannot be covered by any configured format and is rejected via the capability path.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
@@ -48,10 +48,8 @@ public class IpParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        return Set.of(
-            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
-            FieldTypeCapabilities.Capability.BLOOM_FILTER,
-            FieldTypeCapabilities.Capability.POINT_RANGE
-        );
+        // No POINT_RANGE: the pluggable data format writes no BKD points for ip fields, so a mapping
+        // that requests search (index:true) is rejected via the capability path.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
@@ -48,8 +48,6 @@ public class IpParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // No POINT_RANGE: the pluggable data format writes no BKD points for ip fields, so a mapping
-        // that requests search (index:true) is rejected via the capability path.
         return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -55,6 +55,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.indices.IndicesService;
@@ -169,7 +170,8 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
             stateWithTemplate,
             xContentRegistry,
             indicesService,
-            aliasValidator
+            aliasValidator,
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
         );
 
         final Map<String, List<String>> overlapping = new HashMap<>();
@@ -220,7 +222,8 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
         final ClusterState simulatedState,
         final NamedXContentRegistry xContentRegistry,
         final IndicesService indicesService,
-        final AliasValidator aliasValidator
+        final AliasValidator aliasValidator,
+        final boolean clusterPluggableDataFormatEnabled
     ) throws Exception {
         Settings settings = resolveSettings(simulatedState.metadata(), matchingTemplate);
 
@@ -230,13 +233,19 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
         );
 
         // create the index with dummy settings in the cluster state so we can parse and validate the aliases
-        Settings dummySettings = Settings.builder()
+        Settings.Builder dummySettingsBuilder = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(settings)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-            .build();
+            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
+        // When a pluggable data format is the cluster-wide default, simulate the mapping as a
+        // pluggable index would see it — unless the template opts out explicitly — so the preview
+        // matches what real index creation would do (rejecting a field that sets index:true).
+        if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(settings) == false) {
+            dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+        }
+        Settings dummySettings = dummySettingsBuilder.build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(indexName).settings(dummySettings).build();
 
         final ClusterState tempClusterState = ClusterState.builder(simulatedState)

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -171,7 +171,8 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
             xContentRegistry,
             indicesService,
             aliasValidator,
-            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
         );
 
         final Map<String, List<String>> overlapping = new HashMap<>();
@@ -223,7 +224,8 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
         final NamedXContentRegistry xContentRegistry,
         final IndicesService indicesService,
         final AliasValidator aliasValidator,
-        final boolean clusterPluggableDataFormatEnabled
+        final boolean clusterPluggableDataFormatEnabled,
+        final String clusterPluggableDataFormatValue
     ) throws Exception {
         Settings settings = resolveSettings(simulatedState.metadata(), matchingTemplate);
 
@@ -244,6 +246,13 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
         // matches what real index creation would do (rejecting a field that sets index:true).
         if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(settings) == false) {
             dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+        }
+        // Carry the cluster's default data format name too (mirroring MetadataCreateIndexService) so the
+        // preview resolves a format and rejects index:true; with no name there is no format to check.
+        if (clusterPluggableDataFormatEnabled
+            && clusterPluggableDataFormatValue.isEmpty() == false
+            && IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(settings) == false) {
+            dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), clusterPluggableDataFormatValue);
         }
         Settings dummySettings = dummySettingsBuilder.build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(indexName).settings(dummySettings).build();

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -187,7 +187,8 @@ public class TransportSimulateTemplateAction extends TransportClusterManagerNode
             stateWithTemplate,
             xContentRegistry,
             indicesService,
-            aliasValidator
+            aliasValidator,
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
         );
         listener.onResponse(new SimulateIndexTemplateResponse(template, overlapping));
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -188,7 +188,8 @@ public class TransportSimulateTemplateAction extends TransportClusterManagerNode
             xContentRegistry,
             indicesService,
             aliasValidator,
-            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
         );
         listener.onResponse(new SimulateIndexTemplateResponse(template, overlapping));
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -334,7 +334,13 @@ public class MetadataIndexTemplateService {
             return currentState;
         }
 
-        validateTemplate(finalSettings, stringMappings, indicesService, xContentRegistry);
+        validateTemplate(
+            finalSettings,
+            stringMappings,
+            indicesService,
+            xContentRegistry,
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+        );
         validate(name, finalComponentTemplate);
 
         // Validate all composable index templates that use this component template
@@ -352,7 +358,8 @@ public class MetadataIndexTemplateService {
                         composableTemplateName,
                         composableTemplate,
                         indicesService,
-                        xContentRegistry
+                        xContentRegistry,
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
                     );
                 } catch (Exception e) {
                     if (validationFailure == null) {
@@ -711,7 +718,14 @@ public class MetadataIndexTemplateService {
         // Finally, right before adding the template, we need to ensure that the composite settings,
         // mappings, and aliases are valid after it's been composed with the component templates
         try {
-            validateCompositeTemplate(currentState, name, finalIndexTemplate, indicesService, xContentRegistry);
+            validateCompositeTemplate(
+                currentState,
+                name,
+                finalIndexTemplate,
+                indicesService,
+                xContentRegistry,
+                clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+            );
         } catch (Exception e) {
             throw new IllegalArgumentException(
                 "composable template ["
@@ -1035,7 +1049,13 @@ public class MetadataIndexTemplateService {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    validateTemplate(request.settings, request.mappings, indicesService, xContentRegistry);
+                    validateTemplate(
+                        request.settings,
+                        request.mappings,
+                        indicesService,
+                        xContentRegistry,
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                    );
                     return innerPutTemplate(currentState, request, templateBuilder);
                 }
 
@@ -1422,7 +1442,8 @@ public class MetadataIndexTemplateService {
         final String templateName,
         final ComposableIndexTemplate template,
         final IndicesService indicesService,
-        final NamedXContentRegistry xContentRegistry
+        final NamedXContentRegistry xContentRegistry,
+        final boolean clusterPluggableDataFormatEnabled
     ) throws Exception {
         final ClusterState stateWithTemplate = ClusterState.builder(state)
             .metadata(Metadata.builder(state.metadata()).put(templateName, template))
@@ -1440,13 +1461,19 @@ public class MetadataIndexTemplateService {
         int shardReplicas = resolvedSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0);
 
         // Create the final aggregate settings, which will be used to create the temporary index metadata to validate everything
-        Settings finalResolvedSettings = Settings.builder()
+        Settings.Builder finalResolvedSettingsBuilder = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(resolvedSettings)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, dummyShards)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, shardReplicas)
-            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-            .build();
+            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
+        // When a pluggable data format is the cluster-wide default, validate the composed mapping as a
+        // pluggable index would see it — unless the template opts out explicitly — so that a field
+        // setting index:true is rejected here rather than failing every index the template creates.
+        if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(resolvedSettings) == false) {
+            finalResolvedSettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+        }
+        Settings finalResolvedSettings = finalResolvedSettingsBuilder.build();
 
         // Validate index metadata (settings)
         final ClusterState stateWithIndex = ClusterState.builder(stateWithTemplate)
@@ -1496,13 +1523,15 @@ public class MetadataIndexTemplateService {
         Settings validateSettings,
         String mappings,
         IndicesService indicesService,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        boolean clusterPluggableDataFormatEnabled
     ) throws Exception {
         validateTemplate(
             validateSettings,
             Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, mappings),
             indicesService,
-            xContentRegistry
+            xContentRegistry,
+            clusterPluggableDataFormatEnabled
         );
     }
 
@@ -1510,7 +1539,8 @@ public class MetadataIndexTemplateService {
         Settings validateSettings,
         Map<String, String> mappings,
         IndicesService indicesService,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        boolean clusterPluggableDataFormatEnabled
     ) throws Exception {
         // First check to see if mappings are valid XContent
         Map<String, Map<String, Object>> mappingsForValidation = new HashMap<>();
@@ -1545,13 +1575,19 @@ public class MetadataIndexTemplateService {
             int shardReplicas = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0);
 
             // create index service for parsing and validating "mappings"
-            Settings dummySettings = Settings.builder()
+            Settings.Builder dummySettingsBuilder = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(settings)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, dummyShards)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, shardReplicas)
-                .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-                .build();
+                .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
+            // When a pluggable data format is the cluster-wide default, validate the mapping as a
+            // pluggable index would see it — unless the template opts out explicitly — so that a field
+            // setting index:true is rejected here rather than failing every index the template creates.
+            if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(settings) == false) {
+                dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+            }
+            Settings dummySettings = dummySettingsBuilder.build();
 
             final IndexMetadata tmpIndexMetadata = IndexMetadata.builder(temporaryIndexName).settings(dummySettings).build();
             IndexService dummyIndexService = indicesService.createIndex(tmpIndexMetadata, Collections.emptyList(), false);

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -339,7 +339,8 @@ public class MetadataIndexTemplateService {
             stringMappings,
             indicesService,
             xContentRegistry,
-            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+            clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
         );
         validate(name, finalComponentTemplate);
 
@@ -359,7 +360,8 @@ public class MetadataIndexTemplateService {
                         composableTemplate,
                         indicesService,
                         xContentRegistry,
-                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
                     );
                 } catch (Exception e) {
                     if (validationFailure == null) {
@@ -724,7 +726,8 @@ public class MetadataIndexTemplateService {
                 finalIndexTemplate,
                 indicesService,
                 xContentRegistry,
-                clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+                clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
             );
         } catch (Exception e) {
             throw new IllegalArgumentException(
@@ -1054,7 +1057,8 @@ public class MetadataIndexTemplateService {
                         request.mappings,
                         indicesService,
                         xContentRegistry,
-                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING),
+                        clusterService.getClusterSettings().get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
                     );
                     return innerPutTemplate(currentState, request, templateBuilder);
                 }
@@ -1443,7 +1447,8 @@ public class MetadataIndexTemplateService {
         final ComposableIndexTemplate template,
         final IndicesService indicesService,
         final NamedXContentRegistry xContentRegistry,
-        final boolean clusterPluggableDataFormatEnabled
+        final boolean clusterPluggableDataFormatEnabled,
+        final String clusterPluggableDataFormatValue
     ) throws Exception {
         final ClusterState stateWithTemplate = ClusterState.builder(state)
             .metadata(Metadata.builder(state.metadata()).put(templateName, template))
@@ -1472,6 +1477,16 @@ public class MetadataIndexTemplateService {
         // setting index:true is rejected here rather than failing every index the template creates.
         if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(resolvedSettings) == false) {
             finalResolvedSettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+        }
+
+        // Also carry the cluster's default data format name (mirroring MetadataCreateIndexService) so the
+        // dummy index resolves a format and the capability path can reject index:true. When no name is
+        // configured there is no format to validate against; such an index cannot start its shards at
+        // creation anyway (no data format), so there is nothing to reject here.
+        if (clusterPluggableDataFormatEnabled
+            && clusterPluggableDataFormatValue.isEmpty() == false
+            && IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(resolvedSettings) == false) {
+            finalResolvedSettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), clusterPluggableDataFormatValue);
         }
         Settings finalResolvedSettings = finalResolvedSettingsBuilder.build();
 
@@ -1524,14 +1539,16 @@ public class MetadataIndexTemplateService {
         String mappings,
         IndicesService indicesService,
         NamedXContentRegistry xContentRegistry,
-        boolean clusterPluggableDataFormatEnabled
+        boolean clusterPluggableDataFormatEnabled,
+        String clusterPluggableDataFormatValue
     ) throws Exception {
         validateTemplate(
             validateSettings,
             Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, mappings),
             indicesService,
             xContentRegistry,
-            clusterPluggableDataFormatEnabled
+            clusterPluggableDataFormatEnabled,
+            clusterPluggableDataFormatValue
         );
     }
 
@@ -1540,7 +1557,8 @@ public class MetadataIndexTemplateService {
         Map<String, String> mappings,
         IndicesService indicesService,
         NamedXContentRegistry xContentRegistry,
-        boolean clusterPluggableDataFormatEnabled
+        boolean clusterPluggableDataFormatEnabled,
+        String clusterPluggableDataFormatValue
     ) throws Exception {
         // First check to see if mappings are valid XContent
         Map<String, Map<String, Object>> mappingsForValidation = new HashMap<>();
@@ -1586,6 +1604,15 @@ public class MetadataIndexTemplateService {
             // setting index:true is rejected here rather than failing every index the template creates.
             if (clusterPluggableDataFormatEnabled && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(settings) == false) {
                 dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true);
+            }
+            // Also carry the cluster's default data format name (mirroring MetadataCreateIndexService) so the
+            // dummy index resolves a format and the capability path can reject index:true. When no name is
+            // configured there is no format to validate against; such an index cannot start its shards at
+            // creation anyway (no data format), so there is nothing to reject here.
+            if (clusterPluggableDataFormatEnabled
+                && clusterPluggableDataFormatValue.isEmpty() == false
+                && IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(settings) == false) {
+                dummySettingsBuilder.put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), clusterPluggableDataFormatValue);
             }
             Settings dummySettings = dummySettingsBuilder.build();
 

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -1274,6 +1274,20 @@ public final class IndexModule {
     }
 
     /**
+     * creates a new mapper service to do administrative work like mapping updates. This *should not* be used for document parsing.
+     * doing so will result in an exception.
+     * <p>
+     * Overload retained for binary compatibility; delegates with no pluggable data format registry.
+     */
+    public MapperService newIndexMapperService(
+        NamedXContentRegistry xContentRegistry,
+        MapperRegistry mapperRegistry,
+        ScriptService scriptService
+    ) throws IOException {
+        return newIndexMapperService(xContentRegistry, mapperRegistry, scriptService, null);
+    }
+
+    /**
      * Forces a certain query cache to use instead of the default one. If this is set
      * and query caching is not disabled with {@code index.queries.cache.enabled}, then
      * the given provider will be used.

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -1255,7 +1255,8 @@ public final class IndexModule {
     public MapperService newIndexMapperService(
         NamedXContentRegistry xContentRegistry,
         MapperRegistry mapperRegistry,
-        ScriptService scriptService
+        ScriptService scriptService,
+        DataFormatRegistry dataFormatRegistry
     ) throws IOException {
         return new MapperService(
             indexSettings,
@@ -1267,7 +1268,8 @@ public final class IndexModule {
                 throw new UnsupportedOperationException("no index query shard context available");
             },
             () -> false,
-            scriptService
+            scriptService,
+            dataFormatRegistry
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
@@ -45,6 +45,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
@@ -126,8 +127,28 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Float> boost = Parameter.boostParam();
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
+        /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructor that receives index settings, so builders created
+         * for internal field types — derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        private boolean pluggableDataFormat;
+
         public Builder(String name) {
+            this(name, Settings.EMPTY);
+        }
+
+        public Builder(String name, Settings settings) {
             super(name);
+            if (Mapper.isPluggableDataFormatEnabled(settings)) {
+                // Pluggable data formats serve boolean queries from the doc-values column and write no
+                // terms for the field in the Lucene secondary, so it is not searchable through the
+                // inverted index. Default `index` to false; an explicit `index: true` overwrites this
+                // during parameter parsing and is rejected in build().
+                this.pluggableDataFormat = true;
+                this.indexed.setValue(false);
+            }
         }
 
         @Override
@@ -137,6 +158,18 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public BooleanFieldMapper build(BuilderContext context) {
+            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
+            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
+            // pluggable data format index cannot be honoured, since the field's terms are not written.
+            if (pluggableDataFormat && indexed.getValue()) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + name
+                        + "] of type ["
+                        + CONTENT_TYPE
+                        + "] cannot set [index] to true on an index using a pluggable data format"
+                );
+            }
             MappedFieldType ft = new BooleanFieldType(
                 buildFullName(context),
                 indexed.getValue(),
@@ -150,7 +183,7 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
-    public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
+    public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n, c.getSettings()));
 
     /**
      * Field type for boolean field mapper

--- a/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
@@ -113,7 +113,7 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> docValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
-        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
+        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, () -> pluggableDataFormat == false);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
         private final Parameter<Boolean> nullValue = new Parameter<>(
@@ -127,28 +127,13 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Float> boost = Parameter.boostParam();
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
-        /**
-         * True when this builder defaulted {@code index} to false because the index uses a pluggable
-         * data format. Only set by the constructor that receives index settings, so builders created
-         * for internal field types — derived fields, which evaluate queries against an in-memory
-         * index of their own rather than the pluggable storage — are unaffected.
-         */
-        private boolean pluggableDataFormat;
-
         public Builder(String name) {
             this(name, Settings.EMPTY);
         }
 
         public Builder(String name, Settings settings) {
             super(name);
-            if (Mapper.isPluggableDataFormatEnabled(settings)) {
-                // Pluggable data formats serve boolean queries from the doc-values column and write no
-                // terms for the field in the Lucene secondary, so it is not searchable through the
-                // inverted index. Default `index` to false; an explicit `index: true` overwrites this
-                // during parameter parsing and is rejected in build().
-                this.pluggableDataFormat = true;
-                this.indexed.setValue(false);
-            }
+            this.pluggableDataFormat = Mapper.isPluggableDataFormatEnabled(settings);
         }
 
         @Override
@@ -158,18 +143,6 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public BooleanFieldMapper build(BuilderContext context) {
-            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
-            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
-            // pluggable data format index cannot be honoured, since the field's terms are not written.
-            if (pluggableDataFormat && indexed.getValue()) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + name
-                        + "] of type ["
-                        + CONTENT_TYPE
-                        + "] cannot set [index] to true on an index using a pluggable data format"
-                );
-            }
             MappedFieldType ft = new BooleanFieldType(
                 buildFullName(context),
                 indexed.getValue(),
@@ -395,7 +368,7 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         CopyTo copyTo,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.isPluggableDataFormat());
         this.nullValue = builder.nullValue.getValue();
         this.stored = builder.stored.getValue();
         this.indexed = builder.indexed.getValue();

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -50,6 +50,7 @@ import org.opensearch.common.TriFunction;
 import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.lucene.BytesRefs;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.time.DateFormatters;
 import org.opensearch.common.time.DateMathParser;
@@ -310,12 +311,31 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         private final Resolution resolution;
         private final Version indexCreatedVersion;
 
+        /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructor that receives index settings, so builders created
+         * for internal field types — derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        private boolean pluggableDataFormat;
+
         public Builder(
             String name,
             Resolution resolution,
             DateFormatter dateFormatter,
             boolean ignoreMalformedByDefault,
             Version indexCreatedVersion
+        ) {
+            this(name, resolution, dateFormatter, ignoreMalformedByDefault, indexCreatedVersion, Settings.EMPTY);
+        }
+
+        public Builder(
+            String name,
+            Resolution resolution,
+            DateFormatter dateFormatter,
+            boolean ignoreMalformedByDefault,
+            Version indexCreatedVersion,
+            Settings settings
         ) {
             super(name);
             this.resolution = resolution;
@@ -330,6 +350,14 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
                 this.format.setValue(dateFormatter.pattern());
                 this.printFormat.setValue(dateFormatter.printPattern());
                 this.locale.setValue(dateFormatter.locale());
+            }
+            if (Mapper.isPluggableDataFormatEnabled(settings)) {
+                // Pluggable data formats serve date queries from the doc-values column and write no
+                // BKD points, so the field is not point-searchable. Default `index` to false; an
+                // explicit `index: true` overwrites this during parameter parsing and is rejected in
+                // build().
+                this.pluggableDataFormat = true;
+                this.index.setValue(false);
             }
         }
 
@@ -371,6 +399,19 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public DateFieldMapper build(BuilderContext context) {
+            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
+            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
+            // pluggable data format index cannot be honoured — no BKD points are written — and would
+            // route queries to a point branch that matches nothing.
+            if (pluggableDataFormat && index.getValue()) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + name
+                        + "] of type ["
+                        + resolution.type()
+                        + "] cannot set [index] to true on an index using a pluggable data format"
+                );
+            }
             DateFieldType ft = new DateFieldType(
                 buildFullName(context),
                 index.getValue(),
@@ -394,12 +435,26 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser MILLIS_PARSER = new TypeParser((n, c) -> {
         boolean ignoreMalformedByDefault = IGNORE_MALFORMED_SETTING.get(c.getSettings());
-        return new Builder(n, Resolution.MILLISECONDS, c.getDateFormatter(), ignoreMalformedByDefault, c.indexVersionCreated());
+        return new Builder(
+            n,
+            Resolution.MILLISECONDS,
+            c.getDateFormatter(),
+            ignoreMalformedByDefault,
+            c.indexVersionCreated(),
+            c.getSettings()
+        );
     });
 
     public static final TypeParser NANOS_PARSER = new TypeParser((n, c) -> {
         boolean ignoreMalformedByDefault = IGNORE_MALFORMED_SETTING.get(c.getSettings());
-        return new Builder(n, Resolution.NANOSECONDS, c.getDateFormatter(), ignoreMalformedByDefault, c.indexVersionCreated());
+        return new Builder(
+            n,
+            Resolution.NANOSECONDS,
+            c.getDateFormatter(),
+            ignoreMalformedByDefault,
+            c.indexVersionCreated(),
+            c.getSettings()
+        );
     });
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -270,7 +270,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).indexed, true);
+        private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).indexed, () -> pluggableDataFormat == false);
         private final Parameter<Boolean> docValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> store = Parameter.storeParam(m -> toType(m).store, false);
         private final Parameter<Boolean> skiplist = new Parameter<>(
@@ -311,14 +311,6 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         private final Resolution resolution;
         private final Version indexCreatedVersion;
 
-        /**
-         * True when this builder defaulted {@code index} to false because the index uses a pluggable
-         * data format. Only set by the constructor that receives index settings, so builders created
-         * for internal field types — derived fields, which evaluate queries against an in-memory
-         * index of their own rather than the pluggable storage — are unaffected.
-         */
-        private boolean pluggableDataFormat;
-
         public Builder(
             String name,
             Resolution resolution,
@@ -351,14 +343,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
                 this.printFormat.setValue(dateFormatter.printPattern());
                 this.locale.setValue(dateFormatter.locale());
             }
-            if (Mapper.isPluggableDataFormatEnabled(settings)) {
-                // Pluggable data formats serve date queries from the doc-values column and write no
-                // BKD points, so the field is not point-searchable. Default `index` to false; an
-                // explicit `index: true` overwrites this during parameter parsing and is rejected in
-                // build().
-                this.pluggableDataFormat = true;
-                this.index.setValue(false);
-            }
+            this.pluggableDataFormat = Mapper.isPluggableDataFormatEnabled(settings);
         }
 
         private DateFormatter buildFormatter() {
@@ -399,19 +384,6 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public DateFieldMapper build(BuilderContext context) {
-            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
-            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
-            // pluggable data format index cannot be honoured — no BKD points are written — and would
-            // route queries to a point branch that matches nothing.
-            if (pluggableDataFormat && index.getValue()) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + name
-                        + "] of type ["
-                        + resolution.type()
-                        + "] cannot set [index] to true on an index using a pluggable data format"
-                );
-            }
             DateFieldType ft = new DateFieldType(
                 buildFullName(context),
                 index.getValue(),
@@ -836,7 +808,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         Resolution resolution,
         Builder builder
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.isPluggableDataFormat());
         this.store = builder.store.getValue();
         this.indexed = builder.index.getValue();
         this.hasDocValues = builder.docValues.getValue();

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -229,9 +229,17 @@ public class DocumentMapper implements ToXContentFragment {
         // Assign capabilities for dynamically merged mappers that bypass the Builder path.
         final DataFormatRegistry registry = mapperService.documentMapperParser().getDataFormatRegistry();
         if (indexSettings.isPluggableDataFormatEnabled() && registry != null) {
-            assignCapabilitiesRecursive(mapping.root(), registry, indexSettings);
-            for (MetadataFieldMapper metadataMapper : mapping.metadataMappers) {
-                registry.assignCapabilities(metadataMapper.fieldType(), indexSettings);
+            try {
+                assignCapabilitiesRecursive(mapping.root(), registry, indexSettings);
+                for (MetadataFieldMapper metadataMapper : mapping.metadataMappers) {
+                    registry.assignCapabilities(metadataMapper.fieldType(), indexSettings);
+                }
+            } catch (UnsupportedOperationException e) {
+                // A field type that declares no search capability (e.g. geo_point) cannot be backed by a
+                // pluggable data format. Surface this as a MapperParsingException (400) rather than letting a
+                // raw UnsupportedOperationException escape as a NotSerializableExceptionWrapper (500) on the
+                // put-mapping path, which parses directly and bypasses the merge path's exception wrapping.
+                throw new MapperParsingException(e.getMessage(), e);
             }
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1329,7 +1329,8 @@ final class DocumentParser {
                                 DateFieldMapper.Resolution.MILLISECONDS,
                                 dateTimeFormatter,
                                 ignoreMalformed,
-                                IndexMetadata.indexCreated(context.indexSettings().getSettings())
+                                IndexMetadata.indexCreated(context.indexSettings().getSettings()),
+                                context.indexSettings().getSettings()
                             );
                         });
                     }
@@ -1371,7 +1372,10 @@ final class DocumentParser {
         } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
             Mapper.Builder builder = findTemplateBuilder(context, currentFieldName, XContentFieldType.BOOLEAN, dynamic, fullPath);
             if (builder == null) {
-                return handleNoTemplateFound(dynamic, () -> new BooleanFieldMapper.Builder(currentFieldName));
+                return handleNoTemplateFound(
+                    dynamic,
+                    () -> new BooleanFieldMapper.Builder(currentFieldName, context.indexSettings().getSettings())
+                );
             }
             return builder;
         } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1654,7 +1654,8 @@ final class DocumentParser {
                                 DateFieldMapper.Resolution.MILLISECONDS,
                                 dateTimeFormatter,
                                 ignoreMalformed,
-                                IndexMetadata.indexCreated(context.indexSettings().getSettings())
+                                IndexMetadata.indexCreated(context.indexSettings().getSettings()),
+                                context.indexSettings().getSettings()
                             );
                         });
                     }
@@ -1696,7 +1697,10 @@ final class DocumentParser {
         } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
             Mapper.Builder builder = findTemplateBuilder(context, currentFieldName, XContentFieldType.BOOLEAN, dynamic, fullPath);
             if (builder == null) {
-                return handleNoTemplateFound(dynamic, () -> new BooleanFieldMapper.Builder(currentFieldName));
+                return handleNoTemplateFound(
+                    dynamic,
+                    () -> new BooleanFieldMapper.Builder(currentFieldName, context.indexSettings().getSettings())
+                );
             }
             return builder;
         } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -57,6 +57,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.index.compositeindex.datacube.DimensionType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
@@ -114,7 +115,19 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         private final boolean ignoreMalformedByDefault;
         private final Version indexCreatedVersion;
 
+        /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructor that receives index settings, so builders created
+         * for internal field types — derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        private boolean pluggableDataFormat;
+
         public Builder(String name, boolean ignoreMalformedByDefault, Version indexCreatedVersion) {
+            this(name, ignoreMalformedByDefault, indexCreatedVersion, Settings.EMPTY);
+        }
+
+        public Builder(String name, boolean ignoreMalformedByDefault, Version indexCreatedVersion, Settings settings) {
             super(name);
             this.ignoreMalformedByDefault = ignoreMalformedByDefault;
             this.indexCreatedVersion = indexCreatedVersion;
@@ -124,6 +137,13 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
                 m -> toType(m).ignoreMalformed,
                 ignoreMalformedByDefault
             );
+            if (Mapper.isPluggableDataFormatEnabled(settings)) {
+                // Pluggable data formats serve IP queries from the doc-values column and write no BKD
+                // points, so the field is not point-searchable. Default `index` to false; an explicit
+                // `index: true` overwrites this during parameter parsing and is rejected in build().
+                this.pluggableDataFormat = true;
+                this.indexed.setValue(false);
+            }
         }
 
         Builder nullValue(String nullValue) {
@@ -158,6 +178,19 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public IpFieldMapper build(BuilderContext context) {
+            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
+            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
+            // pluggable data format index cannot be honoured — no BKD points are written — and would
+            // route queries to a point branch that matches nothing.
+            if (pluggableDataFormat && indexed.getValue()) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + name
+                        + "] of type ["
+                        + CONTENT_TYPE
+                        + "] cannot set [index] to true on an index using a pluggable data format"
+                );
+            }
             return new IpFieldMapper(
                 name,
                 new IpFieldType(
@@ -183,7 +216,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> {
         boolean ignoreMalformedByDefault = IGNORE_MALFORMED_SETTING.get(c.getSettings());
-        return new Builder(n, ignoreMalformedByDefault, c.indexVersionCreated());
+        return new Builder(n, ignoreMalformedByDefault, c.indexVersionCreated(), c.getSettings());
     });
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -102,7 +102,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
+        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, () -> pluggableDataFormat == false);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
@@ -114,14 +114,6 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         private final boolean ignoreMalformedByDefault;
         private final Version indexCreatedVersion;
-
-        /**
-         * True when this builder defaulted {@code index} to false because the index uses a pluggable
-         * data format. Only set by the constructor that receives index settings, so builders created
-         * for internal field types — derived fields, which evaluate queries against an in-memory
-         * index of their own rather than the pluggable storage — are unaffected.
-         */
-        private boolean pluggableDataFormat;
 
         public Builder(String name, boolean ignoreMalformedByDefault, Version indexCreatedVersion) {
             this(name, ignoreMalformedByDefault, indexCreatedVersion, Settings.EMPTY);
@@ -137,13 +129,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
                 m -> toType(m).ignoreMalformed,
                 ignoreMalformedByDefault
             );
-            if (Mapper.isPluggableDataFormatEnabled(settings)) {
-                // Pluggable data formats serve IP queries from the doc-values column and write no BKD
-                // points, so the field is not point-searchable. Default `index` to false; an explicit
-                // `index: true` overwrites this during parameter parsing and is rejected in build().
-                this.pluggableDataFormat = true;
-                this.indexed.setValue(false);
-            }
+            this.pluggableDataFormat = Mapper.isPluggableDataFormatEnabled(settings);
         }
 
         Builder nullValue(String nullValue) {
@@ -178,19 +164,6 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public IpFieldMapper build(BuilderContext context) {
-            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
-            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
-            // pluggable data format index cannot be honoured — no BKD points are written — and would
-            // route queries to a point branch that matches nothing.
-            if (pluggableDataFormat && indexed.getValue()) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + name
-                        + "] of type ["
-                        + CONTENT_TYPE
-                        + "] cannot set [index] to true on an index using a pluggable data format"
-                );
-            }
             return new IpFieldMapper(
                 name,
                 new IpFieldType(
@@ -639,7 +612,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
     private final Version indexCreatedVersion;
 
     private IpFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.isPluggableDataFormat());
         this.ignoreMalformedByDefault = builder.ignoreMalformedByDefault;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -140,8 +140,24 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
 
         private final NumberType type;
 
+        /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructor that receives index settings, so builders created
+         * for internal field types — derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        private boolean pluggableDataFormat;
+
         public Builder(String name, NumberType type, Settings settings) {
             this(name, type, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
+            if (Mapper.isPluggableDataFormatEnabled(settings)) {
+                // Pluggable data formats serve numeric queries from the doc-values column and write
+                // no BKD points, so the field is not point-searchable. Default `index` to false; an
+                // explicit `index: true` overwrites this during parameter parsing and is rejected in
+                // build().
+                this.pluggableDataFormat = true;
+                this.indexed.setValue(false);
+            }
         }
 
         public static Builder docValuesOnly(String name, NumberType type) {
@@ -186,6 +202,19 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public NumberFieldMapper build(BuilderContext context) {
+            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
+            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
+            // pluggable data format index cannot be honoured — no BKD points are written — and would
+            // route queries to a point branch that matches nothing.
+            if (pluggableDataFormat && indexed.getValue()) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + name
+                        + "] of type ["
+                        + type.typeName()
+                        + "] cannot set [index] to true on an index using a pluggable data format"
+                );
+            }
             MappedFieldType ft = new NumberFieldType(buildFullName(context), this);
             return new NumberFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -120,7 +120,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
+        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, () -> pluggableDataFormat == false);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
         private final Parameter<Boolean> skiplist = new Parameter<>(
@@ -140,24 +140,9 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
 
         private final NumberType type;
 
-        /**
-         * True when this builder defaulted {@code index} to false because the index uses a pluggable
-         * data format. Only set by the constructor that receives index settings, so builders created
-         * for internal field types — derived fields, which evaluate queries against an in-memory
-         * index of their own rather than the pluggable storage — are unaffected.
-         */
-        private boolean pluggableDataFormat;
-
         public Builder(String name, NumberType type, Settings settings) {
             this(name, type, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
-            if (Mapper.isPluggableDataFormatEnabled(settings)) {
-                // Pluggable data formats serve numeric queries from the doc-values column and write
-                // no BKD points, so the field is not point-searchable. Default `index` to false; an
-                // explicit `index: true` overwrites this during parameter parsing and is rejected in
-                // build().
-                this.pluggableDataFormat = true;
-                this.indexed.setValue(false);
-            }
+            this.pluggableDataFormat = Mapper.isPluggableDataFormatEnabled(settings);
         }
 
         public static Builder docValuesOnly(String name, NumberType type) {
@@ -202,19 +187,6 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public NumberFieldMapper build(BuilderContext context) {
-            // Runs after parameter parsing, so a still-true `index` here means the mapping explicitly
-            // set it and overwrote the not-indexed default from the constructor. Enabling `index` on a
-            // pluggable data format index cannot be honoured — no BKD points are written — and would
-            // route queries to a point branch that matches nothing.
-            if (pluggableDataFormat && indexed.getValue()) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + name
-                        + "] of type ["
-                        + type.typeName()
-                        + "] cannot set [index] to true on an index using a pluggable data format"
-                );
-            }
             MappedFieldType ft = new NumberFieldType(buildFullName(context), this);
             return new NumberFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
@@ -2158,7 +2130,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
     private final boolean coerceByDefault;
 
     private NumberFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo, Builder builder) {
-        super(simpleName, mappedFieldType, multiFields, copyTo);
+        super(simpleName, mappedFieldType, multiFields, copyTo, builder.isPluggableDataFormat());
         this.type = builder.type;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -82,10 +82,31 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ParametrizedFieldMapper.class);
 
     /**
+     * True when the index uses a pluggable data format. Remembered here so {@link #getMergeBuilder()} can
+     * rebuild a settings-less builder that still knows this, keeping parameter defaults correct (e.g.
+     * {@code index} defaulting to false) during serialization and mapping merges.
+     */
+    protected final boolean pluggableDataFormat;
+
+    /**
      * Creates a new ParametrizedFieldMapper
      */
     protected ParametrizedFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo) {
+        this(simpleName, mappedFieldType, multiFields, copyTo, false);
+    }
+
+    /**
+     * Creates a new ParametrizedFieldMapper, recording whether the index uses a pluggable data format.
+     */
+    protected ParametrizedFieldMapper(
+        String simpleName,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        boolean pluggableDataFormat
+    ) {
         super(simpleName, new FieldType(), mappedFieldType, multiFields, copyTo);
+        this.pluggableDataFormat = pluggableDataFormat;
     }
 
     /**
@@ -382,7 +403,16 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             Function<FieldMapper, Boolean> initializer,
             boolean defaultValue
         ) {
-            return new Parameter<>(name, updateable, () -> defaultValue, (n, c, o) -> XContentMapValues.nodeBooleanValue(o), initializer);
+            return boolParam(name, updateable, initializer, () -> defaultValue);
+        }
+
+        public static Parameter<Boolean> boolParam(
+            String name,
+            boolean updateable,
+            Function<FieldMapper, Boolean> initializer,
+            Supplier<Boolean> defaultValue
+        ) {
+            return new Parameter<>(name, updateable, defaultValue, (n, c, o) -> XContentMapValues.nodeBooleanValue(o), initializer);
         }
 
         /**
@@ -556,6 +586,10 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             return Parameter.boolParam("index", false, initializer, defaultValue);
         }
 
+        public static Parameter<Boolean> indexParam(Function<FieldMapper, Boolean> initializer, Supplier<Boolean> defaultValue) {
+            return Parameter.boolParam("index", false, initializer, defaultValue);
+        }
+
         public static Parameter<Boolean> storeParam(Function<FieldMapper, Boolean> initializer, boolean defaultValue) {
             return Parameter.boolParam("store", false, initializer, defaultValue);
         }
@@ -690,6 +724,14 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         protected final CopyTo.Builder copyTo = new CopyTo.Builder();
 
         /**
+         * True when this builder defaulted {@code index} to false because the index uses a pluggable
+         * data format. Only set by the constructors that receive index settings, so builders created
+         * for internal field types — such as derived fields, which evaluate queries against an in-memory
+         * index of their own rather than the pluggable storage — are unaffected.
+         */
+        protected boolean pluggableDataFormat;
+
+        /**
          * Creates a new Builder with a field name
          */
         protected Builder(String name) {
@@ -775,6 +817,15 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         }
 
         /**
+         * @return true when the index uses a pluggable data format. Exposed so mappers in other modules
+         *         (which cannot access the protected field across class loaders) can propagate the flag
+         *         when constructing their mapper.
+         */
+        public boolean isPluggableDataFormat() {
+            return pluggableDataFormat;
+        }
+
+        /**
          * Initialises all parameters from an existing mapper
          */
         public Builder init(FieldMapper initializer) {
@@ -783,6 +834,11 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             }
             for (Mapper subField : initializer.multiFields) {
                 multiFieldsBuilder.add(subField);
+            }
+            // Carry the pluggable-data-format flag over from the mapper being merged/serialized so a
+            // settings-less merge builder keeps the correct parameter defaults (e.g. `index` -> false).
+            if (initializer instanceof ParametrizedFieldMapper) {
+                this.pluggableDataFormat = ((ParametrizedFieldMapper) initializer).pluggableDataFormat;
             }
             return this;
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -1343,7 +1343,7 @@ public class IndicesService extends AbstractLifecycleComponent
             dataFormatAwareStoreDirectoryFactories
         );
         pluginsService.onIndexModule(indexModule);
-        return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry, scriptService);
+        return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry, scriptService, dataFormatRegistry);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/metadata/PluggableDataFormatTemplateValidationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/PluggableDataFormatTemplateValidationTests.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.action.admin.indices.template.post.TransportSimulateIndexTemplateAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.compress.CompressedXContent;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Validates that, when a pluggable data format is the cluster-wide default
+ * ({@code cluster.pluggable.dataformat.enabled}), templates carrying an explicit {@code index: true}
+ * on a doc-values-backed field are rejected at template-creation time — so they cannot later fail
+ * every index (including rollovers) the template creates. Templates that omit {@code index} or set
+ * it to false are accepted, and a template that explicitly opts out of the pluggable data format
+ * (producing vanilla indices) may still set {@code index: true}.
+ */
+public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingleNodeTestCase {
+
+    private static final String INDEX_TRUE = "{\"properties\":{\"n\":{\"type\":\"long\",\"index\":true}}}";
+    private static final String INDEX_FALSE = "{\"properties\":{\"n\":{\"type\":\"long\",\"index\":false}}}";
+    private static final String INDEX_OMITTED = "{\"properties\":{\"n\":{\"type\":\"long\"}}}";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        // Supplies a committer factory so EngineConfigFactory accepts pluggable-dataformat indices,
+        // which the dummy index built during template validation requires.
+        return Collections.singletonList(MockCommitterEnginePlugin.class);
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true).build();
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .build();
+    }
+
+    private MetadataIndexTemplateService templateService() {
+        return getInstanceFromNode(MetadataIndexTemplateService.class);
+    }
+
+    /** Concatenates the message of a throwable and its full cause chain, for order-independent matching. */
+    private static String fullMessage(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+            sb.append(cur.getMessage()).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static ComponentTemplate componentTemplate(String mapping) throws Exception {
+        return new ComponentTemplate(new Template(Settings.EMPTY, new CompressedXContent(mapping), null), 1L, new HashMap<>());
+    }
+
+    private static ComposableIndexTemplate composableTemplate(Settings settings, String mapping) throws Exception {
+        return new ComposableIndexTemplate(
+            Collections.singletonList("pdf-*"),
+            new Template(settings, new CompressedXContent(mapping), null),
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    public void testComponentTemplateRejectsIndexTrue() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        Exception e = expectThrows(
+            Exception.class,
+            () -> service.addComponentTemplate(ClusterState.EMPTY_STATE, false, "ct", componentTemplate(INDEX_TRUE))
+        );
+        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    public void testComponentTemplateAcceptsIndexFalse() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        ClusterState state = service.addComponentTemplate(ClusterState.EMPTY_STATE, false, "ct", componentTemplate(INDEX_FALSE));
+        assertNotNull(state.metadata().componentTemplates().get("ct"));
+    }
+
+    public void testComponentTemplateAcceptsIndexOmitted() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        ClusterState state = service.addComponentTemplate(ClusterState.EMPTY_STATE, false, "ct", componentTemplate(INDEX_OMITTED));
+        assertNotNull(state.metadata().componentTemplates().get("ct"));
+    }
+
+    public void testComposableTemplateRejectsIndexTrue() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        Exception e = expectThrows(
+            Exception.class,
+            () -> service.addIndexTemplateV2(ClusterState.EMPTY_STATE, false, "it", composableTemplate(Settings.EMPTY, INDEX_TRUE))
+        );
+        // The composable path wraps the mapper rejection; assert on the full cause chain.
+        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    public void testComposableTemplateAcceptsIndexFalse() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        ClusterState state = service.addIndexTemplateV2(
+            ClusterState.EMPTY_STATE,
+            false,
+            "it",
+            composableTemplate(Settings.EMPTY, INDEX_FALSE)
+        );
+        assertNotNull(state.metadata().templatesV2().get("it"));
+    }
+
+    /**
+     * A template that explicitly opts out of the pluggable data format produces vanilla indices, where
+     * index: true is valid — so it must be accepted even while the cluster default is on.
+     */
+    public void testComposableTemplateWithExplicitOptOutAcceptsIndexTrue() throws Exception {
+        MetadataIndexTemplateService service = templateService();
+        Settings optOut = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false).build();
+        ClusterState state = service.addIndexTemplateV2(ClusterState.EMPTY_STATE, false, "it", composableTemplate(optOut, INDEX_TRUE));
+        assertNotNull(state.metadata().templatesV2().get("it"));
+    }
+
+    /**
+     * The simulate API resolves the composed template against a dummy pluggable index, so a preview of
+     * a template with index: true is rejected the same way real index creation would be — the preview
+     * must not report success for a template that could never create an index.
+     */
+    public void testSimulateResolveTemplateRejectsIndexTrue() throws Exception {
+        // Stage the template directly in metadata, bypassing put-time validation, to exercise the
+        // resolve/simulate path in isolation.
+        ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder().put("it", composableTemplate(Settings.EMPTY, INDEX_TRUE)))
+            .build();
+        Exception e = expectThrows(
+            Exception.class,
+            () -> TransportSimulateIndexTemplateAction.resolveTemplate(
+                "it",
+                "pdf-1",
+                state,
+                xContentRegistry(),
+                getInstanceFromNode(IndicesService.class),
+                new AliasValidator(),
+                true
+            )
+        );
+        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** A template with index: false resolves cleanly through the simulate path. */
+    public void testSimulateResolveTemplateAcceptsIndexFalse() throws Exception {
+        ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder().put("it", composableTemplate(Settings.EMPTY, INDEX_FALSE)))
+            .build();
+        Template resolved = TransportSimulateIndexTemplateAction.resolveTemplate(
+            "it",
+            "pdf-1",
+            state,
+            xContentRegistry(),
+            getInstanceFromNode(IndicesService.class),
+            new AliasValidator(),
+            true
+        );
+        assertNotNull(resolved);
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/metadata/PluggableDataFormatTemplateValidationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/PluggableDataFormatTemplateValidationTests.java
@@ -15,6 +15,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
@@ -22,6 +23,7 @@ import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -41,9 +43,10 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        // Supplies a committer factory so EngineConfigFactory accepts pluggable-dataformat indices,
-        // which the dummy index built during template validation requires.
-        return Collections.singletonList(MockCommitterEnginePlugin.class);
+        // MockCommitterEnginePlugin supplies a committer factory so EngineConfigFactory accepts pluggable
+        // indices; MockDocValuesDataFormatPlugin registers the "mock-dv" data format (columnar storage
+        // only for doc-values-backed types) so the capability path rejects index:true.
+        return List.of(MockCommitterEnginePlugin.class, MockDocValuesDataFormatPlugin.class);
     }
 
     @Override
@@ -56,6 +59,7 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
         return Settings.builder()
             .put(super.nodeSettings())
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), MockDocValuesDataFormatPlugin.FORMAT_NAME)
             .build();
     }
 
@@ -93,7 +97,7 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
             Exception.class,
             () -> service.addComponentTemplate(ClusterState.EMPTY_STATE, false, "ct", componentTemplate(INDEX_TRUE))
         );
-        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(fullMessage(e), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     public void testComponentTemplateAcceptsIndexFalse() throws Exception {
@@ -115,7 +119,7 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
             () -> service.addIndexTemplateV2(ClusterState.EMPTY_STATE, false, "it", composableTemplate(Settings.EMPTY, INDEX_TRUE))
         );
         // The composable path wraps the mapper rejection; assert on the full cause chain.
-        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(fullMessage(e), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     public void testComposableTemplateAcceptsIndexFalse() throws Exception {
@@ -160,10 +164,11 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
                 xContentRegistry(),
                 getInstanceFromNode(IndicesService.class),
                 new AliasValidator(),
-                true
+                true,
+                MockDocValuesDataFormatPlugin.FORMAT_NAME
             )
         );
-        assertThat(fullMessage(e), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(fullMessage(e), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     /** A template with index: false resolves cleanly through the simulate path. */
@@ -178,7 +183,8 @@ public class PluggableDataFormatTemplateValidationTests extends OpenSearchSingle
             xContentRegistry(),
             getInstanceFromNode(IndicesService.class),
             new AliasValidator(),
-            true
+            true,
+            MockDocValuesDataFormatPlugin.FORMAT_NAME
         );
         assertNotNull(resolved);
     }

--- a/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
@@ -57,6 +57,8 @@ import org.opensearch.index.mapper.ParseContext.Document;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class BooleanFieldMapperTests extends MapperTestCase {
 
     private static final String FIELD_NAME = "field";
@@ -445,5 +447,58 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                 .anyMatch(e -> e.getKey().name().equals(fieldName) && expectedValue.equals(e.getValue()));
             assertTrue("Pluggable path should capture field '" + fieldName + "' with value '" + expectedValue + "'", pluggableFound);
         }
+    }
+
+    private static Settings pluggableSettings() {
+        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+    }
+
+    /**
+     * On a pluggable-dataformat index the Lucene secondary writes no terms for boolean fields, so
+     * {@code index} defaults to false and the field reports itself as not searchable — routing
+     * queries to the doc-values column instead of an empty inverted index.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** An explicit {@code index: false} is accepted on a pluggable-dataformat index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatAcceptsExplicitIndexFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /**
+     * An explicit {@code index: true} cannot be honoured on a pluggable-dataformat index, so the
+     * mapping is rejected rather than silently producing a field whose queries match nothing.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrue() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("index", true);
+            }))
+        );
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
+    public void testNonPluggableDataFormatKeepsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertTrue(mapperService.fieldType("field").isSearchable());
+
+        MapperService explicit = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", true);
+        }));
+        assertTrue(explicit.fieldType("field").isSearchable());
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
@@ -501,4 +501,36 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         }));
         assertTrue(explicit.fieldType("field").isSearchable());
     }
+
+    /**
+     * A field added by a later mapping update also defaults to not-indexed, and the update leaves the
+     * value of the already-mapped field unchanged.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateDefaultsNewFieldToNotIndexed() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+
+        merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.endObject();
+        }));
+
+        assertFalse("newly added field should default to not-indexed", mapperService.fieldType("field2").isSearchable());
+        assertFalse("existing field's value should be preserved across the update", mapperService.fieldType("field").isSearchable());
+    }
+
+    /** A mapping update that sets index:true on a new field is rejected on a pluggable data format index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateRejectsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.field("index", true);
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
@@ -53,9 +53,13 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.index.mapper.ParseContext.Document;
+import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -449,8 +453,16 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         }
     }
 
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MockDocValuesDataFormatPlugin());
+    }
+
     private static Settings pluggableSettings() {
-        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", MockDocValuesDataFormatPlugin.FORMAT_NAME)
+            .build();
     }
 
     /**
@@ -487,7 +499,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                 b.field("index", true);
             }))
         );
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [FULL_TEXT_SEARCH]"));
     }
 
     /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
@@ -531,6 +543,6 @@ public class BooleanFieldMapperTests extends MapperTestCase {
             b.field("index", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [FULL_TEXT_SEARCH]"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -1022,4 +1022,75 @@ public class DateFieldMapperTests extends MapperTestCase {
             assertTrue("Pluggable path should capture field '" + fieldName + "' with value '" + expectedValue + "'", pluggableFound);
         }
     }
+
+    private static Settings pluggableSettings() {
+        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+    }
+
+    /**
+     * On a pluggable-dataformat index no BKD points are written for date fields, so {@code index}
+     * defaults to false and the field reports itself as not searchable — routing queries to the
+     * doc-values column instead of an empty point index.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** {@code date_nanos} resolves through a separate type parser, so it is covered explicitly. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalseForDateNanos() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> b.field("type", "date_nanos")));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** An explicit {@code index: false} is accepted on a pluggable-dataformat index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatAcceptsExplicitIndexFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /**
+     * An explicit {@code index: true} cannot be honoured on a pluggable-dataformat index — no point
+     * index is written — so the mapping is rejected rather than silently producing a field whose
+     * queries match nothing.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrue() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("index", true);
+            }))
+        );
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** The rejection names the concrete resolution so {@code date_nanos} is not reported as {@code date}. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrueForDateNanos() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> b.field("type", "date_nanos").field("index", true)))
+        );
+        assertThat(e.getMessage(), containsString("of type [date_nanos]"));
+    }
+
+    /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
+    public void testNonPluggableDataFormatKeepsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertTrue(mapperService.fieldType("field").isSearchable());
+
+        MapperService explicit = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", true);
+        }));
+        assertTrue(explicit.fieldType("field").isSearchable());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -1093,4 +1093,36 @@ public class DateFieldMapperTests extends MapperTestCase {
         }));
         assertTrue(explicit.fieldType("field").isSearchable());
     }
+
+    /**
+     * A field added by a later mapping update also defaults to not-indexed, and the update leaves the
+     * value of the already-mapped field unchanged.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateDefaultsNewFieldToNotIndexed() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+
+        merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.endObject();
+        }));
+
+        assertFalse("newly added field should default to not-indexed", mapperService.fieldType("field2").isSearchable());
+        assertFalse("existing field's value should be preserved across the update", mapperService.fieldType("field").isSearchable());
+    }
+
+    /** A mapping update that sets index:true on a new field is rejected on a pluggable data format index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateRejectsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.field("index", true);
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -54,14 +54,17 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexSortConfig;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.index.fieldvisitor.SingleFieldsVisitor;
 import org.opensearch.index.termvectors.TermVectorsService;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.search.DocValueFormat;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -1023,8 +1026,16 @@ public class DateFieldMapperTests extends MapperTestCase {
         }
     }
 
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MockDocValuesDataFormatPlugin());
+    }
+
     private static Settings pluggableSettings() {
-        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", MockDocValuesDataFormatPlugin.FORMAT_NAME)
+            .build();
     }
 
     /**
@@ -1069,7 +1080,7 @@ public class DateFieldMapperTests extends MapperTestCase {
                 b.field("index", true);
             }))
         );
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     /** The rejection names the concrete resolution so {@code date_nanos} is not reported as {@code date}. */
@@ -1123,6 +1134,6 @@ public class DateFieldMapperTests extends MapperTestCase {
             b.field("index", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -3934,4 +3934,37 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertThat(keywordSubField, instanceOf(KeywordFieldMapper.class));
         assertEquals("dynamic_text.keyword", keywordSubField.name());
     }
+
+    /**
+     * Dynamically inferred numeric, date and boolean fields on a pluggable-dataformat index must
+     * default to not-indexed, just like explicitly mapped ones — otherwise inferred fields would keep
+     * index:true and their range/term queries would match nothing. Guards the settings passed to the
+     * dynamic mapper builders in {@link DocumentParser}.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testDynamicallyMappedFieldsAreNotIndexedForPluggableDataFormat() throws Exception {
+        Settings pluggableSettings = Settings.builder()
+            .put("index.version.created", Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .build();
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings, mapping(b -> {}));
+        DocumentInput<?> noopInput = new CapturingDocumentInput();
+        ParsedDocument doc = mapper.parse(
+            source(b -> b.field("dyn_long", 42).field("dyn_double", 1.5).field("dyn_date", "2024-01-01").field("dyn_bool", true)),
+            noopInput
+        );
+
+        assertNotNull(doc.dynamicMappingsUpdate());
+        for (String field : new String[] { "dyn_long", "dyn_double", "dyn_date", "dyn_bool" }) {
+            Mapper m = doc.dynamicMappingsUpdate().root().getMapper(field);
+            assertNotNull("expected a dynamic mapping for [" + field + "]", m);
+            assertThat(m, instanceOf(FieldMapper.class));
+            assertFalse(
+                "dynamically mapped [" + field + "] should not be indexed on a pluggable data format index",
+                ((FieldMapper) m).fieldType().isSearchable()
+            );
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
@@ -399,4 +399,58 @@ public class IpFieldMapperTests extends MapperTestCase {
             assertTrue("Pluggable path should capture field '" + fieldName + "'", pluggableHasField);
         }
     }
+
+    private static Settings pluggableSettings() {
+        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+    }
+
+    /**
+     * On a pluggable-dataformat index no BKD points are written for ip fields, so {@code index}
+     * defaults to false and the field reports itself as not searchable — routing queries to the
+     * doc-values column instead of an empty point index.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** An explicit {@code index: false} is accepted on a pluggable-dataformat index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatAcceptsExplicitIndexFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /**
+     * An explicit {@code index: true} cannot be honoured on a pluggable-dataformat index — no point
+     * index is written — so the mapping is rejected rather than silently producing a field whose
+     * queries match nothing.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrue() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("index", true);
+            }))
+        );
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
+    public void testNonPluggableDataFormatKeepsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertTrue(mapperService.fieldType("field").isSearchable());
+
+        MapperService explicit = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", true);
+        }));
+        assertTrue(explicit.fieldType("field").isSearchable());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
@@ -52,10 +52,14 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.index.termvectors.TermVectorsService;
+import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -400,8 +404,16 @@ public class IpFieldMapperTests extends MapperTestCase {
         }
     }
 
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MockDocValuesDataFormatPlugin());
+    }
+
     private static Settings pluggableSettings() {
-        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", MockDocValuesDataFormatPlugin.FORMAT_NAME)
+            .build();
     }
 
     /**
@@ -439,7 +451,7 @@ public class IpFieldMapperTests extends MapperTestCase {
                 b.field("index", true);
             }))
         );
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
@@ -483,6 +495,6 @@ public class IpFieldMapperTests extends MapperTestCase {
             b.field("index", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
@@ -453,4 +453,36 @@ public class IpFieldMapperTests extends MapperTestCase {
         }));
         assertTrue(explicit.fieldType("field").isSearchable());
     }
+
+    /**
+     * A field added by a later mapping update also defaults to not-indexed, and the update leaves the
+     * value of the already-mapped field unchanged.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateDefaultsNewFieldToNotIndexed() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+
+        merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.endObject();
+        }));
+
+        assertFalse("newly added field should default to not-indexed", mapperService.fieldType("field2").isSearchable());
+        assertFalse("existing field's value should be preserved across the update", mapperService.fieldType("field").isSearchable());
+    }
+
+    /** A mapping update that sets index:true on a new field is rejected on a pluggable data format index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateRejectsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.field("index", true);
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
@@ -876,4 +876,58 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             assertTrue("Pluggable path should capture field '" + fieldName + "' with value '" + expectedValue + "'", pluggableFound);
         }
     }
+
+    private static Settings pluggableSettings() {
+        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+    }
+
+    /**
+     * On a pluggable-dataformat index no BKD points are written for numeric fields, so {@code index}
+     * defaults to false and the field reports itself as not searchable — routing queries to the
+     * doc-values column instead of an empty point index.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatDefaultsIndexToFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /** An explicit {@code index: false} is accepted on a pluggable-dataformat index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatAcceptsExplicitIndexFalse() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+    }
+
+    /**
+     * An explicit {@code index: true} cannot be honoured on a pluggable-dataformat index — no point
+     * index is written — so the mapping is rejected rather than silently producing a field whose
+     * queries match nothing.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatRejectsExplicitIndexTrue() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("index", true);
+            }))
+        );
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
+
+    /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
+    public void testNonPluggableDataFormatKeepsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertTrue(mapperService.fieldType("field").isSearchable());
+
+        MapperService explicit = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", true);
+        }));
+        assertTrue(explicit.fieldType("field").isSearchable());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
@@ -930,4 +930,36 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         }));
         assertTrue(explicit.fieldType("field").isSearchable());
     }
+
+    /**
+     * A field added by a later mapping update also defaults to not-indexed, and the update leaves the
+     * value of the already-mapped field unchanged.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateDefaultsNewFieldToNotIndexed() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        assertFalse(mapperService.fieldType("field").isSearchable());
+
+        merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.endObject();
+        }));
+
+        assertFalse("newly added field should default to not-indexed", mapperService.fieldType("field2").isSearchable());
+        assertFalse("existing field's value should be preserved across the update", mapperService.fieldType("field").isSearchable());
+    }
+
+    /** A mapping update that sets index:true on a new field is rejected on a pluggable data format index. */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatMappingUpdateRejectsIndexTrue() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), fieldMapping(this::minimalMapping));
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(mapperService, mapping(b -> {
+            b.startObject("field2");
+            minimalMapping(b);
+            b.field("index", true);
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
@@ -57,13 +57,16 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.engine.dataformat.stub.MockDocValuesDataFormatPlugin;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberType;
 import org.opensearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
 import org.opensearch.index.termvectors.TermVectorsService;
+import org.opensearch.plugins.Plugin;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -877,8 +880,16 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         }
     }
 
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MockDocValuesDataFormatPlugin());
+    }
+
     private static Settings pluggableSettings() {
-        return Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
+        return Settings.builder()
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", MockDocValuesDataFormatPlugin.FORMAT_NAME)
+            .build();
     }
 
     /**
@@ -916,7 +927,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
                 b.field("index", true);
             }))
         );
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 
     /** Indices that do not use a pluggable dataformat keep the standard {@code index: true} default. */
@@ -960,6 +971,6 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             b.field("index", true);
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("cannot set [index] to true on an index using a pluggable data format"));
+        assertThat(e.getMessage(), containsString("cannot cover: [POINT_RANGE]"));
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDocValuesDataFormatPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDocValuesDataFormatPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.COLUMNAR_STORAGE;
+
+/**
+ * A mock data format plugin whose format backs only <b>columnar storage</b> for doc-values-backed field
+ * types (numeric, date, ip, boolean, scaled_float) — it declares no {@code POINT_RANGE} /
+ * {@code FULL_TEXT_SEARCH} for them, mirroring the real pluggable data format.
+ * <p>
+ * This class only <i>declares</i> capabilities. Rejecting {@code index:true} (a request for a search
+ * capability the format does not back) is done by the core capability path
+ * ({@link org.opensearch.index.engine.dataformat.DataFormatPlugin#assignCapabilities}), not here — so
+ * there is deliberately no exception thrown in this mock.
+ * <p>
+ * It reuses {@link MockParquetDataFormatPlugin}'s metadata/text coverage so that system fields resolve
+ * during mapping build, and adds the doc-values-backed value types with {@code COLUMNAR_STORAGE} only.
+ */
+public class MockDocValuesDataFormatPlugin extends MockDataFormatPlugin {
+
+    /** Format name to set in {@code index.pluggable.dataformat}. */
+    public static final String FORMAT_NAME = "mock-dv";
+
+    private static final List<String> DOC_VALUES_BACKED_TYPES = List.of(
+        "byte",
+        "short",
+        "integer",
+        "long",
+        "float",
+        "double",
+        "half_float",
+        "unsigned_long",
+        "date",
+        "date_nanos",
+        "ip",
+        "boolean",
+        "scaled_float"
+    );
+
+    public MockDocValuesDataFormatPlugin() {
+        super(new MockDataFormat(FORMAT_NAME, 100L, columnarStorageFields()));
+    }
+
+    private static Set<FieldTypeCapabilities> columnarStorageFields() {
+        // Reuse the parquet mock's metadata + text coverage so system/metadata fields resolve during build,
+        // then add each doc-values-backed value type with columnar storage only (no search capability).
+        Set<FieldTypeCapabilities> fields = new HashSet<>(new MockParquetDataFormatPlugin().getDataFormat().supportedFields());
+        for (String type : DOC_VALUES_BACKED_TYPES) {
+            fields.add(new FieldTypeCapabilities(type, Set.of(COLUMNAR_STORAGE)));
+        }
+        return Set.copyOf(fields);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
@@ -53,6 +53,8 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
 import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityService;
@@ -60,6 +62,7 @@ import org.opensearch.indices.IndicesModule;
 import org.opensearch.indices.mapper.MapperRegistry;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.script.ScriptModule;
 import org.opensearch.script.ScriptService;
@@ -96,6 +99,24 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
 
     protected Collection<? extends Plugin> getPlugins() {
         return emptyList();
+    }
+
+    /**
+     * Builds a {@link DataFormatRegistry} from any {@link DataFormatPlugin}s returned by {@link #getPlugins()},
+     * so tests exercising a pluggable data format get capability assignment during mapping build. Returns
+     * {@code null} when no data-format plugin is registered (the default), preserving existing behavior.
+     */
+    protected DataFormatRegistry getDataFormatRegistry() {
+        List<DataFormatPlugin> dataFormatPlugins = getPlugins().stream()
+            .filter(p -> p instanceof DataFormatPlugin)
+            .map(p -> (DataFormatPlugin) p)
+            .collect(toList());
+        if (dataFormatPlugins.isEmpty()) {
+            return null;
+        }
+        PluginsService pluginsService = mock(PluginsService.class);
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(dataFormatPlugins);
+        return new DataFormatRegistry(pluginsService);
     }
 
     protected Settings getIndexSettings() {
@@ -175,7 +196,8 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
                 throw new UnsupportedOperationException();
             },
             () -> true,
-            scriptService
+            scriptService,
+            getDataFormatRegistry()
         );
         merge(mapperService, mapping);
         return mapperService;
@@ -211,7 +233,8 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
                 throw new UnsupportedOperationException();
             },
             () -> true,
-            scriptService
+            scriptService,
+            getDataFormatRegistry()
         );
         merge(mapperService, mapping);
         return mapperService;


### PR DESCRIPTION
### Description

On an index using a pluggable data format (composite Parquet primary + Lucene secondary), doc-values-backed fields — numeric (all widths), `date`, `date_nanos`, `ip`, `boolean`, and `scaled_float` — are served from the primary's doc-values column, and the Lucene secondary writes **no BKD points** for them. The mapping nevertheless reported `index: true`, so `IndexOrDocValuesQuery` selected its point branch, which reports `cost=0` and therefore wins the cost race — and `range`, `term`, and `terms` queries returned **zero hits**.

This change makes these field types default `index` to `false` on pluggable data format indices, so queries route through the doc-values branch and return correct results. An explicit `index: true` cannot be honoured (no BKD is written) and is rejected. Indices that do not use a pluggable data format are unchanged.

The same not-indexed state also corrects several other paths that assume a point index exists — aggregation filter-rewrite (`PointTreeTraversal`), sort min/max extraction, `pointReaderIfPossible()`, and `DateFieldType.isFieldWithinQuery` — all of which now correctly decline rather than reading an index that was never written.

**How the default and rejection work**

- **Default (`index: false`).** Set in the field-mapper builders (`NumberFieldMapper`, `DateFieldMapper`, `IpFieldMapper`, `BooleanFieldMapper`, `ScaledFloatFieldMapper`) via a *parameter default* rather than an explicit `setValue`, so it is a genuine default and is not serialized into the mapping. The `pluggableDataFormat` flag is hoisted onto `ParametrizedFieldMapper` / `ParametrizedFieldMapper.Builder` and is set only by the constructors that receive index settings, so builders created for internal field types — notably derived fields, which evaluate queries against their own in-memory index where points do exist — keep the standard default.
- **Rejecting `index: true` — via the capability path, not a core throw.** The data formats no longer declare a *search* capability for these types (`POINT_RANGE` for numeric/date/ip, `FULL_TEXT_SEARCH` for boolean). An explicit `index: true` therefore requests a capability no configured format can cover and is rejected during capability negotiation (`DataFormatRegistry#assignCapabilities` → `MapperParsingException`) — the same path that already rejects unsupported field types. Core mapper code contains no hardcoded pluggable-specific throw.
- **`DocumentParser`:** index settings are passed when creating mappers for dynamically mapped numeric, date, and boolean fields, so the default applies to inferred fields too.
- **Mapping updates:** `createIndexMapperService` (used by the put-mapping validation path) now carries the real `DataFormatRegistry`, so capability assignment runs on `_mapping` updates and `index: true` is rejected before it is persisted (previously it was accepted and the index then failed to reopen).
- **Templates & simulate:** when `cluster.pluggable.dataformat.enabled` is the cluster-wide default, component, composable, and legacy V1 templates that set `index: true` are rejected at template-creation time so they cannot fail every index (including rollovers) they later create. Template/simulate validation injects *both* cluster defaults — `index.pluggable.dataformat.enabled` **and** `index.pluggable.dataformat` (the format name) — onto its dummy index (mirroring `MetadataCreateIndexService`), so the capability check can resolve a format. A template that explicitly opts out (`index.pluggable.dataformat.enabled: false`) produces vanilla indices and may still set `index: true`.

### Metadata behavior

`GET _mapping` reports no `index` key (the field defaults to not-indexed) and `_field_caps` reports `searchable: false` for these fields on pluggable indices. This is accurate about the implementation, but the fields *are* efficiently searchable via doc values with Parquet page-level skipping.

### Testing

**Unit tests**
- `NumberFieldMapperTests`, `DateFieldMapperTests`, `IpFieldMapperTests`, `BooleanFieldMapperTests`, `ScaledFloatFieldMapperTests`: default `index:false`, accept explicit `index:false`, reject explicit `index:true` (via the capability path), mapping-update accepts a new field and rejects `index:true` at PUT, and non-pluggable indices keep `index:true`.
- `DocumentParserTests`: dynamically mapped numeric/date/boolean fields default to not-indexed on pluggable indices.
- `PluggableDataFormatTemplateValidationTests`: component, composable, and legacy V1 templates and the simulate API reject `index:true` under the cluster default, accept `index:false`/omitted, and accept `index:true` for an explicit opt-out (vanilla) template.
- Rejection is exercised with a mock `DataFormatPlugin` that declares columnar storage only, so the tests assert the real capability-negotiation message.

**Manual / cluster validation** (all affected field types) — direct create (default / `index:false` / `index:true`), mapping update (accept + reject), recovery (close/open), dynamic mapping (default-off + dynamic-template `index:true` rejected at ingest), templates (component/composable/legacy), simulate, rollover, and ingestion; vanilla-index control confirmed unchanged. Cluster-default path (`cluster.pluggable.dataformat.enabled` + name) confirmed to reject `index:true` for both direct creation and templates.

### Related Issues

<!-- link the internal issue / discussion here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable.
- [X] Public documentation issue/PR created (follow-up in documentation-website). https://github.com/opensearch-project/documentation-website/issues/12986

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.