### PR TITLE
Revert "Promote lowest-version replica on doc-rep failover and make node_version decider Lucene-aware (#22668)"

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -42,7 +42,6 @@ import org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
-import org.opensearch.common.annotation.DeprecatedApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.Assertions;
@@ -414,16 +413,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      * no active replica is found.
      * <p>
      * Since replicas could possibly be on nodes with an older version of OpenSearch than
-     * the primary is, this will return replicas on the highest version of OpenSearch.
-     *
-     * @deprecated no longer used for primary promotion. Promoting the highest-version replica
-     * raises the primary's version, after which
-     * {@link org.opensearch.cluster.routing.allocation.decider.NodeVersionAllocationDecider}
-     * refuses to allocate that shard's replicas onto any not-yet-upgraded node. Both replication
-     * types now promote via {@link #activeReplicaWithOldestVersion(ShardId)}.
+     * the primary is, this will return replicas on the highest version of OpenSearch when document
+     * replication is enabled.
      */
-    @Deprecated
-    @DeprecatedApi(since = "3.8.0", forRemoval = "4.0.0")
     public ShardRouting activeReplicaWithHighestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null, when disassociating dead nodes
         // that have been removed, the shards are failed, and part of the shard failing
@@ -447,9 +439,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      * no active replica is found.
      * <p>
      * Since replicas could possibly be on nodes with a higher version of OpenSearch than
-     * the primary is, this will return replicas on the oldest version of OpenSearch so that
-     * remaining nodes (including not-yet-upgraded ones) are able to read/replicate the
-     * promoted primary's segments and remain eligible allocation targets.
+     * the primary is, this will return replicas on the oldest version of OpenSearch when segment
+     * replication is enabled to allow for replica to read segments from primary.
+     *
      */
     public ShardRouting activeReplicaWithOldestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null. Therefore, we need to protect against the version being null
@@ -805,10 +797,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             activeReplica = activeReplicaOnRemoteNode(failedShard.shardId());
         }
         if (activeReplica == null) {
-            // Promote the oldest-version in-sync replica for both document and segment replication so the
-            // new primary stays at the minimum version present, keeping it a valid recovery source/target for
-            // any not-yet-upgraded node during a rolling upgrade.
-            activeReplica = activeReplicaWithOldestVersion(failedShard.shardId());
+            if (metadata.isSegmentReplicationEnabled(failedShard.getIndexName())) {
+                activeReplica = activeReplicaWithOldestVersion(failedShard.shardId());
+            } else {
+                activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
+            }
         }
         if (activeReplica == null) {
             moveToUnassigned(failedShard, unassignedInfo);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.routing.allocation.decider;
 
-import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
@@ -48,13 +47,10 @@ import java.util.stream.Collectors;
 
 /**
  * An allocation decider that prevents relocation or allocation from nodes
- * that might not be Lucene format compatible. If we relocate from a node that writes
- * segments in a newer Lucene major/minor version than the node we relocate to understands,
- * this might cause {@link org.apache.lucene.index.IndexFormatTooNewException} on the lowest
- * level since it might have already written segments that use a new postings format or codec
- * that is not available on the target node. Nodes on the same Lucene major/minor version (e.g.
- * differing only by an OpenSearch patch release) are always considered compatible, since a
- * Lucene patch release does not change the on-disk segment/codec format.
+ * that might not be version compatible. If we relocate from a node that runs
+ * a newer version than the node we relocate to this might cause {@link org.apache.lucene.index.IndexFormatTooNewException}
+ * on the lowest level since it might have already written segments that use a new postings format or codec that is not
+ * available on the target node.
  *
  * @opensearch.internal
  */
@@ -68,21 +64,6 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
         replicationType = IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.get(settings);
     }
 
