### PR TITLE
Fix Duplicate PeerFinder Wakeup Chains on Reactivation

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/opensearch/discovery/PeerFinder.java
@@ -109,8 +109,7 @@ public abstract class PeerFinder {
 
     private volatile long currentTerm;
     private boolean active;
-    // incremented on every activation so that the wakeup chain scheduled by a previous activation dies out instead of running
-    // alongside the chain scheduled by the current one
+    // bumped on each activation so a superseded activation's wakeup chain stops instead of running alongside the current one
     private long activationCount;
     private DiscoveryNodes lastAcceptedNodes;
     private final Map<TransportAddress, Peer> peersByAddress = new LinkedHashMap<>();
@@ -350,8 +349,7 @@ public abstract class PeerFinder {
             protected void doRun() {
                 synchronized (mutex) {
                     if (scheduledActivationCount != activationCount) {
-                        // this wakeup belongs to a previous activation which has since been superseded; the current activation has its
-                        // own wakeup chain, so let this one die out rather than running a duplicate chain alongside it.
+                        // superseded activation: the current one has its own chain, so stop rather than duplicate it
                         logger.trace("not handling wakeup from stale activation [{}]", scheduledActivationCount);
                         return;
                     }

--- a/server/src/main/java/org/opensearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/opensearch/discovery/PeerFinder.java
@@ -109,6 +109,9 @@ public abstract class PeerFinder {
 
     private volatile long currentTerm;
     private boolean active;
+    // incremented on every activation so that the wakeup chain scheduled by a previous activation dies out instead of running
+    // alongside the chain scheduled by the current one
+    private long activationCount;
     private DiscoveryNodes lastAcceptedNodes;
     private final Map<TransportAddress, Peer> peersByAddress = new LinkedHashMap<>();
     private Optional<DiscoveryNode> leader = Optional.empty();
@@ -160,6 +163,7 @@ public abstract class PeerFinder {
         synchronized (mutex) {
             assert assertInactiveWithNoKnownPeers();
             active = true;
+            activationCount += 1;
             this.lastAcceptedNodes = lastAcceptedNodes;
             leader = Optional.empty();
             handleWakeUp(); // return value discarded: there are no known peers, so none can be disconnected
@@ -329,6 +333,7 @@ public abstract class PeerFinder {
             }
         });
 
+        final long scheduledActivationCount = activationCount;
         transportService.getThreadPool().scheduleUnlessShuttingDown(findPeersInterval, Names.GENERIC, new AbstractRunnable() {
             @Override
             public boolean isForceExecution() {
@@ -344,6 +349,12 @@ public abstract class PeerFinder {
             @Override
             protected void doRun() {
                 synchronized (mutex) {
+                    if (scheduledActivationCount != activationCount) {
+                        // this wakeup belongs to a previous activation which has since been superseded; the current activation has its
+                        // own wakeup chain, so let this one die out rather than running a duplicate chain alongside it.
+                        logger.trace("not handling wakeup from stale activation [{}]", scheduledActivationCount);
+                        return;
+                    }
                     if (handleWakeUp() == false) {
                         return;
                     }

--- a/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
@@ -101,6 +101,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
     private TestPeerFinder peerFinder;
     private List<TransportAddress> providedAddresses;
     private long addressResolveDelay; // -1 means address resolution fails
+    private int resolveConfiguredHostsCount; // counts find-peers wakeups, one resolve per wakeup
 
     private Set<DiscoveryNode> disconnectedNodes = new HashSet<>();
     private Set<DiscoveryNode> connectedNodes = new HashSet<>();
@@ -193,6 +194,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
     }
 
     private void resolveConfiguredHosts(Consumer<List<TransportAddress>> onResult) {
+        resolveConfiguredHostsCount++;
         if (addressResolveDelay >= 0) {
             deterministicTaskQueue.scheduleAt(deterministicTaskQueue.getCurrentTimeMillis() + addressResolveDelay, new Runnable() {
                 @Override
@@ -262,6 +264,163 @@ public class PeerFinderTests extends OpenSearchTestCase {
     public void deactivateAndRunRemainingTasks() {
         peerFinder.deactivate(localNode);
         deterministicTaskQueue.runAllRunnableTasks();
+    }
+
+    private static final long FIND_PEERS_INTERVAL_MILLIS = 1000L;
+    private static final int FLAP_COUNT = 5;
+
+    /**
+     * Drives CANDIDATE -&gt; FOLLOWER -&gt; CANDIDATE transitions, as {@link org.opensearch.cluster.coordination.Coordinator} does via
+     * {@code becomeCandidate}/{@code becomeFollower}. Each cycle is separated by {@code staggerMillis} so that the wakeup chain
+     * scheduled by each activation gets its own phase offset, as it would in a real cluster.
+     */
+    private void flapCandidateToFollower(int cycles, long staggerMillis) {
+        for (int i = 0; i < cycles; i++) {
+            peerFinder.deactivate(localNode);
+            peerFinder.activate(lastAcceptedNodes);
+            runAllRunnableTasks();
+            respondToAllPeersRequests();
+            if (staggerMillis > 0) {
+                advanceTimeBy(staggerMillis);
+            }
+        }
+    }
+
+    /** Advances the clock by exactly the given number of milliseconds, running everything that comes due on the way. */
+    private void advanceTimeBy(long millis) {
+        final long target = deterministicTaskQueue.getCurrentTimeMillis() + millis;
+        deterministicTaskQueue.scheduleAt(target, new Runnable() {
+            @Override
+            public void run() {}
+
+            @Override
+            public String toString() {
+                return "clock marker at " + target;
+            }
+        });
+        while (deterministicTaskQueue.getCurrentTimeMillis() < target) {
+            deterministicTaskQueue.advanceTime();
+            runAllRunnableTasks();
+        }
+    }
+
+    /** Responds to every outstanding peers request so that no request is left in flight, and returns how many there were. */
+    private int respondToAllPeersRequests() {
+        final CapturedRequest[] capturedRequests = capturingTransport.getCapturedRequestsAndClear();
+        for (final CapturedRequest capturedRequest : capturedRequests) {
+            assertThat(capturedRequest.action, is(REQUEST_PEERS_ACTION_NAME));
+            capturingTransport.handleResponse(
+                capturedRequest.requestId,
+                new PeersResponse(Optional.empty(), emptyList(), randomNonNegativeLong())
+            );
+        }
+        return capturedRequests.length;
+    }
+
+    /**
+     * Demonstrates the defect: {@code deactivate()} cannot cancel the wakeup already scheduled by {@code handleWakeUp()}, so if
+     * {@code activate()} runs again before that wakeup fires, the stale wakeup finds {@code active == true} and reschedules itself
+     * forever alongside the chain the new activation just started. Every activation therefore leaks one extra self-perpetuating
+     * chain, permanently multiplying the rate at which seed hosts are resolved and peers are probed.
+     */
+    public void testFindPeersWakeupChainIsNotDuplicatedOnReactivation() {
+        final DiscoveryNode otherNode = newDiscoveryNode("node-1");
+        providedAddresses.add(otherNode.getAddress());
+        transportAddressConnector.addReachableNode(otherNode);
+
+        peerFinder.activate(lastAcceptedNodes);
+        runAllRunnableTasks();
+        assertFoundPeers(otherNode);
+
+        // Flap without advancing the clock, so every stale wakeup is still pending when the next activation happens.
+        flapCandidateToFollower(FLAP_COUNT, 0L);
+
+        // The chain count is stable once leaked, so measure several consecutive intervals.
+        final int[] wakeupsPerInterval = new int[3];
+        for (int i = 0; i < wakeupsPerInterval.length; i++) {
+            resolveConfiguredHostsCount = 0;
+            advanceTimeBy(FIND_PEERS_INTERVAL_MILLIS);
+            wakeupsPerInterval[i] = resolveConfiguredHostsCount;
+            logger.info("--> find-peers wakeups in interval {}: {}", i + 1, wakeupsPerInterval[i]);
+        }
+
+        for (int i = 0; i < wakeupsPerInterval.length; i++) {
+            assertThat(
+                "expected exactly one find-peers wakeup per interval in interval " + (i + 1) + " after " + FLAP_COUNT + " activations",
+                wakeupsPerInterval[i],
+                equalTo(1)
+            );
+        }
+    }
+
+    /**
+     * The externally visible consequence of the leaked chains: peers are polled once per leaked chain per interval rather than once
+     * per interval. The activations are staggered here so each chain fires at a different moment and its own peers request goes out,
+     * which is what a real cluster sees.
+     */
+    public void testPeersRequestsAreNotAmplifiedOnReactivation() {
+        final DiscoveryNode otherNode = newDiscoveryNode("node-1");
+        providedAddresses.add(otherNode.getAddress());
+        transportAddressConnector.addReachableNode(otherNode);
+
+        peerFinder.activate(lastAcceptedNodes);
+        runAllRunnableTasks();
+        assertFoundPeers(otherNode);
+        respondToAllPeersRequests();
+
+        flapCandidateToFollower(FLAP_COUNT, FIND_PEERS_INTERVAL_MILLIS / 10);
+
+        // Let the staggered chains settle into their steady state before measuring.
+        advanceTimeBy(2 * FIND_PEERS_INTERVAL_MILLIS);
+        respondToAllPeersRequests();
+
+        // Count over the half-open window [now, now + interval) so that a chain sitting exactly on either boundary is counted once.
+        int peersRequests = 0;
+        final long deadline = deterministicTaskQueue.getCurrentTimeMillis() + FIND_PEERS_INTERVAL_MILLIS;
+        while (true) {
+            deterministicTaskQueue.advanceTime();
+            if (deterministicTaskQueue.getCurrentTimeMillis() >= deadline) {
+                break;
+            }
+            runAllRunnableTasks();
+            peersRequests += respondToAllPeersRequests();
+        }
+        logger.info("--> {} requests to {} in one find_peers_interval", peersRequests, REQUEST_PEERS_ACTION_NAME);
+
+        assertThat(
+            "expected one " + REQUEST_PEERS_ACTION_NAME + " per peer per interval after " + FLAP_COUNT + " activations",
+            peersRequests,
+            equalTo(1)
+        );
+    }
+
+    /**
+     * Control for {@link #testFindPeersWakeupChainIsNotDuplicatedOnReactivation}: identical flapping, except each stale wakeup is
+     * given the chance to fire while inactive, so it observes {@code active == false} and declines to reschedule. This isolates the
+     * leak to surviving stale wakeups rather than to activation itself, and passes both with and without the fix.
+     */
+    public void testWakeupChainIsNotDuplicatedWhenStaleWakeupsAreDrained() {
+        final DiscoveryNode otherNode = newDiscoveryNode("node-1");
+        providedAddresses.add(otherNode.getAddress());
+        transportAddressConnector.addReachableNode(otherNode);
+
+        peerFinder.activate(lastAcceptedNodes);
+        runAllRunnableTasks();
+        assertFoundPeers(otherNode);
+
+        for (int i = 0; i < FLAP_COUNT; i++) {
+            peerFinder.deactivate(localNode);
+            // Drain the pending wakeup while inactive: it fires, sees active == false, and does not reschedule.
+            advanceTimeBy(FIND_PEERS_INTERVAL_MILLIS);
+            peerFinder.activate(lastAcceptedNodes);
+            runAllRunnableTasks();
+        }
+
+        resolveConfiguredHostsCount = 0;
+        advanceTimeBy(FIND_PEERS_INTERVAL_MILLIS);
+        logger.info("--> control: find-peers wakeups in one interval: {}", resolveConfiguredHostsCount);
+
+        assertThat(resolveConfiguredHostsCount, equalTo(1));
     }
 
     public void testAddsReachableNodesFromUnicastHostsList() {

--- a/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
@@ -269,11 +269,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
     private static final long FIND_PEERS_INTERVAL_MILLIS = 1000L;
     private static final int FLAP_COUNT = 5;
 
-    /**
-     * Drives CANDIDATE -&gt; FOLLOWER -&gt; CANDIDATE transitions, as {@link org.opensearch.cluster.coordination.Coordinator} does via
-     * {@code becomeCandidate}/{@code becomeFollower}. Each cycle is separated by {@code staggerMillis} so that the wakeup chain
-     * scheduled by each activation gets its own phase offset, as it would in a real cluster.
-     */
+    /** Drives CANDIDATE -&gt; FOLLOWER -&gt; CANDIDATE transitions, spacing each cycle by {@code staggerMillis} to vary the chain phase. */
     private void flapCandidateToFollower(int cycles, long staggerMillis) {
         for (int i = 0; i < cycles; i++) {
             peerFinder.deactivate(localNode);
@@ -286,7 +282,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
         }
     }
 
-    /** Advances the clock by exactly the given number of milliseconds, running everything that comes due on the way. */
+    /** Advances the clock by exactly {@code millis}, running everything that comes due on the way. */
     private void advanceTimeBy(long millis) {
         final long target = deterministicTaskQueue.getCurrentTimeMillis() + millis;
         deterministicTaskQueue.scheduleAt(target, new Runnable() {
@@ -304,7 +300,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
         }
     }
 
-    /** Responds to every outstanding peers request so that no request is left in flight, and returns how many there were. */
+    /** Responds to every outstanding peers request so none is left in flight, returning how many there were. */
     private int respondToAllPeersRequests() {
         final CapturedRequest[] capturedRequests = capturingTransport.getCapturedRequestsAndClear();
         for (final CapturedRequest capturedRequest : capturedRequests) {
@@ -318,10 +314,8 @@ public class PeerFinderTests extends OpenSearchTestCase {
     }
 
     /**
-     * Demonstrates the defect: {@code deactivate()} cannot cancel the wakeup already scheduled by {@code handleWakeUp()}, so if
-     * {@code activate()} runs again before that wakeup fires, the stale wakeup finds {@code active == true} and reschedules itself
-     * forever alongside the chain the new activation just started. Every activation therefore leaks one extra self-perpetuating
-     * chain, permanently multiplying the rate at which seed hosts are resolved and peers are probed.
+     * A wakeup left over from a previous activation must not reschedule itself alongside the current activation's chain, which would
+     * leak one extra chain per activation and permanently multiply the find-peers rate.
      */
     public void testFindPeersWakeupChainIsNotDuplicatedOnReactivation() {
         final DiscoveryNode otherNode = newDiscoveryNode("node-1");
@@ -354,9 +348,8 @@ public class PeerFinderTests extends OpenSearchTestCase {
     }
 
     /**
-     * The externally visible consequence of the leaked chains: peers are polled once per leaked chain per interval rather than once
-     * per interval. The activations are staggered here so each chain fires at a different moment and its own peers request goes out,
-     * which is what a real cluster sees.
+     * The visible consequence of leaked chains: peers polled once per chain per interval instead of once. Activations are staggered
+     * so each chain fires at a distinct moment and sends its own request, as in a real cluster.
      */
     public void testPeersRequestsAreNotAmplifiedOnReactivation() {
         final DiscoveryNode otherNode = newDiscoveryNode("node-1");
@@ -374,7 +367,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
         advanceTimeBy(2 * FIND_PEERS_INTERVAL_MILLIS);
         respondToAllPeersRequests();
 
-        // Count over the half-open window [now, now + interval) so that a chain sitting exactly on either boundary is counted once.
+        // Half-open window [now, now + interval) so a chain on either boundary is counted once.
         int peersRequests = 0;
         final long deadline = deterministicTaskQueue.getCurrentTimeMillis() + FIND_PEERS_INTERVAL_MILLIS;
         while (true) {
@@ -395,9 +388,8 @@ public class PeerFinderTests extends OpenSearchTestCase {
     }
 
     /**
-     * Control for {@link #testFindPeersWakeupChainIsNotDuplicatedOnReactivation}: identical flapping, except each stale wakeup is
-     * given the chance to fire while inactive, so it observes {@code active == false} and declines to reschedule. This isolates the
-     * leak to surviving stale wakeups rather than to activation itself, and passes both with and without the fix.
+     * Control for {@link #testFindPeersWakeupChainIsNotDuplicatedOnReactivation}: identical flapping, but each stale wakeup fires
+     * while inactive and declines to reschedule. Pins the leak to surviving stale wakeups; passes with and without the fix.
      */
     public void testWakeupChainIsNotDuplicatedWhenStaleWakeupsAreDrained() {
         final DiscoveryNode otherNode = newDiscoveryNode("node-1");


### PR DESCRIPTION
## Issue

`PeerFinder.handleWakeUp()` reschedules itself, forming a self-perpetuating "wakeup chain" that drives discovery. Two things start a chain and nothing stops one:

- `activate()` calls `handleWakeUp()`, scheduling a fresh chain.
- A firing wakeup reschedules itself whenever `active == true`, with no check that it belongs to the *current* activation.

`deactivate()` sets `active = false` but cannot cancel an already-scheduled task. If `activate()` runs before that task fires, the stale task wakes to `active == true` and **reschedules itself indefinitely**, running permanently in parallel with the chain `activate()` just created. The leak is therefore not a one-shot extra probe; each leaked chain persists for as long as the node stays active.

The race window is `discovery.find_peers_interval`, **1 second by default**. `Coordinator` drives exactly this cycle:

- `becomeCandidate` → `peerFinder.activate(...)` ([Coordinator.java#L757](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java#L757))
- `becomeLeader` → `peerFinder.deactivate(...)` ([Coordinator.java#L798](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java#L798))
- `becomeFollower` → `peerFinder.deactivate(...)` ([Coordinator.java#L835](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java#L835))

A term bump followed by a publish from the new leader cycles candidate → follower → candidate well inside one second, which is precisely what happens during an election storm.

Measured behavior: **N activations → N+1 active wakeup chains** (verified at 5→6 and 10→11), with the leaked chains persisting indefinitely.

### Provenance

This is inherited upstream Elasticsearch structure, **not a regression introduced by a recent OpenSearch change** — there is no specific commit to point at. It very likely affects upstream as well.

## Impact

Each leaked chain independently performs a full discovery round every interval:

- Re-resolves configured seed hosts, including DNS lookups.
- Probes cluster-manager nodes from the last accepted state.
- Fans out `internal:discovery/request_peers` requests to connected peers.

This amplifies discovery traffic during cluster instability, creating a positive feedback loop where increased discovery and probe load makes cluster stabilization harder.

The leak also defeats the intent of `discovery.find_peers_interval_during_decommission`. That setting exists to back decommissioned nodes off from 1s to 120s so they stop hammering the cluster manager, but the backoff is applied *per chain*, so leaked chains restore the traffic the setting is intended to suppress.

## Fix

Associate every wakeup chain with the activation that created it.

A monotonically increasing `activationCount` is incremented on every `activate()`. Each scheduled wakeup captures the current activation count and exits without rescheduling if it belongs to a superseded activation.

```java
private long activationCount; // guarded by mutex, incremented in activate()

final long scheduledActivationCount = activationCount;

protected void doRun() {
    synchronized (mutex) {
        if (scheduledActivationCount != activationCount) {
            return;
        }
        if (handleWakeUp() == false) {
            return;
        }
    }
    onFoundPeersUpdated();
}
```

This is an 11-line change in `PeerFinder.java`.

There is no behavior change for the current activation's chain. Stale chains simply terminate instead of rescheduling themselves. Deactivation is unaffected: a current-activation chain that fires while inactive still declines to reschedule, as before.

## Post-Fix Behavior

- Exactly **one find-peers wakeup chain** exists per active `PeerFinder`.
- Repeated candidate/follower transitions do not create additional chains.
- Seed-host resolution returns to once per `discovery.find_peers_interval`.
- `request_peers` fan-out is no longer amplified.
- `discovery.find_peers_interval_during_decommission` applies to the single intended chain.

## Testing

Three tests were added to `PeerFinderTests`:

| Test | Without Fix | With Fix |
| --- | --- | --- |
| `testFindPeersWakeupChainIsNotDuplicatedOnReactivation` | FAIL — 6 wakeups per interval instead of 1 (6, 6, 6 across 3 consecutive intervals) | PASS |
| `testPeersRequestsAreNotAmplifiedOnReactivation` | FAIL — 5 `request_peers` per interval instead of 1 | PASS |
| `testWakeupChainIsNotDuplicatedWhenStaleWakeupsAreDrained` (control) | PASS | PASS |

The second test validates real transport fan-out using `CapturingTransport`, with activations staggered so leaked chains run at different phase offsets. All requests are responded to, ensuring the result is not masked by `peersRequestInFlight`.

The control test isolates the race condition: stale wakeups are allowed to fire while inactive and die naturally. It passes both before and after the fix, confirming that the failure depends specifically on a stale wakeup surviving until re-activation, rather than on flapping in general.

### Note on the measured counts

The `request_peers` count of **5 is a floor, not an exact chain count**. Because that test staggers activations to give each chain its own phase offset, one of the 6 chains falls outside the half-open `[now, now + interval)` measurement window. The wakeup-level test measures all 6 directly. The two numbers are consistent; they are measured at different layers and with different windowing.

## Validation

- **419 tests passed, 0 failures, 0 errors** across **37 suites** in `org.opensearch.discovery.*` and `org.opensearch.cluster.coordination.*`, including all 55 `CoordinatorTests` simulation tests.
- `spotlessJavaCheck` passed.

## Related Issues

None — found by inspection of the `org.opensearch.discovery` package.

## Check List

- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created — not applicable; no user-facing behavior or setting changes.
- [ ] API changes companion pull request created — not applicable; no public API change.
