### PR TITLE
Don't log throwables from Flight client stream paths on virtual threads

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
@@ -14,6 +14,7 @@ import org.apache.arrow.flight.Ticket;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.arrow.flight.stats.FlightCallTracker;
 import org.opensearch.arrow.flight.stats.FlightStatsCollector;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -450,11 +451,11 @@ class FlightClientChannel implements TcpChannel {
 
     /**
      * Logs a per-stream failure as a one-line summary at ERROR, with the full stack trace available
-     * only at DEBUG.
+     * only at TRACE.
      *
-     * <p><b>Do not pass a throwable to an enabled-by-default logger from these paths.</b> They run on the
-     * per-stream prefetch virtual thread started by {@link FlightTransportResponse#openAndPrefetchAsync},
-     * and rendering a stack trace there can wedge the whole node:
+     * <p><b>Never hand a throwable to log4j from these paths.</b> They run on the per-stream prefetch
+     * virtual thread started by {@link FlightTransportResponse#openAndPrefetchAsync}, and letting log4j
+     * render a stack trace there can wedge the whole node:
      *
      * <ol>
      *   <li>OpenSearch's JSON layout always appends {@code %exceptionAsJson}, so a logged throwable reaches
@@ -471,13 +472,14 @@ class FlightClientChannel implements TcpChannel {
      *       while making no progress.</li>
      * </ol>
      *
-     * <p>DEBUG is safe because it is off by default. Enabling it is a deliberate single-node debugging step,
-     * not something a production storm can trigger.
+     * <p>The TRACE line is safe for the same reason: it passes a pre-rendered string, so log4j never sees a
+     * throwable and the extended renderer never runs. {@link ExceptionsHelper#stackTrace} only formats frames
+     * that were captured when the throwable was constructed, resolving no classes and taking no lock.
      */
     private void logFailure(String message, Throwable cause) {
         logger.error("{}: {}", message, FlightUtils.causeSummary(cause));
-        if (logger.isDebugEnabled()) {
-            logger.debug(message, cause);
+        if (logger.isTraceEnabled()) {
+            logger.trace("{}: {}", message, ExceptionsHelper.stackTrace(cause));
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightClientChannel.java
@@ -397,7 +397,12 @@ class FlightClientChannel implements TcpChannel {
                 try (var dispatchMark = streamResponse.markDispatchThread()) {
                     try (var ignored = threadContext.stashContext()) {
                         if (header == null) {
+                            // Must return: handleStreamException does not throw, so falling through here
+                            // would NPE on getHeaders() below and mask the real failure. A null header is
+                            // reachable whenever the middleware never stored one (HeaderContext.getHeader
+                            // is a plain map remove), e.g. a call closed before its headers arrived.
                             handleStreamException(streamResponse, new StreamException(StreamErrorCode.INTERNAL, "Header is null"));
+                            return;
                         }
                         threadContext.setHeaders(header.getHeaders());
                         handler.handleStreamResponse(streamResponse);
@@ -420,12 +425,12 @@ class FlightClientChannel implements TcpChannel {
         try {
             streamResponse.close();
         } catch (IOException e) {
-            logger.error("Failed to close stream response", e);
+            logFailure("Failed to close stream response", e);
         }
     }
 
     private void handleStreamException(FlightTransportResponse<?> streamResponse, Exception exception) {
-        logger.error("Exception while handling stream response", exception);
+        logFailure("Exception while handling stream response for correlationId [" + streamResponse.getCorrelationId() + "]", exception);
         try {
             cancelStream(streamResponse, exception);
             TransportResponseHandler<?> handler = streamResponse.getHandler();
@@ -439,7 +444,40 @@ class FlightClientChannel implements TcpChannel {
         try {
             streamResponse.cancel("Client-side exception: " + cause.getMessage(), cause);
         } catch (Exception cancelEx) {
-            logger.warn("Failed to cancel stream after exception", cancelEx);
+            logFailure("Failed to cancel stream after exception", cancelEx);
+        }
+    }
+
+    /**
+     * Logs a per-stream failure as a one-line summary at ERROR, with the full stack trace available
+     * only at DEBUG.
+     *
+     * <p><b>Do not pass a throwable to an enabled-by-default logger from these paths.</b> They run on the
+     * per-stream prefetch virtual thread started by {@link FlightTransportResponse#openAndPrefetchAsync},
+     * and rendering a stack trace there can wedge the whole node:
+     *
+     * <ol>
+     *   <li>OpenSearch's JSON layout always appends {@code %exceptionAsJson}, so a logged throwable reaches
+     *       log4j's <em>extended</em> stack-trace renderer, which annotates every frame with its source JAR.</li>
+     *   <li>To do that it resolves each frame's declaring class via {@code Class.forName}. The resulting
+     *       {@code forName0} <em>native</em> frame sits on the stack while the classloader monitor is
+     *       contended, and a continuation carrying a native frame cannot be unmounted. So the virtual thread
+     *       pins its carrier instead of yielding it, even on JDK 25 where JEP 491 lets {@code synchronized}
+     *       blocking unmount.</li>
+     *   <li>The scheduler's carrier count defaults to {@code availableProcessors}. A mass stream failure
+     *       (for example every stream reconnecting at once after a network partition heals) can therefore pin
+     *       every carrier, while the thread holding the classloader lock is itself unmounted and can never be
+     *       rescheduled to release it. That circular wait does not resolve: the node keeps reporting healthy
+     *       while making no progress.</li>
+     * </ol>
+     *
+     * <p>DEBUG is safe because it is off by default. Enabling it is a deliberate single-node debugging step,
+     * not something a production storm can trigger.
+     */
+    private void logFailure(String message, Throwable cause) {
+        logger.error("{}: {}", message, FlightUtils.causeSummary(cause));
+        if (logger.isDebugEnabled()) {
+            logger.debug(message, cause);
         }
     }
 
@@ -464,7 +502,8 @@ class FlightClientChannel implements TcpChannel {
         try {
             handler.handleException(exception);
         } catch (Exception handlerEx) {
-            logger.error("Handler failed to process exception", handlerEx);
+            // Runs on the prefetch virtual thread when the handler declares the SAME executor.
+            logFailure("Handler failed to process exception", handlerEx);
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -18,6 +18,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.transport.TransportResponse;
@@ -312,17 +313,18 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     }
 
     /**
-     * Logs a one-line summary at WARN, with the full stack trace only at DEBUG.
+     * Logs a one-line summary at WARN, with the full stack trace only at TRACE.
      *
      * <p>Every path in this class can run on the per-stream prefetch virtual thread started by
-     * {@link #openAndPrefetchAsync}. Passing a throwable to an enabled-by-default logger there risks pinning
-     * the carrier inside log4j's extended stack-trace renderer, which can stall the virtual-thread scheduler
-     * under a mass stream failure. See {@code FlightClientChannel#logFailure} for the full mechanism.
+     * {@link #openAndPrefetchAsync}. Handing a throwable to log4j there risks pinning the carrier inside its
+     * extended stack-trace renderer, which can stall the virtual-thread scheduler under a mass stream failure.
+     * Both lines below pass strings only, so the renderer never runs at any level. See
+     * {@code FlightClientChannel#logFailure} for the full mechanism.
      */
     private void logFailure(String message, Throwable cause) {
         logger.warn("{} for correlationId [{}]: {}", message, correlationId, FlightUtils.causeSummary(cause));
-        if (logger.isDebugEnabled()) {
-            logger.debug(message, cause);
+        if (logger.isTraceEnabled()) {
+            logger.trace("{} for correlationId [{}]: {}", message, correlationId, ExceptionsHelper.stackTrace(cause));
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -139,7 +139,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
                                 notifyClosed();
                             }
                         } catch (StreamException e) {
-                            logger.warn("Error closing flight stream after close() raced the prefetch", e);
+                            logFailure("Error closing flight stream after close() raced the prefetch", e);
                         }
                         future.completeExceptionally(new StreamException(StreamErrorCode.UNAVAILABLE, "Stream is closed"));
                         return;
@@ -176,6 +176,11 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
 
     TransportResponseHandler<T> getHandler() {
         return handler;
+    }
+
+    /** Correlates this response with its request in logs and in {@link HeaderContext}. */
+    long getCorrelationId() {
+        return correlationId;
     }
 
     /**
@@ -250,7 +255,7 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         try {
             if (flightStream != null) flightStream.cancel(reason, cause);
         } catch (Exception e) {
-            logger.warn("Error cancelling flight stream", e);
+            logFailure("Error cancelling flight stream", e);
         } finally {
             close();
         }
@@ -302,7 +307,22 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
         try {
             stream.cancel(reason, null);
         } catch (Exception e) {
-            logger.warn("Error requesting flight stream cancellation", e);
+            logFailure("Error requesting flight stream cancellation", e);
+        }
+    }
+
+    /**
+     * Logs a one-line summary at WARN, with the full stack trace only at DEBUG.
+     *
+     * <p>Every path in this class can run on the per-stream prefetch virtual thread started by
+     * {@link #openAndPrefetchAsync}. Passing a throwable to an enabled-by-default logger there risks pinning
+     * the carrier inside log4j's extended stack-trace renderer, which can stall the virtual-thread scheduler
+     * under a mass stream failure. See {@code FlightClientChannel#logFailure} for the full mechanism.
+     */
+    private void logFailure(String message, Throwable cause) {
+        logger.warn("{} for correlationId [{}]: {}", message, correlationId, FlightUtils.causeSummary(cause));
+        if (logger.isDebugEnabled()) {
+            logger.debug(message, cause);
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
@@ -27,4 +27,42 @@ class FlightUtils {
         }
         return totalSize;
     }
+
+    /** Cause-chain depth included in {@link #causeSummary}; deeper causes are elided. */
+    private static final int MAX_CAUSE_DEPTH = 5;
+
+    /**
+     * Renders {@code t} and its cause chain as a single line, e.g.
+     * {@code StreamException[UNAVAILABLE, ...]; caused by: FlightRuntimeException[...]}.
+     *
+     * <p>This exists so the client-side stream paths can report a failure without handing the throwable
+     * to log4j. Those paths run on per-stream virtual threads, and log4j's extended stack-trace renderer
+     * (which OpenSearch's JSON layout always applies) resolves every frame's declaring class via
+     * {@code Class.forName}. The resulting {@code forName0} native frame cannot be unmounted, so a
+     * contended classloader lock pins the carrier thread rather than yielding it — see
+     * {@code FlightClientChannel#logFailure}. Only class names and messages are read here, so nothing is
+     * loaded and no lock is taken.
+     */
+    static String causeSummary(Throwable t) {
+        if (t == null) {
+            return "none";
+        }
+        StringBuilder sb = new StringBuilder();
+        Throwable current = t;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
+            if (depth > 0) {
+                sb.append("; caused by: ");
+            }
+            sb.append(current.getClass().getSimpleName());
+            if (current.getMessage() != null) {
+                sb.append('[').append(current.getMessage()).append(']');
+            }
+            Throwable cause = current.getCause();
+            current = cause == current ? null : cause;
+        }
+        if (current != null) {
+            sb.append("; ...");
+        }
+        return sb.toString();
+    }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
@@ -27,6 +27,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.junit.annotations.TestLogging;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Header;
 import org.opensearch.transport.StreamTransportResponseHandler;
@@ -416,8 +417,7 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
     }
 
     /**
-     * A stream failure must be reported without handing the throwable to log4j at an
-     * enabled-by-default level.
+     * A stream failure must be reported without ever handing the throwable to log4j, at any level.
      *
      * <p>These paths run on the per-stream prefetch virtual thread. OpenSearch's JSON layout always applies
      * log4j's extended stack-trace renderer, which resolves every frame's class via {@code Class.forName};
@@ -425,7 +425,12 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
      * instead of yielding it. With one such failure per stream, a mass reconnect can pin every carrier while
      * the lock holder sits unmounted and unschedulable, and the node stops making progress while still
      * reporting healthy. The cause must therefore reach the log as text.
+     *
+     * <p>TRACE is enabled here on purpose. The verbose branch is the one an operator reaches for while
+     * debugging this very failure, so it is the branch that most needs to be safe: turning it on must not be
+     * what arms the deadlock.
      */
+    @TestLogging(value = "org.opensearch.arrow.flight.transport.FlightClientChannel:TRACE", reason = "verbose branch must be safe")
     public void testStreamFailureIsLoggedWithoutAThrowable() throws Exception {
         when(mockFlightClient.getStream(any(Ticket.class), any())).thenThrow(
             CallStatus.UNAVAILABLE.withDescription("connection reset").toRuntimeException()
@@ -444,7 +449,16 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
                     "*Exception while handling stream response*connection reset*"
                 )
             );
-            appender.addExpectation(new NoThrowableAttachedExpectation(FlightClientChannel.class.getCanonicalName(), Level.ERROR));
+            // The stack trace is still available, just pre-rendered as text instead of as a throwable.
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "stack trace rendered as text at TRACE",
+                    FlightClientChannel.class.getCanonicalName(),
+                    Level.TRACE,
+                    "*Exception while handling stream response*\n\tat *"
+                )
+            );
+            appender.addExpectation(new NoThrowableAttachedExpectation(FlightClientChannel.class.getCanonicalName()));
 
             sendStreamRequest(streamingHandler(ThreadPool.Names.SAME, streamResponse -> {
                 throw new AssertionError("consumer must not be invoked after an open failure");
@@ -456,22 +470,20 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
     }
 
     /**
-     * Fails if any event at {@code level} carries a throwable. The framework's expectations all assert
-     * that something was seen; this asserts a property of everything that was.
+     * Fails if any event from {@code logger} carries a throwable, whatever its level. The framework's
+     * expectations all assert that something was seen; this asserts a property of everything that was.
      */
     private static final class NoThrowableAttachedExpectation implements MockLogAppender.LoggingExpectation {
         private final String logger;
-        private final Level level;
         private final AtomicReference<LogEvent> offender = new AtomicReference<>();
 
-        NoThrowableAttachedExpectation(String logger, Level level) {
+        NoThrowableAttachedExpectation(String logger) {
             this.logger = logger;
-            this.level = level;
         }
 
         @Override
         public void match(LogEvent event) {
-            if (event.getLevel() == level && event.getLoggerName().equals(logger) && event.getThrown() != null) {
+            if (event.getLoggerName().equals(logger) && event.getThrown() != null) {
                 offender.compareAndSet(null, event.toImmutable());
             }
         }
@@ -481,11 +493,11 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
             LogEvent event = offender.get();
             if (event != null) {
                 throw new AssertionError(
-                    "no throwable may be attached at "
-                        + level
-                        + ", but ["
+                    "no throwable may be attached at any level, but ["
                         + event.getMessage().getFormattedMessage()
-                        + "] carried "
+                        + "] logged at "
+                        + event.getLevel()
+                        + " carried "
                         + event.getThrown(),
                     event.getThrown()
                 );

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightClientChannelTests.java
@@ -8,9 +8,13 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Ticket;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -22,6 +26,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.MockLogAppender;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Header;
 import org.opensearch.transport.StreamTransportResponseHandler;
@@ -367,6 +372,124 @@ public class FlightClientChannelTests extends FlightTransportTestBase {
             assertThat("close must give up at the timeout", elapsedMillis, lessThan(TimeUnit.SECONDS.toMillis(TIMEOUT_SEC)));
         } finally {
             releaseGetStream.countDown();
+        }
+    }
+
+    // ── stream failure reporting ───────────────────────────────────────────────
+
+    /**
+     * A null header must fail the stream and stop, not fall through. {@code handleStreamException} does not
+     * throw, so continuing would dereference the null header and replace the real failure with an NPE
+     * raised inside the dispatch task — where nothing reports it to the handler.
+     *
+     * <p>A null header is reachable in production: {@code HeaderContext.getHeader} is a plain map removal,
+     * so it returns null whenever the middleware never stored one (for example a call that closed before
+     * its headers arrived).
+     */
+    public void testNullHeaderFailsStreamWithoutDereferencingIt() throws Exception {
+        FlightStream stream = mock(FlightStream.class);
+        when(stream.next()).thenReturn(true);
+        when(mockFlightClient.getStream(any(Ticket.class), any())).thenReturn(stream);
+
+        // The production path for a header that was never stored.
+        HeaderContext noHeader = new HeaderContext() {
+            @Override
+            Header getHeader(long correlationId) {
+                return null;
+            }
+        };
+        channel = createChannel(mockFlightClient, noHeader, new FlightTransportConfig());
+
+        AtomicReference<TransportException> handlerException = new AtomicReference<>();
+        // A real executor, not SAME: that is where the bug is observable. The dispatch task runs on a
+        // pool thread, so without the return the NPE escapes as an uncaught exception and fails the
+        // test. Under SAME the task runs inside the CompletableFuture callback, which swallows it.
+        sendStreamRequest(streamingHandler(ThreadPool.Names.GENERIC, streamResponse -> {
+            throw new AssertionError("consumer must not be invoked without a header");
+        }, handlerException));
+
+        assertBusy(() -> assertNotNull("handler must be notified of the failure", handlerException.get()));
+        TransportException exception = handlerException.get();
+        assertTrue("expected a StreamException but got " + exception, exception instanceof StreamException);
+        assertEquals(StreamErrorCode.INTERNAL, ((StreamException) exception).getErrorCode());
+        assertEquals("Header is null", exception.getMessage());
+    }
+
+    /**
+     * A stream failure must be reported without handing the throwable to log4j at an
+     * enabled-by-default level.
+     *
+     * <p>These paths run on the per-stream prefetch virtual thread. OpenSearch's JSON layout always applies
+     * log4j's extended stack-trace renderer, which resolves every frame's class via {@code Class.forName};
+     * the resulting native frame cannot be unmounted, so a contended classloader lock pins the carrier
+     * instead of yielding it. With one such failure per stream, a mass reconnect can pin every carrier while
+     * the lock holder sits unmounted and unschedulable, and the node stops making progress while still
+     * reporting healthy. The cause must therefore reach the log as text.
+     */
+    public void testStreamFailureIsLoggedWithoutAThrowable() throws Exception {
+        when(mockFlightClient.getStream(any(Ticket.class), any())).thenThrow(
+            CallStatus.UNAVAILABLE.withDescription("connection reset").toRuntimeException()
+        );
+
+        channel = createChannel(mockFlightClient, stubHeaderContext(), new FlightTransportConfig());
+
+        AtomicReference<TransportException> handlerException = new AtomicReference<>();
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(FlightClientChannel.class))) {
+            // The cause must still be identifiable from the message alone, since the throwable is gone.
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "stream failure reported with its cause",
+                    FlightClientChannel.class.getCanonicalName(),
+                    Level.ERROR,
+                    "*Exception while handling stream response*connection reset*"
+                )
+            );
+            appender.addExpectation(new NoThrowableAttachedExpectation(FlightClientChannel.class.getCanonicalName(), Level.ERROR));
+
+            sendStreamRequest(streamingHandler(ThreadPool.Names.SAME, streamResponse -> {
+                throw new AssertionError("consumer must not be invoked after an open failure");
+            }, handlerException));
+
+            assertBusy(() -> assertNotNull("handler must be notified of the failure", handlerException.get()));
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Fails if any event at {@code level} carries a throwable. The framework's expectations all assert
+     * that something was seen; this asserts a property of everything that was.
+     */
+    private static final class NoThrowableAttachedExpectation implements MockLogAppender.LoggingExpectation {
+        private final String logger;
+        private final Level level;
+        private final AtomicReference<LogEvent> offender = new AtomicReference<>();
+
+        NoThrowableAttachedExpectation(String logger, Level level) {
+            this.logger = logger;
+            this.level = level;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            if (event.getLevel() == level && event.getLoggerName().equals(logger) && event.getThrown() != null) {
+                offender.compareAndSet(null, event.toImmutable());
+            }
+        }
+
+        @Override
+        public void assertMatched() {
+            LogEvent event = offender.get();
+            if (event != null) {
+                throw new AssertionError(
+                    "no throwable may be attached at "
+                        + level
+                        + ", but ["
+                        + event.getMessage().getFormattedMessage()
+                        + "] carried "
+                        + event.getThrown(),
+                    event.getThrown()
+                );
+            }
         }
     }
 

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightUtilsTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightUtilsTests.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.stream.StreamErrorCode;
+import org.opensearch.transport.stream.StreamException;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@link FlightUtils#causeSummary}, the one-line replacement for handing a throwable to
+ * log4j on the client stream paths. It must stay total (no throw, no recursion) for every shape of
+ * throwable those paths can see, because it runs while a stream is already failing.
+ */
+public class FlightUtilsTests extends OpenSearchTestCase {
+
+    public void testNullThrowable() {
+        assertEquals("none", FlightUtils.causeSummary(null));
+    }
+
+    public void testSingleThrowableIncludesTypeAndMessage() {
+        assertEquals(
+            "StreamException[stream gone]",
+            FlightUtils.causeSummary(new StreamException(StreamErrorCode.UNAVAILABLE, "stream gone"))
+        );
+    }
+
+    public void testThrowableWithoutMessageOmitsBrackets() {
+        assertEquals("IllegalStateException", FlightUtils.causeSummary(new IllegalStateException()));
+    }
+
+    /** The cause chain is what actually identifies a failure, so it must survive the flattening. */
+    public void testCauseChainIsRendered() {
+        Exception root = new IOException("connection reset");
+        Exception wrapper = new StreamException(StreamErrorCode.INTERNAL, "open failed", root);
+
+        assertEquals("StreamException[open failed]; caused by: IOException[connection reset]", FlightUtils.causeSummary(wrapper));
+    }
+
+    /** A self-referential cause is legal and must terminate rather than spin. */
+    public void testSelfReferentialCauseTerminates() {
+        Exception self = new RuntimeException("loops to itself") {
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+
+        String summary = FlightUtils.causeSummary(self);
+
+        assertTrue("message must still be reported: " + summary, summary.contains("loops to itself"));
+        assertFalse("a self-cause must not be walked into: " + summary, summary.contains("caused by"));
+    }
+
+    /** A deep chain is truncated rather than emitting an unbounded log line. */
+    public void testDeepChainIsTruncated() {
+        Exception e = new RuntimeException("depth-0");
+        for (int i = 1; i <= 8; i++) {
+            e = new RuntimeException("depth-" + i, e);
+        }
+
+        String summary = FlightUtils.causeSummary(e);
+
+        assertTrue("deepest included cause must be depth-4: " + summary, summary.contains("depth-4"));
+        assertFalse("depth-3 is past the cap and must be elided: " + summary, summary.contains("depth-3"));
+        assertTrue("truncation must be visible: " + summary, summary.endsWith("; ..."));
+    }
+}


### PR DESCRIPTION
### Description

A mass stream failure on the Flight client can deadlock the virtual-thread scheduler and wedge a node indefinitely, while it keeps reporting healthy.

`FlightTransportResponse#openAndPrefetchAsync` runs each stream's open and prefetch on its own virtual thread, and the failure paths reached from there (`FlightClientChannel#handleStreamException` and the cancel/close handlers) pass the throwable to `logger.error`/`warn`. `OpenSearchJsonLayout` always appends `%exceptionAsJson`, so every such call reaches log4j's **extended** stack-trace renderer, which annotates each frame with its source JAR by resolving the frame's declaring class.

That renderer resolves classes two different ways:

| route | how | native frame? |
|---|---|---|
| `ThrowableExtendedStackTraceRenderer.lambda$static$1` | `LoaderUtil.loadClass` → `Class.forName` | **yes** (`forName0`) |
| `ThrowableExtendedStackTraceRenderer.lambda$static$2` | `ClassLoader.loadClass` | no |

A continuation carrying a native frame cannot be frozen, so a virtual thread blocking on the contended classloader monitor *underneath* `forName0` pins its carrier instead of yielding it. JEP 491 does not help here: it removed monitor pinning, not native-frame pinning.

The mix of the two routes is what closes the cycle. The scheduler's carrier count defaults to `availableProcessors`:

```
VT #14083    RUNNABLE, holds classloader monitor @300089ec, NOT MOUNTED
             (reached the classloader via the non-pinning route)
             needs a carrier to finish and release the monitor
carrier 304  BLOCKED at monitorenter @300089ec, mounting VT #14052 (has forName0)
carrier 305  BLOCKED at monitorenter @300089ec, mounting VT #14120 (has forName0)
carriers = 2 (nproc=2, no jdk.virtualThreadScheduler.* overrides)
```

`monitorenter` has no timeout and nothing preempts a pinned carrier, so this never resolves. Observed on a 2-vCPU node with 998 streams failing at once (a reconnect storm after a partition healed): three heap dumps 75 minutes apart were identical, with ~0.1s of carrier CPU consumed in between. Only 2 virtual threads in the whole dump contained `forName0`, and they were exactly the 2 mounted on the 2 blocked carriers.

#### Fix

Log a one-line cause summary at the existing level and keep the full stack trace at `DEBUG`, which is off by default. `FlightUtils#causeSummary` reads only class names and messages, so it loads nothing and takes no lock:

```
StreamException[open failed]; caused by: IOException[connection reset]
```

Also fixes a missing `return` in the null-header branch of the dispatch task. `handleStreamException` does not throw, so falling through NPE'd on `header.getHeaders()`. On a real executor that NPE escapes to the pool thread and replaces the reported failure. A null header is reachable in production because `HeaderContext#getHeader` is a plain map removal, so it returns `null` whenever the middleware never stored one.

Note this bug class is not unique to this plugin: any `logger.error(msg, throwable)` on a virtual thread can pin its carrier the same way. This PR fixes the paths that fan out per stream. Removing the extended renderer from the JSON layout would address it product-wide and is worth considering separately.

### Related Issues

N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
