### PR TITLE
Fix ClusterStateChecksum deadlock when a checksum task throws

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterStateChecksum.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterStateChecksum.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import com.jcraft.jzlib.JZlib;
@@ -76,46 +77,47 @@ public class ClusterStateChecksum implements ToXContentFragment, Writeable {
         long start = threadpool.relativeTimeInNanos();
         ExecutorService executorService = threadpool.executor(ThreadPool.Names.REMOTE_STATE_CHECKSUM);
         CountDownLatch latch = new CountDownLatch(COMPONENT_SIZE);
+        AtomicReference<Exception> firstFailure = new AtomicReference<>();
 
         executeChecksumTask((stream) -> {
             clusterState.routingTable().writeVerifiableTo(stream);
             return null;
-        }, checksum -> routingTableChecksum = checksum, executorService, latch);
+        }, checksum -> routingTableChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             clusterState.nodes().writeVerifiableTo(stream);
             return null;
-        }, checksum -> nodesChecksum = checksum, executorService, latch);
+        }, checksum -> nodesChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             clusterState.coordinationMetadata().writeVerifiableTo(stream);
             return null;
-        }, checksum -> coordinationMetadataChecksum = checksum, executorService, latch);
+        }, checksum -> coordinationMetadataChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             Settings.writeSettingsToStream(clusterState.metadata().persistentSettings(), stream);
             return null;
-        }, checksum -> settingMetadataChecksum = checksum, executorService, latch);
+        }, checksum -> settingMetadataChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             Settings.writeSettingsToStream(clusterState.metadata().transientSettings(), stream);
             return null;
-        }, checksum -> transientSettingsMetadataChecksum = checksum, executorService, latch);
+        }, checksum -> transientSettingsMetadataChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             clusterState.metadata().templatesMetadata().writeVerifiableTo(stream);
             return null;
-        }, checksum -> templatesMetadataChecksum = checksum, executorService, latch);
+        }, checksum -> templatesMetadataChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             stream.writeStringCollection(clusterState.metadata().customs().keySet());
             return null;
-        }, checksum -> customMetadataMapChecksum = checksum, executorService, latch);
+        }, checksum -> customMetadataMapChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             ((DiffableStringMap) clusterState.metadata().hashesOfConsistentSettings()).writeTo(stream);
             return null;
-        }, checksum -> hashesOfConsistentSettingsChecksum = checksum, executorService, latch);
+        }, checksum -> hashesOfConsistentSettingsChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             stream.writeMapValues(
@@ -123,22 +125,27 @@ public class ClusterStateChecksum implements ToXContentFragment, Writeable {
                 (checksumStream, value) -> value.writeVerifiableTo((BufferedChecksumStreamOutput) checksumStream)
             );
             return null;
-        }, checksum -> indicesChecksum = checksum, executorService, latch);
+        }, checksum -> indicesChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             clusterState.blocks().writeVerifiableTo(stream);
             return null;
-        }, checksum -> blocksChecksum = checksum, executorService, latch);
+        }, checksum -> blocksChecksum = checksum, executorService, latch, firstFailure);
 
         executeChecksumTask((stream) -> {
             stream.writeStringCollection(clusterState.customs().keySet());
             return null;
-        }, checksum -> clusterStateCustomsChecksum = checksum, executorService, latch);
+        }, checksum -> clusterStateCustomsChecksum = checksum, executorService, latch, firstFailure);
 
         try {
             latch.await();
         } catch (InterruptedException e) {
-            throw new RemoteStateTransferException("Failed to create checksum for cluster state.", e);
+            Thread.currentThread().interrupt();
+            throw new RemoteStateTransferException("Interrupted while creating checksum for cluster state.", e);
+        }
+        Exception failure = firstFailure.get();
+        if (failure != null) {
+            throw new RemoteStateTransferException("Failed to create checksum for cluster state.", failure);
         }
         createClusterStateChecksum();
         logger.debug("Checksum execution time {}", TimeValue.nsecToMSec(threadpool.relativeTimeInNanos() - start));
