### PR TITLE
Redact storage paths from physical_plan in profile API responses

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Snapshots an {@link ExecutionGraph} into a {@link QueryProfile}. Pure read — no
@@ -128,6 +129,28 @@ public final class QueryProfileBuilder {
         static final DataNodePayload EMPTY = new DataNodePayload(null, null);
     }
 
+    /**
+     * DataFusion's plan {@code Display} impl for file-scan nodes (e.g. {@code DataSourceExec},
+     * {@code ParquetExec}) always embeds the real storage location(s) it's reading from —
+     * local filesystem paths, or object-store URIs/keys when backed by S3/GCS/Azure. That's
+     * appropriate detail for a physical plan, but the profile API can expose it to any caller
+     * already authorized to run the query, which is more than they need to see. Strips the
+     * path list while preserving the group count, which is still useful for diagnosing scan
+     * fan-out (how many files/partitions were touched) without leaking storage layout.
+     *
+     * <p>Matches {@code file_groups={N group(s): [[...]]}} — there are no nested {@code {}} in
+     * this segment (only {@code []} nesting for multiple groups/files), so {@code [^}]*} safely
+     * spans across any number of bracketed sub-lists up to the next closing brace.
+     */
+    private static final Pattern FILE_GROUPS_PATTERN = Pattern.compile("file_groups=\\{(\\d+ groups?): [^}]*\\}");
+
+    // Package-private (not private) so FILE_GROUPS_PATTERN's behavior can be unit-tested
+    // directly without constructing a full ExecutionGraph/Stage/QueryContext fixture.
+    static String redactPhysicalPlan(String plan) {
+        if (plan == null) return null;
+        return FILE_GROUPS_PATTERN.matcher(plan).replaceAll("file_groups={$1: <redacted>}");
+    }
+
     @SuppressWarnings("unchecked")
     private static DataNodePayload parseDataNodePayload(byte[] json) {
         if (json == null || json.length == 0) return DataNodePayload.EMPTY;
@@ -139,7 +162,7 @@ public final class QueryProfileBuilder {
             Map<String, Long> metrics = new LinkedHashMap<>();
             for (Map.Entry<String, Object> entry : raw.entrySet()) {
                 if ("physical_plan".equals(entry.getKey()) && entry.getValue() instanceof String s) {
-                    physicalPlan = s;
+                    physicalPlan = redactPhysicalPlan(s);
                 } else if (entry.getValue() instanceof Number n) {
                     metrics.put(entry.getKey(), n.longValue());
                 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/profile/QueryProfileBuilderRedactionTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/profile/QueryProfileBuilderRedactionTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link QueryProfileBuilder#redactPhysicalPlan}, which strips storage
+ * locations (local filesystem paths or object-store URIs/keys) from DataFusion physical
+ * plan text before it's surfaced in the {@code profile=true} API response.
+ */
+public class QueryProfileBuilderRedactionTests extends OpenSearchTestCase {
+
+    public void testRedactsSingleGroupLocalPath() {
+        String plan = "DataSourceExec: file_groups={1 group: "
+            + "[[home/ubuntu/data/indices/uuid/0/parquet/_parquet_file_generation_1.parquet]]}, "
+            + "projection=[__row_id__@9 + row_base@11 as __row_id__, str0, num1], file_type=parquet";
+
+        String redacted = QueryProfileBuilder.redactPhysicalPlan(plan);
+
+        assertFalse("path must not survive redaction", redacted.contains("parquet_file_generation"));
+        assertFalse("path must not survive redaction", redacted.contains("/home/ubuntu"));
+        assertTrue("group count must be preserved", redacted.contains("file_groups={1 group: <redacted>}"));
+        // Everything outside file_groups must be untouched
+        assertTrue(redacted.contains("projection=[__row_id__@9 + row_base@11 as __row_id__, str0, num1]"));
+        assertTrue(redacted.contains("file_type=parquet"));
+    }
+
+    public void testRedactsMultipleGroups() {
+        String plan = "DataSourceExec: file_groups={2 groups: "
+            + "[[/data/a.parquet, /data/b.parquet], [/data/c.parquet]]}, file_type=parquet";
+
+        String redacted = QueryProfileBuilder.redactPhysicalPlan(plan);
+
+        assertFalse(redacted.contains("/data/"));
+        assertTrue("plural group count must be preserved", redacted.contains("file_groups={2 groups: <redacted>}"));
+    }
+
+    public void testRedactsObjectStoreUri() {
+        // Object-store backed indices (S3/GCS/Azure) would leak bucket names/keys here instead
+        // of local paths — the pattern must not special-case "looks like a filesystem path."
+        String plan = "DataSourceExec: file_groups={1 group: [[s3://my-bucket/indices/uuid/0/segment.parquet]]}, " + "file_type=parquet";
+
+        String redacted = QueryProfileBuilder.redactPhysicalPlan(plan);
+
+        assertFalse(redacted.contains("my-bucket"));
+        assertFalse(redacted.contains("s3://"));
+        assertTrue(redacted.contains("file_groups={1 group: <redacted>}"));
+    }
+
+    public void testPlanWithoutFileGroupsIsUnchanged() {
+        // Non-scan operators (aggregates, sorts, projections) carry no storage location and
+        // must pass through byte-for-byte — the regex must not be overly aggressive.
+        String plan = "AggregateExec: mode=Final, gby=[], aggr=[avg(score)]\n" + "  SortExec: TopK(fetch=5), expr=[num0@0 ASC]";
+
+        assertEquals(plan, QueryProfileBuilder.redactPhysicalPlan(plan));
+    }
+
+    public void testNullInputReturnsNull() {
+        assertNull(QueryProfileBuilder.redactPhysicalPlan(null));
+    }
+
+    public void testMultiOperatorPlanOnlyRedactsFileGroupsSegment() {
+        // Mirrors a real multi-node plan: only the DataSourceExec's file_groups segment should
+        // change; the SortExec line and every other field on the DataSourceExec line survive.
+        String plan = "SortPreservingMergeExec: [num0@0 ASC]\n"
+            + "  DataSourceExec: file_groups={1 group: [[/secret/path/segment.parquet]]}, "
+            + "projection=[num0, str0], predicate=num0 IS NOT NULL, file_type=parquet";
+
+        String redacted = QueryProfileBuilder.redactPhysicalPlan(plan);
+
+        assertTrue(redacted.contains("SortPreservingMergeExec: [num0@0 ASC]"));
+        assertTrue(redacted.contains("projection=[num0, str0]"));
+        assertTrue(redacted.contains("predicate=num0 IS NOT NULL"));
+        assertTrue(redacted.contains("file_type=parquet"));
+        assertFalse(redacted.contains("/secret/path"));
+        assertTrue(redacted.contains("file_groups={1 group: <redacted>}"));
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/ExplainApiIT.java
@@ -304,6 +304,52 @@ public class ExplainApiIT extends AnalyticsRestTestCase {
             physicalPlan.contains("QueryShardExec"));
     }
 
+    /**
+     * Verifies that the physical_plan surfaced by profile=true does NOT leak storage locations.
+     * DataFusion's file-scan Display embeds the real parquet file path(s) in {@code file_groups={...}};
+     * QueryProfileBuilder redacts that path list to {@code <redacted>} while preserving the group
+     * count. This guards against re-introducing the leak (local filesystem paths, or object-store
+     * URIs/keys on S3/GCS/Azure-backed indices) into an API any query-authorized caller can hit.
+     */
+    @SuppressWarnings("unchecked")
+    public void testProfilePhysicalPlanRedactsStoragePaths() throws IOException {
+        ensureClickBenchProvisioned();
+        Map<String, Object> result = executeWithProfile(
+            "source=" + CLICKBENCH.indexName + " | stats avg(AdvEngineID) by RegionID"
+        );
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        // Collect every physical_plan string across all stages/tasks — redaction must hold everywhere,
+        // not just on the one stage the happy-path test happens to inspect.
+        boolean sawFileGroups = false;
+        for (Map<String, Object> stage : stages) {
+            List<Map<String, Object>> tasks = (List<Map<String, Object>>) stage.get("tasks");
+            if (tasks == null) {
+                continue;
+            }
+            for (Map<String, Object> task : tasks) {
+                Object plan = task.get("physical_plan");
+                if (plan instanceof String s && s.isEmpty() == false) {
+                    // No absolute filesystem path or object-store URI should survive redaction.
+                    assertFalse("physical_plan must not leak a filesystem path, got: " + s, s.contains(".parquet"));
+                    assertFalse("physical_plan must not leak a data dir path, got: " + s, s.contains("/nodes/"));
+                    assertFalse("physical_plan must not leak an object-store URI, got: " + s, s.contains("s3://"));
+                    if (s.contains("file_groups=")) {
+                        sawFileGroups = true;
+                        // The redaction marker replaces the path list but keeps the group count.
+                        assertTrue("file_groups must be redacted, got: " + s, s.contains("<redacted>"));
+                    }
+                }
+            }
+        }
+        // Sanity: this query scans parquet, so at least one scan node with file_groups must exist —
+        // otherwise the assertions above would vacuously pass without exercising redaction.
+        assertTrue("expected at least one file_groups scan node in the profile", sawFileGroups);
+    }
+
 
     @SuppressWarnings("unchecked")
     public void testProfileCoordinatorReduceHasMetrics() throws IOException {


### PR DESCRIPTION
## Summary

DataFusion's `Display` implementation for file-scan nodes (`DataSourceExec`, `ParquetExec`) provides the local filesystem paths it is reading from. The `profile=true` API surfaces this `physical_plan` text verbatim back to the caller, exposing internal storage details unnecessarily.

## Fix

All stage types (`SHARD_FRAGMENT`, `COORDINATOR_REDUCE`, `LATE_MATERIALIZATION`) funnel their `physical_plan` text through `QueryProfileBuilder.parseDataNodePayload()`.

This change adds a regex redaction there for `file_groups={...}` to strip the full path.

```
Before: DataSourceExec: file_groups={1 group: [[/home/user/data/indices/uuid/0/parquet/segment.parquet]]}, ...
After:  DataSourceExec: file_groups={1 group: <redacted>}, ...
```

## Testing

- UTs QueryProfileBuilderRedactionTests
- ITs ExplainApiIT.testProfileReturnsPhysicalPlan