-    /**
-     * Returns true if a node running {@code target} can read segments written by a node running
-     * {@code source}, based on the actual Lucene version of each (rather than the raw OpenSearch
-     * version id). This is the case when {@code target}'s Lucene major.minor is the same as or
-     * newer than {@code source}'s -- in particular this allows OpenSearch patch-level differences
-     * that share the same Lucene major.minor, since Lucene patch releases do not change the
-     * segment/codec format.
-     */
-    private static boolean isLuceneVersionCompatible(Version target, Version source) {
-        org.apache.lucene.util.Version targetLucene = target.luceneVersion;
-        org.apache.lucene.util.Version sourceLucene = source.luceneVersion;
-        return targetLucene.major > sourceLucene.major
-            || (targetLucene.major == sourceLucene.major && targetLucene.minor >= sourceLucene.minor);
-    }
-
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         if (shardRouting.primary()) {
@@ -93,17 +74,13 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
                     .filter(shr -> !shr.primary() && shr.active())
                     .collect(Collectors.toList());
                 for (ShardRouting replica : replicas) {
-                    // With segment replication the replica continuously reads segments written by the primary,
-                    // so the replica's Lucene version must be able to read the primary's for the life of the
-                    // shard. Block a newer target unless the replica can still read what it would write (e.g.
-                    // an OpenSearch patch-level difference that shares the same Lucene major.minor).
+                    // can not allocate if target node version > any existing replica version
                     RoutingNode replicaNode = allocation.routingNodes().node(replica.currentNodeId());
-                    if (node.node().getVersion().after(replicaNode.node().getVersion())
-                        && isLuceneVersionCompatible(replicaNode.node().getVersion(), node.node().getVersion()) == false) {
+                    if (node.node().getVersion().after(replicaNode.node().getVersion())) {
                         return allocation.decision(
                             Decision.NO,
                             NAME,
-                            "When segment replication is enabled, cannot relocate primary shard to a node with version [%s] if it has a replica on older, Lucene-incompatible version [%s]",
+                            "When segment replication is enabled, cannot relocate primary shard to a node with version [%s] if it has a replica on older version [%s]",
                             node.node().getVersion(),
                             replicaNode.node().getVersion()
                         );
@@ -141,12 +118,11 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
         final RoutingAllocation allocation
     ) {
         final RoutingNode source = routingNodes.node(sourceNodeId);
-        if (target.node().getVersion().onOrAfter(source.node().getVersion())
-            || isLuceneVersionCompatible(target.node().getVersion(), source.node().getVersion())) {
+        if (target.node().getVersion().onOrAfter(source.node().getVersion())) {
             return allocation.decision(
                 Decision.YES,
                 NAME,
-                "can relocate primary shard from a node with version [%s] to a node with equal-or-newer, Lucene-compatible version [%s]",
+                "can relocate primary shard from a node with version [%s] to a node with equal-or-newer version [%s]",
                 source.node().getVersion(),
                 target.node().getVersion()
             );
@@ -154,7 +130,7 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
             return allocation.decision(
                 Decision.NO,
                 NAME,
-                "cannot relocate primary shard from a node with version [%s] to a node with older, Lucene-incompatible version [%s]",
+                "cannot relocate primary shard from a node with version [%s] to a node with older version [%s]",
                 source.node().getVersion(),
                 target.node().getVersion()
             );
@@ -168,16 +144,14 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
         final RoutingAllocation allocation
     ) {
         final RoutingNode source = routingNodes.node(sourceNodeId);
-        if (target.node().getVersion().onOrAfter(source.node().getVersion())
-            || isLuceneVersionCompatible(target.node().getVersion(), source.node().getVersion())) {
-            /* we can allocate if we can recover from a node that is younger or on the same version, or if the
-             * target's Lucene version can still read the source's segments (e.g. an OpenSearch patch-level
-             * difference that shares the same Lucene major.minor). If the primary is already running a newer
-             * Lucene major/minor that won't work due to possible differences in the lucene index format etc. */
+        if (target.node().getVersion().onOrAfter(source.node().getVersion())) {
+            /* we can allocate if we can recover from a node that is younger or on the same version
+             * if the primary is already running on a newer version that won't work due to possible
+             * differences in the lucene index format etc.*/
             return allocation.decision(
                 Decision.YES,
                 NAME,
-                "can allocate replica shard to a node with version [%s] since this is equal-or-newer than, or Lucene-compatible with, the primary version [%s]",
+                "can allocate replica shard to a node with version [%s] since this is equal-or-newer than the primary version [%s]",
                 target.node().getVersion(),
                 source.node().getVersion()
             );
@@ -185,7 +159,7 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
             return allocation.decision(
                 Decision.NO,
                 NAME,
-                "cannot allocate replica shard to a node with version [%s] since this is older than, and Lucene-incompatible with, the primary version [%s]",
+                "cannot allocate replica shard to a node with version [%s] since this is older than the primary version [%s]",
                 target.node().getVersion(),
                 source.node().getVersion()
             );
@@ -197,14 +171,12 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
         final RoutingNode target,
         final RoutingAllocation allocation
     ) {
-        if (target.node().getVersion().onOrAfter(recoverySource.version())
-            || isLuceneVersionCompatible(target.node().getVersion(), recoverySource.version())) {
-            /* we can allocate if we can restore from a snapshot that is older or on the same version, or if the
-             * target's Lucene version can still read the snapshot's segments. */
+        if (target.node().getVersion().onOrAfter(recoverySource.version())) {
+            /* we can allocate if we can restore from a snapshot that is older or on the same version */
             return allocation.decision(
                 Decision.YES,
                 NAME,
-                "node version [%s] is the same or newer than, or Lucene-compatible with, snapshot version [%s]",
+                "node version [%s] is the same or newer than snapshot version [%s]",
                 target.node().getVersion(),
                 recoverySource.version()
             );
@@ -212,7 +184,7 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
             return allocation.decision(
                 Decision.NO,
                 NAME,
-                "node version [%s] is older than, and Lucene-incompatible with, the snapshot version [%s]",
+                "node version [%s] is older than the snapshot version [%s]",
                 target.node().getVersion(),
                 recoverySource.version()
             );

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -599,7 +599,7 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         clusterState = startShardsAndReroute(allocation, clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0));
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
         assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
 
         // fail the primary shard, check replicas get removed as well...
         ShardRouting primaryShardToFail = clusterState.routingTable().index("test").shard(0).primaryShard();
@@ -658,11 +658,11 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         assertThat(newPrimaryShard, not(equalTo(primaryShardToFail)));
     }
 
-    public void testReplicaOnOldestVersionIsPromotedDocRep() {
+    public void testReplicaOnNewestVersionIsPromoted() {
         testReplicaIsPromoted(false);
     }
 
-    public void testReplicaOnOldestVersionIsPromotedSegRep() {
+    public void testReplicaOnOldestVersionIsPromoted() {
         testReplicaIsPromoted(true);
     }
 
@@ -737,7 +737,12 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(4));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
 
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
+        ShardRouting startedReplica;
+        if (isSegmentReplicationEnabled) {
+            startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
+        } else {
+            startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        }
         logger.info("--> all shards allocated, replica that should be promoted: {}", startedReplica);
 
         // fail the primary shard again and make sure the correct replica is promoted
@@ -762,13 +767,24 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            assertTrue(
-                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
-                replicaNodeVersion.onOrBefore(nodeVer)
-            );
+            if (isSegmentReplicationEnabled) {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                    replicaNodeVersion.onOrBefore(nodeVer)
+                );
+            } else {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer)
+                );
+            }
         }
 
-        startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
+        if (isSegmentReplicationEnabled) {
+            startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
+        } else {
+            startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        }
         logger.info("--> failing primary shard a second time, should select: {}", startedReplica);
 
         // fail the primary shard again, and ensure the same thing happens
@@ -794,10 +810,17 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            assertTrue(
-                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
-                replicaNodeVersion.onOrBefore(nodeVer)
-            );
+            if (isSegmentReplicationEnabled) {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                    replicaNodeVersion.onOrBefore(nodeVer)
+                );
+            } else {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer)
+                );
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -530,10 +530,6 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
     }
 
     public void testRebalanceDoesNotAllocatePrimaryOnHigherVersionNodesSegrepEnabled() {
-        // Note: this relies on Version.CURRENT and VersionUtils.getPreviousVersion() differing in their
-        // Lucene major.minor (today 10.5.x vs 10.4.x). The segment-replication guard is keyed on Lucene
-        // format compatibility, so if a future release pairs them on the same Lucene minor the primary
-        // would legitimately be allowed to relocate and this test would need an explicitly older version.
         ShardId shard1 = new ShardId("test1", "_na_", 0);
         ShardId shard2 = new ShardId("test2", "_na_", 0);
         final DiscoveryNode newNode1 = new DiscoveryNode(
@@ -787,7 +783,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "can relocate primary shard from a node with version ["
                     + oldNode.node().getVersion()
-                    + "] to a node with equal-or-newer, Lucene-compatible version ["
+                    + "] to a node with equal-or-newer version ["
                     + newNode.node().getVersion()
                     + "]"
             )
@@ -800,7 +796,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "cannot relocate primary shard from a node with version ["
                     + newNode.node().getVersion()
-                    + "] to a node with older, Lucene-incompatible version ["
+                    + "] to a node with older version ["
                     + oldNode.node().getVersion()
                     + "]"
             )
@@ -831,7 +827,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "node version ["
                     + oldNode.node().getVersion()
-                    + "] is older than, and Lucene-incompatible with, the snapshot version ["
+                    + "] is older than the snapshot version ["
                     + newNode.node().getVersion()
                     + "]"
             )
@@ -848,7 +844,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "node version ["
                     + newNode.node().getVersion()
-                    + "] is the same or newer than, or Lucene-compatible with, snapshot version ["
+                    + "] is the same or newer than snapshot version ["
                     + oldNode.node().getVersion()
                     + "]"
             )
