### PR TITLE
Log Flight stream slow next() at debug instead of warn

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -212,7 +212,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         } finally {
             long took = System.currentTimeMillis() - startTime;
             if (took > config.getSlowLogThreshold().millis()) {
-                logger.warn("Flight stream next() took [{}ms], exceeding threshold [{}ms]", took, config.getSlowLogThreshold().millis());
+                logger.debug("Flight stream next() took [{}ms], exceeding threshold [{}ms]", took, config.getSlowLogThreshold().millis());
             }
             logger.debug("FlightClient.next() for correlationId: {} took {}ms", correlationId, took);
         }


### PR DESCRIPTION
### Description

The slow `next()` slow-log in `FlightTransportResponse` logs at `warn` every time a Flight stream `next()` call exceeds the slow-log threshold. 

Lower it to `debug` so it stays available for diagnosis without adding warn-level noise by default.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing (n/a — log-level-only change)
- [x] Public documentation issue/PR [created] (n/a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).