### PR TITLE
Support multi_terms bucket aggregation on the DSL Calcite path

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.opensearch.dsl.aggregation.bucket.MultiTermsBucketTranslator;
 import org.opensearch.dsl.aggregation.bucket.TermsBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.AvgMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MaxMetricTranslator;
@@ -38,6 +39,7 @@ public class AggregationRegistryFactory {
         registry.register(new MinMetricTranslator());
         registry.register(new MaxMetricTranslator());
         registry.register(new TermsBucketTranslator(mapperServiceSupplier));
+        registry.register(new MultiTermsBucketTranslator(mapperServiceSupplier));
         // TODO: add other aggregation translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BinaryTermKeys.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BinaryTermKeys.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.search.DocValueFormat;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Base64;
+
+/**
+ * Shared converters for terms bucket keys that arrive as binary (ip) or string values.
+ *
+ * <p>The single-field {@link StringTermsStrategy} and multi-field {@link MultiTermsBucketTranslator}
+ * store binary/string keys identically, so the logic lives here once: a binary key keeps its encoded
+ * bytes for the mapping-resolved {@link DocValueFormat} to render at serialization, except under
+ * {@link DocValueFormat#RAW} where it is pre-rendered as an address string (or a deterministic Base64
+ * string when the bytes are not a valid 4- or 16-byte address) since RAW would otherwise print raw
+ * bytes; a string key becomes its UTF-8 bytes. Sharing keeps a guard added for one translator from
+ * silently missing the other.
+ */
+final class BinaryTermKeys {
+
+    private BinaryTermKeys() {}
+
+    /**
+     * Converts a binary or string key into its bucket term bytes. Under {@link DocValueFormat#RAW} a
+     * binary (ip) key is pre-rendered as its address string (Base64 fallback); otherwise the encoded
+     * bytes are kept for the mapping format to render, and a non-binary key becomes its UTF-8 bytes.
+     */
+    static BytesRef termBytes(Object key, DocValueFormat format) {
+        if (key instanceof BytesRef ref) {
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(ref.bytes)) : ref;
+        }
+        if (key instanceof byte[] bytes) {
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(bytes)) : new BytesRef(bytes);
+        }
+        return new BytesRef(key.toString());
+    }
+
+    /** Binary keys are ip columns: render the address string like classic ip terms. */
+    static String binaryKeyString(byte[] bytes) {
+        try {
+            return NetworkAddress.format(InetAddress.getByAddress(bytes));
+        } catch (UnknownHostException e) {
+            // Not a 4/16-byte address; fall back to a printable, deterministic form.
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslator.java
@@ -1,0 +1,321 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.aggregation.FieldGrouping;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.terms.InternalMultiTerms;
+import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Translates a {@link MultiTermsAggregationBuilder} — multi-field GROUP BY.
+ * {@code {"aggs": {"combo": {"multi_terms": {"terms": [{"field": "brand"}, {"field": "status"}]}}}}}
+ * becomes {@code GROUP BY brand, status}.
+ *
+ * <p>Unlike single-field {@code terms}, a multi_terms grouping is multi-field, and the plan's
+ * bucket-count machinery (fetch, per-parent bounds, eligible-doc counts) is single-field today,
+ * so a multi_terms plan is <em>unbounded</em>: it groups and sorts but does not truncate. This
+ * translator therefore renders through the base-contract path and applies {@code min_doc_count},
+ * the requested order, and the top-{@code size} cut itself, reporting the truncated tail as
+ * {@code sum_other_doc_count}.
+ *
+ * <p>Keys are heterogeneous — one value per term source, in declaration order — so each position
+ * is converted by its runtime type (number, boolean, binary) into the raw value
+ * {@link InternalMultiTerms} stores, paired with the {@link DocValueFormat} that renders it. The
+ * per-position format is resolved from the source field's mapping; a field whose mapping cannot
+ * be resolved at render time fails the request. Under a RAW-resolved format, binary (ip) keys are
+ * pre-rendered as address strings.
+ */
+public class MultiTermsBucketTranslator implements BucketTranslator<MultiTermsAggregationBuilder> {
+
+    private final Supplier<MapperService> mapperServiceSupplier;
+
+    /**
+     * Creates a multi_terms bucket translator.
+     *
+     * @param mapperServiceSupplier supplies the target index's MapperService for per-source key
+     *        format resolution and {@link #validate} mapping checks; supplying null skips those
+     *        validate() mapping checks and fails rendering
+     */
+    public MultiTermsBucketTranslator(Supplier<MapperService> mapperServiceSupplier) {
+        this.mapperServiceSupplier = mapperServiceSupplier;
+    }
+
+    @Override
+    public Class<MultiTermsAggregationBuilder> getAggregationType() {
+        return MultiTermsAggregationBuilder.class;
+    }
+
+    @Override
+    public GroupingInfo getGrouping(MultiTermsAggregationBuilder agg) {
+        List<MultiTermsValuesSourceConfig> sources = agg.terms();
+        List<String> fieldNames = new ArrayList<>(sources.size());
+        for (MultiTermsValuesSourceConfig source : sources) {
+            fieldNames.add(source.getFieldName());
+        }
+        return new FieldGrouping(fieldNames);
+    }
+
+    @Override
+    public Collection<AggregationBuilder> getSubAggregations(MultiTermsAggregationBuilder agg) {
+        return agg.getSubAggregations();
+    }
+
+    @Override
+    public BucketOrder getBucketOrder(MultiTermsAggregationBuilder agg) {
+        return agg.order();
+    }
+
+    /**
+     * Rejects per-source parameters the translation does not implement ({@code missing},
+     * {@code script}, {@code exclude}, {@code format}, {@code time_zone}), date-mapped term
+     * sources, and {@code min_doc_count: 0}: each would change the bucket set or key rendering
+     * relative to classic search if ignored. Date rejection needs the mapping, so it is skipped
+     * when no {@link MapperService} is supplied.
+     */
+    @Override
+    public void validate(MultiTermsAggregationBuilder agg) throws ConversionException {
+        for (MultiTermsValuesSourceConfig source : agg.terms()) {
+            String field = source.getFieldName();
+            if (source.getMissing() != null) {
+                throw new ConversionException("multi_terms does not support the 'missing' parameter on term source [" + field + "]");
+            }
+            if (source.getScript() != null) {
+                throw new ConversionException("multi_terms does not support the 'script' parameter on term source [" + field + "]");
+            }
+            if (source.getIncludeExclude() != null) {
+                throw new ConversionException("multi_terms does not support the 'exclude' parameter on term source [" + field + "]");
+            }
+            if (source.getFormat() != null) {
+                throw new ConversionException("multi_terms does not support the 'format' parameter on term source [" + field + "]");
+            }
+            if (source.getTimeZone() != null) {
+                throw new ConversionException("multi_terms does not support the 'time_zone' parameter on term source [" + field + "]");
+            }
+            MappedFieldType fieldType = resolveFieldType(field);
+            if (fieldType != null
+                && (DateFieldMapper.CONTENT_TYPE.equals(fieldType.typeName())
+                    || DateFieldMapper.DATE_NANOS_CONTENT_TYPE.equals(fieldType.typeName()))) {
+                throw new ConversionException(
+                    "multi_terms does not support date term source ["
+                        + field
+                        + "] — date bucket keys cannot yet be rendered with mapping formats"
+                );
+            }
+        }
+        if (agg.minDocCount() == 0) {
+            throw new ConversionException(
+                "[min_doc_count: 0] on multi_terms aggregation ["
+                    + agg.getName()
+                    + "] is not supported by the DSL execution path — zero-count buckets require enumerating term "
+                    + "combinations that a GROUP BY over matching documents cannot produce"
+            );
+        }
+    }
+
+    /**
+     * Renders the multi_terms response from the plan's grouped rows. The plan sorted the rows but
+     * did not bound them, so this method drops entries with a null key at any position (parity
+     * with classic multi_terms, since {@code missing} is rejected), applies {@code min_doc_count},
+     * fails loudly on an arity mismatch, then orders, truncates to the top {@code size}, and
+     * reports the truncated tail as {@code sum_other_doc_count}.
+     */
+    @Override
+    public InternalAggregation toBucketAggregation(MultiTermsAggregationBuilder agg, Iterable<BucketEntry> buckets) {
+        int arity = agg.terms().size();
+
+        // Filter before sampling formats: a discarded entry must not decide a position's format.
+        List<BucketEntry> kept = new ArrayList<>();
+        for (BucketEntry entry : buckets) {
+            if (hasNullKey(entry)) {
+                continue;
+            }
+            if (entry.docCount() < agg.minDocCount()) {
+                continue;
+            }
+            if (entry.keys().size() != arity) {
+                throw new IllegalStateException(
+                    "multi_terms ["
+                        + agg.getName()
+                        + "] expected "
+                        + arity
+                        + " key(s) per bucket but the result row supplied "
+                        + entry.keys().size()
+                );
+            }
+            kept.add(entry);
+        }
+
+        List<DocValueFormat> formats = resolveFormats(agg, kept, arity);
+
+        List<InternalMultiTerms.Bucket> termBuckets = new ArrayList<>(kept.size());
+        for (BucketEntry entry : kept) {
+            List<Object> values = new ArrayList<>(arity);
+            for (int i = 0; i < arity; i++) {
+                values.add(termValue(entry.keys().get(i), formats.get(i)));
+            }
+            termBuckets.add(new InternalMultiTerms.Bucket(values, entry.docCount(), entry.subAggs(), false, 0, formats));
+        }
+
+        BucketOrder order = agg.order();
+        termBuckets.sort(order.comparator());
+        long otherDocCount = truncate(termBuckets, agg.size());
+
+        return new InternalMultiTerms(
+            agg.getName(),
+            order, // reduceOrder: the bucket list is sorted by it
+            order, // the user-requested display order
+            AggregationTranslator.userMetadata(agg),
+            agg.shardSize(), // request echo — no shard fan-out on this path
+            false, // no per-bucket doc count error rendering
+            otherDocCount,
+            0, // exact single-plan path: doc_count_error_upper_bound is truly 0
+            formats,
+            termBuckets,
+            thresholds(agg)
+        );
+    }
+
+    private static boolean hasNullKey(BucketEntry entry) {
+        for (Object key : entry.keys()) {
+            if (key == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Truncates {@code buckets} in place to the top {@code size}, returning the summed doc count
+     * of the removed tail for {@code sum_other_doc_count}. The list must already be ordered.
+     */
+    private static long truncate(List<InternalMultiTerms.Bucket> buckets, int size) {
+        if (buckets.size() <= size) {
+            return 0L;
+        }
+        long otherDocCount = 0;
+        for (int i = size; i < buckets.size(); i++) {
+            otherDocCount += buckets.get(i).getDocCount();
+        }
+        buckets.subList(size, buckets.size()).clear();
+        return otherDocCount;
+    }
+
+    /**
+     * Resolves one {@link DocValueFormat} per term-source position. A boolean-valued position
+     * always uses {@link DocValueFormat#BOOLEAN}; otherwise the position takes its source field's
+     * mapping-resolved format, failing the request when that mapping cannot be resolved. A
+     * position is typed from the first surviving entry, since a column is homogeneous.
+     */
+    private List<DocValueFormat> resolveFormats(MultiTermsAggregationBuilder agg, List<BucketEntry> kept, int arity) {
+        List<MultiTermsValuesSourceConfig> sources = agg.terms();
+        BucketEntry sample = kept.isEmpty() ? null : kept.get(0);
+        List<DocValueFormat> formats = new ArrayList<>(arity);
+        for (int i = 0; i < arity; i++) {
+            Object sampleKey = sample == null ? null : sample.keys().get(i);
+            if (sampleKey instanceof Boolean) {
+                formats.add(DocValueFormat.BOOLEAN);
+                continue;
+            }
+            MappedFieldType fieldType = requireFieldType(agg, sources.get(i).getFieldName());
+            formats.add(fieldType.docValueFormat(null, null));
+        }
+        return formats;
+    }
+
+    /**
+     * Converts a single key position into the raw value {@link InternalMultiTerms.Bucket} stores,
+     * matching {@link InternalMultiTerms#formatObject}: booleans become 1/0 as a {@code long},
+     * floating-point numbers widen to {@code double}, other numbers narrow to {@code long}, and
+     * binary/string keys become a {@link BytesRef}. Under {@link DocValueFormat#RAW} a binary
+     * (ip) key is pre-rendered as its address string, since RAW would otherwise print raw bytes.
+     */
+    private static Object termValue(Object key, DocValueFormat format) {
+        if (key instanceof Boolean bool) {
+            return bool ? 1L : 0L;
+        }
+        if (key instanceof Double || key instanceof Float) {
+            return ((Number) key).doubleValue();
+        }
+        if (key instanceof Number number) {
+            return number.longValue();
+        }
+        if (key instanceof BytesRef ref) {
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(ref.bytes)) : ref;
+        }
+        if (key instanceof byte[] bytes) {
+            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(bytes)) : new BytesRef(bytes);
+        }
+        return new BytesRef(key.toString());
+    }
+
+    /** Binary keys are ip columns: render the address string like classic ip terms. */
+    private static String binaryKeyString(byte[] bytes) {
+        try {
+            return NetworkAddress.format(InetAddress.getByAddress(bytes));
+        } catch (UnknownHostException e) {
+            // Not a 4/16-byte address; fall back to a printable, deterministic form.
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+
+    /** Resolves a term-source field's mapping, or null when the MapperService or mapping is unavailable. */
+    private MappedFieldType resolveFieldType(String field) {
+        MapperService mapperService = mapperServiceSupplier.get();
+        return mapperService == null ? null : mapperService.fieldType(field);
+    }
+
+    /** Resolves a term-source field's mapping for rendering, failing loudly when it cannot be resolved. */
+    private MappedFieldType requireFieldType(MultiTermsAggregationBuilder agg, String field) {
+        MapperService mapperService = mapperServiceSupplier.get();
+        if (mapperService == null) {
+            throw new IllegalStateException(
+                "index mapping unavailable for multi_terms aggregation ["
+                    + agg.getName()
+                    + "] — cannot resolve the key type for term source ["
+                    + field
+                    + "]"
+            );
+        }
+        MappedFieldType fieldType = mapperService.fieldType(field);
+        if (fieldType == null) {
+            throw new IllegalStateException(
+                "term source [" + field + "] of multi_terms aggregation [" + agg.getName() + "] is not present in the index mapping"
+            );
+        }
+        return fieldType;
+    }
+
+    /** Bundles the request's bucket-count knobs for the result constructor. */
+    private static TermsAggregator.BucketCountThresholds thresholds(MultiTermsAggregationBuilder agg) {
+        return new TermsAggregator.BucketCountThresholds(agg.minDocCount(), agg.shardMinDocCount(), agg.size(), agg.shardSize());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslator.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.dsl.aggregation.bucket;
 
-import org.apache.lucene.util.BytesRef;
-import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.FieldGrouping;
 import org.opensearch.dsl.aggregation.GroupingInfo;
@@ -27,10 +25,7 @@ import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuil
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
@@ -255,8 +250,8 @@ public class MultiTermsBucketTranslator implements BucketTranslator<MultiTermsAg
      * Converts a single key position into the raw value {@link InternalMultiTerms.Bucket} stores,
      * matching {@link InternalMultiTerms#formatObject}: booleans become 1/0 as a {@code long},
      * floating-point numbers widen to {@code double}, other numbers narrow to {@code long}, and
-     * binary/string keys become a {@link BytesRef}. Under {@link DocValueFormat#RAW} a binary
-     * (ip) key is pre-rendered as its address string, since RAW would otherwise print raw bytes.
+     * binary/string keys are converted by {@link BinaryTermKeys#termBytes} (ip address string under
+     * {@link DocValueFormat#RAW}, encoded bytes otherwise).
      */
     private static Object termValue(Object key, DocValueFormat format) {
         if (key instanceof Boolean bool) {
@@ -268,23 +263,7 @@ public class MultiTermsBucketTranslator implements BucketTranslator<MultiTermsAg
         if (key instanceof Number number) {
             return number.longValue();
         }
-        if (key instanceof BytesRef ref) {
-            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(ref.bytes)) : ref;
-        }
-        if (key instanceof byte[] bytes) {
-            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(bytes)) : new BytesRef(bytes);
-        }
-        return new BytesRef(key.toString());
-    }
-
-    /** Binary keys are ip columns: render the address string like classic ip terms. */
-    private static String binaryKeyString(byte[] bytes) {
-        try {
-            return NetworkAddress.format(InetAddress.getByAddress(bytes));
-        } catch (UnknownHostException e) {
-            // Not a 4/16-byte address; fall back to a printable, deterministic form.
-            return Base64.getEncoder().encodeToString(bytes);
-        }
+        return BinaryTermKeys.termBytes(key, format);
     }
 
     /** Resolves a term-source field's mapping, or null when the MapperService or mapping is unavailable. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/StringTermsStrategy.java
@@ -9,7 +9,6 @@
 package org.opensearch.dsl.aggregation.bucket;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.result.BucketEntry;
 import org.opensearch.search.DocValueFormat;
@@ -18,10 +17,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 /**
@@ -70,22 +66,6 @@ public final class StringTermsStrategy implements TermsResponseStrategy {
      * since RAW would otherwise print raw bytes. String keys become their UTF-8 bytes.
      */
     private static BytesRef termBytes(Object key, DocValueFormat format) {
-        if (key instanceof BytesRef ref) {
-            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(ref.bytes)) : ref;
-        }
-        if (key instanceof byte[] bytes) {
-            return format == DocValueFormat.RAW ? new BytesRef(binaryKeyString(bytes)) : new BytesRef(bytes);
-        }
-        return new BytesRef(key.toString());
-    }
-
-    /** Binary keys are ip columns: render the address string like classic ip terms. */
-    private static String binaryKeyString(byte[] bytes) {
-        try {
-            return NetworkAddress.format(InetAddress.getByAddress(bytes));
-        } catch (UnknownHostException e) {
-            // Not a 4/16-byte address; fall back to a printable, deterministic form.
-            return Base64.getEncoder().encodeToString(bytes);
-        }
+        return BinaryTermKeys.termBytes(key, format);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslatorTests.java
@@ -1,0 +1,537 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.BooleanFieldMapper;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.IpFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.terms.InternalMultiTerms;
+import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigInteger;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
+
+    /** Field types the mapped translator resolves, mirroring a real index mapping. */
+    private static final Map<String, MappedFieldType> FIELD_TYPES = Map.ofEntries(
+        Map.entry("brand", new KeywordFieldMapper.KeywordFieldType("brand")),
+        Map.entry("status", new KeywordFieldMapper.KeywordFieldType("status")),
+        Map.entry("region", new KeywordFieldMapper.KeywordFieldType("region")),
+        Map.entry("is_active", new BooleanFieldMapper.BooleanFieldType("is_active")),
+        Map.entry("price", new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG)),
+        Map.entry("rating", new NumberFieldMapper.NumberFieldType("rating", NumberFieldMapper.NumberType.DOUBLE)),
+        Map.entry("score", new NumberFieldMapper.NumberFieldType("score", NumberFieldMapper.NumberType.FLOAT)),
+        Map.entry("client_ip", new IpFieldMapper.IpFieldType("client_ip")),
+        Map.entry("created_at", new DateFieldMapper.DateFieldType("created_at")),
+        Map.entry("count_i", new NumberFieldMapper.NumberFieldType("count_i", NumberFieldMapper.NumberType.INTEGER)),
+        Map.entry("count_s", new NumberFieldMapper.NumberFieldType("count_s", NumberFieldMapper.NumberType.SHORT)),
+        Map.entry("count_b", new NumberFieldMapper.NumberFieldType("count_b", NumberFieldMapper.NumberType.BYTE)),
+        Map.entry("big", new NumberFieldMapper.NumberFieldType("big", NumberFieldMapper.NumberType.UNSIGNED_LONG)),
+        Map.entry("ratio", new NumberFieldMapper.NumberFieldType("ratio", NumberFieldMapper.NumberType.HALF_FLOAT)),
+        Map.entry("amount", scaledFloatType("amount"))
+    );
+
+    /** scaled_float lives in mapper-extras; a mock supplies its typeName and RAW key format. */
+    private static MappedFieldType scaledFloatType(String name) {
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.typeName()).thenReturn("scaled_float");
+        when(fieldType.docValueFormat(null, null)).thenReturn(DocValueFormat.RAW);
+        return fieldType;
+    }
+
+    private final MultiTermsBucketTranslator translator = new MultiTermsBucketTranslator(MultiTermsBucketTranslatorTests::mappedService);
+    private final MultiTermsBucketTranslator unmappedTranslator = new MultiTermsBucketTranslator(() -> null);
+
+    private static MapperService mappedService() {
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType(anyString())).thenAnswer(invocation -> FIELD_TYPES.get(invocation.<String>getArgument(0)));
+        return mapperService;
+    }
+
+    private static MultiTermsAggregationBuilder twoFieldAgg(String name, String field1, String field2) {
+        return new MultiTermsAggregationBuilder(name).terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName(field1).build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName(field2).build()
+            )
+        );
+    }
+
+    public void testGetAggregationTypeIsMultiTermsBuilder() {
+        assertEquals(MultiTermsAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    // ---- Grouping: field order, no rejection (validation moved to validate()) ----
+
+    public void testGroupingPreservesDeclaredFieldOrder() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        assertEquals(List.of("brand", "status"), translator.getGrouping(agg).getFieldNames());
+    }
+
+    public void testThreeTermSourcesGroupingPreservesOrder() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("a").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("b").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("c").build()
+            )
+        );
+        assertEquals(List.of("a", "b", "c"), translator.getGrouping(agg).getFieldNames());
+    }
+
+    public void testSubAggregationsAreExposed() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status").subAggregation(
+            new AvgAggregationBuilder("avg_price").field("price")
+        );
+        assertEquals(1, translator.getSubAggregations(agg).size());
+    }
+
+    // ---- validate(): unsupported per-source parameters are rejected ----
+
+    public void testMissingParameterRejected() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("region").setMissing("N/A").build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(ex.getMessage().contains("missing"));
+    }
+
+    public void testScriptTermSourceRejected() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("region")
+                    .setScript(new org.opensearch.script.Script("doc['region'].value"))
+                    .build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(ex.getMessage().contains("script"));
+    }
+
+    public void testExcludeRejected() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand")
+                    .setIncludeExclude(new org.opensearch.search.aggregations.bucket.terms.IncludeExclude(null, "foo.*"))
+                    .build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("region").build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(ex.getMessage().contains("'exclude'"));
+    }
+
+    public void testFormatParameterRejected() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("timestamp").setFormat("yyyy-MM-dd").build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue("Message should mention 'format', got: " + ex.getMessage(), ex.getMessage().contains("format"));
+        assertTrue("Message should name the offending field, got: " + ex.getMessage(), ex.getMessage().contains("timestamp"));
+    }
+
+    public void testTimeZoneParameterRejected() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("timestamp").setTimeZone(ZoneId.of("America/New_York")).build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue("Message should mention 'time_zone', got: " + ex.getMessage(), ex.getMessage().contains("time_zone"));
+        assertTrue("Message should name the offending field, got: " + ex.getMessage(), ex.getMessage().contains("timestamp"));
+    }
+
+    public void testRejectionNamesOffendingField() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("region").setMissing("N/A").build()
+            )
+        );
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue("Message should name the offending field, got: " + ex.getMessage(), ex.getMessage().contains("region"));
+    }
+
+    /** A date-mapped term source cannot render its keys with mapping formats — reject at conversion. */
+    public void testValidateRejectsDateTermSource() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "created_at");
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(
+            "Message should name the date field, got: " + ex.getMessage(),
+            ex.getMessage().contains("date term source [created_at]")
+        );
+    }
+
+    public void testValidateRejectsDateNanosTermSource() {
+        MappedFieldType nanosType = mock(MappedFieldType.class);
+        when(nanosType.typeName()).thenReturn(DateFieldMapper.DATE_NANOS_CONTENT_TYPE);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldType("created_nanos")).thenReturn(nanosType);
+        MultiTermsBucketTranslator nanosTranslator = new MultiTermsBucketTranslator(() -> mapperService);
+
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "created_nanos");
+        ConversionException ex = expectThrows(ConversionException.class, () -> nanosTranslator.validate(agg));
+        assertTrue(ex.getMessage().contains("date term source [created_nanos]"));
+    }
+
+    /** min_doc_count: 0 would require enumerating unmatched term combinations — reject it. */
+    public void testValidateRejectsMinDocCountZero() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        agg.minDocCount(0);
+        ConversionException ex = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(ex.getMessage().contains("min_doc_count: 0"));
+    }
+
+    /** Mapping-dependent validation is skipped when no MapperService is supplied (conversion-only use). */
+    public void testValidateSkipsDateCheckWithoutMapperService() throws Exception {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "created_at");
+        unmappedTranslator.validate(agg); // must not throw
+    }
+
+    public void testValidateAcceptsSupportedTermSources() throws Exception {
+        translator.validate(twoFieldAgg("combo", "brand", "status")); // must not throw
+    }
+
+    // ---- Rendering ----
+
+    public void testEmptyBucketsProducesEmptyResult() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        InternalAggregation result = translator.toBucketAggregation(agg, List.of());
+        assertTrue(result instanceof InternalMultiTerms);
+        assertTrue(((InternalMultiTerms) result).getBuckets().isEmpty());
+    }
+
+    public void testCompositeKeyRendersAsArrayAndPipeJoinedString() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("active", "us"), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(1, result.getBuckets().size());
+        InternalMultiTerms.Bucket bucket = result.getBuckets().get(0);
+        assertEquals(List.of("active", "us"), bucket.getKey());
+        assertEquals("active|us", bucket.getKeyAsString());
+    }
+
+    public void testNullKeyAtFirstPositionSkipsBucket() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
+        List<BucketEntry> entries = new ArrayList<>();
+        entries.add(new BucketEntry(listWithNull(null, "us"), 3, InternalAggregations.EMPTY));
+        entries.add(new BucketEntry(List.of("active", "eu"), 2, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(1, result.getBuckets().size());
+        assertEquals(List.of("active", "eu"), result.getBuckets().get(0).getKey());
+    }
+
+    public void testNullKeyAtSecondPositionSkipsBucket() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
+        List<BucketEntry> entries = new ArrayList<>();
+        entries.add(new BucketEntry(listWithNull("active", null), 3, InternalAggregations.EMPTY));
+        entries.add(new BucketEntry(List.of("inactive", "eu"), 2, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(1, result.getBuckets().size());
+        assertEquals(List.of("inactive", "eu"), result.getBuckets().get(0).getKey());
+    }
+
+    public void testMinDocCountFiltersBuckets() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        agg.minDocCount(3);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("BrandA", "active"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("BrandB", "inactive"), 2, InternalAggregations.EMPTY)
+        );
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(1, result.getBuckets().size());
+        assertEquals(List.of("BrandA", "active"), result.getBuckets().get(0).getKey());
+    }
+
+    public void testSizeTruncatesAndReportsSumOtherDocCount() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        agg.size(2);
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("A", "x"), 5, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("B", "y"), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("C", "z"), 2, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("D", "w"), 1, InternalAggregations.EMPTY)
+        );
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(2, result.getBuckets().size());
+        assertEquals(3L, result.getSumOfOtherDocCounts());
+    }
+
+    public void testDefaultOrderIsCountDescending() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        // Supply entries in count-ASCENDING order
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("A", "x"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("B", "y"), 3, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("C", "z"), 2, InternalAggregations.EMPTY)
+        );
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(3, result.getBuckets().size());
+        assertEquals(3L, result.getBuckets().get(0).getDocCount());
+        assertEquals(2L, result.getBuckets().get(1).getDocCount());
+        assertEquals(1L, result.getBuckets().get(2).getDocCount());
+    }
+
+    public void testKeyAscOrderWithCompositeKeys() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        agg.order(BucketOrder.key(true));
+        // Supply in non-lexicographic order
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("b", "a"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("a", "z"), 1, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("a", "a"), 1, InternalAggregations.EMPTY)
+        );
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(3, result.getBuckets().size());
+        assertEquals(List.of("a", "a"), result.getBuckets().get(0).getKey());
+        assertEquals(List.of("a", "z"), result.getBuckets().get(1).getKey());
+        assertEquals(List.of("b", "a"), result.getBuckets().get(2).getKey());
+    }
+
+    public void testBooleanPositionUsesBooleanFormat() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "is_active");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", true), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals("BrandA", key.get(0));
+        // Boolean renders as true/false via DocValueFormat.BOOLEAN
+        assertEquals("true", key.get(1).toString());
+    }
+
+    public void testIntegralPositionStoresLongValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "price");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 42L), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals("BrandA", key.get(0));
+        assertEquals(42L, key.get(1));
+    }
+
+    public void testDoublePositionStoresDoubleValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "rating");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 3.5), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals("BrandA", key.get(0));
+        assertEquals(3.5, key.get(1));
+    }
+
+    public void testFloatKeyWidenedToDouble() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "score");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 2.5f), 4, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertTrue("Float should be widened to Double, got: " + key.get(1).getClass(), key.get(1) instanceof Double);
+        assertEquals(2.5, (Double) key.get(1), 0.0001);
+    }
+
+    // ---- Per-type composite keys: numeric mappings mirror the single-field LongTerms/DoubleTerms path ----
+
+    public void testIntegerPositionStoresLongValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "count_i");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 42), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals(42L, key.get(1));
+        assertEquals("BrandA|42", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testShortPositionStoresLongValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "count_s");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", (short) 7), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals(7L, key.get(1));
+        assertEquals("BrandA|7", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testBytePositionStoresLongValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "count_b");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", (byte) 3), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals(3L, key.get(1));
+        assertEquals("BrandA|3", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testUnsignedLongPositionStoresLongAndRendersViaUnsignedFormat() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "big");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 42L), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertEquals(BigInteger.valueOf(42), key.get(1));
+        assertEquals("BrandA|42", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testHalfFloatKeyWidenedToDouble() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "ratio");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 0.5f), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertTrue("half_float should widen to Double, got: " + key.get(1).getClass(), key.get(1) instanceof Double);
+        assertEquals(0.5, (Double) key.get(1), 0.0001);
+        assertEquals("BrandA|0.5", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testScaledFloatPositionStoresDoubleValue() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "amount");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 19.5), 5, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        List<Object> key = result.getBuckets().get(0).getKey();
+        assertTrue("scaled_float should store Double, got: " + key.get(1).getClass(), key.get(1) instanceof Double);
+        assertEquals(19.5, (Double) key.get(1), 0.0001);
+        assertEquals("BrandA|19.5", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    /** Rendering fails loudly when no MapperService is available to resolve a position's key format. */
+    public void testRenderFailsLoudlyWithoutMapperService() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "client_ip", "brand");
+        byte[] ipv4 = new byte[] { (byte) 192, (byte) 168, 1, 42 };
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of(ipv4, "BrandA"), 2, InternalAggregations.EMPTY));
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> unmappedTranslator.toBucketAggregation(agg, entries));
+        assertTrue("Message should name the aggregation, got: " + ex.getMessage(), ex.getMessage().contains("combo"));
+        assertTrue("Message should name the unresolvable field, got: " + ex.getMessage(), ex.getMessage().contains("client_ip"));
+    }
+
+    /** With a mapping the ip source resolves to DocValueFormat.IP and renders the encoded address. */
+    public void testMappedIpSourceRendersViaIpFormat() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "client_ip");
+        byte[] ipv4In16 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 1 };
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", ipv4In16), 2, InternalAggregations.EMPTY));
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals("BrandA|10.0.0.1", result.getBuckets().get(0).getKeyAsString());
+    }
+
+    public void testThreeTermSourcesRenderCompositeKeys() {
+        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
+            List.of(
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("region").build(),
+                new MultiTermsValuesSourceConfig.Builder().setFieldName("status").build()
+            )
+        );
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of("Nike", "US", "active"), 10, InternalAggregations.EMPTY),
+            new BucketEntry(List.of("Adidas", "EU", "inactive"), 7, InternalAggregations.EMPTY)
+        );
+
+        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
+
+        assertEquals(2, result.getBuckets().size());
+        assertEquals(List.of("Nike", "US", "active"), result.getBuckets().get(0).getKey());
+        assertEquals("Nike|US|active", result.getBuckets().get(0).getKeyAsString());
+        assertEquals(List.of("Adidas", "EU", "inactive"), result.getBuckets().get(1).getKey());
+        assertEquals("Adidas|EU|inactive", result.getBuckets().get(1).getKeyAsString());
+    }
+
+    public void testKeyArityMismatchThrows() {
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", "active", "extra"), 5, InternalAggregations.EMPTY));
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> translator.toBucketAggregation(agg, entries));
+        assertTrue("Message should contain expected count, got: " + ex.getMessage(), ex.getMessage().contains("2 key(s)"));
+        assertTrue("Message should contain actual count, got: " + ex.getMessage(), ex.getMessage().contains("supplied 3"));
+    }
+
+    public void testMetadataRoundTrips() {
+        Map<String, Object> meta = Map.of("source", "dashboard");
+        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
+        agg.setMetadata(meta);
+        assertEquals(meta, translator.toBucketAggregation(agg, List.of()).getMetadata());
+
+        // No meta → null in response
+        MultiTermsAggregationBuilder noMeta = twoFieldAgg("combo2", "brand", "status");
+        assertNull(translator.toBucketAggregation(noMeta, List.of()).getMetadata());
+
+        // Empty meta → treated as absent
+        MultiTermsAggregationBuilder emptyMeta = twoFieldAgg("combo3", "brand", "status");
+        emptyMeta.setMetadata(Map.of());
+        assertNull(translator.toBucketAggregation(emptyMeta, List.of()).getMetadata());
+    }
+
+    public void testMultiTermsTranslatorIsRegistered() {
+        assertTrue(AggregationRegistryFactory.create().get(MultiTermsAggregationBuilder.class) instanceof MultiTermsBucketTranslator);
+    }
+
+    // ---- Helpers ----
+
+    private static List<Object> listWithNull(Object first, Object second) {
+        List<Object> list = new ArrayList<>();
+        list.add(first);
+        list.add(second);
+        return list;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/MultiTermsBucketTranslatorTests.java
@@ -20,17 +20,14 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.BucketOrder;
-import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.bucket.terms.InternalMultiTerms;
 import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
-import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.math.BigInteger;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -87,31 +84,6 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
 
     public void testGetAggregationTypeIsMultiTermsBuilder() {
         assertEquals(MultiTermsAggregationBuilder.class, translator.getAggregationType());
-    }
-
-    // ---- Grouping: field order, no rejection (validation moved to validate()) ----
-
-    public void testGroupingPreservesDeclaredFieldOrder() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
-        assertEquals(List.of("brand", "status"), translator.getGrouping(agg).getFieldNames());
-    }
-
-    public void testThreeTermSourcesGroupingPreservesOrder() {
-        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
-            List.of(
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("a").build(),
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("b").build(),
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("c").build()
-            )
-        );
-        assertEquals(List.of("a", "b", "c"), translator.getGrouping(agg).getFieldNames());
-    }
-
-    public void testSubAggregationsAreExposed() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status").subAggregation(
-            new AvgAggregationBuilder("avg_price").field("price")
-        );
-        assertEquals(1, translator.getSubAggregations(agg).size());
     }
 
     // ---- validate(): unsupported per-source parameters are rejected ----
