### PR TITLE
Fix node crash on partially-consumed stream teardown

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -16,7 +16,6 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.backend.EngineResultStream;
 import org.opensearch.analytics.exec.shuffle.ShuffleCompression;
 import org.opensearch.analytics.exec.task.AnalyticsShardTask;
@@ -1055,14 +1054,9 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         BackendExecutionContext backendContext
     ) {
         FilterTreeCallbacks.register(contextId, handle, tracker);
-        return () -> {
-            FilterTreeCallbacks.unregister(contextId);
-            try {
-                handle.close();
-            } catch (Exception e) {
-                LOGGER.warn(new ParameterizedMessage("FilterDelegationHandle.close() failed for contextId={}", contextId), e);
-            }
-        };
+        // requestClose owns handle.close(): late release upcalls from partially-consumed
+        // native streams must still find the binding, so closing here would race them.
+        return () -> FilterTreeCallbacks.requestClose(contextId);
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacks.java
@@ -13,9 +13,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.spi.DelegationThreadTracker;
 import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.common.util.concurrent.AbstractRefCounted;
 
 import java.lang.foreign.MemorySegment;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Static callback targets invoked by the native engine via FFM upcalls.
@@ -30,8 +32,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ol>
  *   <li>Before query execution: {@link #register(long, FilterDelegationHandle, DelegationThreadTracker)}
  *       installs a binding for the query's contextId.</li>
- *   <li>FFM upcalls route to the correct per-query handle via contextId.</li>
- *   <li>After query completion: {@link #unregister(long)} removes the binding.</li>
+ *   <li>FFM upcalls route to the correct per-query handle via contextId. Each
+ *       successful {@code create*} upcall holds a reference on the binding; the
+ *       matching {@code release*} upcall drops it.</li>
+ *   <li>After query completion: {@link #requestClose(long)} drops the query's own
+ *       reference. The binding is removed — and the handle closed — when the last
+ *       reference drops, so late release upcalls from a partially-consumed native
+ *       stream (e.g. a satisfied LIMIT, whose final drop runs on a DataFusion
+ *       runtime thread after Java-side teardown returns) still find the binding.</li>
  * </ol>
  *
  * <h2>Error-handling contract</h2>
@@ -43,7 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>When assertions are enabled ({@code -ea}, default in tests and {@code ./gradlew run}),
  * the callbacks {@code assert} that a binding exists before performing the upcall, and
  * {@link #register} asserts no stale binding is left behind. These catch lifecycle bugs
- * (double-register, premature unregister, leaked bindings) during development without
+ * (double-register, premature teardown, leaked bindings) during development without
  * affecting production behavior — assertions are off in production, where the same paths
  * fall back to returning -1 silently.
  */
@@ -57,8 +65,132 @@ public final class FilterTreeCallbacks {
      */
     private static final ConcurrentHashMap<Long, QueryBinding> BINDINGS = new ConcurrentHashMap<>();
 
-    /** Immutable pair of handle + tracker for a single query. */
-    private record QueryBinding(FilterDelegationHandle handle, DelegationThreadTracker tracker) {
+    /**
+     * Per-query binding whose lifetime is reference-counted: the query itself holds
+     * one reference (dropped by {@link #requestClose}), and every live native handle
+     * (provider or collector) holds one ({@code create*} acquires it, {@code release*}
+     * drops it — all through the internal {@code refCounter}). The
+     * binding is removed — and the delegation handle closed — exactly once, when the
+     * last reference drops, which is what keeps late release upcalls from
+     * partially-consumed native streams safe.
+     */
+    private static final class QueryBinding {
+        private final long contextId;
+        private final FilterDelegationHandle handle;
+        private final DelegationThreadTracker tracker;
+        /** Ensures {@link #requestClose} drops the query's reference at most once. */
+        final AtomicBoolean closeRequested = new AtomicBoolean();
+        /**
+         * Owns the binding's lifetime: born at 1 (the query's reference), one more per
+         * live native handle. Reaching zero closes the binding — {@code closeInternal}
+         * links the counter to {@link #close()}.
+         */
+        private final AbstractRefCounted refCounter = new AbstractRefCounted("filter-delegation-binding") {
+            @Override
+            protected void closeInternal() {
+                QueryBinding.this.close();
+            }
+        };
+
+        QueryBinding(long contextId, FilterDelegationHandle handle, DelegationThreadTracker tracker) {
+            this.contextId = contextId;
+            this.handle = java.util.Objects.requireNonNull(handle, "handle");
+            this.tracker = tracker;
+        }
+
+        DelegationThreadTracker tracker() {
+            return tracker;
+        }
+
+        /**
+         * Create a provider via the handle, acquiring one reference for the native
+         * handle on success. Returns -1 (without holding a reference) if the binding
+         * is already fully closed or the handle refuses.
+         */
+        int createProvider(int annotationId) {
+            if (refCounter.tryIncRef() == false) {
+                assert false : "createProvider: binding already fully closed for contextId=" + contextId;
+                return -1;
+            }
+            boolean created = false;
+            try {
+                int key = handle.createProvider(annotationId);
+                created = key >= 0;
+                return key;
+            } finally {
+                if (created == false) {
+                    refCounter.decRef(); // no native handle exists to release this reference later
+                }
+            }
+        }
+
+        /** Collector twin of {@link #createProvider(int)} — same reference contract. */
+        int createCollector(int providerKey, long writerGeneration, int minDoc, int maxDoc) {
+            if (refCounter.tryIncRef() == false) {
+                assert false : "createCollector: binding already fully closed for contextId=" + contextId;
+                return -1;
+            }
+            boolean created = false;
+            try {
+                int key = handle.createCollector(providerKey, writerGeneration, minDoc, maxDoc);
+                created = key >= 0;
+                return key;
+            } finally {
+                if (created == false) {
+                    refCounter.decRef();
+                }
+            }
+        }
+
+        /** Release a provider and drop its reference; the last drop closes the binding. */
+        void releaseProvider(int providerKey) {
+            try {
+                handle.releaseProvider(providerKey);
+            } finally {
+                refCounter.decRef();
+            }
+        }
+
+        /** Release a collector and drop its reference; the last drop closes the binding. */
+        void releaseCollector(int collectorKey) {
+            try {
+                handle.releaseCollector(collectorKey);
+            } finally {
+                refCounter.decRef();
+            }
+        }
+
+        /** Delegate a doc-collection call; refuses (-1) when the query is cancelled. */
+        long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment outPtr, long outWordCap) {
+            if (handle.isCancelled()) {
+                return -1L;
+            }
+            int maxWords = (int) Math.min(outWordCap, (long) Integer.MAX_VALUE);
+            MemorySegment view = outPtr.reinterpret((long) maxWords * Long.BYTES);
+            long result = handle.collectDocs(collectorKey, minDoc, maxDoc, view);
+            return (result < 0) ? -1L : result;
+        }
+
+        /**
+         * Drop the query's own reference (at most once). The binding closes — and the
+         * delegation handle with it — when the last native handle's reference drops.
+         */
+        void requestClose() {
+            if (closeRequested.compareAndSet(false, true)) {
+                refCounter.decRef();
+            }
+        }
+
+        /** Runs exactly once, when the last reference (query or native handle) drops. */
+        private void close() {
+            BINDINGS.remove(contextId);
+            try {
+                handle.close();
+            } catch (Throwable throwable) {
+                // May run on an FFM upcall thread — must not throw.
+                LOGGER.warn(new ParameterizedMessage("FilterDelegationHandle.close() failed for contextId={}", contextId), throwable);
+            }
+        }
     }
 
     private FilterTreeCallbacks() {}
@@ -68,24 +200,41 @@ public final class FilterTreeCallbacks {
      * Must be called before query execution begins.
      *
      * <p>Asserts no prior binding exists for {@code contextId}. A pre-existing binding
-     * indicates a leaked binding from an earlier query (missing {@link #unregister}) or
-     * a duplicate register call.
+     * indicates a leaked binding from an earlier query (missing {@link #requestClose(long)})
+     * or a duplicate register call.
      *
      * @param contextId the per-query identifier (from the native {@code QueryTrackingContext})
      * @param handle    the delegation handle for this query (must not be null)
      * @param tracker   the thread tracker for this query (may be null)
      */
     public static void register(long contextId, FilterDelegationHandle handle, DelegationThreadTracker tracker) {
-        QueryBinding prev = BINDINGS.put(contextId, new QueryBinding(handle, tracker));
+        QueryBinding prev = BINDINGS.put(contextId, new QueryBinding(contextId, handle, tracker));
         assert prev == null : "FilterTreeCallbacks.register: binding already present for contextId=" + contextId;
     }
 
     /**
-     * Remove the per-query binding for {@code contextId}.
-     * Must be called after query execution completes (in a finally block).
+     * Request teardown of the binding for {@code contextId}: closes and removes it
+     * immediately if no native handles are outstanding, otherwise defers until the
+     * last {@code release*} upcall arrives (late drops of partially-consumed native
+     * streams happen on DataFusion runtime threads after Java-side teardown returns).
      *
-     * <p>Idempotent — calling with no current binding is a no-op.
+     * <p>Owns {@code handle.close()} — callers must not close the handle themselves.
+     * Idempotent — calling with no current binding is a no-op.
      */
+    public static void requestClose(long contextId) {
+        QueryBinding binding = BINDINGS.get(contextId);
+        if (binding == null) {
+            return;
+        }
+        binding.requestClose();
+    }
+
+    /**
+     * Force-remove the binding without closing the handle. Test-only escape hatch for
+     * suites that manage handle lifecycles themselves; production teardown must use
+     * {@link #requestClose(long)}.
+     */
+    // VisibleForTesting
     public static void unregister(long contextId) {
         BINDINGS.remove(contextId);
     }
@@ -122,14 +271,15 @@ public final class FilterTreeCallbacks {
     }
 
     /**
-     * Asserts a binding exists. Lifecycle bugs (premature unregister, missing register,
+     * Asserts a binding exists. Lifecycle bugs (premature teardown, missing register,
      * stale Rust handle outliving its query) trip this in tests; production silently
      * returns -1 from the caller's null check.
      *
      * <p>Throws {@link AssertionError} when assertions are enabled and binding is null.
      * Upcall methods catch {@code Throwable} and re-throw {@code AssertionError} so it
      * surfaces in tests (causing the JVM to exit through the FFM stub) rather than
-     * being silently logged.
+     * being silently logged. Under the refcounted lifecycle a missing binding is a
+     * genuine bug: bindings stay alive until the last native handle is released.
      */
     private static void assertBindingExists(QueryBinding binding, String op, long contextId) {
         assert binding != null : "FilterTreeCallbacks."
@@ -151,10 +301,10 @@ public final class FilterTreeCallbacks {
         try {
             QueryBinding binding = BINDINGS.get(contextId);
             assertBindingExists(binding, "createProvider", contextId);
-            if (binding == null || binding.handle() == null) {
+            if (binding == null) {
                 return -1;
             }
-            return binding.handle().createProvider(annotationId);
+            return binding.createProvider(annotationId);
         } catch (AssertionError e) {
             // Propagate so lifecycle bugs surface in tests; in production -ea is off and this branch never runs.
             throw e;
@@ -173,8 +323,8 @@ public final class FilterTreeCallbacks {
         try {
             QueryBinding binding = BINDINGS.get(contextId);
             assertBindingExists(binding, "releaseProvider", contextId);
-            if (binding != null && binding.handle() != null) {
-                binding.handle().releaseProvider(providerKey);
+            if (binding != null) {
+                binding.releaseProvider(providerKey);
             }
         } catch (AssertionError e) {
             throw e;
@@ -198,10 +348,10 @@ public final class FilterTreeCallbacks {
         try {
             QueryBinding binding = BINDINGS.get(contextId);
             assertBindingExists(binding, "createCollector", contextId);
-            if (binding == null || binding.handle() == null) {
+            if (binding == null) {
                 return -1;
             }
-            return binding.handle().createCollector(providerKey, writerGeneration, minDoc, maxDoc);
+            return binding.createCollector(providerKey, writerGeneration, minDoc, maxDoc);
         } catch (AssertionError e) {
             throw e;
         } catch (Throwable throwable) {
@@ -230,17 +380,10 @@ public final class FilterTreeCallbacks {
         try {
             QueryBinding binding = BINDINGS.get(contextId);
             assertBindingExists(binding, "collectDocs", contextId);
-            if (binding == null || binding.handle() == null) {
+            if (binding == null) {
                 return -1L;
             }
-            FilterDelegationHandle handle = binding.handle();
-            if (handle.isCancelled()) {
-                return -1L;
-            }
-            int maxWords = (int) Math.min(outWordCap, (long) Integer.MAX_VALUE);
-            MemorySegment view = outPtr.reinterpret((long) maxWords * Long.BYTES);
-            long result = handle.collectDocs(collectorKey, minDoc, maxDoc, view);
-            return (result < 0) ? -1L : result;
+            return binding.collectDocs(collectorKey, minDoc, maxDoc, outPtr, outWordCap);
         } catch (AssertionError e) {
             throw e;
         } catch (Throwable throwable) {
@@ -267,8 +410,8 @@ public final class FilterTreeCallbacks {
         try {
             QueryBinding binding = BINDINGS.get(contextId);
             assertBindingExists(binding, "releaseCollector", contextId);
-            if (binding != null && binding.handle() != null) {
-                binding.handle().releaseCollector(collectorKey);
+            if (binding != null) {
+                binding.releaseCollector(collectorKey);
             }
         } catch (AssertionError e) {
             throw e;

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/DelegationTaskTrackingTests.java
@@ -101,11 +101,10 @@ public class DelegationTaskTrackingTests extends OpenSearchTestCase {
 
     /**
      * Lifecycle assertion: invoking an upcall on a contextId that has no registered
-     * binding throws AssertionError when -ea is on. This catches premature unregister
-     * or stale Rust handles outliving their query.
-     *
-     * In production (no -ea), this same path silently returns -1 — the upcall's null
-     * check is the production safety net.
+     * binding throws AssertionError when -ea is on. Under the refcounted lifecycle
+     * this is a genuine bug signal (bindings survive until the last native handle
+     * releases), so it should fail loudly in tests; production (no -ea) silently
+     * returns -1 — the upcall's null check is the production safety net.
      */
     public void testUnregisteredContextIdAssertsInTests() throws Exception {
         long unregisteredCtx = 9999L;

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacksTeardownTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/FilterTreeCallbacksTeardownTests.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.indexfilter;
+
+import org.opensearch.analytics.spi.FilterDelegationHandle;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for the refcounted deferred-close binding lifecycle in
+ * {@link FilterTreeCallbacks}.
+ *
+ * <p>Regression coverage for the node-killing teardown race
+ * (<a href="https://github.com/opensearch-project/OpenSearch/issues/22753">#22753</a>):
+ * a partially-consumed native stream's final drop runs on a DataFusion runtime thread
+ * after Java-side teardown, so its {@code release*} upcalls arrive after the old
+ * {@code unregister} removed the binding — and the stub's re-thrown
+ * {@code AssertionError} crossed the FFM boundary, fatally crashing the JVM.
+ */
+public class FilterTreeCallbacksTeardownTests extends OpenSearchTestCase {
+
+    private static final long CTX = 4242L;
+
+    /** Minimal handle counting create/release/close calls. */
+    private static final class CountingHandle implements FilterDelegationHandle {
+        final AtomicInteger nextKey = new AtomicInteger();
+        final AtomicInteger released = new AtomicInteger();
+        final AtomicInteger closed = new AtomicInteger();
+
+        @Override
+        public int createProvider(int annotationId) {
+            return nextKey.getAndIncrement();
+        }
+
+        @Override
+        public int createCollector(int providerKey, long writerGeneration, int minDoc, int maxDoc) {
+            return nextKey.getAndIncrement();
+        }
+
+        @Override
+        public long collectDocs(int collectorKey, int minDoc, int maxDoc, MemorySegment out) {
+            return 0L;
+        }
+
+        @Override
+        public void releaseCollector(int collectorKey) {
+            released.incrementAndGet();
+        }
+
+        @Override
+        public void releaseProvider(int providerKey) {
+            released.incrementAndGet();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            closed.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FilterTreeCallbacks.unregister(CTX);
+        super.tearDown();
+    }
+
+    /** requestClose with no outstanding native handles closes immediately. */
+    public void testRequestCloseWithNoOutstandingHandlesClosesImmediately() {
+        CountingHandle handle = new CountingHandle();
+        FilterTreeCallbacks.register(CTX, handle, null);
+
+        FilterTreeCallbacks.requestClose(CTX);
+
+        assertEquals("handle must be closed", 1, handle.closed.get());
+        // Binding is gone: a subsequent create trips the lifecycle assert.
+        expectThrows(AssertionError.class, () -> FilterTreeCallbacks.createProvider(CTX, 1));
+    }
+
+    /**
+     * The #22753 regression: teardown runs while native handles are outstanding.
+     * The binding must survive until the late release upcalls arrive; the last
+     * release completes the close. No throw anywhere.
+     */
+    public void testLateReleaseAfterRequestCloseCompletesTeardown() {
+        CountingHandle handle = new CountingHandle();
+        FilterTreeCallbacks.register(CTX, handle, null);
+
+        int providerKey = FilterTreeCallbacks.createProvider(CTX, 7);
+        int collectorKey = FilterTreeCallbacks.createCollector(CTX, providerKey, 1L, 0, 100);
+        assertTrue(providerKey >= 0 && collectorKey >= 0);
+
+        // Java-side teardown finishes first (the reported interleaving).
+        FilterTreeCallbacks.requestClose(CTX);
+        assertEquals("close must be deferred while handles are outstanding", 0, handle.closed.get());
+
+        // Late upcalls from the native drop (previously: AssertionError -> JVM fatal).
+        // The binding is still alive, so these must succeed without tripping any assert.
+        FilterTreeCallbacks.releaseCollector(CTX, collectorKey);
+        assertEquals("still one handle outstanding", 0, handle.closed.get());
+
+        FilterTreeCallbacks.releaseProvider(CTX, providerKey);
+        assertEquals("last release must complete the deferred close", 1, handle.closed.get());
+        assertEquals("both releases must reach the handle", 2, handle.released.get());
+    }
+
+    /** After the deferred close completes, a further release IS a genuine bug — asserts in tests. */
+    public void testReleaseAfterFullTeardownAsserts() {
+        CountingHandle handle = new CountingHandle();
+        FilterTreeCallbacks.register(CTX, handle, null);
+        int key = FilterTreeCallbacks.createProvider(CTX, 7);
+        FilterTreeCallbacks.requestClose(CTX);
+        FilterTreeCallbacks.releaseProvider(CTX, key); // completes close
+
+        // Double release: the binding is gone, the lifecycle assert fires.
+        expectThrows(AssertionError.class, () -> FilterTreeCallbacks.releaseProvider(CTX, key));
+        assertEquals("handle must not be closed twice", 1, handle.closed.get());
+    }
+
+    /** Creates racing requestClose must never double-close or lose the close. */
+    public void testConcurrentReleasesAndRequestCloseCloseExactlyOnce() throws Exception {
+        for (int iter = 0; iter < 100; iter++) {
+            CountingHandle handle = new CountingHandle();
+            FilterTreeCallbacks.register(CTX, handle, null);
+            int k1 = FilterTreeCallbacks.createProvider(CTX, 1);
+            int k2 = FilterTreeCallbacks.createCollector(CTX, k1, 1L, 0, 10);
+
+            CountDownLatch start = new CountDownLatch(1);
+            Thread releaser1 = new Thread(() -> {
+                await(start);
+                FilterTreeCallbacks.releaseCollector(CTX, k2);
+            });
+            Thread releaser2 = new Thread(() -> {
+                await(start);
+                FilterTreeCallbacks.releaseProvider(CTX, k1);
+            });
+            Thread closer = new Thread(() -> {
+                await(start);
+                FilterTreeCallbacks.requestClose(CTX);
+            });
+            releaser1.start();
+            releaser2.start();
+            closer.start();
+            start.countDown();
+            releaser1.join();
+            releaser2.join();
+            closer.join();
+
+            assertEquals("iter " + iter + ": handle must be closed exactly once", 1, handle.closed.get());
+            FilterTreeCallbacks.unregister(CTX);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/indexfilter/IndexFilterCallbackTests.java
@@ -79,7 +79,8 @@ public class IndexFilterCallbackTests extends OpenSearchTestCase {
      * Lifecycle assertion: invoking an upcall on an unregistered contextId trips
      * {@code assert binding != null}. With {@code -ea} on (test default), this throws
      * AssertionError rather than silently returning -1 — surfacing missing-register
-     * or premature-unregister bugs.
+     * or premature-teardown bugs. Under the refcounted lifecycle this is a genuine
+     * bug signal: bindings stay alive until the last native handle is released.
      */
     public void testUnregisteredContextIdAsserts() {
         FilterTreeCallbacks.unregister(CTX);

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PartialStreamDropCrashIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/PartialStreamDropCrashIT.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reproduction for the reported node-killing crash on partially-consumed stream drop
+ * ({@code upcallLinker.cpp:137} fatal, {@code SecurityException: SharedUtils is not
+ * allowed to call System::exit(1)}).
+ *
+ * <p><b>Reported mechanism (from the reporter's hs_err):</b>
+ * <ol>
+ *   <li>An unsorted filter + LIMIT query satisfies the limit and DataFusion's
+ *       {@code LimitStream} stops reading; the {@code IndexedStream} is dropped
+ *       partially consumed.</li>
+ *   <li>The drop releases the last {@code Arc} to the per-query
+ *       {@code HashMap<annotationId, OnceLock<ProviderHandle>>};
+ *       {@code ProviderHandle::drop} upcalls {@code releaseProvider} into Java.</li>
+ *   <li>The Java side throws (binding already unregistered / handle already closed).</li>
+ *   <li>An exception cannot cross an FFM upcall; the JDK falls back to
+ *       {@code System.exit(1)}, the security policy forbids it, and the JVM dies
+ *       fatally.</li>
+ * </ol>
+ *
+ * <p><b>Why this lives in the REST QA module:</b> the crash needs (a) a real
+ * distribution with the agent security policy (so {@code System.exit} is denied),
+ * (b) the Lucene secondary so the filter leaf is delegation-possible and the
+ * provider map is actually populated (parquet-only fixtures never allocate a
+ * {@code ProviderHandle}), and (c) enough matching rows that batches are still
+ * in flight when LIMIT stops reading.
+ *
+ * <p>The alternation below is the reporter's exact PPL sequence; they observed the
+ * node dying at round 5, or up to ~30s after a single query (deferred drop).
+ * If the bug fires, the cluster stops answering — asserted by the post-round probes.
+ *
+ * @opensearch.internal
+ */
+public class PartialStreamDropCrashIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "bench";
+    private static final int TOTAL_DOCS = 500_000;
+    private static final int BULK_BATCH = 10_000;
+    private static final int ROUNDS = 5;
+
+    public void testAlternatingPplRoundsDoNotKillTheNode() throws Exception {
+        createBenchIndex();
+        seedDocs();
+
+        for (int round = 1; round <= ROUNDS; round++) {
+            assertRowCount("round " + round + " q1", executePpl("source=" + INDEX + " | head 10"), 10);
+            assertRowCount("round " + round + " q2", executePpl("source=" + INDEX + " | where brand='brand-3' | head 10"), 10);
+            assertRowCount("round " + round + " q3", executePpl("source=" + INDEX + " | where brand='brand-3' | stats count()"), 1);
+            assertRowCount("round " + round + " q4", executePpl("source=" + INDEX + " | stats avg(price) by brand"), 5);
+            logger.info("--> round {} ok", round);
+        }
+
+        // The reported crash can be deferred up to ~30s after the triggering query
+        // (native drop on a runtime thread after Java tore down the query binding).
+        // Probe through that window; if the upcall fatal fires the node is gone and
+        // the probe request fails.
+        for (int i = 1; i <= 7; i++) {
+            Thread.sleep(5_000);
+            Response health = client().performRequest(new Request("GET", "/_cluster/health"));
+            assertEquals("node must survive deferred cleanup (t+" + i * 5 + "s)", 200, health.getStatusLine().getStatusCode());
+            assertRowCount("post-round probe t+" + i * 5 + "s", executePpl("source=" + INDEX + " | head 10"), 10);
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private void assertRowCount(String context, Map<String, Object> pplResponse, int expected) {
+        List<Object> rows = (List<Object>) pplResponse.get("datarows");
+        assertNotNull(context + ": datarows missing in " + pplResponse.keySet(), rows);
+        assertEquals(context + ": row count", expected, rows.size());
+    }
+
+    private void createBenchIndex() throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {
+            // index may not exist yet
+        }
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity(
+            "{"
+                + "\"settings\": {"
+                + "  \"number_of_shards\": 1,"
+                + "  \"number_of_replicas\": 0,"
+                + "  \"index.pluggable.dataformat.enabled\": true,"
+                + "  \"index.pluggable.dataformat\": \"composite\","
+                + "  \"index.composite.primary_data_format\": \"parquet\","
+                + "  \"index.composite.secondary_data_formats\": \"lucene\""
+                + "},"
+                + "\"mappings\": {"
+                + "  \"properties\": {"
+                // Indexed keyword: makes `where brand=...` a delegation-possible leaf so
+                // the per-query ProviderHandle map is populated — required to reach the
+                // crashing drop path.
+                + "    \"brand\": { \"type\": \"keyword\" },"
+                + "    \"price\": { \"type\": \"integer\" }"
+                + "  }"
+                + "}"
+                + "}"
+        );
+        Response response = client().performRequest(create);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    /** 500k docs (reporter's scale), brand-0..brand-4 round-robin → 100k rows per brand. */
+    private void seedDocs() throws IOException {
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < TOTAL_DOCS; i++) {
+            bulk.append("{\"index\":{}}\n")
+                .append("{\"brand\":\"brand-")
+                .append(i % 5)
+                .append("\",\"price\":")
+                .append(i % 1000)
+                .append("}\n");
+            if ((i + 1) % BULK_BATCH == 0) {
+                sendBulk(bulk.toString());
+                bulk.setLength(0);
+                if ((i + 1) % 100_000 == 0) {
+                    client().performRequest(new Request("POST", "/" + INDEX + "/_refresh"));
+                    client().performRequest(new Request("POST", "/" + INDEX + "/_flush"));
+                    logger.info("--> seeded {} docs", i + 1);
+                }
+            }
+        }
+        if (bulk.length() > 0) {
+            sendBulk(bulk.toString());
+        }
+        client().performRequest(new Request("POST", "/" + INDEX + "/_refresh"));
+        client().performRequest(new Request("POST", "/" + INDEX + "/_flush"));
+    }
+
+    private void sendBulk(String body) throws IOException {
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.setJsonEntity(body);
+        Response response = client().performRequest(bulk);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+}


### PR DESCRIPTION
### Description

Fixes the node-killing crash on partially-consumed native stream teardown (#22753).

**Root cause.** A filter + LIMIT query stops reading its native `IndexedStream` once the limit is satisfied. The stream's final drop runs on a DataFusion runtime thread *after* Java-side teardown returns, so its `releaseProvider`/`releaseCollector` upcalls arrived after `FilterTreeCallbacks.unregister` removed the per-query binding. The stubs re-threw the resulting `AssertionError`, and an exception cannot cross an FFM upcall: the JDK falls back to `System.exit(1)`, the security policy denies it, and the JVM dies fatally (`upcallLinker.cpp:137`). Without `-ea` the same race silently leaked the Lucene collector/weight instead.

**Fix.**
- The per-query binding is now reference-counted (`AbstractRefCounted`): the query holds one reference (dropped by `requestClose`, which now owns `handle.close()`), and every live native handle holds one — `create*` acquires via `tryIncRef` (failing soft if teardown already completed), `release*` drops it. The binding is removed and the delegation handle closed exactly once, when the last reference drops — so late release upcalls always find their binding.
- The lifecycle asserts stay loud: with the refcount in place, a missing binding on any upcall is a *genuine* bug (double release, create after final teardown), so the stubs still re-throw `AssertionError` under `-ea` — that diagnostic contract is unchanged. What the fix removes is the false positive: late releases from deferred native drops now always find their binding, so the assert only fires for real bugs.

**Testing.**
- `PartialStreamDropCrashIT` (new, `sandbox/qa/analytics-engine-rest`): runs the reported PPL alternation on 500k docs with a lucene secondary. Reproduces the fatal deterministically on unfixed main (round 1); passes with the fix, including a 35s deferred-cleanup window probe.
- `FilterTreeCallbacksTeardownTests` (new): deferred-close state machine — immediate close when idle, late-release completion, double-release asserts, concurrent release×close closes exactly once (100 iterations).
- Existing `IndexFilterCallbackTests` / `DelegationTaskTrackingTests` pass with their assert-throw expectations intact; `FilterDelegationGoldenIT` and `SearchFieldExistsDelegationIT` pass unchanged.

### Related Issues

Resolves #22753

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
