### PR TITLE
Run big5 benchmark configs on c5.2xlarge instances

### DIFF
--- a/.github/benchmark-configs.json
+++ b/.github/benchmark-configs.json
@@ -40,6 +40,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"big5_1_shard_single_client\"}",
       "CAPTURE_NODE_STAT": "true",
@@ -47,9 +48,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_4": {
     "description": "Indexing and search configuration for pmc workload",
@@ -89,6 +90,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "search.concurrent_segment_search.enabled:true",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"big5_1_shard_single_client\"}",
@@ -97,9 +99,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_7": {
     "description": "Search only test-procedure for big5 with concurrent segment search mode as all",
@@ -107,6 +109,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "search.concurrent_segment_search.mode:all",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"big5_1_shard_single_client\"}",
@@ -115,9 +118,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_8": {
     "description": "Search only test-procedure for big5 with concurrent segment search mode as auto",
@@ -125,6 +128,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "search.concurrent_segment_search.mode:auto",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"big5_1_shard_single_client\"}",
@@ -133,9 +137,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_9": {
     "description": "Search only test-procedure for big5, uses snapshot to restore the data for OS-3.0.0. Enables range query approximation.",
@@ -143,6 +147,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "opensearch.experimental.feature.approximate_point_range_query.enabled:true",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"big5_1_shard_single_client\"}",
@@ -151,9 +156,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_10": {
     "description": "Benchmarking config for NESTED workload, benchmarks nested queries with inner-hits",
@@ -211,6 +216,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "search.concurrent_segment_search.mode:auto",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.3.2\",\"snapshot_name\":\"big5_1_shard_text_field\"}",
@@ -219,9 +225,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_14": {
     "description": "Intra-segment search test-procedure for http_logs with concurrent segment search mode as auto",
@@ -247,6 +253,7 @@
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
       "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "TEST_WORKLOAD": "big5",
       "ADDITIONAL_CONFIG": "search.concurrent_segment_search.partition_strategy:force",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.3.2\",\"snapshot_name\":\"big5_1_shard_text_field\"}",
@@ -255,9 +262,9 @@
     },
     "cluster_configuration": {
       "size": "Single-Node",
-      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
-    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+    "baseline_cluster_config": "x64-c5.2xlarge-1-shard-0-replica-snapshot"
   },
   "id_16": {
     "description": "clickbench workload DSL queries test",


### PR DESCRIPTION
### Description
Switches all big5 benchmark configurations to the `c5.2xlarge` data instance type (8vCPU, 32G Mem, 16G Heap) and updates their baseline cluster config accordingly.

Affected configs in `.github/benchmark-configs.json`: `id_3`, `id_6`, `id_7`, `id_8`, `id_9`, `id_13`, `id_15`.

For each:
- Added `"DATA_INSTANCE_TYPE": "c5.2xlarge"`
- Updated `data_instance_config` from `4vCPU, 32G Mem, 16G Heap` to `8vCPU, 32G Mem, 16G Heap`
- Updated `baseline_cluster_config` to `x64-c5.2xlarge-1-shard-0-replica-snapshot`

### Check List
- [x] Functionality includes testing (n/a — CI benchmark config only)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.