### PR TITLE
[Sandbox] Guard against excessive filter predicate count

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+
+/**
+ * Guards against excessively complex filter predicates by counting leaf predicates
+ * in a {@link RexNode} condition tree.
+ *
+ * <p>A "leaf predicate" is any {@link RexCall} that is not a boolean connective
+ * ({@code AND}, {@code OR}, {@code NOT}). A flat {@code a=1 OR b=2 OR c=3} counts
+ * as 3 leaf predicates regardless of the tree's nesting shape.
+ *
+ * <p>Boolean nesting depth is intentionally not guarded here: the SQL plugin's
+ * {@code plugins.query.max_expression_depth} (default 1000) already bounds parse-tree
+ * recursion depth before a query reaches the analytics engine, and Calcite flattens
+ * associative {@code AND}/{@code OR} chains during optimization, so pathological depth
+ * rarely survives to this point. Predicate count is the gap that guard doesn't cover —
+ * a flat fan-out of many OR-ed conditions passes the SQL plugin's depth check easily.
+ *
+ * @opensearch.internal
+ */
+public final class FilterPredicateGuard {
+
+    private FilterPredicateGuard() {}
+
+    /**
+     * Validates the filter condition against the configured leaf-predicate count limit.
+     * Throws {@link IllegalArgumentException} (HTTP 400) if the limit is exceeded.
+     *
+     * @param condition the filter's RexNode condition tree
+     * @param maxCount  maximum leaf predicates allowed (0 = unlimited)
+     */
+    public static void validate(RexNode condition, int maxCount) {
+        if (maxCount <= 0) {
+            return; // guard disabled
+        }
+        int leafCount = countLeaves(condition);
+        if (leafCount > maxCount) {
+            throw new IllegalArgumentException(
+                "Filter condition contains "
+                    + leafCount
+                    + " predicates, exceeding the maximum allowed ["
+                    + maxCount
+                    + "]. Simplify the query by reducing the number of filter conditions."
+            );
+        }
+    }
+
+    /**
+     * Returns the number of leaf predicates in the given RexNode tree. Boolean connectives
+     * ({@code AND}/{@code OR}/{@code NOT}) are not counted themselves — only their operands
+     * contribute, recursively.
+     */
+    static int countLeaves(RexNode node) {
+        if (!(node instanceof RexCall call)) {
+            // Literal or input ref — not a predicate by itself
+            return 0;
+        }
+
+        if (call.getKind() == SqlKind.AND || call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT) {
+            int total = 0;
+            for (RexNode operand : call.getOperands()) {
+                total += countLeaves(operand);
+            }
+            return total;
+        }
+
+        // Leaf predicate (comparison, function call, etc.)
+        return 1;
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/PlannerContext.java
@@ -123,6 +123,10 @@ public class PlannerContext {
         return plannerSettings.getOversamplingFactor();
     }
 
+    public int getMaxFilterPredicateCount() {
+        return plannerSettings.getMaxFilterPredicateCount();
+    }
+
     public OpenSearchDistributionTraitDef getDistributionTraitDef() {
         return distributionTraitDef;
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -19,6 +19,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.CapabilityRegistry;
+import org.opensearch.analytics.planner.FilterPredicateGuard;
 import org.opensearch.analytics.planner.PlannerContext;
 import org.opensearch.analytics.planner.RelNodeUtils;
 import org.opensearch.analytics.planner.rel.AnnotatedPredicate;
@@ -81,6 +82,9 @@ public class OpenSearchFilterRule extends RelOptRule {
 
         List<String> childViableBackends = openSearchInput.getViableBackends();
         List<FieldStorageInfo> childFieldStorage = openSearchInput.getOutputFieldStorage();
+
+        // Guard: reject excessively complex filter conditions early, before annotation.
+        FilterPredicateGuard.validate(filter.getCondition(), context.getMaxFilterPredicateCount());
 
         // Annotate every leaf predicate with viable backends.
         RexNode annotatedCondition = annotateCondition(filter.getCondition(), childFieldStorage, childViableBackends);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/AnalyticsQuerySettings.java
@@ -115,8 +115,36 @@ public final class AnalyticsQuerySettings {
         Setting.Property.Dynamic
     );
 
+    /**
+     * Maximum number of leaf predicates allowed in a single filter condition. A leaf predicate is
+     * any comparison or function call that is not a boolean connective (AND/OR/NOT). Queries
+     * exceeding this limit are rejected with HTTP 400 during planning.
+     *
+     * <p>Note that comparisons against the same field connected by OR (e.g. {@code x=1 OR x=2 OR
+     * x=3}, or {@code x IN (1,2,3)}) are folded by Calcite into a single {@code SEARCH(x, Sarg[...])}
+     * predicate before this guard runs, so they count as one predicate regardless of value count.
+     * The guard therefore targets fan-out across <em>distinct</em> fields, which cannot be folded
+     * and stays as N separate leaves — the shape that actually multiplies per-predicate planning and
+     * execution cost.
+     *
+     * <p>Default 500. Set to 0 to disable the guard.
+     */
+    public static final Setting<Integer> MAX_FILTER_PREDICATE_COUNT = Setting.intSetting(
+        "analytics.query.max_filter_predicate_count",
+        500,
+        0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     public static List<Setting<?>> all() {
-        return List.of(DELEGATION_BLOCKED_PREDICATES, MAX_SHARDS_PER_QUERY, PRE_FILTER_SHARD_SIZE, MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE);
+        return List.of(
+            DELEGATION_BLOCKED_PREDICATES,
+            MAX_SHARDS_PER_QUERY,
+            PRE_FILTER_SHARD_SIZE,
+            MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE,
+            MAX_FILTER_PREDICATE_COUNT
+        );
     }
 
     private AnalyticsQuerySettings() {}

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/settings/PlannerSettings.java
@@ -33,10 +33,12 @@ import org.opensearch.common.settings.Settings;
 public final class PlannerSettings {
 
     private volatile double oversamplingFactor;
+    private volatile int maxFilterPredicateCount;
     private final DelegationBlockList delegationBlockList;
 
-    private PlannerSettings(double oversamplingFactor, DelegationBlockList delegationBlockList) {
+    private PlannerSettings(double oversamplingFactor, int maxFilterPredicateCount, DelegationBlockList delegationBlockList) {
         this.oversamplingFactor = oversamplingFactor;
+        this.maxFilterPredicateCount = maxFilterPredicateCount;
         this.delegationBlockList = delegationBlockList;
     }
 
@@ -49,27 +51,36 @@ public final class PlannerSettings {
         DelegationBlockList blockList = DelegationBlockList.create(clusterSettings, initialSettings, registry);
         PlannerSettings settings = new PlannerSettings(
             AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR.get(initialSettings),
+            AnalyticsQuerySettings.MAX_FILTER_PREDICATE_COUNT.get(initialSettings),
             blockList
         );
         clusterSettings.addSettingsUpdateConsumer(
             AnalyticsApproximationSettings.SHARD_BUCKET_OVERSAMPLING_FACTOR,
             v -> settings.oversamplingFactor = v
         );
+        clusterSettings.addSettingsUpdateConsumer(
+            AnalyticsQuerySettings.MAX_FILTER_PREDICATE_COUNT,
+            v -> settings.maxFilterPredicateCount = v
+        );
         return settings;
     }
 
     /** Planner defaults for unit tests: no oversampling, nothing blocked. */
     public static PlannerSettings defaults() {
-        return new PlannerSettings(0.0, DelegationBlockList.empty());
+        return new PlannerSettings(0.0, 500, DelegationBlockList.empty());
     }
 
     /** Explicit values for tests that exercise a specific setting. */
     public static PlannerSettings of(double oversamplingFactor, DelegationBlockList delegationBlockList) {
-        return new PlannerSettings(oversamplingFactor, delegationBlockList);
+        return new PlannerSettings(oversamplingFactor, 500, delegationBlockList);
     }
 
     public double getOversamplingFactor() {
         return oversamplingFactor;
+    }
+
+    public int getMaxFilterPredicateCount() {
+        return maxFilterPredicateCount;
     }
 
     /** Per-backend delegation block-list consulted at marking time. Never null (defaults to empty). */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for {@link FilterPredicateGuard}.
+ */
+public class FilterPredicateGuardTests extends OpenSearchTestCase {
+
+    private final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(org.apache.calcite.rel.type.RelDataTypeSystem.DEFAULT);
+    private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+
+    public void testSinglePredicatePassesCountLimit() {
+        RexNode predicate = makeComparison();
+        // 1 predicate, limit 200 — should pass
+        FilterPredicateGuard.validate(predicate, 200);
+    }
+
+    public void testFlatOrExceedsCountLimit() {
+        // Build: a=1 OR b=2 OR c=3 OR ... (30 predicates, flat)
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            predicates.add(makeComparison());
+        }
+        RexNode bigOr = buildFlatOr(predicates);
+
+        // 30 predicates with limit 10 — should fail
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FilterPredicateGuard.validate(bigOr, 10));
+        assertTrue(e.getMessage().contains("30 predicates"));
+        assertTrue(e.getMessage().contains("maximum allowed [10]"));
+    }
+
+    public void testFlatOrPassesCountLimit() {
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            predicates.add(makeComparison());
+        }
+        RexNode bigOr = buildFlatOr(predicates);
+
+        // 30 predicates with limit 200 — should pass
+        FilterPredicateGuard.validate(bigOr, 200);
+    }
+
+    public void testDisabledGuardPassesEverything() {
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            predicates.add(makeComparison());
+        }
+        RexNode bigOr = buildFlatOr(predicates);
+
+        // Limit 0 = disabled — should pass regardless of size
+        FilterPredicateGuard.validate(bigOr, 0);
+    }
+
+    public void testCountMeasurement() {
+        // flat OR with 5 predicates: count=5
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            predicates.add(makeComparison());
+        }
+        RexNode flatOr = buildFlatOr(predicates);
+        assertEquals("leaf count", 5, FilterPredicateGuard.countLeaves(flatOr));
+    }
+
+    public void testNestedPredicatesCountedAcrossConnectives() {
+        // AND(AND(AND(a=1, b=2), c=3), d=4) — 4 leaf predicates regardless of nesting shape
+        RexNode inner = rexBuilder.makeCall(SqlStdOperatorTable.AND, makeComparison(), makeComparison());
+        RexNode mid = rexBuilder.makeCall(SqlStdOperatorTable.AND, inner, makeComparison());
+        RexNode outer = rexBuilder.makeCall(SqlStdOperatorTable.AND, mid, makeComparison());
+
+        assertEquals("leaf count", 4, FilterPredicateGuard.countLeaves(outer));
+    }
+
+    public void testNotDoesNotCountAsPredicate() {
+        // NOT(a=1) — 1 leaf predicate; NOT itself doesn't count
+        RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, makeComparison());
+        assertEquals("leaf count", 1, FilterPredicateGuard.countLeaves(notNode));
+    }
+
+    private RexNode makeComparison() {
+        return rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0),
+            rexBuilder.makeExactLiteral(BigDecimal.ONE)
+        );
+    }
+
+    private RexNode buildFlatOr(List<RexNode> operands) {
+        if (operands.size() == 1) return operands.get(0);
+        return rexBuilder.makeCall(SqlStdOperatorTable.OR, operands);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterPredicateGuardIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/FilterPredicateGuardIT.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Integration test for the filter predicate count guard
+ * ({@code analytics.query.max_filter_predicate_count}).
+ *
+ * <p>Covers the two shapes that behave differently against the guard:
+ * <ul>
+ *   <li><b>Distinct-field fan-out</b> ({@code a=1 OR b=2 OR c=3 ...}) — cannot be folded, stays as
+ *       N separate leaf predicates, and IS caught by the guard.</li>
+ *   <li><b>Same-field fan-out</b> ({@code x=1 OR x=2 OR x=3 ...}) — folded by Calcite into a single
+ *       {@code SEARCH(x, Sarg[...])} before the guard runs, counts as one predicate, and is NOT
+ *       caught regardless of the value count.</li>
+ * </ul>
+ */
+public class FilterPredicateGuardIT extends AnalyticsRestTestCase {
+
+    private static final Dataset DATASET = new Dataset("calcs", "calcs");
+    private static boolean dataProvisioned = false;
+
+    // calcs has num0..num4 and int0..int3 — nine distinct numeric fields. Using each field at most
+    // once guarantees no two comparisons can SARG-fold together (folding requires the same field).
+    private static final String[] DISTINCT_FIELDS = { "num0", "num1", "num2", "num3", "num4", "int0", "int1", "int2" };
+
+    private void ensureDataProvisioned() throws IOException {
+        if (dataProvisioned == false) {
+            DatasetProvisioner.provision(client(), DATASET);
+            dataProvisioned = true;
+        }
+    }
+
+    /**
+     * Distinct-field fan-out is NOT foldable and IS caught by the guard.
+     *
+     * <p>Eight predicates, each on a <em>different</em> field ({@code num0=0 OR num1=1 OR num2=2
+     * ...}), cannot collapse into a SARG — a Sarg is a range-set over a single field, so folding
+     * only combines comparisons that share a field. All eight survive to the marking phase as
+     * separate leaves. With the limit lowered to 5, the guard rejects with 400.
+     */
+    public void testDistinctFieldPredicatesExceedingLimitRejected() throws Exception {
+        ensureDataProvisioned();
+
+        updateClusterSetting("analytics.query.max_filter_predicate_count", "5");
+        try {
+            // 8 predicates, one per distinct field → 8 non-foldable leaves (> limit of 5).
+            String predicates = IntStream.range(0, DISTINCT_FIELDS.length)
+                .mapToObj(i -> DISTINCT_FIELDS[i] + "=" + i)
+                .collect(Collectors.joining(" OR "));
+            String ppl = "source=" + DATASET.indexName + " | where " + predicates + " | fields num0";
+
+            ResponseException e = expectThrows(ResponseException.class, () -> executePpl(ppl));
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            assertEquals("Expected HTTP 400 for excessive distinct-field predicate count", 400, status);
+            String body = org.apache.hc.core5.http.io.entity.EntityUtils.toString(e.getResponse().getEntity());
+            assertTrue(
+                "Error message should mention predicate count, got: " + body,
+                body.contains("predicates") && body.contains("maximum allowed")
+            );
+        } finally {
+            updateClusterSetting("analytics.query.max_filter_predicate_count", null);
+        }
+    }
+
+    /**
+     * Same-field fan-out IS folded and is NOT caught by the guard.
+     *
+     * <p>This is the key contrast to {@link #testDistinctFieldPredicatesExceedingLimitRejected}.
+     * Fifty comparisons all against {@code num0} ({@code num0=0 OR num0=1 OR ... OR num0=49}) are
+     * folded by Calcite's {@code ReduceExpressionsRule} into a single {@code SEARCH(num0, Sarg[..])}
+     * predicate during the {@code reduceExpressions} phase, which runs <em>before</em> the marking
+     * phase where the guard counts leaves. So even with the limit lowered to 5 — far below the 50
+     * literal values — the folded condition counts as one predicate and the query succeeds. This
+     * confirms the guard targets genuine per-predicate cost (distinct-field fan-out), not cheap
+     * SARG-foldable value lists.
+     */
+    public void testSameFieldFoldedPredicatesNotCaught() throws Exception {
+        ensureDataProvisioned();
+
+        updateClusterSetting("analytics.query.max_filter_predicate_count", "5");
+        try {
+            // 50 same-field equalities → folded to ONE SEARCH(num0, Sarg[...]) before the guard runs.
+            String predicates = IntStream.range(0, 50)
+                .mapToObj(i -> "num0=" + i)
+                .collect(Collectors.joining(" OR "));
+            String ppl = "source=" + DATASET.indexName + " | where " + predicates + " | fields num0";
+            executePpl(ppl); // should NOT throw despite 50 literals and a limit of 5
+        } finally {
+            updateClusterSetting("analytics.query.max_filter_predicate_count", null);
+        }
+    }
+
+    /**
+     * A distinct-field query within the limit succeeds.
+     */
+    public void testAcceptablePredicateCountSucceeds() throws Exception {
+        ensureDataProvisioned();
+
+        // 3 distinct-field predicates, well under the default limit.
+        String ppl = "source=" + DATASET.indexName + " | where num0=1 OR num1=2 OR num2=3 | fields num0";
+        executePpl(ppl); // should not throw
+    }
+
+    /**
+     * Setting the limit to 0 disables the guard entirely.
+     */
+    public void testDisabledGuardAllowsAnything() throws Exception {
+        ensureDataProvisioned();
+
+        updateClusterSetting("analytics.query.max_filter_predicate_count", "0");
+        try {
+            // 8 distinct-field predicates — would be caught at a limit of 5, but 0 means unlimited.
+            String predicates = IntStream.range(0, DISTINCT_FIELDS.length)
+                .mapToObj(i -> DISTINCT_FIELDS[i] + "=" + i)
+                .collect(Collectors.joining(" OR "));
+            String ppl = "source=" + DATASET.indexName + " | where " + predicates + " | fields num0";
+            executePpl(ppl); // should not throw
+        } finally {
+            updateClusterSetting("analytics.query.max_filter_predicate_count", null);
+        }
+    }
+
+    private void updateClusterSetting(String key, String value) throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        if (value != null) {
+            request.setJsonEntity("{\"transient\": {\"" + key + "\": " + value + "}}");
+        } else {
+            request.setJsonEntity("{\"transient\": {\"" + key + "\": null}}");
+        }
+        client().performRequest(request);
+    }
+}


### PR DESCRIPTION
Adds a dynamic cluster setting to reject queries with too many filter predicates during planning: `analytics.query.max_filter_predicate_count` (default 500, 0 = disabled).

Note: The SQL plugin's `plugins.query.max_expression_depth` already bounds parse-tree recursion before a query reaches the analytics engine, and Calcite flattens associative AND/OR chains during optimization, however predicate count (e.g. `where a=1 OR b=2 OR ... OR z=26`) is a gap the existing frontend guard doesn't cover.