### PR TITLE
Fix NPE in routing table serialization when primary shard is null

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -1219,7 +1219,7 @@ public class IndexShardRoutingTable extends AbstractDiffable<IndexShardRoutingTa
                     }
                 });
             // is primary assigned
-            out.writeBoolean(indexShard.primaryShard().allocationId() != null);
+            out.writeBoolean(indexShard.primaryShard() != null && indexShard.primaryShard().allocationId() != null);
             out.writeVInt(indexShard.shards.size() - assignedShardCount.get());
         }
     }


### PR DESCRIPTION
### Description

When `POST /{index}/_scale` with `{"search_only": true}` runs on an index that has search replicas, the routing table serialization path in `IndexShardRoutingTable.writeToThin` calls `indexShard.primaryShard()` which returns null (since all shards are search-only replicas with no primary), and then `.allocationId()` is invoked on the null result, causing a `NullPointerException`.

### Root Cause

`IndexShardRoutingTable.primaryShard()` returns the `primary` field which can be null when no primary shard exists (e.g., after scaling to search-only replicas). The serialization code at line 1222 calls `.allocationId()` on the result without a null check.

### Fix

Add a null check before calling `allocationId()` on the primary shard.

### Related Issues
Fixes #22716