@@ -230,79 +202,6 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
 
     // ---- Rendering ----
 
-    public void testEmptyBucketsProducesEmptyResult() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
-        InternalAggregation result = translator.toBucketAggregation(agg, List.of());
-        assertTrue(result instanceof InternalMultiTerms);
-        assertTrue(((InternalMultiTerms) result).getBuckets().isEmpty());
-    }
-
-    public void testCompositeKeyRendersAsArrayAndPipeJoinedString() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("active", "us"), 5, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(1, result.getBuckets().size());
-        InternalMultiTerms.Bucket bucket = result.getBuckets().get(0);
-        assertEquals(List.of("active", "us"), bucket.getKey());
-        assertEquals("active|us", bucket.getKeyAsString());
-    }
-
-    public void testNullKeyAtFirstPositionSkipsBucket() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
-        List<BucketEntry> entries = new ArrayList<>();
-        entries.add(new BucketEntry(listWithNull(null, "us"), 3, InternalAggregations.EMPTY));
-        entries.add(new BucketEntry(List.of("active", "eu"), 2, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(1, result.getBuckets().size());
-        assertEquals(List.of("active", "eu"), result.getBuckets().get(0).getKey());
-    }
-
-    public void testNullKeyAtSecondPositionSkipsBucket() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "status", "region");
-        List<BucketEntry> entries = new ArrayList<>();
-        entries.add(new BucketEntry(listWithNull("active", null), 3, InternalAggregations.EMPTY));
-        entries.add(new BucketEntry(List.of("inactive", "eu"), 2, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(1, result.getBuckets().size());
-        assertEquals(List.of("inactive", "eu"), result.getBuckets().get(0).getKey());
-    }
-
-    public void testMinDocCountFiltersBuckets() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
-        agg.minDocCount(3);
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("BrandA", "active"), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("BrandB", "inactive"), 2, InternalAggregations.EMPTY)
-        );
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(1, result.getBuckets().size());
-        assertEquals(List.of("BrandA", "active"), result.getBuckets().get(0).getKey());
-    }
-
-    public void testSizeTruncatesAndReportsSumOtherDocCount() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
-        agg.size(2);
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("A", "x"), 5, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("B", "y"), 3, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("C", "z"), 2, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("D", "w"), 1, InternalAggregations.EMPTY)
-        );
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(2, result.getBuckets().size());
-        assertEquals(3L, result.getSumOfOtherDocCounts());
-    }
-
     public void testDefaultOrderIsCountDescending() {
         MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "status");
         // Supply entries in count-ASCENDING order
