### PR TITLE
Route _validate/query through the DSL converter on the Calcite path

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryExecutorIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryExecutorIT.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 /**
  * Integration test that verifies the full DSL query execution pipeline:
- * SearchActionFilter → TransportDslExecuteAction → SearchSourceConverter → DslQueryPlanExecutor → SearchResponse.
+ * SearchActionFilter → TransportExecuteAction → SearchSourceConverter → DslQueryPlanExecutor → SearchResponse.
  */
 @AwaitsFix(bugUrl = "analytics engine pipeline not E2E complete: fragment conversion + shard execution + Arrow Flight drain not yet wired")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/action/RequestScopedMapperServiceIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/action/RequestScopedMapperServiceIT.java
@@ -25,7 +25,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  * Verifies response-typing mapping resolution on a coordinating-only node (hosting no shard)
  * while dynamic mapping updates arrive from documents indexed on a separate data node. Drives
  * {@link RequestScopedMapperService} against the coordinator's real {@link IndicesService} and
- * cluster state, as {@code TransportDslExecuteAction} wires it; the DSL plugins are not
+ * cluster state, as {@code TransportExecuteAction} wires it; the DSL plugins are not
  * installed because the machinery under test does not depend on the engine.
  */
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -15,9 +15,11 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.dsl.action.DslExecuteAction;
+import org.opensearch.dsl.action.ExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
-import org.opensearch.dsl.action.TransportDslExecuteAction;
+import org.opensearch.dsl.action.TransportExecuteAction;
+import org.opensearch.dsl.action.TransportValidateAction;
+import org.opensearch.dsl.action.ValidateAction;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugins.ActionPlugin;
@@ -36,7 +38,7 @@ import java.util.function.Supplier;
 
 /**
  * Plugin entry point. Registers {@link SearchActionFilter} to intercept _search requests
- * and {@link TransportDslExecuteAction} to handle DSL-to-Calcite conversion and execution.
+ * and {@link TransportExecuteAction} to handle DSL-to-Calcite conversion and execution.
  */
 public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
 
@@ -65,7 +67,10 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return List.of(new ActionHandler<>(DslExecuteAction.INSTANCE, TransportDslExecuteAction.class));
+        return List.of(
+            new ActionHandler<>(ExecuteAction.INSTANCE, TransportExecuteAction.class),
+            new ActionHandler<>(ValidateAction.INSTANCE, TransportValidateAction.class)
+        );
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/ExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/ExecuteAction.java
@@ -15,16 +15,16 @@ import org.opensearch.action.search.SearchResponse;
  * Internal action for executing DSL queries through the analytics engine.
  * Accepts a {@link org.opensearch.action.search.SearchRequest} and returns a {@link SearchResponse}.
  */
