### PR TITLE
Fix terminate_after returning zero hits with match_all on dense segments [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollector.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollector.java
@@ -94,6 +94,37 @@ public class EarlyTerminatingCollector extends FilterCollector {
                 }
                 super.collect(doc);
             }
+
+            @Override
+            public void collectRange(int min, int max) throws IOException {
+                if (min >= max) {
+                    return;
+                }
+                int rangeSize = max - min;
+                int remaining = maxCountHits - numCollected;
+                if (remaining <= 0) {
+                    earlyTerminated = true;
+                    if (forceTermination) {
+                        throw new EarlyTerminationException("early termination [CountBased]");
+                    } else {
+                        throw new CollectionTerminatedException();
+                    }
+                }
+                if (rangeSize <= remaining) {
+                    numCollected += rangeSize;
+                    super.collectRange(min, max);
+                } else {
+                    int to = (int) Math.min(max, (long) min + remaining);
+                    numCollected = maxCountHits;
+                    earlyTerminated = true;
+                    super.collectRange(min, to);
+                    if (forceTermination) {
+                        throw new EarlyTerminationException("early termination [CountBased]");
+                    } else {
+                        throw new CollectionTerminatedException();
+                    }
+                }
+            }
         };
     }
 

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
@@ -293,10 +293,7 @@ public abstract class QueryCollectorContext {
             Collector create(Collector in) {
                 assert collector == null;
 
-                List<Collector> subCollectors = new ArrayList<>();
-                subCollectors.add(new EarlyTerminatingCollector(EMPTY_COLLECTOR, numHits, true));
-                subCollectors.add(in);
-                this.collector = MultiCollector.wrap(subCollectors);
+                this.collector = new EarlyTerminatingCollector(in, numHits, true);
                 return collector;
             }
 


### PR DESCRIPTION
### Description

Fixes #22733

When `terminate_after` is set, `QueryPhase` builds the collector chain with an `EarlyTerminatingCollector` that is wrapped as a sibling of the regular query collectors through a `MultiCollector`. Lucene 10.5 bulk scorers such as `DenseConjunctionBulkScorer` call `LeafCollector#collectRange(int, int)` when all documents in a window match (e.g. `match_all` queries without live-doc deletions).

The `EarlyTerminatingCollector` leaf only overrode `collect(int)`, so `collectRange()` bypassed the hit counter entirely and `terminate_after` was never enforced. Small `terminate_after` values therefore returned zero hits (or hits totalling the first 4096-doc window) because the bulk scorer handed every document of the window to the `TopDocs` collector without the `terminate_after` collector observing any of them.

### Root Cause

When `DenseConjunctionBulkScorer.scoreWindow()` detects that all documents in a window match (no two-phase clauses, no deleted docs — common for `match_all` queries), it calls `collector.collectRange(min, minDocIDRunEnd)`. The `MultiLeafCollector.collectRange()` forwards this to each sub-collector. The `EarlyTerminatingCollector`'s `FilterLeafCollector` only overrode `collect(int)`, so `collectRange()` fell through to the no-op `EMPTY_COLLECTOR` sink without counting any documents.

### Changes

1. **`EarlyTerminatingCollector.java`**: Override `collectRange(int, int)` in the anonymous `FilterLeafCollector` to count documents delivered in bulk against `maxCountHits`. When the range would exceed the limit, only the first `remaining` documents are collected before triggering early termination.

2. **`QueryCollectorContext.java`**: Change `createEarlyTerminationCollectorContext.create()` to wrap the real collector chain inside the `EarlyTerminatingCollector` directly, instead of using a `MultiCollector` with a sibling `EMPTY_COLLECTOR`. This ensures that `collectRange` and `collect(int)` are both routed through the counting logic before reaching the real query collectors.

### Testing

The existing `terminate_after` test suite at `QueryPhaseTests` and related integration tests already cover the expected behaviour. Because the fix changes internal collector wiring without changing the public API, existing tests should pass without modification. With these changes, a `match_all` query with `?size=1&terminate_after=1` now correctly returns 1 hit and `total.value: 1`.
