### PR TITLE
Add core multi_value mapping parameter for field arity

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
@@ -270,6 +270,16 @@ public abstract class FilterFieldType extends MappedFieldType {
     }
 
     @Override
+    public boolean isMultiValued() {
+        return delegate.isMultiValued();
+    }
+
+    @Override
+    public void setMultiValued(boolean multiValued) {
+        delegate.setMultiValued(multiValued);
+    }
+
+    @Override
     public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
         return delegate.docValueFormat(format, timeZone);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -175,6 +175,14 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
         private final Parameter<Float> boost = Parameter.boostParam();
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Lucene is inherently multi-valued, so the flag matters only to consumers projecting a fixed
+         * schema — e.g. a pluggable format whose column type is fixed per file (Parquet stores a
+         * declared field as {@code LIST<element>}). Not updateable: arity is baked into written data.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         private final IndexAnalyzers indexAnalyzers;
         private final boolean canConsumeRawValueForSource;
 
@@ -224,7 +232,8 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
                 normalizer,
                 splitQueriesOnWhitespace,
                 boost,
-                meta
+                meta,
+                multiValue
             );
         }
 
@@ -343,6 +352,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
             setEagerGlobalOrdinals(builder.eagerGlobalOrdinals.getValue());
             setIndexAnalyzer(normalizer);
             setBoost(builder.boost.getValue());
+            setMultiValued(builder.multiValue.getValue());
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
             this.useSimilarity = builder.useSimilarity.getValue();
@@ -830,6 +840,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     private final boolean useSimilarity;
     private final String normalizerName;
     private final boolean splitQueriesOnWhitespace;
+    private final boolean multiValued;
     private final KeywordFieldType rawKeywordValueFieldType;
 
     private final IndexAnalyzers indexAnalyzers;
@@ -856,6 +867,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         this.useSimilarity = builder.useSimilarity.getValue();
         this.normalizerName = builder.normalizer.getValue();
         this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace.getValue();
+        this.multiValued = builder.multiValue.getValue();
         this.indexAnalyzers = builder.indexAnalyzers;
         this.canConsumeRawValueForSource = builder.canConsumeRawValueForSource;
         this.rawKeywordValueFieldType = buildRawKeywordValueFieldType();
@@ -886,7 +898,18 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
      */
     private KeywordFieldType buildRawKeywordValueFieldType() {
         if (isIneligibleForGeneratingSource() && canConsumeRawValueForSource) {
-            return new KeywordFieldType("_ignored_source." + fieldType().name(), false, true, false, false, fieldType().meta());
+            KeywordFieldType rawValueType = new KeywordFieldType(
+                "_ignored_source." + fieldType().name(),
+                false,
+                true,
+                false,
+                false,
+                fieldType().meta()
+            );
+            // The companion carries the pre-normalization values for derived source, so it must
+            // mirror the parent's cardinality or source reconstruction would lose values.
+            rawValueType.setMultiValued(multiValued);
+            return rawValueType;
         }
         return null;
     }

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -97,6 +97,7 @@ public abstract class MappedFieldType {
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
+    private boolean multiValued;
 
     /**
      * Capability map assigning each registered {@link DataFormat} to the set of capabilities it owns for this field type.
@@ -476,6 +477,30 @@ public abstract class MappedFieldType {
 
     public void setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+    }
+
+    /**
+     * Whether this field is declared to hold multiple values per document in columnar data
+     * formats ({@code multi_value} mapping parameter). Lucene is inherently multi-valued, so
+     * this flag only matters to pluggable formats whose column type is fixed per file (e.g.
+     * Parquet, where a declared field is stored as {@code LIST<element>}).
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public boolean isMultiValued() {
+        return multiValued;
+    }
+
+    /**
+     * Declares this field multi-valued for columnar data formats. Set during mapping build by
+     * mappers exposing the {@code multi_value} parameter.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public void setMultiValued(boolean multiValued) {
+        this.multiValued = multiValued;
     }
 
     @ExperimentalApi

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -189,6 +189,9 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     @PublicApi(since = "1.0.0")
     public static final class Parameter<T> implements Supplier<T> {
 
+        /** Name of the shared {@code multi_value} arity parameter; see {@link #multiValueParam()}. */
+        public static final String MULTI_VALUE_PARAM_NAME = "multi_value";
+
         public final String name;
         private final List<String> deprecatedNames = new ArrayList<>();
         private final Supplier<T> defaultValue;
@@ -394,6 +397,23 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 (n, c, o) -> new Explicit<>(XContentMapValues.nodeBooleanValue(o), true),
                 initializer
             ).setSerializer((b, n, v) -> b.field(n, v.value()), v -> Boolean.toString(v.value()));
