### PR TITLE
Bound Arrow native pools when node.native_memory.limit is unknown

### DIFF
--- a/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
+++ b/plugins/arrow-base/src/main/java/org/opensearch/arrow/allocator/ArrowBasePlugin.java
@@ -48,6 +48,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import io.netty.util.internal.PlatformDependent;
+
 /**
  * Top-level plugin that owns the unified Arrow-backed native memory allocator.
  *
@@ -436,10 +438,32 @@ public class ArrowBasePlugin extends Plugin implements ExtensiblePlugin, ActionP
 
     static String derivePoolMaxDefault(Settings settings, int percent) {
         ByteSizeValue nativeLimit = ResourceTrackerSettings.NODE_NATIVE_MEMORY_LIMIT_SETTING.get(settings);
-        if (nativeLimit.getBytes() <= 0) {
-            return Long.toString(Long.MAX_VALUE);
+        if (nativeLimit.getBytes() > 0) {
+            return Long.toString(Math.max(0L, nativeLimit.getBytes() * percent / 100));
         }
-        return Long.toString(Math.max(0L, nativeLimit.getBytes() * percent / 100));
+        // node.native_memory.limit could not be derived (e.g. a restricted container where physical-memory
+        // probing returns 0). Falling back to Long.MAX_VALUE would leave the pool UNBOUNDED, so the pool's
+        // own limit stops guarding allocations and the only remaining ceiling is the JVM-wide direct-memory
+        // budget (MaxDirectMemorySize). A burst of concurrent allocations then exhausts that shared budget
+        // and fails as a hard OutOfDirectMemoryError instead of a contained, per-pool OutOfMemoryException.
+        // Fall back to the same percentage of MaxDirectMemorySize (always known - it is a JVM setting) so the
+        // pool stays bounded strictly below the wall and over-budget allocations circuit-break within the pool.
+        long maxDirect = maxDirectMemoryBytes();
+        if (maxDirect > 0) {
+            return Long.toString(Math.max(0L, maxDirect * percent / 100));
+        }
+        // MaxDirectMemorySize itself is unavailable (should not happen on a supported JVM); preserve the
+        // historical unbounded behaviour rather than accidentally pinning the pool to 0.
+        return Long.toString(Long.MAX_VALUE);
+    }
+
+    /** JVM {@code -XX:MaxDirectMemorySize} in bytes, or -1 when it cannot be determined. */
+    static long maxDirectMemoryBytes() {
+        try {
+            return PlatformDependent.maxDirectMemory();
+        } catch (Throwable t) {
+            return -1L;
+        }
     }
 
     static String derivePoolMinDefault(Settings settings, int percent) {

--- a/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
+++ b/plugins/arrow-base/src/test/java/org/opensearch/arrow/allocator/ArrowBasePluginTests.java
@@ -21,10 +21,14 @@ import java.util.Set;
 public class ArrowBasePluginTests extends OpenSearchTestCase {
 
     public void testQuerySettingsExposeDefaults() {
-        // Explicit 0 expresses "AC unconfigured" so QUERY_MAX falls back to Long.MAX_VALUE.
+        // Explicit 0 expresses "AC unconfigured": the min stays 0, but the max no longer falls back to an
+        // unbounded Long.MAX_VALUE. It is bounded to a percentage of MaxDirectMemorySize so the pool keeps
+        // guarding allocations (see testPoolMaxDefaultsFallBackToMaxDirectWhenAcUnset).
         Settings s = Settings.builder().put("node.native_memory.limit", "0b").build();
         assertEquals(Long.valueOf(0L), ArrowBasePlugin.QUERY_MIN_SETTING.get(s));
-        assertEquals(Long.valueOf(Long.MAX_VALUE), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
+        long maxDirect = ArrowBasePlugin.maxDirectMemoryBytes();
+        long expected = maxDirect > 0 ? maxDirect * 5 / 100 : Long.MAX_VALUE;
+        assertEquals(Long.valueOf(expected), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
     }
 
     public void testFlightAndIngestMinDerivedFromBudget() {
@@ -37,11 +41,25 @@ public class ArrowBasePluginTests extends OpenSearchTestCase {
         assertEquals(Long.valueOf(budget * 2 / 100), ArrowBasePlugin.INGEST_MIN_SETTING.get(s));
     }
 
-    public void testPoolMaxDefaultsAreLongMaxValueWhenAcUnset() {
+    public void testPoolMaxDefaultsFallBackToMaxDirectWhenAcUnset() {
+        // When node.native_memory.limit cannot be derived (0b, e.g. a container that cannot read cgroup
+        // RAM), the pool max must NOT be unbounded (Long.MAX_VALUE) - that would remove the pool's own
+        // ceiling and let a burst exhaust the JVM-wide direct-memory budget as a hard OutOfDirectMemoryError.
+        // Instead it falls back to the same percentage of MaxDirectMemorySize so the pool stays bounded below
+        // the JVM wall and over-budget allocations circuit-break within the pool.
         Settings s = Settings.builder().put("node.native_memory.limit", "0b").build();
-        assertEquals(Long.valueOf(Long.MAX_VALUE), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(Long.MAX_VALUE), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
-        assertEquals(Long.valueOf(Long.MAX_VALUE), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
+        long maxDirect = ArrowBasePlugin.maxDirectMemoryBytes();
+        if (maxDirect > 0) {
+            assertEquals(Long.valueOf(maxDirect * 5 / 100), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
+            assertEquals(Long.valueOf(maxDirect * 5 / 100), ArrowBasePlugin.INGEST_MAX_SETTING.get(s));
+            assertEquals(Long.valueOf(maxDirect * 5 / 100), ArrowBasePlugin.QUERY_MAX_SETTING.get(s));
+            // The bound is real (below the JVM direct-memory wall), not the old unbounded sentinel.
+            assertTrue(ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s) < Long.MAX_VALUE);
+            assertTrue(ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s) < maxDirect);
+        } else {
+            // MaxDirectMemorySize unavailable (not expected on a supported JVM): historical unbounded fallback.
+            assertEquals(Long.valueOf(Long.MAX_VALUE), ArrowBasePlugin.FLIGHT_MAX_SETTING.get(s));
+        }
     }
 
     public void testPoolMaxDefaultsScaleFromAcBudget() {


### PR DESCRIPTION
### Description

`ArrowBasePlugin.derivePoolMaxDefault` sizes each native pool's max (flight / ingest / query) as a percentage of `node.native_memory.limit`. When that limit resolves to `0b` — which is the default in restricted containers where physical-memory probing returns 0 (`OsProbe.getTotalPhysicalMemorySize() == 0`) — it returned `Long.MAX_VALUE`, leaving the pools **unbounded**.

An unbounded pool stops guarding allocations, so the only remaining ceiling is the JVM-wide `MaxDirectMemorySize`, shared by all direct-memory users on the node. Under a burst of concurrent allocations the pool then exhausts that shared budget and fails as a hard `OutOfDirectMemoryError` — global exhaustion that can strike any direct allocation and, being an `Error`, can destabilize the node. When the pool is bounded (the non-container case), the same pressure instead surfaces as a contained, per-pool `OutOfMemoryException` that the caller recovers from.

**Fix:** when `node.native_memory.limit` is unknown, fall back to the same percentage of `MaxDirectMemorySize` (always available via `PlatformDependent.maxDirectMemory()`) instead of `Long.MAX_VALUE`, so every pool stays bounded below the JVM wall in all environments. `Long.MAX_VALUE` is retained only if `MaxDirectMemorySize` itself is unreadable (not expected on a supported JVM).

### Related Issues

N/A

### Check List
- [x] Functionality includes unit tests (`ArrowBasePluginTests` asserts the pool is bounded below `MaxDirectMemorySize` when `node.native_memory.limit=0b`).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
