### PR TITLE
Fix ClusterStateChecksum deadlock when a checksum task throws an unchecked exception

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterStateChecksum.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterStateChecksum.java
@@ -154,9 +154,10 @@ public class ClusterStateChecksum implements ToXContentFragment, Writeable {
             try {
                 long checksum = createChecksum(checksumTask);
                 checksumConsumer.accept(checksum);
-                latch.countDown();
             } catch (IOException e) {
                 throw new RemoteStateTransferException("Failed to execute checksum task", e);
+            } finally {
+                latch.countDown();
             }
         });
     }


### PR DESCRIPTION
### Description

Moves `latch.countDown()` into a `finally` block so the `CountDownLatch` is always decremented, even when a checksum task throws an unchecked exception.

### Root cause

`ClusterStateChecksum` computes checksums for 11 cluster state components in parallel on the `REMOTE_STATE_CHECKSUM` thread pool. Its constructor blocks on `latch.await()` until all tasks have called `latch.countDown()`.

Currently `countDown()` sits inside the `try` block and is only reached on the success path. The `catch` clause only handles `IOException`; any unchecked exception (e.g. `NullPointerException`, `RuntimeException`) propagates to the executor's uncaught handler and the worker thread dies **without decrementing the latch**. The constructor's `latch.await()` then blocks forever, and since the cluster manager task thread is single-threaded, every subsequent cluster state update stalls until the process is restarted.

```java
executorService.execute(() -> {
    try {
        long checksum = createChecksum(checksumTask);
        checksumConsumer.accept(checksum);
        latch.countDown();   // only reached on success
    } catch (IOException e) {
        throw new RemoteStateTransferException("Failed to execute checksum task", e);
    }
    // unchecked exception -> thread dies, latch never decremented -> deadlock
});
```

### Fix

Move `latch.countDown()` to a `finally` block:

```java
executorService.execute(() -> {
    try {
        long checksum = createChecksum(checksumTask);
        checksumConsumer.accept(checksum);
    } catch (IOException e) {
        throw new RemoteStateTransferException("Failed to execute checksum task", e);
    } finally {
        latch.countDown();
    }
});
```

This guarantees the latch is always decremented regardless of how the task completes, preventing the cluster manager deadlock described in #22715.

### Issues Resolved

Closes #22715