@@ -871,7 +867,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "cannot allocate replica shard to a node with version ["
                     + oldNode.node().getVersion()
-                    + "] since this is older than, and Lucene-incompatible with, the primary version ["
+                    + "] since this is older than the primary version ["
                     + newNode.node().getVersion()
                     + "]"
             )
@@ -892,235 +888,10 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             is(
                 "can allocate replica shard to a node with version ["
                     + newNode.node().getVersion()
-                    + "] since this is equal-or-newer than, or Lucene-compatible with, the primary version ["
+                    + "] since this is equal-or-newer than the primary version ["
                     + oldNode.node().getVersion()
                     + "]"
             )
-        );
-    }
-
-    public void testAllocatesReplicaOnSameLuceneMinorDifferentOpenSearchPatch() {
-        // reproduces the real-world case (opensearch-project/OpenSearch#22520): primary on a newer
-        // OpenSearch patch release, target node on an older patch release, both sharing the same
-        // Lucene major.minor (9.12.x) -- the target can read the primary's segments, so allocation
-        // should be allowed even though V_2_19_0.onOrAfter(V_2_19_4) is false.
-        assertReplicaAllocationDecision(Version.V_2_19_4, Version.V_2_19_0, Decision.Type.YES);
-    }
-
-    public void testDoesNotAllocateReplicaOnOlderLuceneMinor() {
-        // V_2_17_2 -> Lucene 9.11.1, V_2_19_0 -> Lucene 9.12.1: different Lucene minor, so the
-        // target cannot necessarily read segments written with newer codecs/formats.
-        assertReplicaAllocationDecision(Version.V_2_19_0, Version.V_2_17_2, Decision.Type.NO);
-    }
-
-    public void testDoesNotAllocateReplicaAcrossOlderLuceneMajor() {
-        // V_3_0_0 -> Lucene 10.1.0, V_2_19_0 -> Lucene 9.12.1: different Lucene major, must remain
-        // blocked regardless of the Lucene-minor relaxation.
-        assertReplicaAllocationDecision(Version.V_3_0_0, Version.V_2_19_0, Decision.Type.NO);
-    }
-
-    private void assertReplicaAllocationDecision(Version primaryNodeVersion, Version targetNodeVersion, Decision.Type expected) {
-        Metadata metadata = Metadata.builder()
-            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
-            .build();
-
-        RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
-
-        RoutingNode primaryNode = new RoutingNode("primaryNode", newNode("primaryNode", primaryNodeVersion));
-        RoutingNode targetNode = new RoutingNode("targetNode", newNode("targetNode", targetNodeVersion));
-
-        final org.opensearch.cluster.ClusterName clusterName = org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(
-            Settings.EMPTY
-        );
-        ClusterState clusterState = ClusterState.builder(clusterName)
-            .metadata(metadata)
-            .routingTable(initialRoutingTable)
-            .nodes(DiscoveryNodes.builder().add(primaryNode.node()).add(targetNode.node()))
-            .build();
-
-        final ShardId shardId = clusterState.routingTable().index("test").shard(0).getShardId();
-        final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
-        final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().get(0);
-
-        final RoutingChangesObserver routingChangesObserver = new RoutingChangesObserver.AbstractRoutingChangesObserver();
-        final RoutingNodes routingNodes = new RoutingNodes(clusterState, false);
-        routingNodes.startShard(
-            logger,
-            routingNodes.initializeShard(primaryShard, "primaryNode", null, 0, routingChangesObserver),
-            routingChangesObserver
-        );
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
-        routingAllocation.debugDecision(true);
-
-        final NodeVersionAllocationDecider allocationDecider = new NodeVersionAllocationDecider(Settings.EMPTY);
-        Decision decision = allocationDecider.canAllocate(replicaShard, targetNode, routingAllocation);
-        assertThat(
-            "primary on " + primaryNodeVersion + ", target " + targetNodeVersion + ": " + decision.getExplanation(),
-            decision.type(),
-            is(expected)
-        );
-    }
-
-    public void testSegrepAllowsPrimaryOnSameLuceneMinorDifferentOpenSearchPatch() {
-        // V_2_19_0 -> Lucene 9.12.1, V_2_19_4 -> Lucene 9.12.3: the replica can still read segments
-        // written by a primary on the newer patch, so relocating the primary must be allowed.
-        assertSegrepPrimaryAllocationDecision(Version.V_2_19_0, Version.V_2_19_4, Decision.Type.YES);
-    }
-
-    public void testSegrepBlocksPrimaryOnNewerLuceneMinor() {
-        // V_2_17_2 -> Lucene 9.11.1, V_2_19_0 -> Lucene 9.12.1: a primary on the newer Lucene minor
-        // would write segments the replica cannot read, so this must stay blocked.
-        assertSegrepPrimaryAllocationDecision(Version.V_2_17_2, Version.V_2_19_0, Decision.Type.NO);
-    }
-
-    private void assertSegrepPrimaryAllocationDecision(Version replicaNodeVersion, Version targetNodeVersion, Decision.Type expected) {
-        final Settings segrepSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
-        Metadata metadata = Metadata.builder()
-            .put(
-                IndexMetadata.builder("test").settings(settings(Version.CURRENT).put(segrepSettings)).numberOfShards(1).numberOfReplicas(1)
-            )
-            .build();
-
-        RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
-
-        // keep the current primary at the replica's version so the relocate-primary check cannot be
-        // what drives the decision -- only the segment-replication guard should matter here.
-        RoutingNode primaryNode = new RoutingNode("primaryNode", newNode("primaryNode", replicaNodeVersion));
-        RoutingNode replicaNode = new RoutingNode("replicaNode", newNode("replicaNode", replicaNodeVersion));
-        RoutingNode targetNode = new RoutingNode("targetNode", newNode("targetNode", targetNodeVersion));
-
-        final org.opensearch.cluster.ClusterName clusterName = org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(
-            Settings.EMPTY
-        );
-        ClusterState clusterState = ClusterState.builder(clusterName)
-            .metadata(metadata)
-            .routingTable(initialRoutingTable)
-            .nodes(DiscoveryNodes.builder().add(primaryNode.node()).add(replicaNode.node()).add(targetNode.node()))
-            .build();
-
-        final ShardId shardId = clusterState.routingTable().index("test").shard(0).getShardId();
-        final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
-        final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().get(0);
-
-        final RoutingChangesObserver observer = new RoutingChangesObserver.AbstractRoutingChangesObserver();
-        final RoutingNodes routingNodes = new RoutingNodes(clusterState, false);
-        routingNodes.startShard(logger, routingNodes.initializeShard(primaryShard, "primaryNode", null, 0, observer), observer);
-        routingNodes.startShard(logger, routingNodes.initializeShard(replicaShard, "replicaNode", null, 0, observer), observer);
-
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
-        routingAllocation.debugDecision(true);
-
-        final NodeVersionAllocationDecider allocationDecider = new NodeVersionAllocationDecider(segrepSettings);
-        final ShardRouting startedPrimary = routingNodes.activePrimary(shardId);
-        Decision decision = allocationDecider.canAllocate(startedPrimary, targetNode, routingAllocation);
-        assertThat(
-            "replica on " + replicaNodeVersion + ", target " + targetNodeVersion + ": " + decision.getExplanation(),
-            decision.type(),
-            is(expected)
-        );
-    }
-
-    public void testRelocatesPrimaryOnSameLuceneMinorDifferentOpenSearchPatch() {
-        // V_2_19_4 -> Lucene 9.12.3, V_2_19_0 -> Lucene 9.12.1: the target can read segments written by
-        // the source, so relocation must be allowed even though V_2_19_0.onOrAfter(V_2_19_4) is false.
-        assertPrimaryRelocationDecision(Version.V_2_19_4, Version.V_2_19_0, Decision.Type.YES);
-    }
-
-    public void testDoesNotRelocatePrimaryOnOlderLuceneMinor() {
-        // V_2_19_0 -> Lucene 9.12.1, V_2_17_2 -> Lucene 9.11.1: different Lucene minor, must stay blocked.
-        assertPrimaryRelocationDecision(Version.V_2_19_0, Version.V_2_17_2, Decision.Type.NO);
-    }
-
-    private void assertPrimaryRelocationDecision(Version sourceNodeVersion, Version targetNodeVersion, Decision.Type expected) {
-        Metadata metadata = Metadata.builder()
-            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
-            .build();
-        RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
-
-        RoutingNode sourceNode = new RoutingNode("sourceNode", newNode("sourceNode", sourceNodeVersion));
-        RoutingNode targetNode = new RoutingNode("targetNode", newNode("targetNode", targetNodeVersion));
-
-        final org.opensearch.cluster.ClusterName clusterName = org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(
-            Settings.EMPTY
-        );
-        ClusterState clusterState = ClusterState.builder(clusterName)
-            .metadata(metadata)
-            .routingTable(initialRoutingTable)
-            .nodes(DiscoveryNodes.builder().add(sourceNode.node()).add(targetNode.node()))
-            .build();
-
-        final ShardId shardId = clusterState.routingTable().index("test").shard(0).getShardId();
-        final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
-
-        final RoutingChangesObserver observer = new RoutingChangesObserver.AbstractRoutingChangesObserver();
-        final RoutingNodes routingNodes = new RoutingNodes(clusterState, false);
-        routingNodes.startShard(logger, routingNodes.initializeShard(primaryShard, "sourceNode", null, 0, observer), observer);
-
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
-        routingAllocation.debugDecision(true);
-
-        final NodeVersionAllocationDecider allocationDecider = new NodeVersionAllocationDecider(Settings.EMPTY);
-        Decision decision = allocationDecider.canAllocate(routingNodes.activePrimary(shardId), targetNode, routingAllocation);
-        assertThat(
-            "source " + sourceNodeVersion + ", target " + targetNodeVersion + ": " + decision.getExplanation(),
-            decision.type(),
-            is(expected)
-        );
-    }
-
-    public void testRestoresSnapshotOnSameLuceneMinorDifferentOpenSearchPatch() {
-        // Snapshot taken on V_2_19_4 (Lucene 9.12.3) restored onto a V_2_19_0 node (Lucene 9.12.1):
-        // the node can read the snapshot's segments, so the restore must be allowed.
-        assertSnapshotRestoreDecision(Version.V_2_19_4, Version.V_2_19_0, Decision.Type.YES);
-    }
-
-    public void testDoesNotRestoreSnapshotOnOlderLuceneMinor() {
-        // V_2_19_0 -> Lucene 9.12.1 snapshot onto a V_2_17_2 node -> Lucene 9.11.1: must stay blocked.
-        assertSnapshotRestoreDecision(Version.V_2_19_0, Version.V_2_17_2, Decision.Type.NO);
-    }
-
-    private void assertSnapshotRestoreDecision(Version snapshotVersion, Version targetNodeVersion, Decision.Type expected) {
-        final Snapshot snapshot = new Snapshot("rep1", new SnapshotId("snp1", UUIDs.randomBase64UUID()));
-        final IndexId indexId = new IndexId("test", UUIDs.randomBase64UUID(random()));
-
-        Metadata metadata = Metadata.builder()
-            .put(
-                IndexMetadata.builder("test")
-                    .settings(settings(Version.CURRENT))
-                    .numberOfShards(1)
-                    .numberOfReplicas(0)
-                    .putInSyncAllocationIds(0, Collections.singleton("_test_"))
-            )
-            .build();
-
-        RoutingTable routingTable = RoutingTable.builder()
-            .addAsRestore(metadata.index("test"), new SnapshotRecoverySource(UUIDs.randomBase64UUID(), snapshot, snapshotVersion, indexId))
-            .build();
-
-        RoutingNode targetNode = new RoutingNode("targetNode", newNode("targetNode", targetNodeVersion));
-
-        final org.opensearch.cluster.ClusterName clusterName = org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(
-            Settings.EMPTY
-        );
-        ClusterState clusterState = ClusterState.builder(clusterName)
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(targetNode.node()))
-            .build();
-
-        final ShardId shardId = clusterState.routingTable().index("test").shard(0).getShardId();
-        final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
-
-        final RoutingNodes routingNodes = new RoutingNodes(clusterState, false);
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
-        routingAllocation.debugDecision(true);
-
-        final NodeVersionAllocationDecider allocationDecider = new NodeVersionAllocationDecider(Settings.EMPTY);
-        Decision decision = allocationDecider.canAllocate(primaryShard, targetNode, routingAllocation);
-        assertThat(
-            "snapshot " + snapshotVersion + ", target " + targetNodeVersion + ": " + decision.getExplanation(),
-            decision.type(),
-            is(expected)
         );
     }
 }


### PR DESCRIPTION
This reverts commit 36edc05ac84f6812fd44c21cb47f771d16f42558.

The commit introduced test failures in `NodeVersionAllocationDeciderTests` and `IndexShardConstraintDeciderOverlapTests` on the main branch. 7 existing tests fail because the updated allocation logic relaxed version constraints without updating corresponding test expectations.

**Failing tests:**
- `NodeVersionAllocationDeciderTests.testMessages` — Expected: `NO`, got: `YES`
- `NodeVersionAllocationDeciderTests.testRebalanceDoesNotAllocatePrimaryAndReplicasOnDifferentVersionNodes`
- `NodeVersionAllocationDeciderTests.testRebalanceDoesNotAllocatePrimaryOnHigherVersionNodesSegrepEnabled` — Expected: `1`, got: `2`
- `NodeVersionAllocationDeciderTests.testRollingRestart`
- `NodeVersionAllocationDeciderTests.testRandom`
- `NodeVersionAllocationDeciderTests.testDoNotAllocateFromPrimary`
- `IndexShardConstraintDeciderOverlapTests.testNodeVersionCompatibilityOverlap`

**CI link:** https://build.ci.opensearch.org/job/gradle-check/83440/

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).