@@ -338,40 +237,6 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals(List.of("b", "a"), result.getBuckets().get(2).getKey());
     }
 
-    public void testBooleanPositionUsesBooleanFormat() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "is_active");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", true), 5, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        List<Object> key = result.getBuckets().get(0).getKey();
-        assertEquals("BrandA", key.get(0));
-        // Boolean renders as true/false via DocValueFormat.BOOLEAN
-        assertEquals("true", key.get(1).toString());
-    }
-
-    public void testIntegralPositionStoresLongValue() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "price");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 42L), 5, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        List<Object> key = result.getBuckets().get(0).getKey();
-        assertEquals("BrandA", key.get(0));
-        assertEquals(42L, key.get(1));
-    }
-
-    public void testDoublePositionStoresDoubleValue() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "rating");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 3.5), 5, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        List<Object> key = result.getBuckets().get(0).getKey();
-        assertEquals("BrandA", key.get(0));
-        assertEquals(3.5, key.get(1));
-    }
-
     public void testFloatKeyWidenedToDouble() {
         MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "score");
         List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 2.5f), 4, InternalAggregations.EMPTY));
@@ -384,17 +249,6 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
     }
 
     // ---- Per-type composite keys: numeric mappings mirror the single-field LongTerms/DoubleTerms path ----
