### PR TITLE
Avoid blocking keyed cache invalidation

### DIFF
--- a/server/src/main/java/org/opensearch/common/cache/Cache.java
+++ b/server/src/main/java/org/opensearch/common/cache/Cache.java
@@ -32,6 +32,9 @@
 
 package org.opensearch.common.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.concurrent.ReleasableLock;
@@ -87,6 +90,8 @@ import java.util.function.ToLongBiFunction;
  */
 @PublicApi(since = "1.0.0")
 public class Cache<K, V> {
+
+    private static final Logger logger = LogManager.getLogger(Cache.class);
 
     // positive if entries have an expiration
     private long expireAfterAccessNanos = -1;
@@ -570,7 +575,7 @@ public class Cache<K, V> {
      * of a load, such as a reader close listener or a cache cleaner sweep, and a load can take arbitrarily long.
      * So the deletion is handed to whichever thread completes the load instead.
      * <p>
-     * Either order is safe. If the deletion runs first the entry is still {@code NEW}, so {@link #delete} claims it
+     * Either order is safe. If the deletion runs first the entry is still {@code NEW}, so {@link #detach} claims it
      * by marking it {@code DELETED} and the pending {@code promote()} becomes a no-op; if the promotion runs first
      * the entry is {@code EXISTING} and gets unlinked in the usual way.
      *
@@ -580,10 +585,16 @@ public class Cache<K, V> {
     private void deleteWhenLoaded(CompletableFuture<Entry<K, V>> future, RemovalReason removalReason) {
         if (future.isDone() == false) {
             future.whenComplete((entry, throwable) -> {
-                if (entry != null) {
-                    try (ReleasableLock ignored = lruLock.acquire()) {
-                        delete(entry, removalReason);
-                    }
+                if (entry == null) {
+                    // the load failed, so there is no value to delete
+                    return;
+                }
+                try {
+                    deleteAndNotify(entry, removalReason);
+                } catch (RuntimeException e) {
+                    // whenComplete() discards whatever this callback throws, so a failed removal notification has to
+                    // be reported here or it is lost. The deletion itself is already done at this point.
+                    logger.warn(() -> new ParameterizedMessage("failed to notify the removal of key [{}]", entry.key), e);
                 }
             });
             return;
@@ -591,14 +602,32 @@ public class Cache<K, V> {
         // the value is already loaded, which is every case except a removal that races a load: delete on the calling
         // thread, so that the removal notification is issued before the caller returns as it always has been
         try {
-            Entry<K, V> entry = future.get();
-            try (ReleasableLock ignored = lruLock.acquire()) {
-                delete(entry, removalReason);
-            }
+            deleteAndNotify(future.get(), removalReason);
         } catch (ExecutionException e) {
             // the load failed, so there is no value to delete
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Delete an entry and notify the removal listener after the LRU lock is released, as the eviction path in
+     * {@link #promote} does.
+     * <p>
+     * The removal listener is caller-supplied code of unknown cost, and the LRU lock is a single lock that every
+     * mutation of the cache has to take. To hold that lock across the listener blocks every other thread that
+     * mutates the cache, including the threads that load values.
+     *
+     * @param entry the entry to delete
+     * @param removalReason the reason to report to the removal listener
+     */
+    private void deleteAndNotify(Entry<K, V> entry, RemovalReason removalReason) {
+        final RemovalNotification<K, V> removalNotification;
+        try (ReleasableLock ignored = lruLock.acquire()) {
+            removalNotification = detach(entry, removalReason);
+        }
+        if (removalNotification != null) {
+            removalListener.onRemoval(removalNotification);
         }
     }
 
@@ -981,6 +1010,22 @@ public class Cache<K, V> {
     private void delete(Entry<K, V> entry, RemovalReason removalReason) {
         assert lruLock.isHeldByCurrentThread();
 
+        RemovalNotification<K, V> removalNotification = detach(entry, removalReason);
+        if (removalNotification != null) {
+            removalListener.onRemoval(removalNotification);
+        }
+    }
+
+    /**
+     * Take an entry out of the LRU list, or claim it if it is not linked into that list yet.
+     *
+     * @param entry the entry to detach
+     * @param removalReason the reason to report to the removal listener
+     * @return the notification to issue for the entry, or null if another thread already removed it
+     */
+    private RemovalNotification<K, V> detach(Entry<K, V> entry, RemovalReason removalReason) {
+        assert lruLock.isHeldByCurrentThread();
+
         final boolean removed;
         if (entry.state == State.NEW) {
             // The entry was removed from the segment map before the thread that loaded it acquired the LRU lock to
@@ -994,9 +1039,7 @@ public class Cache<K, V> {
         } else {
             removed = unlink(entry);
         }
-        if (removed) {
-            removalListener.onRemoval(new RemovalNotification<>(entry.key, entry.value, removalReason));
-        }
+        return removed ? new RemovalNotification<>(entry.key, entry.value, removalReason) : null;
     }
 
     private boolean shouldPrune(Entry<K, V> entry, long now) {

--- a/server/src/main/java/org/opensearch/common/cache/Cache.java
+++ b/server/src/main/java/org/opensearch/common/cache/Cache.java
@@ -557,35 +557,57 @@ public class Cache<K, V> {
         }
     }
 
-    private final Consumer<CompletableFuture<Entry<K, V>>> invalidationConsumer = f -> {
-        try {
-            Entry<K, V> entry = f.get();
-            try (ReleasableLock ignored = lruLock.acquire()) {
-                delete(entry, RemovalReason.INVALIDATED);
-            }
-        } catch (ExecutionException e) {
-            // ok
-        } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
-        }
-    };
+    private final Consumer<CompletableFuture<Entry<K, V>>> invalidationConsumer = f -> deleteWhenLoaded(f, RemovalReason.INVALIDATED);
 
-    private final Consumer<CompletableFuture<Entry<K, V>>> removalConsumer = f -> {
+    private final Consumer<CompletableFuture<Entry<K, V>>> removalConsumer = f -> deleteWhenLoaded(f, RemovalReason.EXPLICIT);
+
+    /**
+     * Delete an entry whose key has already been removed from its segment map, once its value is available.
+     * <p>
+     * A value that is still being loaded has to be waited for, because the entry that has to be unlinked from the
+     * LRU list and reported to the removal listener does not exist until the load completes. That wait must not
+     * happen on the calling thread: keyed removal is called from paths that cannot afford to block for the length
+     * of a load, such as a reader close listener or a cache cleaner sweep, and a load can take arbitrarily long.
+     * So the deletion is handed to whichever thread completes the load instead.
+     * <p>
+     * Either order is safe. If the deletion runs first the entry is still {@code NEW}, so {@link #delete} claims it
+     * by marking it {@code DELETED} and the pending {@code promote()} becomes a no-op; if the promotion runs first
+     * the entry is {@code EXISTING} and gets unlinked in the usual way.
+     *
+     * @param future the future for the entry whose key was removed from the segment map
+     * @param removalReason the reason to report to the removal listener
+     */
+    private void deleteWhenLoaded(CompletableFuture<Entry<K, V>> future, RemovalReason removalReason) {
+        if (future.isDone() == false) {
+            future.whenComplete((entry, throwable) -> {
+                if (entry != null) {
+                    try (ReleasableLock ignored = lruLock.acquire()) {
+                        delete(entry, removalReason);
+                    }
+                }
+            });
+            return;
+        }
+        // the value is already loaded, which is every case except a removal that races a load: delete on the calling
+        // thread, so that the removal notification is issued before the caller returns as it always has been
         try {
-            Entry<K, V> entry = f.get();
+            Entry<K, V> entry = future.get();
             try (ReleasableLock ignored = lruLock.acquire()) {
-                delete(entry, RemovalReason.EXPLICIT);
+                delete(entry, removalReason);
             }
         } catch (ExecutionException e) {
-            // ok
+            // the load failed, so there is no value to delete
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
         }
-    };
+    }
 
     /**
      * Invalidate the association for the specified key. A removal notification will be issued for invalidated
      * entries with {@link RemovalReason} INVALIDATED.
+     * <p>
+     * If a load for the key is still in flight, this method does not wait for it: the key is removed before
+     * returning, but the removal notification is issued once the load completes.
      *
      * @param key the key whose mapping is to be invalidated from the cache
      */
@@ -597,6 +619,9 @@ public class Cache<K, V> {
     /**
      * Removes the association for the specified key. A removal notification will be issued for removed
      * entry with {@link RemovalReason} EXPLICIT.
+     * <p>
+     * If a load for the key is still in flight, this method does not wait for it: the key is removed before
+     * returning, but the removal notification is issued once the load completes.
      *
      * @param key the key whose mapping is to be removed from the cache
      */

--- a/server/src/test/java/org/opensearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/CacheTests.java
@@ -32,7 +32,10 @@
 
 package org.opensearch.common.cache;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -1092,6 +1095,113 @@ public class CacheTests extends OpenSearchTestCase {
         assertEquals(List.of(), lruKeys(cache));
         assertEquals(0, cache.count());
         assertEquals(0L, cache.weight());
+    }
+
+    /**
+     * A keyed removal notifies the removal listener without the LRU lock. That lock serializes every mutation of
+     * the cache, so to hold it across a listener would block every other thread for as long as the listener takes.
+     */
+    public void testKeyedRemovalNotifiesOutsideLruLock() throws Exception {
+        final AtomicReference<Cache<String, String>> cacheRef = new AtomicReference<>();
+        final AtomicBoolean lruLockWasFree = new AtomicBoolean();
+        final AtomicInteger notifications = new AtomicInteger();
+
+        final Cache<String, String> cache = CacheBuilder.<String, String>builder().removalListener(notification -> {
+            notifications.incrementAndGet();
+            lruLockWasFree.set(lruLockIsFree(cacheRef.get()));
+        }).build();
+        cacheRef.set(cache);
+
+        cache.put("key", "value");
+        cache.invalidate("key");
+
+        assertEquals("the removal listener should have been notified", 1, notifications.get());
+        assertTrue("the removal listener should not hold the LRU lock", lruLockWasFree.get());
+    }
+
+    /** As {@link #testKeyedRemovalNotifiesOutsideLruLock}, for a removal that races an in-flight load. */
+    public void testDeferredRemovalNotifiesOutsideLruLock() throws Exception {
+        final AtomicReference<Cache<String, String>> cacheRef = new AtomicReference<>();
+        final AtomicBoolean lruLockWasFree = new AtomicBoolean();
+        final AtomicInteger notifications = new AtomicInteger();
+        final CountDownLatch loadStarted = new CountDownLatch(1);
+        final CountDownLatch releaseLoad = new CountDownLatch(1);
+
+        final Cache<String, String> cache = CacheBuilder.<String, String>builder().removalListener(notification -> {
+            notifications.incrementAndGet();
+            lruLockWasFree.set(lruLockIsFree(cacheRef.get()));
+        }).build();
+        cacheRef.set(cache);
+
+        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad, new CountDownLatch(1)), "loader");
+        loader.start();
+        assertTrue(loadStarted.await(10, TimeUnit.SECONDS));
+
+        cache.invalidate(IN_FLIGHT_KEY);
+        releaseLoad.countDown();
+        loader.join(10_000);
+        assertFalse(loader.isAlive());
+
+        assertEquals("the loading thread should have notified the removal", 1, notifications.get());
+        assertTrue("the removal listener should not hold the LRU lock", lruLockWasFree.get());
+    }
+
+    /**
+     * A removal listener that throws on the deferred path gets its failure logged. {@code whenComplete()} discards
+     * whatever its callback throws, so a failure that is not caught and logged there is lost. The deletion itself
+     * is done before the listener runs, so the cache is left consistent.
+     */
+    public void testDeferredRemovalLogsListenerFailure() throws Exception {
+        final Cache<String, String> cache = CacheBuilder.<String, String>builder().removalListener(notification -> {
+            throw new RuntimeException("removal listener failure");
+        }).build();
+        final CountDownLatch loadStarted = new CountDownLatch(1);
+        final CountDownLatch releaseLoad = new CountDownLatch(1);
+
+        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad, new CountDownLatch(1)), "loader");
+        loader.start();
+        assertTrue(loadStarted.await(10, TimeUnit.SECONDS));
+        cache.invalidate(IN_FLIGHT_KEY);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(Cache.class))) {
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "removal listener failure",
+                    Cache.class.getCanonicalName(),
+                    Level.WARN,
+                    "failed to notify the removal of key [" + IN_FLIGHT_KEY + "]"
+                )
+            );
+            releaseLoad.countDown();
+            loader.join(10_000);
+            assertFalse("the failed notification should not have disturbed the loading thread", loader.isAlive());
+            appender.assertAllExpectationsMatched();
+        }
+
+        assertNull(cache.get(IN_FLIGHT_KEY));
+        assertEquals(List.of(), cache.keysSnapshot());
+        assertEquals(List.of(), lruKeys(cache));
+        assertEquals(0, cache.count());
+        assertEquals(0L, cache.weight());
+    }
+
+    /**
+     * True if the calling thread does not hold the LRU lock: another thread can take that lock, and so mutate the
+     * cache, while this thread waits.
+     */
+    private boolean lruLockIsFree(Cache<String, String> cache) {
+        final CountDownLatch mutated = new CountDownLatch(1);
+        // refresh() takes the LRU lock and nothing else
+        Thread mutator = new Thread(() -> {
+            cache.refresh();
+            mutated.countDown();
+        }, "mutator");
+        mutator.start();
+        try {
+            return mutated.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/CacheTests.java
@@ -55,9 +55,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -1035,19 +1037,30 @@ public class CacheTests extends OpenSearchTestCase {
 
     // A cache segment maps each key to a CompletableFuture, and computeIfAbsent installs that future in the segment
     // map before the value is loaded, so there is a window in which a key is in the segment map but its entry is not
-    // yet linked into the LRU list. The two tests below cover what invalidate(key) does with a key in that window.
+    // yet linked into the LRU list. The tests below cover what keyed removal does with a key in that window.
 
     /**
      * {@link Cache#keysSnapshot()} contains keys whose load is still in flight, and
-     * {@link Cache#invalidate(Object)} on such a key parks the caller until the load completes: the
-     * invalidation consumer calls {@code future.get()} on the incomplete future with no timeout.
+     * {@link Cache#invalidate(Object)} on such a key removes it without waiting for the load: the removal
+     * notification is issued by the loading thread, once there is a value to report.
      */
-    public void testInvalidateBlocksOnInFlightLoad() throws Exception {
-        final Cache<String, String> cache = CacheBuilder.<String, String>builder().build();
+    public void testInvalidateDoesNotBlockOnInFlightLoad() throws Exception {
+        assertKeyedRemovalDoesNotBlockOnInFlightLoad(cache -> cache.invalidate(IN_FLIGHT_KEY), RemovalReason.INVALIDATED);
+    }
+
+    /** As {@link #testInvalidateDoesNotBlockOnInFlightLoad}, for {@link Cache#remove(Object)}. */
+    public void testRemoveDoesNotBlockOnInFlightLoad() throws Exception {
+        assertKeyedRemovalDoesNotBlockOnInFlightLoad(cache -> cache.remove(IN_FLIGHT_KEY), RemovalReason.EXPLICIT);
+    }
+
+    private void assertKeyedRemovalDoesNotBlockOnInFlightLoad(Consumer<Cache<String, String>> removal, RemovalReason expectedRemovalReason)
+        throws Exception {
+        final List<RemovalNotification<String, String>> removals = new CopyOnWriteArrayList<>();
+        final Cache<String, String> cache = CacheBuilder.<String, String>builder().removalListener(removals::add).build();
         final CountDownLatch loadStarted = new CountDownLatch(1);
         final CountDownLatch releaseLoad = new CountDownLatch(1);
 
-        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad), "loader");
+        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad, new CountDownLatch(1)), "loader");
         loader.start();
         assertTrue(loadStarted.await(10, TimeUnit.SECONDS));
 
@@ -1057,19 +1070,28 @@ public class CacheTests extends OpenSearchTestCase {
         assertEquals(List.of(), lruKeys(cache));
         assertEquals(0, cache.count());
 
-        Thread invalidator = new Thread(() -> cache.invalidate(IN_FLIGHT_KEY), "invalidator");
-        invalidator.start();
+        // the removal returns while the load is still in flight; it runs on a thread of its own so that a
+        // regression fails this test rather than hanging it
+        Thread remover = new Thread(() -> removal.accept(cache), "remover");
+        remover.start();
+        remover.join(10_000);
+        assertFalse("keyed removal should not wait for the in-flight load", remover.isAlive());
 
-        // invalidate() cannot return while the load is in flight
-        assertBusy(() -> assertEquals(Thread.State.WAITING, invalidator.getState()));
-        invalidator.join(500);
-        assertTrue("invalidate() should still be blocked on the in-flight load", invalidator.isAlive());
+        // the key is gone, but there is no value to hand to the removal listener yet
+        assertEquals(List.of(), cache.keysSnapshot());
+        assertEquals(0, removals.size());
 
-        // it only unblocks once the loader finishes, however long that takes
+        // the loading thread finishes the removal, and never links the entry into the LRU list
         releaseLoad.countDown();
-        invalidator.join(10_000);
         loader.join(10_000);
-        assertFalse(invalidator.isAlive());
+        assertFalse(loader.isAlive());
+        assertEquals("the removal listener should have been notified", 1, removals.size());
+        assertEquals(IN_FLIGHT_KEY, removals.get(0).getKey());
+        assertEquals(expectedRemovalReason, removals.get(0).getRemovalReason());
+        assertNull(cache.get(IN_FLIGHT_KEY));
+        assertEquals(List.of(), lruKeys(cache));
+        assertEquals(0, cache.count());
+        assertEquals(0L, cache.weight());
     }
 
     /**
@@ -1080,29 +1102,38 @@ public class CacheTests extends OpenSearchTestCase {
      * unreachable via {@code get()}, and can no longer be invalidated by key -- so its removal listener
      * never fires and the memory it accounts for is never given back.
      * <p>
-     * The interleaving is forced rather than raced for: the weigher runs inside {@code linkAtHead()},
-     * which gives the test thread a point where it holds the LRU lock, so the loading thread cannot
-     * promote its entry until the test thread has finished invalidating it.
+     * The interleaving is forced rather than raced for: the weigher runs inside {@code linkAtHead()} while the
+     * LRU lock is held, so the test thread can wait there until the loading thread has loaded its value and
+     * parked on that lock in {@code promote()}, and invalidate the key while its entry is still {@code NEW}.
      */
     public void testInvalidateBeforePromoteLeavesUnreclaimableEntry() throws Exception {
         final AtomicReference<Cache<String, String>> cacheRef = new AtomicReference<>();
+        final AtomicReference<Thread> loaderRef = new AtomicReference<>();
         final List<RemovalNotification<String, String>> removals = new CopyOnWriteArrayList<>();
         final CountDownLatch loadStarted = new CountDownLatch(1);
         final CountDownLatch releaseLoad = new CountDownLatch(1);
+        final CountDownLatch loadReturned = new CountDownLatch(1);
         final AtomicBoolean invalidatedUnderLruLock = new AtomicBoolean();
+        final AtomicInteger inFlightWeighings = new AtomicInteger();
 
         final Cache<String, String> cache = CacheBuilder.<String, String>builder().weigher((key, value) -> {
+            if (IN_FLIGHT_KEY.equals(key)) {
+                // the weigher only runs when an entry is linked into or unlinked from the LRU list
+                inFlightWeighings.incrementAndGet();
+            }
             if (STALL_KEY.equals(key) && invalidatedUnderLruLock.compareAndSet(false, true)) {
-                // holding the LRU lock: let the load finish and invalidate IN_FLIGHT_KEY before its entry
-                // can be promoted. invalidate() blocks until the load completes, then reenters the LRU lock.
+                // holding the LRU lock: let the load finish, wait for the loading thread to park on this lock
+                // in promote(), and invalidate IN_FLIGHT_KEY while its entry is loaded but still NEW
                 releaseLoad.countDown();
+                awaitParkedOnLruLock(loaderRef.get(), loadReturned);
                 cacheRef.get().invalidate(IN_FLIGHT_KEY);
             }
             return 1L;
         }).removalListener(removals::add).build();
         cacheRef.set(cache);
 
-        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad), "loader");
+        Thread loader = new Thread(() -> loadInFlightKey(cache, loadStarted, releaseLoad, loadReturned), "loader");
+        loaderRef.set(loader);
         loader.start();
         assertTrue(loadStarted.await(10, TimeUnit.SECONDS));
 
@@ -1111,6 +1142,9 @@ public class CacheTests extends OpenSearchTestCase {
         loader.join(10_000);
         assertFalse(loader.isAlive());
         assertTrue("the weigher never ran, so the interleaving under test did not happen", invalidatedUnderLruLock.get());
+        // a linked entry means either that the entry leaked, or that it was promoted before it was invalidated and
+        // so the interleaving under test did not happen
+        assertEquals("the invalidated entry should never have been linked into the LRU list", 0, inFlightWeighings.get());
 
         assertEquals("the invalidated key should be gone from the segment map", List.of(STALL_KEY), cache.keysSnapshot());
         assertNull(cache.get(IN_FLIGHT_KEY));
@@ -1122,14 +1156,34 @@ public class CacheTests extends OpenSearchTestCase {
         assertEquals(RemovalReason.INVALIDATED, removals.get(0).getRemovalReason());
     }
 
-    private void loadInFlightKey(Cache<String, String> cache, CountDownLatch loadStarted, CountDownLatch releaseLoad) {
+    private void loadInFlightKey(
+        Cache<String, String> cache,
+        CountDownLatch loadStarted,
+        CountDownLatch releaseLoad,
+        CountDownLatch loadReturned
+    ) {
         try {
             cache.computeIfAbsent(IN_FLIGHT_KEY, k -> {
                 loadStarted.countDown();
                 releaseLoad.await();
+                loadReturned.countDown();
                 return "v";
             });
         } catch (ExecutionException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Wait until {@code loader} has loaded its value and parked on the LRU lock in {@code promote()}, so that its
+     * entry exists but is still {@code NEW}. Once the load function has returned, the loading thread only completes
+     * its future and then contends for that lock, so the next time it blocks it is parked there.
+     */
+    private void awaitParkedOnLruLock(Thread loader, CountDownLatch loadReturned) {
+        try {
+            assertTrue(loadReturned.await(10, TimeUnit.SECONDS));
+            assertBusy(() -> assertEquals(Thread.State.WAITING, loader.getState()));
+        } catch (Exception e) {
             throw new AssertionError(e);
         }
     }


### PR DESCRIPTION
## Why
Keyed cache invalidation currently waits for an in-flight load to finish, which can block latency-sensitive reader-close listeners and cache-cleaner sweeps indefinitely.

## What
- Defer deletion of an in-flight entry to the thread that completes its load
- Preserve synchronous removal notifications when the value is already loaded
- Issue keyed removal notifications after the LRU lock is released, as the eviction path in `promote()` already does, so a listener cannot stall a loading thread and every other cache mutation behind that single lock
- Log a removal listener that fails on the deferred path, which `whenComplete()` would otherwise discard
- Cover both `invalidate` and `remove` across the relevant load/deletion orderings

## Risk Assessment
Medium — this changes removal-notification timing only when keyed removal races an in-flight cache load; completed-load behavior remains synchronous, and focused concurrency tests cover both completion orders. On that deferred path the listener now runs on the loading thread, but outside the LRU lock, so it no longer serializes with the rest of the cache.

## References
- Source commit: https://github.com/jwils/OpenSearch/commit/6e327a3aaca
- Builds on https://github.com/opensearch-project/OpenSearch/pull/22662
