### PR TITLE
Fix index.codec error message to list all valid values

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -154,32 +155,34 @@ public final class EngineConfig {
      * allocated on both `kind` of nodes.
      */
     public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", "default", s -> {
-        switch (s) {
-            case "default":
-            case "lz4":
-            case "best_compression":
-            case "zlib":
-            case "lucene_default":
-                return s;
-            default:
-                if (Codec.availableCodecs().contains(s)) {
-                    return s;
-                }
-
-                for (String codecName : Codec.availableCodecs()) {
-                    Codec codec = Codec.forName(codecName);
-                    if (codec instanceof CodecAliases codecWithAlias) {
-                        if (codecWithAlias.aliases().contains(s)) {
-                            return s;
-                        }
-                    }
-                }
-
-                throw new IllegalArgumentException(
-                    "unknown value for [index.codec] must be one of [default, lz4, best_compression, zlib] but was: " + s
-                );
+        Set<String> validNames = availableIndexCodecNames();
+        if (validNames.contains(s)) {
+            return s;
         }
+        throw new IllegalArgumentException("unknown value for [index.codec] must be one of " + validNames + " but was: " + s);
     }, Property.IndexScope, Property.NodeScope);
+
+    /**
+     * Returns the codec names accepted by {@link #INDEX_CODEC_SETTING}: the OpenSearch built-ins, every codec
+     * registered with Lucene and any alias exposed by a {@link CodecAliases} codec. Used both to validate the
+     * setting and to build the error message so the two can never drift apart.
+     */
+    private static Set<String> availableIndexCodecNames() {
+        TreeSet<String> names = new TreeSet<>();
+        names.add("default");
+        names.add("lz4");
+        names.add("best_compression");
+        names.add("zlib");
+        names.add("lucene_default");
+        names.addAll(Codec.availableCodecs());
+        for (String codecName : Codec.availableCodecs()) {
+            Codec codec = Codec.forName(codecName);
+            if (codec instanceof CodecAliases codecWithAlias) {
+                names.addAll(codecWithAlias.aliases());
+            }
+        }
+        return names;
+    }
 
     /**
      * Index setting to change the compression level of zstd and zstd_no_dict lucene codecs.

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.engine;
 
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
@@ -21,6 +22,7 @@ import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -89,6 +91,25 @@ public class EngineConfigTests extends OpenSearchTestCase {
         assertSame(mapperService, copy.getMapperService());
         assertSame(committerFactory, copy.getCommitterFactory());
         assertSame(checksumStrategies, copy.getChecksumStrategies());
+    }
+
+    public void testInvalidCodecMessageListsAllAcceptedNames() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> EngineConfig.INDEX_CODEC_SETTING.get(Settings.builder().put("index.codec", "not_a_codec").build())
+        );
+        String message = e.getMessage();
+        assertTrue(message, message.contains("lucene_default"));
+        assertTrue(message, message.contains("best_compression"));
+        for (String codec : Codec.availableCodecs()) {
+            assertTrue(message, message.contains(codec));
+        }
+    }
+
+    public void testValidCodecNamesAreAccepted() {
+        for (String codec : List.of("default", "lz4", "best_compression", "zlib", "lucene_default")) {
+            assertEquals(codec, EngineConfig.INDEX_CODEC_SETTING.get(Settings.builder().put("index.codec", codec).build()));
+        }
     }
 
     private EngineConfig createReadOnlyEngine(IndexSettings indexSettings) {


### PR DESCRIPTION
The error message for invalid  values currently lists only , which doesn't match what the setting actually accepts. This causes confusion when users get an error referencing values not in the docs.

This change builds the error message from the same set of names used for validation: the five built-in codecs, every codec registered with Lucene, and any  aliases. The message and the accepted values can no longer drift apart.

Two new tests in :
- : passes an invalid codec name and asserts the message lists all registered codecs
- : asserts the five built-in codec names are still accepted

Closes #17561