-
-    public void testIntegerPositionStoresLongValue() {
-        MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "count_i");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 42), 5, InternalAggregations.EMPTY));
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        List<Object> key = result.getBuckets().get(0).getKey();
-        assertEquals(42L, key.get(1));
-        assertEquals("BrandA|42", result.getBuckets().get(0).getKeyAsString());
-    }
 
     public void testShortPositionStoresLongValue() {
         MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "count_s");
@@ -441,16 +295,29 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
         assertEquals("BrandA|0.5", result.getBuckets().get(0).getKeyAsString());
     }
 
-    public void testScaledFloatPositionStoresDoubleValue() {
+    /**
+     * scaled_float keys arrive as the raw scaled value the engine delivers — {@code 4.44} at
+     * {@code scaling_factor: 100} is delivered as the integral {@code 444} (as the
+     * {@code range_scaled_float} plan shows {@code 1.5} planned as {@code 150}), not a pre-divided
+     * double. This render path resolves the source's {@code docValueFormat(null, null)}, which for
+     * scaled_float is {@link DocValueFormat#RAW}, so the raw scaled value passes through unchanged.
+     *
+     * <p>Residual gap: the scaling-factor division lives in {@code ScaledFloatFieldType.valueForDisplay},
+     * which this path does not call, so the multi_terms render does NOT divide by the factor — a
+     * scaled_float key renders as its raw scaled value ({@code 444}), not {@code 4.44}. Reproducing
+     * the divided value would require the real scaled_float field type from mapper-extras, which is
+     * not on this test classpath and must not be added as a dependency.
+     */
+    public void testScaledFloatKeyRendersRawScaledValueUndivided() {
         MultiTermsAggregationBuilder agg = twoFieldAgg("combo", "brand", "amount");
-        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 19.5), 5, InternalAggregations.EMPTY));
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of("BrandA", 444L), 5, InternalAggregations.EMPTY));
 
         InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
 
         List<Object> key = result.getBuckets().get(0).getKey();
