### PR TITLE
Fix search.request.took.current leaking when search fails before its first phase starts

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -498,6 +498,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest, parentTask, indexNameExpressionResolver);
                 listener = searchRequest.transformResponseListener(updatedListener);
             } catch (Exception e) {
+                searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(null, searchRequestContext);
                 updatedListener.onFailure(e);
                 return;
             }
@@ -521,7 +522,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         rewriteListener
                     );
                 }
-            }, listener::onFailure);
+            }, e -> { searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(null, searchRequestContext); listener.onFailure(e); });
             searchRequest.transformRequest(requestTransformListener);
         }
     }
@@ -641,11 +642,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                                 searchAsyncActionProvider,
                                 searchRequestContext
                             );
-                        }, listener::onFailure)
+                        }, e -> { searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(null, searchRequestContext); listener.onFailure(e); })
                     );
                 }
             }
-        }, listener::onFailure);
+        }, e -> { searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(null, searchRequestContext); listener.onFailure(e); });
     }
 
     static boolean shouldMinimizeRoundtrips(SearchRequest searchRequest) {


### PR DESCRIPTION
### Description

Fixes #22745

When a search request fails before entering any search phase (e.g. querying a non-existent index), `search.request.took.current` leaks upwards because `onRequestStart` is called in `TransportSearchAction.executeRequest` but `onRequestEnd` / `onRequestFailure` is never called.

### Root Cause

`onRequestStart` (line 486) is called early in `executeRequest`, but the paired `onRequestEnd` / `onRequestFailure` is only called by `AbstractSearchAsyncAction` — which is created only after index resolution and search phase initialization. If the request fails before that point (pipeline resolution, index resolution, shard collection), the counter is never decremented.

### Fix

Added `onRequestFailure` calls in four pre-phase failure paths within `TransportSearchAction.executeRequest`:
1. **Pipeline resolution failure** (catch block)
2. **requestTransformListener failure** (ActionListener error handler)
3. **collectSearchShards failure** (ActionListener error handler in CCS path)
4. **buildRewriteListener failure** (ActionListener error handler — catches the primary repro case: `IndexNotFoundException` from `extractRequestedIndices`)

### Verification

Reproduction (from the issue):
```bash
# baseline
curl -s 'localhost:9200/_nodes/stats/indices/search?filter_path=nodes.*.indices.search.request.took'

# failing search — 404 index_not_found_exception
curl -s 'localhost:9200/does_not_exist/_search'

# took.current no longer leaks
curl -s 'localhost:9200/_nodes/stats/indices/search?filter_path=nodes.*.indices.search.request.took'
```

### Related Issues

- PR #19340 fixed the underflow side (over-decrement)
- This PR fixes the overflow side (unpaired increment)

**Signed-off-by:** waterWang &lt;waterwang@proton.me&gt;