### PR TITLE
Fix NPE in routing table checksum when a shard has no primary

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -1219,7 +1219,8 @@ public class IndexShardRoutingTable extends AbstractDiffable<IndexShardRoutingTa
                     }
                 });
             // is primary assigned
-            out.writeBoolean(indexShard.primaryShard().allocationId() != null);
+            ShardRouting primary = indexShard.primaryShard();
+            out.writeBoolean(primary != null && primary.allocationId() != null);
             out.writeVInt(indexShard.shards.size() - assignedShardCount.get());
         }
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/IndexShardRoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/IndexShardRoutingTableTests.java
@@ -99,6 +99,31 @@ public class IndexShardRoutingTableTests extends OpenSearchTestCase {
         assertEquals(checksumOut.getChecksum(), checksumOut2.getChecksum());
     }
 
+    public void testWriteVerifiableToWithoutPrimary() throws IOException {
+        // A shard can end up with no primary. For example, after the finalize step
+        // of `POST /{index}/_scale {"search_only": true}`, only search-only replicas
+        // remain, and search-only replicas have primary()==false, so primaryShard()
+        // returns null.
+        Index index = new Index("a", "b");
+        ShardId shardId = new ShardId(index, 1);
+        ShardRouting searchOnlyReplica = TestShardRouting.newShardRouting(
+            shardId,
+            null,
+            null,
+            false,
+            true,
+            ShardRoutingState.UNASSIGNED,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+        IndexShardRoutingTable table = new IndexShardRoutingTable(shardId, List.of(searchOnlyReplica));
+        assertNull("Precondition: this state has no primary", table.primaryShard());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        BufferedChecksumStreamOutput checksumOut = new BufferedChecksumStreamOutput(out);
+        // Must not throw NullPointerException.
+        IndexShardRoutingTable.Builder.writeVerifiableTo(table, checksumOut);
+    }
+
     public void testShardsMatchingPredicate() {
         ShardId shardId = new ShardId(new Index("a", UUID.randomUUID().toString()), 0);
         ShardRouting primary = TestShardRouting.newShardRouting(shardId, "node-1", true, ShardRoutingState.STARTED);


### PR DESCRIPTION
### Description
`IndexShardRoutingTable.Builder.writeVerifiableTo` unconditionally called `indexShard.primaryShard().allocationId()` to record whether the primary is assigned. When the routing table has a shard without a primary (for example after the finalize step of `POST/{index}/_scale {"search_only": true}`, where only search-only replicas remain and search-only replicas have `primary()==false`), `primaryShard()` returns `null` and the checksum path throws `NullPointerException`.

Treat "no primary" as "primary is not assigned" and record `false`. Every state that previously produced a checksum necessarily had a non-null primary, so the on-the-wire content is unchanged for those states.

A new unit test constructs a shard with only a search-only replica so that `primaryShard()` returns `null`, and asserts that `writeVerifiableTo` completes without throwing.

### Related Issues
Resolves #22716
Related to #22715

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