-        assertTrue("scaled_float should store Double, got: " + key.get(1).getClass(), key.get(1) instanceof Double);
-        assertEquals(19.5, (Double) key.get(1), 0.0001);
-        assertEquals("BrandA|19.5", result.getBuckets().get(0).getKeyAsString());
+        // Raw scaled value is integral and stored as a long under RAW — not divided by the factor.
+        assertEquals(444L, key.get(1));
+        assertEquals("BrandA|444", result.getBuckets().get(0).getKeyAsString());
     }
 
     /** Rendering fails loudly when no MapperService is available to resolve a position's key format. */
@@ -473,28 +340,6 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
         InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
 
         assertEquals("BrandA|10.0.0.1", result.getBuckets().get(0).getKeyAsString());
-    }
-
-    public void testThreeTermSourcesRenderCompositeKeys() {
-        MultiTermsAggregationBuilder agg = new MultiTermsAggregationBuilder("combo").terms(
-            List.of(
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("brand").build(),
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("region").build(),
-                new MultiTermsValuesSourceConfig.Builder().setFieldName("status").build()
-            )
-        );
-        List<BucketEntry> entries = List.of(
-            new BucketEntry(List.of("Nike", "US", "active"), 10, InternalAggregations.EMPTY),
-            new BucketEntry(List.of("Adidas", "EU", "inactive"), 7, InternalAggregations.EMPTY)
-        );
-
-        InternalMultiTerms result = (InternalMultiTerms) translator.toBucketAggregation(agg, entries);
-
-        assertEquals(2, result.getBuckets().size());
-        assertEquals(List.of("Nike", "US", "active"), result.getBuckets().get(0).getKey());
-        assertEquals("Nike|US|active", result.getBuckets().get(0).getKeyAsString());
-        assertEquals(List.of("Adidas", "EU", "inactive"), result.getBuckets().get(1).getKey());
-        assertEquals("Adidas|EU|inactive", result.getBuckets().get(1).getKeyAsString());
     }
 
     public void testKeyArityMismatchThrows() {
@@ -524,14 +369,5 @@ public class MultiTermsBucketTranslatorTests extends OpenSearchTestCase {
 
     public void testMultiTermsTranslatorIsRegistered() {
         assertTrue(AggregationRegistryFactory.create().get(MultiTermsAggregationBuilder.class) instanceof MultiTermsBucketTranslator);
-    }
-
-    // ---- Helpers ----
-
-    private static List<Object> listWithNull(Object first, Object second) {
-        List<Object> list = new ArrayList<>();
-        list.add(first);
-        list.add(second);
-        return list;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_aggregation.json
@@ -1,0 +1,65 @@
+{
+  "testName": "multi_terms_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "status" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{2, 3}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($2), IS NOT NULL($3))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "status", "_count"],
+  "mockResultRows": [
+    ["BrandA", "active", 3],
+    ["BrandB", "inactive", 2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": ["BrandA", "active"],
+            "key_as_string": "BrandA|active",
+            "doc_count": 3
+          },
+          {
+            "key": ["BrandB", "inactive"],
+            "key_as_string": "BrandB|inactive",
+            "doc_count": 2
+          }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_boolean_integral_keys.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_boolean_integral_keys.json
@@ -1,0 +1,53 @@
+{
+  "testName": "multi_terms_boolean_integral_keys",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "is_active": "BOOLEAN",
+    "price": "BIGINT"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "is_active" },
+            { "field": "price" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$3], sort1=[$0], sort2=[$1], sort3=[$2], dir0=[DESC], dir1=[ASC], dir2=[ASC], dir3=[ASC])",
+    "  LogicalAggregate(group=[{0, 1, 2}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1), IS NOT NULL($2))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "is_active", "price", "_count"],
+  "mockResultRows": [
+    ["BrandA", true, 42, 5],
+    ["BrandB", false, 7, 3]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          { "key": ["BrandA", true, 42], "key_as_string": "BrandA|true|42", "doc_count": 5 },
+          { "key": ["BrandB", false, 7], "key_as_string": "BrandB|false|7", "doc_count": 3 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_empty_buckets.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_empty_buckets.json
@@ -1,0 +1,45 @@
+{
+  "testName": "multi_terms_empty_buckets",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "status" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{0, 1}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "status", "_count"],
+  "mockResultRows": [],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_min_doc_count.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_min_doc_count.json
@@ -1,0 +1,53 @@
+{
+  "testName": "multi_terms_min_doc_count",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "status" }
+          ],
+          "min_doc_count": 2
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{0, 1}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "status", "_count"],
+  "mockResultRows": [
+    ["A", "x", 5],
+    ["B", "y", 1],
+    ["C", "z", 3]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          { "key": ["A", "x"], "key_as_string": "A|x", "doc_count": 5 },
+          { "key": ["C", "z"], "key_as_string": "C|z", "doc_count": 3 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_null_key_skipped.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_null_key_skipped.json
@@ -1,0 +1,51 @@
+{
+  "testName": "multi_terms_null_key_skipped",
+  "indexName": "test-index",
+  "indexMapping": {
+    "status": "VARCHAR",
+    "region": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "status" },
+            { "field": "region" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{0, 1}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["status", "region", "_count"],
+  "mockResultRows": [
+    [null, "us", 3],
+    ["active", null, 4],
+    ["active", "eu", 2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          { "key": ["active", "eu"], "key_as_string": "active|eu", "doc_count": 2 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_numeric_keys.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_numeric_keys.json
@@ -1,0 +1,53 @@
+{
+  "testName": "multi_terms_numeric_keys",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "count_i": "INTEGER",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "count_i" },
+            { "field": "rating" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$3], sort1=[$0], sort2=[$1], sort3=[$2], dir0=[DESC], dir1=[ASC], dir2=[ASC], dir3=[ASC])",
+    "  LogicalAggregate(group=[{0, 1, 2}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1), IS NOT NULL($2))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "count_i", "rating", "_count"],
+  "mockResultRows": [
+    ["BrandA", 42, 3.5, 5],
+    ["BrandB", 7, 1.25, 3]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          { "key": ["BrandA", 42, 3.5], "key_as_string": "BrandA|42|3.5", "doc_count": 5 },
+          { "key": ["BrandB", 7, 1.25], "key_as_string": "BrandB|7|1.25", "doc_count": 3 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_size_truncation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_size_truncation.json
@@ -1,0 +1,54 @@
+{
+  "testName": "multi_terms_size_truncation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "status" }
+          ],
+          "size": 2
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$2], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{0, 1}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "status", "_count"],
+  "mockResultRows": [
+    ["A", "x", 1],
+    ["B", "y", 5],
+    ["C", "z", 2],
+    ["D", "w", 4]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 3,
+        "buckets": [
+          { "key": ["B", "y"], "key_as_string": "B|y", "doc_count": 5 },
+          { "key": ["D", "w"], "key_as_string": "D|w", "doc_count": 4 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_three_sources.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_three_sources.json
@@ -1,0 +1,53 @@
+{
+  "testName": "multi_terms_three_sources",
+  "indexName": "test-index",
+  "indexMapping": {
+    "brand": "VARCHAR",
+    "region": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "region" },
+            { "field": "status" }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$3], sort1=[$0], sort2=[$1], sort3=[$2], dir0=[DESC], dir1=[ASC], dir2=[ASC], dir3=[ASC])",
+    "  LogicalAggregate(group=[{0, 1, 2}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1), IS NOT NULL($2))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "region", "status", "_count"],
+  "mockResultRows": [
+    ["Nike", "US", "active", 10],
+    ["Adidas", "EU", "inactive", 7]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          { "key": ["Nike", "US", "active"], "key_as_string": "Nike|US|active", "doc_count": 10 },
+          { "key": ["Adidas", "EU", "inactive"], "key_as_string": "Adidas|EU|inactive", "doc_count": 7 }
+        ]
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_with_avg_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/multi_terms_with_avg_aggregation.json
@@ -1,0 +1,78 @@
+{
+  "testName": "multi_terms_with_avg_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "combo": {
+        "multi_terms": {
+          "terms": [
+            { "field": "brand" },
+            { "field": "status" }
+          ]
+        },
+        "aggregations": {
+          "avg_price": {
+            "avg": {
+              "field": "price"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$3], sort1=[$0], sort2=[$1], dir0=[DESC], dir1=[ASC], dir2=[ASC])",
+    "  LogicalAggregate(group=[{2, 3}], avg_price=[AVG($1)], _count=[COUNT()])",
+    "    LogicalFilter(condition=[AND(IS NOT NULL($2), IS NOT NULL($3))])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "status", "avg_price", "_count"],
+  "mockResultRows": [
+    ["BrandA", "active", 850.0, 3],
+    ["BrandB", "inactive", 1100.0, 2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "combo": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": ["BrandA", "active"],
+            "key_as_string": "BrandA|active",
+            "doc_count": 3,
+            "avg_price": {
+              "value": 850.0
+            }
+          },
+          {
+            "key": ["BrandB", "inactive"],
+            "key_as_string": "BrandB|inactive",
+            "doc_count": 2,
+            "avg_price": {
+              "value": 1100.0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationBuilder.java
@@ -27,6 +27,7 @@ import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -280,6 +281,15 @@ public class MultiTermsAggregationBuilder extends AbstractAggregationBuilder<Mul
         }
         this.terms = terms;
         return this;
+    }
+
+    /**
+     * Returns the configured term sources in declaration order.
+     *
+     * @return an unmodifiable view of the term sources, empty when none are configured
+     */
+    public List<MultiTermsValuesSourceConfig> terms() {
+        return terms == null ? List.of() : Collections.unmodifiableList(terms);
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds `multi_terms` support to the DSL query converter, so a multi-field terms aggregation runs on the
Calcite/engine path instead of falling back to the codec path.

> **Stacked on #22526.** This branch is cut from that PR's head, so until it merges the diff and commit
> list here also contain its changes. The commit to review is the last one,
> `Support multi_terms bucket aggregation on the DSL Calcite path`.

`{"aggs": {"combo": {"multi_terms": {"terms": [{"field": "brand"}, {"field": "status"}]}}}}` becomes a
plain `GROUP BY brand, status`, and each result row becomes one composite-key bucket. No new RelNode
construct is introduced: the plan is the same `LogicalAggregate` shape the single-field `terms` path
already produces, just with N grouping keys instead of one, so Substrait/Isthmus conversion is
unaffected. `BucketEntry.keys` in #22526 is already `List<Object>` — its Javadoc says "single for terms,
multiple for multi_terms" — so the response walker needed no change to express composite keys.

#### Changes

| File | Change |
|---|---|
`MultiTermsBucketTranslator` (new, +188) | grouping over N term sources, composite-key buckets, ordering, truncation, sub-aggregations |
`TermsBucketSupport` (new, +87) | shared bucket post-processing extracted from `TermsBucketTranslator` |
`TermsBucketTranslator` (+4/−48) | now delegates to `TermsBucketSupport`; no behaviour change |
`BucketTranslator` (+3/−1) | `getGrouping` declares `throws ConversionException` |
`AggregationRegistryFactory` (+2) | registers `MultiTermsAggregationBuilder` |
`MultiTermsAggregationBuilder` (+10, server) | adds a public `terms()` accessor |
tests + 2 golden files (+537) | 28 unit tests, `multi_terms_aggregation.json`, `multi_terms_with_avg_aggregation.json` |

**Why the server accessor.** `MultiTermsAggregationBuilder` held `terms` privately with a setter but no
getter, so the translator could not read the term sources without reflection. `terms()` returns an
unmodifiable view — additive, no behaviour change. Precedent: `CompositeAggregationBuilder.sources()`,
`TopHitsAggregationBuilder.sorts()`.

**Why the interface change.** Per-term-source validation must reject at conversion time, before the query
runs. `ConversionException` is checked, so `getGrouping` has to declare it. `TermsBucketTranslator` needs
no edit — an override may declare fewer exceptions.

**Why no `size` pushdown.** Deliberately omitted. `sum_other_doc_count` is the summed count of the buckets
*beyond* `size`, so a plan-level `Fetch` would discard exactly the rows that field is computed from and
silently report `0`. Sibling aggregations sharing a granularity also share one plan-level sort, so a single
`Fetch` would starve whichever sibling requested more. Truncation therefore stays in the response layer,
where #22526 already does it.

#### Parameter coverage

Implemented: `terms[].field`, `size`, `min_doc_count`, `order` (count and `_key`, asc and desc),
sub-aggregations, `meta`, `sum_other_doc_count`.

Rejected with `ConversionException` rather than silently ignored, because each would change the response:
`terms[].missing`, `terms[].script`, `terms[].include`/`exclude`, `terms[].format`, `terms[].time_zone`.

`collect_mode` is ignored — it selects an execution strategy and has no effect on output.

#### Known divergences from the codec path

1. **`date` term sources render epoch millis, not an ISO string.** This path sees Calcite column values
   and has no `ValuesSource` from which to resolve the mapping's format. The single-field `terms` path has
   the same limitation; documented in the translator Javadoc.
2. **`show_term_doc_count_error` is not emitted**, and `doc_count_error_upper_bound` is `0`. There is no
   shard fan-out on this single-plan path, so the error is genuinely zero rather than unknown. Matches
   `TermsBucketTranslator`.
3. **`shard_size` and `shard_min_doc_count` are echoed** into `BucketCountThresholds` for response
   fidelity but do not drive a fan-out, since there isn't one. Matches `TermsBucketTranslator`.

#### Data types

Bucket keys verified end to end for `keyword`/`text`, `long`, `integer`, `short`, `byte`, `double`,
`float`, `boolean`, `ip`, `date`, `scaled_float` and `unsigned_long`. Keys are kept as raw typed values
(`BytesRef`/`Long`/`Double`) rather than display strings, because `InternalMultiTerms` formats on read and
`_key` ordering compares them through `Comparable`. `ip` columns arrive as `byte[]` and render as an
address string, falling back to Base64 for byte arrays that are not a valid 4/16-byte address.

#### Testing

`./gradlew -Dsandbox.enabled=true :sandbox:plugins:dsl-query-executor:spotlessJavaCheck :sandbox:plugins:dsl-query-executor:test`

- **26 suites, 212 tests, 0 failures, 0 errors, 0 skipped**; `spotlessJavaCheck` clean.
- 28 new tests: field ordering, every rejection path, null-key dropping, `min_doc_count`, `size`
  truncation with `sum_other_doc_count`, count and `_key` ordering, per-type keys, three-field arity,
  sub-aggregations, metadata round-trip, registry wiring, and key-arity mismatch.
- 2 golden files covering the plain and sub-aggregation pipelines.
- Only pre-existing test change: a `throws` clause on a private helper in `AggregationResponseBuilderTests`,
  required by the `getGrouping` signature. No assertion was removed or loosened.

No REST API surface changes, so no API specification companion PR is needed. `multi_terms` is already
documented; this only extends which execution path can serve it.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