@@ -148,17 +155,29 @@ public class ClusterStateChecksum implements ToXContentFragment, Writeable {
         CheckedFunction<BufferedChecksumStreamOutput, Void, IOException> checksumTask,
         Consumer<Long> checksumConsumer,
         ExecutorService executorService,
-        CountDownLatch latch
+        CountDownLatch latch,
+        AtomicReference<Exception> firstFailure
     ) {
-        executorService.execute(() -> {
-            try {
-                long checksum = createChecksum(checksumTask);
-                checksumConsumer.accept(checksum);
-                latch.countDown();
-            } catch (IOException e) {
-                throw new RemoteStateTransferException("Failed to execute checksum task", e);
-            }
-        });
+        try {
+            executorService.execute(() -> {
+                try {
+                    long checksum = createChecksum(checksumTask);
+                    checksumConsumer.accept(checksum);
+                } catch (Exception e) {
+                    logger.error("Failed to compute cluster state component checksum", e);
+                    firstFailure.compareAndSet(null, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        } catch (Exception e) {
+            // Guard against the executor rejecting the task (for example due to a
+            // saturated queue or executor shutdown). Without this fallback the latch
+            // would never reach zero and the calling thread would block indefinitely.
+            logger.error("Failed to submit cluster state checksum task", e);
+            firstFailure.compareAndSet(null, e);
+            latch.countDown();
+        }
     }
 
     private long createChecksum(CheckedFunction<BufferedChecksumStreamOutput, Void, IOException> task) throws IOException {

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterStateChecksumTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterStateChecksumTests.java
@@ -26,6 +26,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BufferedChecksumStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.index.Index;
@@ -42,6 +43,17 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class ClusterStateChecksumTests extends OpenSearchTestCase {
     private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
@@ -164,6 +176,41 @@ public class ClusterStateChecksumTests extends OpenSearchTestCase {
         ClusterStateChecksum checksum1 = new ClusterStateChecksum(state2, threadPool);
         ClusterStateChecksum checksum2 = new ClusterStateChecksum(state3, threadPool);
         assertEquals(checksum2, checksum1);
+    }
+
+    public void testConstructorDoesNotDeadlockWhenAChecksumTaskFails() throws Exception {
+        // Wrap an otherwise valid cluster state so that one checksum task (routing table)
+        // fails while the other ten succeed. This exercises the guarantee that a failure in
+        // any single task must not leak the internal CountDownLatch and cause the constructor
+        // to block indefinitely.
+        ClusterState spyState = spy(generateClusterState());
+        RoutingTable failingRoutingTable = mock(RoutingTable.class);
+        doThrow(new IOException("simulated routing table failure")).when(failingRoutingTable)
+            .writeVerifiableTo(any(BufferedChecksumStreamOutput.class));
+        doReturn(failingRoutingTable).when(spyState).routingTable();
+
+        // If the latch is leaked, the constructor blocks forever. Isolate that failure mode
+        // into a bounded wait so a regression does not hang the test JVM.
+        try (ExecutorService driver = Executors.newSingleThreadExecutor()) {
+            Future<ClusterStateChecksum> future = driver.submit(() -> new ClusterStateChecksum(spyState, threadPool));
+            try {
+                future.get(10, TimeUnit.SECONDS);
+                fail("Expected constructor to propagate the failing checksum task as an exception");
+            } catch (java.util.concurrent.ExecutionException e) {
+                Throwable cause = e.getCause();
+                assertTrue(
+                    "Expected RemoteStateTransferException but got " + cause.getClass().getName(),
+                    cause instanceof RemoteStateTransferException
+                );
+                assertTrue(
+                    "Expected the original IOException as the root cause but got " + cause.getCause(),
+                    cause.getCause() instanceof IOException
+                );
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                fail("ClusterStateChecksum constructor did not return within 10s; latch was likely leaked");
+            }
+        }
     }
 
     private ClusterState generateClusterState() {


### PR DESCRIPTION
### Description
This change makes the checksum construction resilient to arbitrary task failures.

1. Move `latch.countDown()` into a `finally` block so the latch always advances regardless of task outcome.
2. Record the first task failure in an `AtomicReference` and re-throw it from the constructor as a `RemoteStateTransferException` after `await` returns. Without this, a task failure would silently produce a composite checksum that includes the default (zero) value for the failed component, and publish would proceed with a corrupt checksum.
3. Guard the `executorService.execute` call itself so a synchronous rejection (for example a `RejectedExecutionException` from a saturated queue or an executor shutdown) also releases the latch.
4. Preserve the interrupt status and rename the exception message when `latch.await` is interrupted.

### Related Issues
Resolves #22715
Related to #22716

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