+        }
+
+        /**
+         * Defines the shared {@code multi_value} mapping parameter, declaring whether a field holds a
+         * single value or an array. This captures field <em>arity</em> — distinct from the number of
+         * distinct values a field has, and unrelated to the {@code cardinality} aggregation.
+         *
+         * <p>Field types that can hold arrays should register this in {@code getParameters()} and
+         * stamp its value onto the built field type via {@link MappedFieldType#setMultiValued(boolean)}.
+         * Consumers that project a fixed schema (columnar data formats, SQL/PPL, join) read it back via
+         * {@link MappedFieldType#isMultiValued()}. It defaults to {@code false} and is not updateable —
+         * a field's arity is fixed once data is written.
+         *
+         * @return a {@code Parameter<Boolean>} named {@value #MULTI_VALUE_PARAM_NAME}
+         */
+        public static Parameter<Boolean> multiValueParam() {
+            return Parameter.boolParam(MULTI_VALUE_PARAM_NAME, false, m -> m.fieldType().isMultiValued(), false);
         }
 
         /**

--- a/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
@@ -55,6 +55,8 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
@@ -197,6 +199,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "foo"));
         checker.registerConflictCheck("similarity", b -> b.field("similarity", "boolean"));
         checker.registerConflictCheck("normalizer", b -> b.field("normalizer", "lowercase"));
+        // Not updateable: the column type is baked into every parquet file the index has written.
+        checker.registerConflictCheck("multi_value", b -> b.field("multi_value", true));
 
         checker.registerUpdateCheck(b -> b.field("eager_global_ordinals", true), m -> assertTrue(m.fieldType().eagerGlobalOrdinals()));
         checker.registerUpdateCheck(b -> b.field("ignore_above", 256), m -> assertEquals(256, ((KeywordFieldMapper) m).ignoreAbove()));
@@ -281,6 +285,20 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
         assertTrue(fields[0].fieldType().stored());
+    }
+
+    public void testMultiValueParameter() throws IOException {
+        // Default is single-valued and, being the default, is not serialized.
+        DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        FieldMapper defaultField = (FieldMapper) defaultMapper.mappers().getMapper("field");
+        assertFalse(defaultField.fieldType().isMultiValued());
+        assertFalse(Strings.toString(MediaTypeRegistry.JSON, defaultField).contains("multi_value"));
+
+        // multi_value: true reaches the field type and round-trips through serialization.
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword").field("multi_value", true)));
+        FieldMapper field = (FieldMapper) mapper.mappers().getMapper("field");
+        assertTrue(field.fieldType().isMultiValued());
+        assertTrue(Strings.toString(MediaTypeRegistry.JSON, field).contains("\"multi_value\":true"));
     }
 
     public void testDisableIndex() throws IOException {


### PR DESCRIPTION
### Description

Introduces a shared, reusable `multi_value` mapping parameter in **core**, so field *arity* — whether a field holds a single value or an array — becomes a first-class mapping concept instead of being defined inside a specific data-format plugin.

This is the primitive requested in #16420. It's useful to any consumer that needs to project a fixed schema over an OpenSearch index — columnar data formats, the SQL/PPL engine, and the proposed join support (#15185) — none of which can today tell a single `keyword` apart from an array of `keyword`s, since Lucene makes no distinction.

**On the name.** The issue's latest discussion floated calling this `cardinality`. This PR deliberately uses `multi_value`: *cardinality* conventionally means the number of **distinct** values a field has (as in the `cardinality` aggregation), which is orthogonal to *arity* (one value vs. many). Naming the arity flag `cardinality` would collide with that established meaning. Happy to align on a final name with maintainers — `multi_value` / `arity` both avoid the clash.

### What's included
- `Parameter.multiValueParam()` factory on `ParametrizedFieldMapper.Builder`, so any array-capable field type adopts it in a single line with consistent value stamping. Defaults to `false`; **not updateable** — a field's arity is fixed once data has been written.
- `MappedFieldType.isMultiValued()` / `setMultiValued(boolean)` carry the arity on the field type; `FilterFieldType` delegates.
- `KeywordFieldMapper` wires the shared factory and stamps the field type. Keyword is the only type wired in this PR; other array-capable types can adopt the factory incrementally.

### What's intentionally not here
- **Enforcement** (rejecting multiple values on a single-valued field, or requiring arrays on a multi-valued one) at the core document-parse level.
- **Storage/query consumers.** The flag is read back via `MappedFieldType#isMultiValued()`; e.g. a Parquet `LIST<element>` encoding builds on this in a separate PR.
- The tri-state (`unknown`/single/multi) and dynamic arity inference discussed on #16420.

These are follow-ups so this PR stays a small, reviewable primitive.

### Testing
- `KeywordFieldMapperTests#testMultiValueParameter` — default is single-valued and unserialized; `multi_value: true` reaches the field type and round-trips through serialization.
- `registerConflictCheck("multi_value", ...)` — the parameter is rejected on a mapping update (non-updateable).

### Related
Relates to #16420

### Check List
- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.