-public class DslExecuteAction extends ActionType<SearchResponse> {
+public class ExecuteAction extends ActionType<SearchResponse> {
 
     // TODO: Customers migrating to new indices will need a new Security permission for this action.
     // Evaluate whether this can reuse an existing search permission or needs security plugin integration.
     /** Action name registered with the transport layer. */
     public static final String NAME = "indices:data/read/dsl/execute";
     /** Singleton instance. */
-    public static final DslExecuteAction INSTANCE = new DslExecuteAction();
+    public static final ExecuteAction INSTANCE = new ExecuteAction();
 
-    private DslExecuteAction() {
+    private ExecuteAction() {
         super(NAME, SearchResponse::new);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/IndexResolutionStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/IndexResolutionStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.opensearch.action.IndicesRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+
+import java.util.List;
+
+/**
+ * Resolves an indices-bearing request (which may carry aliases or wildcards) to the concrete indices
+ * the DSL Calcite path will operate on. The implementation owns the cardinality policy:
+ * {@link SingleIndexResolutionStrategy} requires exactly one concrete index (the constraint today),
+ * while a future multi-index strategy may return several. Transport actions call a single
+ * {@link #resolve} and leave the policy to the strategy.
+ */
+interface IndexResolutionStrategy {
+
+    /**
+     * Resolves the request's indices to the concrete indices this strategy permits.
+     *
+     * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
+     * @param state cluster-state snapshot to resolve against
+     * @param request the indices-bearing request (e.g. a {@code SearchRequest} or {@code ValidateQueryRequest})
+     * @return the resolved indices' metadata (never empty)
+     * @throws IllegalArgumentException if the resolved indices violate the strategy's cardinality policy
+     */
+    List<IndexMetadata> resolve(IndexNameExpressionResolver indexNameExpressionResolver, ClusterState state, IndicesRequest request);
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -9,6 +9,9 @@
 package org.opensearch.dsl.action;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryAction;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -21,8 +24,9 @@ import org.opensearch.tasks.Task;
 import org.opensearch.transport.client.node.NodeClient;
 
 /**
- * Intercepts all {@code _search} requests and dispatches them to {@link DslExecuteAction}
- * for execution through the Calcite pipeline. Non-search actions pass through unchanged.
+ * Intercepts all {@code _search} requests (dispatched to {@link ExecuteAction}) and
+ * {@code _validate/query} requests (dispatched to {@link ValidateAction}) for handling
+ * through the Calcite pipeline. Other actions pass through unchanged.
  */
 public class SearchActionFilter implements ActionFilter {
 
@@ -34,7 +38,7 @@ public class SearchActionFilter implements ActionFilter {
     /**
      * Creates a filter that dispatches intercepted searches via the given client.
      *
-     * @param client node client for dispatching to {@link DslExecuteAction}
+     * @param client node client for dispatching to {@link ExecuteAction}
      */
     public SearchActionFilter(NodeClient client) {
         this.client = client;
@@ -59,7 +63,11 @@ public class SearchActionFilter implements ActionFilter {
         // Consider two categories: APIs that execute search vs APIs that only explain/validate.
         if (SearchAction.NAME.equals(action)) {
             SearchRequest searchRequest = (SearchRequest) request;
-            client.execute(DslExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
+            client.execute(ExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
+        } else if (ValidateQueryAction.NAME.equals(action)) {
+            // Cast is safe: the action name identifies the request/listener types.
+            ValidateQueryRequest validateRequest = (ValidateQueryRequest) request;
+            client.execute(ValidateAction.INSTANCE, validateRequest, (ActionListener<ValidateQueryResponse>) listener);
         } else {
             chain.proceed(task, action, request, listener);
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SingleIndexResolutionStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SingleIndexResolutionStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.opensearch.action.IndicesRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.core.index.Index;
+
+import java.util.List;
+
+/**
+ * {@link IndexResolutionStrategy} that requires the request to resolve to exactly one concrete
+ * index — the single-index constraint of the DSL Calcite path today. Resolving to zero or more
+ * than one concrete index is rejected.
+ */
+final class SingleIndexResolutionStrategy implements IndexResolutionStrategy {
+
+    @Override
+    public List<IndexMetadata> resolve(
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterState state,
+        IndicesRequest request
+    ) {
+        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
+        if (concreteIndices.length != 1) {
+            throw new IllegalArgumentException(
+                "DSL currently supports exactly one concrete index, but resolved to " + concreteIndices.length + " indices"
+            );
+        }
+        return List.of(state.metadata().getIndexSafe(concreteIndices[0]));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportExecuteAction.java
@@ -24,7 +24,6 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.index.Index;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.DslQueryPlanExecutor;
@@ -47,15 +46,16 @@ import java.util.concurrent.TimeUnit;
  * <p>Receives {@link QueryPlanExecutor} and {@link EngineContextProvider} from the analytics engine
  * via Guice injection (enabled by {@code extendedPlugins = ['analytics-engine']}).
  */
-public class TransportDslExecuteAction extends HandledTransportAction<SearchRequest, SearchResponse> {
+public class TransportExecuteAction extends HandledTransportAction<SearchRequest, SearchResponse> {
 
-    private static final Logger logger = LogManager.getLogger(TransportDslExecuteAction.class);
+    private static final Logger logger = LogManager.getLogger(TransportExecuteAction.class);
 
     private final EngineContextProvider contextProvider;
     private final DslQueryPlanExecutor planExecutor;
     private final ClusterService clusterService;
     private final IndicesService indicesService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final IndexResolutionStrategy indexResolutionStrategy = new SingleIndexResolutionStrategy();
     private final ThreadPool threadPool;
 
     /**
@@ -69,7 +69,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
      * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
      */
     @Inject
-    public TransportDslExecuteAction(
+    public TransportExecuteAction(
         TransportService transportService,
         ActionFilters actionFilters,
         EngineContextProvider contextProvider,
@@ -79,7 +79,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         IndexNameExpressionResolver indexNameExpressionResolver,
         ThreadPool threadPool
     ) {
-        super(DslExecuteAction.NAME, transportService, actionFilters, SearchRequest::new);
+        super(ExecuteAction.NAME, transportService, actionFilters, SearchRequest::new);
         this.contextProvider = contextProvider;
         this.planExecutor = new DslQueryPlanExecutor(executor);
         this.clusterService = clusterService;
@@ -97,7 +97,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             final ClusterState state = clusterService.state();
             final IndexMetadata indexMetadata;
             try {
-                indexMetadata = resolveToSingleIndex(state, request);
+                indexMetadata = indexResolutionStrategy.resolve(indexNameExpressionResolver, state, request).get(0);
             } catch (Exception e) {
                 listener.onFailure(e);
                 return;
@@ -207,23 +207,5 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             return;
         }
         listener.onResponse(response);
-    }
-
-    // TODO: Consider delegating index resolution to Analytics Core plugin (e.g. via
-    // EngineContextProvider or Schema table lookup) for consistency, and return RelOptTable directly
-    // so this plugin doesn't need its own resolution logic.
-    /**
-     * Resolves the request's indices (which may be aliases or wildcards) to a single concrete
-     * index, returning its metadata from the same cluster state snapshot. Throws if the
-     * resolution yields zero or more than one concrete index.
-     */
-    private IndexMetadata resolveToSingleIndex(ClusterState state, SearchRequest request) {
-        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
-        if (concreteIndices.length != 1) {
-            throw new IllegalArgumentException(
-                "DSL execution currently supports exactly one concrete index, but resolved to " + concreteIndices.length + " indices"
-            );
-        }
-        return state.metadata().getIndexSafe(concreteIndices[0]);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportValidateAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportValidateAction.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.indices.validate.query.QueryExplanation;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.analytics.EngineContextProvider;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.converter.SearchSourceConverter;
+import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.List;
+
+/**
+ * Validates a query against the DSL-to-Calcite conversion pipeline without executing it.
+ *
+ * <p>Vanilla {@code _validate/query} checks whether Lucene can parse the query — the wrong
+ * question on this path, where a query succeeds only if the converter accepts it. Validation
+ * here is conversion without execution: {@link SearchSourceConverter#convert} either produces
+ * plans (valid) or throws {@link ConversionException} (invalid, message reported as the error).
+ *
+ * <p>Scope notes:
+ * <ul>
+ *   <li>Query types without a registered translator convert into {@code UnresolvedQueryCall}
+ *       for the engine's optimizer to resolve or reject at execution time — they validate as
+ *       valid here. Conversion-level validation catches schema errors (unknown fields, unknown
+ *       index), not engine capability limits.</li>
+ *   <li>Like vanilla, explanations are returned only when {@code explain}, {@code rewrite}, or
+ *       {@code all_shards} is set. The explanation text is the converted plan
+ *       ({@code RelNode.explain()}) rather than a rewritten Lucene query.</li>
+ *   <li>Conversion is a coordinator concern — there is no shard fan-out, so shard counts are
+ *       reported as 1/1 and {@code all_shards} adds nothing beyond {@code explain}.</li>
+ * </ul>
+ */
+public class TransportValidateAction extends HandledTransportAction<ValidateQueryRequest, ValidateQueryResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportValidateAction.class);
+
+    private final EngineContextProvider contextProvider;
+    private final ClusterService clusterService;
+    private final IndicesService indicesService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final IndexResolutionStrategy indexResolutionStrategy = new SingleIndexResolutionStrategy();
+    private final ThreadPool threadPool;
+
+    /**
+     * Guice-injected constructor — receives the analytics engine context for schema access.
+     *
+     * @param transportService transport service
+     * @param actionFilters action filters
+     * @param contextProvider analytics engine context providing the Calcite schema
+     * @param clusterService cluster service for resolving index aliases
+     * @param indicesService creates the request-scoped MapperService for mapping-aware validation
+     * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
+     * @param threadPool thread pool for offloading conversion work
+     */
+    @Inject
+    public TransportValidateAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        EngineContextProvider contextProvider,
+        ClusterService clusterService,
+        IndicesService indicesService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ThreadPool threadPool
+    ) {
+        super(ValidateAction.NAME, transportService, actionFilters, ValidateQueryRequest::new);
+        this.contextProvider = contextProvider;
+        this.clusterService = clusterService;
+        this.indicesService = indicesService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    protected void doExecute(Task task, ValidateQueryRequest request, ActionListener<ValidateQueryResponse> listener) {
+        threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
+            try {
+                listener.onResponse(validate(request));
+            } catch (Exception e) {
+                logger.error("DSL validation failed", e);
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Runs the conversion pipeline and maps the outcome to a {@link ValidateQueryResponse}.
+     * A {@link ConversionException} means the query is invalid on this path; any other
+     * exception (index not found, multiple indices) propagates as a request failure,
+     * matching how {@code _search} reports the same conditions.
+     *
+     * <p>Conversion is set up exactly as {@link TransportExecuteAction} does — same cluster-state
+     * snapshot, same mapping-aware {@link SearchSourceConverter} — so a query validates here if and
+     * only if execution would accept it.
+     */
+    private ValidateQueryResponse validate(ValidateQueryRequest request) {
+        // One snapshot per request: index resolution, the engine schema, and mapping resolution
+        // all derive from the same immutable cluster state.
+        final ClusterState state = clusterService.state();
+        final IndexMetadata indexMetadata = indexResolutionStrategy.resolve(indexNameExpressionResolver, state, request).get(0);
+        final String indexName = indexMetadata.getIndex().getName();
+
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        source.query(request.query());
+
+        // Like vanilla, detail (the plan explanation) is returned only when explicitly requested.
+        final boolean detailRequested = request.explain() || request.rewrite() || request.allShards();
+
+        boolean valid;
+        String explanation = null;
+        String error = null;
+        // Mapping pinned at request start, mirroring execution, and released when validation ends.
+        try (
+            RequestScopedMapperService mapperService = new RequestScopedMapperService(
+                indexMetadata,
+                indicesService::createIndexMapperService
+            )
+        ) {
+            SearchSourceConverter converter = new SearchSourceConverter(contextProvider.getContext(state).schema(), mapperService);
+            QueryPlans plans = converter.convert(source, indexName);
+            valid = true;
+            if (detailRequested) {
+                explanation = plans.first().map(plan -> plan.relNode().explain().trim()).orElse(null);
+            }
+        } catch (ConversionException e) {
+            valid = false;
+            error = e.getMessage();
+        }
+
+        List<QueryExplanation> explanations = detailRequested
+            ? List.of(new QueryExplanation(indexName, QueryExplanation.RANDOM_SHARD, valid, valid ? explanation : null, error))
+            : null;
+        return new ValidateQueryResponse(valid, explanations, 1, 1, 0, List.of());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/ValidateAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/ValidateAction.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
+
+/**
+ * Action type for validating a query against the DSL-to-Calcite converter.
+ * Dispatched by {@link SearchActionFilter} when it intercepts a {@code _validate/query} request.
+ */
+public class ValidateAction extends ActionType<ValidateQueryResponse> {
+
+    /** Singleton instance. */
+    public static final ValidateAction INSTANCE = new ValidateAction();
+
+    /** Action name. Follows the {@code dsl/<verb>} convention shared with {@link ExecuteAction}. */
+    public static final String NAME = "indices:data/read/dsl/validate";
+
+    private ValidateAction() {
+        super(NAME, ValidateQueryResponse::new);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/QueryPlans.java
@@ -14,6 +14,7 @@ import org.opensearch.dsl.aggregation.AggregationMetadata;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * One or more query plans produced by DSL to RelNode conversion.
@@ -92,6 +93,11 @@ public final class QueryPlans {
     /** Returns all plans. */
     public List<QueryPlan> getAll() {
         return plans;
+    }
+
+    /** Returns the first plan produced, or empty when conversion yielded none. */
+    public Optional<QueryPlan> first() {
+        return plans.isEmpty() ? Optional.empty() : Optional.of(plans.get(0));
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
@@ -9,9 +9,11 @@
 package org.opensearch.dsl;
 
 import org.opensearch.action.support.ActionFilter;
-import org.opensearch.dsl.action.DslExecuteAction;
+import org.opensearch.dsl.action.ExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
-import org.opensearch.dsl.action.TransportDslExecuteAction;
+import org.opensearch.dsl.action.TransportExecuteAction;
+import org.opensearch.dsl.action.TransportValidateAction;
+import org.opensearch.dsl.action.ValidateAction;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
@@ -47,9 +49,12 @@ public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
     public void testRegistersTransportAction() {
         var actions = plugin.getActions();
 
-        assertEquals(1, actions.size());
-        ActionPlugin.ActionHandler<?, ?> handler = actions.get(0);
-        assertEquals(DslExecuteAction.INSTANCE, handler.getAction());
-        assertEquals(TransportDslExecuteAction.class, handler.getTransportAction());
+        assertEquals(2, actions.size());
+        ActionPlugin.ActionHandler<?, ?> executeHandler = actions.get(0);
+        assertEquals(ExecuteAction.INSTANCE, executeHandler.getAction());
+        assertEquals(TransportExecuteAction.class, executeHandler.getTransportAction());
+        ActionPlugin.ActionHandler<?, ?> validateHandler = actions.get(1);
+        assertEquals(ValidateAction.INSTANCE, validateHandler.getAction());
+        assertEquals(TransportValidateAction.class, validateHandler.getTransportAction());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.dsl.action;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryAction;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.search.SearchAction;
@@ -57,7 +59,16 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
 
         filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
 
-        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), any());
+        verify(client).execute(eq(ExecuteAction.INSTANCE), eq(request), any());
+        verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    public void testReroutesValidateQueryAction() {
+        ValidateQueryRequest request = new ValidateQueryRequest("test-index");
+
+        filter.apply(task, ValidateQueryAction.NAME, request, metadata, listener, chain);
+
+        verify(client).execute(eq(ValidateAction.INSTANCE), eq(request), any());
         verify(chain, never()).proceed(any(), any(), any(), any());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportExecuteActionTests.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.action;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.Version;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.analytics.EngineContextProvider;
+import org.opensearch.analytics.QueryRequestContext;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportExecuteActionTests extends OpenSearchTestCase {
+
+    public void testDoExecuteReturnsSearchResponse() {
+        TransportExecuteAction action = createAction(new Index("test-index", "uuid"));
+
+        TestListener listener = executeWith(action, "test-index");
+
+        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
+        assertNotNull(listener.response.get());
+        assertEquals(200, listener.response.get().status().getStatus());
+    }
+
+    public void testDoExecuteFailsWhenIndexNotInSchema() {
+        TransportExecuteAction action = createAction(new Index("nonexistent-index", "uuid"));
+
+        TestListener listener = executeWith(action, "nonexistent-index");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(listener.failure.get() instanceof IllegalArgumentException);
+        assertTrue(listener.failure.get().getMessage().contains("nonexistent-index"));
+    }
+
+    public void testDoExecuteRejectsMultipleConcreteIndices() {
+        TransportExecuteAction action = createAction(new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+
+        TestListener listener = executeWith(action, "multi-alias");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(listener.failure.get() instanceof IllegalArgumentException);
+        assertTrue(listener.failure.get().getMessage().contains("exactly one concrete index"));
+    }
+
+    public void testDoExecuteFailsWhenIndexNotInClusterState() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("bogus-index"));
+
+        TransportExecuteAction action = new TransportExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            mock(IndicesService.class),
+            resolver,
+            mockThreadPool()
+        );
+
+        TestListener listener = executeWith(action, "bogus-index");
+
+        assertNull(listener.response.get());
+        assertNotNull(listener.failure.get());
+        assertTrue(listener.failure.get() instanceof IndexNotFoundException);
+    }
+
+    private TestListener executeWith(TransportExecuteAction action, String index) {
+        SearchRequest request = new SearchRequest(index);
+        request.source(new SearchSourceBuilder());
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), request, listener);
+        return listener;
+    }
+
+    private TransportExecuteAction createAction(Index... resolvedIndices) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (Index index : resolvedIndices) {
+            metadata.put(
+                IndexMetadata.builder(index.getName())
+                    .settings(
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                            .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+                    )
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .build(),
+                false
+            );
+        }
+        ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(state);
+
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
+
+        return new TransportExecuteAction(
+            mock(TransportService.class),
+            new ActionFilters(Collections.emptySet()),
+            buildEngineContext(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
+            clusterService,
+            mock(IndicesService.class),
+            resolver,
+            mockThreadPool()
+        );
+    }
+
+    private EngineContextProvider buildEngineContext() {
+        QueryRequestContext ctx = new QueryRequestContext(null, buildSchema());
+        return new EngineContextProvider() {
+            @Override
+            public QueryRequestContext getContext(ClusterState clusterState) {
+                return ctx;
+            }
+
+            @Override
+            public QueryRequestContext getContext() {
+                return ctx;
+            }
+        };
+    }
+
+    private SchemaPlus buildSchema() {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory tf) {
+                return tf.builder().add("name", SqlTypeName.VARCHAR).add("price", SqlTypeName.INTEGER).build();
+            }
+        });
+        return schema;
+    }
+
+    private static ThreadPool mockThreadPool() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.executor(any())).thenReturn(executorService);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(executorService).execute(any());
+        return threadPool;
+    }
+
+    private static class TestListener implements ActionListener<SearchResponse> {
+        final AtomicReference<SearchResponse> response = new AtomicReference<>();
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+
+        @Override
+        public void onResponse(SearchResponse r) {
+            response.set(r);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            failure.set(e);
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportValidateActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportValidateActionTests.java
@@ -15,8 +15,8 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.Version;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.analytics.EngineContextProvider;
 import org.opensearch.analytics.QueryRequestContext;
@@ -29,9 +29,10 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
-import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -46,75 +47,102 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TransportDslExecuteActionTests extends OpenSearchTestCase {
+public class TransportValidateActionTests extends OpenSearchTestCase {
 
-    public void testDoExecuteReturnsSearchResponse() {
-        TransportDslExecuteAction action = createAction(new Index("test-index", "uuid"));
+    public void testValidQuery() {
+        TestListener listener = validate(new TermQueryBuilder("name", "laptop"), false);
 
-        TestListener listener = executeWith(action, "test-index");
-
-        assertNull("Expected no failure but got: " + listener.failure.get(), listener.failure.get());
-        assertNotNull(listener.response.get());
-        assertEquals(200, listener.response.get().status().getStatus());
+        assertNull(listener.failure.get());
+        assertTrue(listener.response.get().isValid());
+        // Like vanilla: no explanations unless explain is requested.
+        assertTrue(listener.response.get().getQueryExplanation().isEmpty());
     }
 
-    public void testDoExecuteFailsWhenIndexNotInSchema() {
-        TransportDslExecuteAction action = createAction(new Index("nonexistent-index", "uuid"));
+    public void testValidQueryWithExplainReturnsPlan() {
+        TestListener listener = validate(new TermQueryBuilder("name", "laptop"), true);
 
-        TestListener listener = executeWith(action, "nonexistent-index");
-
-        assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(listener.failure.get() instanceof IllegalArgumentException);
-        assertTrue(listener.failure.get().getMessage().contains("nonexistent-index"));
+        assertTrue(listener.response.get().isValid());
+        assertEquals(1, listener.response.get().getQueryExplanation().size());
+        String explanation = listener.response.get().getQueryExplanation().get(0).getExplanation();
+        assertNotNull(explanation);
+        assertTrue("expected a RelNode plan, got: " + explanation, explanation.contains("LogicalTableScan"));
     }
 
-    public void testDoExecuteRejectsMultipleConcreteIndices() {
-        TransportDslExecuteAction action = createAction(new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+    public void testUnknownFieldIsInvalid() {
+        TestListener listener = validate(new TermQueryBuilder("no_such_field", "x"), true);
 
-        TestListener listener = executeWith(action, "multi-alias");
+        assertNull(listener.failure.get());
+        ValidateQueryResponse response = listener.response.get();
+        assertFalse(response.isValid());
+        assertEquals(1, response.getQueryExplanation().size());
+        assertFalse(response.getQueryExplanation().get(0).isValid());
+        assertTrue(response.getQueryExplanation().get(0).getError().contains("no_such_field"));
+    }
+
+    public void testUnknownFieldWithoutExplainOmitsDetail() {
+        TestListener listener = validate(new TermQueryBuilder("no_such_field", "x"), false);
+
+        assertFalse(listener.response.get().isValid());
+        assertTrue(listener.response.get().getQueryExplanation().isEmpty());
+    }
+
+    /**
+     * Query types without a registered translator become UnresolvedQueryCall for the engine
+     * to resolve or reject at execution time — conversion-level validation reports them valid.
+     */
+    public void testUnregisteredQueryTypeIsValid() {
+        TestListener listener = validate(new MatchQueryBuilder("name", "laptop"), false);
+
+        assertNull(listener.failure.get());
+        assertTrue(listener.response.get().isValid());
+    }
+
+    public void testNullQueryIsValid() {
+        TestListener listener = validate(null, false);
+
+        assertNull(listener.failure.get());
+        assertTrue(listener.response.get().isValid());
+    }
+
+    public void testMultipleConcreteIndicesFails() {
+        TransportValidateAction action = createAction(new Index("index-a", "uuid-a"), new Index("index-b", "uuid-b"));
+
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), new ValidateQueryRequest("multi-alias"), listener);
 
         assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
         assertTrue(listener.failure.get() instanceof IllegalArgumentException);
         assertTrue(listener.failure.get().getMessage().contains("exactly one concrete index"));
     }
 
-    public void testDoExecuteFailsWhenIndexNotInClusterState() {
-        ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+    public void testIndexNotInSchemaFails() {
+        TransportValidateAction action = createAction(new Index("nonexistent-index", "uuid"));
 
-        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenThrow(new IndexNotFoundException("bogus-index"));
-
-        TransportDslExecuteAction action = new TransportDslExecuteAction(
-            mock(TransportService.class),
-            new ActionFilters(Collections.emptySet()),
-            buildEngineContext(),
-            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
-            clusterService,
-            mock(IndicesService.class),
-            resolver,
-            mockThreadPool()
-        );
-
-        TestListener listener = executeWith(action, "bogus-index");
+        TestListener listener = new TestListener();
+        action.doExecute(mock(Task.class), new ValidateQueryRequest("nonexistent-index"), listener);
 
         assertNull(listener.response.get());
-        assertNotNull(listener.failure.get());
-        assertTrue(listener.failure.get() instanceof IndexNotFoundException);
+        assertTrue(listener.failure.get() instanceof IllegalArgumentException);
+        assertTrue(listener.failure.get().getMessage().contains("nonexistent-index"));
     }
 
-    private TestListener executeWith(TransportDslExecuteAction action, String index) {
-        SearchRequest request = new SearchRequest(index);
-        request.source(new SearchSourceBuilder());
+    // ---- Helpers ----
+
+    private TestListener validate(QueryBuilder query, boolean explain) {
+        TransportValidateAction action = createAction(new Index("test-index", "uuid"));
+
+        ValidateQueryRequest request = new ValidateQueryRequest("test-index");
+        if (query != null) {
+            request.query(query);
+        }
+        request.explain(explain);
 
         TestListener listener = new TestListener();
         action.doExecute(mock(Task.class), request, listener);
         return listener;
     }
 
-    private TransportDslExecuteAction createAction(Index... resolvedIndices) {
+    private TransportValidateAction createAction(Index... resolvedIndices) {
         Metadata.Builder metadata = Metadata.builder();
         for (Index index : resolvedIndices) {
             metadata.put(
@@ -135,13 +163,12 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
-        when(resolver.concreteIndices(any(), any(SearchRequest.class))).thenReturn(resolvedIndices);
+        when(resolver.concreteIndices(any(), any(ValidateQueryRequest.class))).thenReturn(resolvedIndices);
 
-        return new TransportDslExecuteAction(
+        return new TransportValidateAction(
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
             buildEngineContext(),
-            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             mock(IndicesService.class),
             resolver,
@@ -186,12 +213,12 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
         return threadPool;
     }
 
-    private static class TestListener implements ActionListener<SearchResponse> {
-        final AtomicReference<SearchResponse> response = new AtomicReference<>();
+    private static class TestListener implements ActionListener<ValidateQueryResponse> {
+        final AtomicReference<ValidateQueryResponse> response = new AtomicReference<>();
         final AtomicReference<Exception> failure = new AtomicReference<>();
 
         @Override
-        public void onResponse(SearchResponse r) {
+        public void onResponse(ValidateQueryResponse r) {
             response.set(r);
         }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/validate/query/ValidateQueryResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/validate/query/ValidateQueryResponse.java
@@ -87,13 +87,31 @@ public class ValidateQueryResponse extends BroadcastResponse {
 
     private final List<QueryExplanation> queryExplanations;
 
-    ValidateQueryResponse(StreamInput in) throws IOException {
+    /**
+     * Deserialization constructor. Public so plugins that intercept
+     * {@code ValidateQueryAction} can register response readers.
+     *
+     * @param in the stream input
+     * @throws IOException on deserialization failure
+     */
+    public ValidateQueryResponse(StreamInput in) throws IOException {
         super(in);
         valid = in.readBoolean();
         queryExplanations = in.readList(QueryExplanation::new);
     }
 
-    ValidateQueryResponse(
+    /**
+     * Creates a validate query response. Public so plugins that intercept
+     * {@code ValidateQueryAction} can construct responses.
+     *
+     * @param valid whether the query is valid
+     * @param queryExplanations per-target explanations, or null for none
+     * @param totalShards total shards the validation ran on
+     * @param successfulShards successful shards
+     * @param failedShards failed shards
+     * @param shardFailures shard failure details
+     */
+    public ValidateQueryResponse(
         boolean valid,
         List<QueryExplanation> queryExplanations,
         int totalShards,


### PR DESCRIPTION
### Description
Makes `_validate/query` Calcite-aware on the DSL query executor path.

Vanilla validate checks whether Lucene can parse the query — the wrong question on this path, where a query only executes if the DSL-to-Calcite converter accepts it. Today the two can disagree in both directions: Lucene validates queries the converter rejects (unknown fields — Lucene is lenient on unmapped fields), and rejects queries this path runs via `UnresolvedQueryCall` pushdown.

Changes:
- `SearchActionFilter` intercepts `indices:admin/validate/query` alongside `_search`
- New `TransportDslValidateAction`: validation = running `SearchSourceConverter.convert()` without executing. Success → `valid: true`; `ConversionException` → `valid: false` with the converter's message as the error. `explain=true` returns the converted RelNode plan as the explanation
- `ValidateQueryResponse` constructors made public (server) so intercepting plugins can construct responses

Example — vanilla says this is valid; the DSL path correctly rejects it:
```
POST /products/_validate/query?explain=true
{"query": {"term": {"no_such_field": "x"}}}

{"valid": false, "explanations": [{"index": "products", "valid": false,
  "error": "Field 'no_such_field' not found in schema"}]}
```

### Scope notes
- Query types without a registered translator convert to `UnresolvedQueryCall` for the engine optimizer to resolve or reject at execution — they validate as valid. Conversion-level validation catches schema errors, not engine capability limits (that would need a plan-without-execute engine API).
- Single concrete index only (multi-index → 400, matching `_search` on this path).
- Like vanilla, explanations are returned only when `explain`/`rewrite`/`all_shards` is set; there is no shard fan-out, so shard counts report 1/1.

### Testing
- 8 new unit tests (`TransportDslValidateActionTests`) + filter/plugin registration tests; 149 plugin tests + precommit green
- Verified end-to-end on a live composite/parquet cluster: valid query, unknown field (invalid + error), explain (plan text), unregistered query type, empty body, and `_search` interception regression

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).