### PR TITLE
Apply http.max_header_size to HTTP/2 request headers

### DIFF
--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
@@ -98,9 +98,11 @@ import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
 import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
+import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -429,7 +431,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
                     if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
                         return new Http2ServerUpgradeCodec(
-                            Http2FrameCodecBuilder.forServer().build(),
+                            createHttp2FrameCodec(),
                             new Http2MultiplexHandler(createHttp2ChannelInitializer(ch.pipeline()))
                         );
                     } else {
@@ -518,8 +520,17 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         }
 
         protected void configureDefaultHttp2Pipeline(ChannelPipeline pipeline) {
-            pipeline.addLast(Http2FrameCodecBuilder.forServer().build())
-                .addLast(new Http2MultiplexHandler(createHttp2ChannelInitializer(pipeline)));
+            pipeline.addLast(createHttp2FrameCodec()).addLast(new Http2MultiplexHandler(createHttp2ChannelInitializer(pipeline)));
+        }
+
+        /**
+         * Advertises {@code http.max_header_size} as SETTINGS_MAX_HEADER_LIST_SIZE, otherwise Netty's 8kb default
+         * caps HTTP/2 request headers regardless of the configured value.
+         */
+        private Http2FrameCodec createHttp2FrameCodec() {
+            return Http2FrameCodecBuilder.forServer()
+                .initialSettings(Http2Settings.defaultSettings().maxHeaderListSize(handlingSettings.getMaxHeaderSize()))
+                .build();
         }
 
         private ChannelInitializer<Channel> createHttp2ChannelInitializerPriorKnowledge() {

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -490,6 +490,44 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
         }
     }
 
+    public void testLargeHeaderHttp2() throws InterruptedException {
+        final Settings settings = createBuilderWithPort().put(HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE.getKey(), "32kb").build();
+        final String url = "/thing";
+        final HttpServerTransport.Dispatcher dispatcher = dispatcherBuilderWithDefaults().withDispatchRequest(
+            (request, channel, threadContext) -> channel.sendResponse(new BytesRestResponse(OK, "done"))
+        ).build();
+
+        try (
+            Netty4HttpServerTransport transport = new Netty4HttpServerTransport(
+                settings,
+                networkService,
+                bigArrays,
+                threadPool,
+                xContentRegistry(),
+                dispatcher,
+                clusterSettings,
+                new SharedGroupFactory(settings),
+                NoopTracer.INSTANCE
+            )
+        ) {
+            transport.start();
+            final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
+
+            try (Netty4HttpClient client = Netty4HttpClient.http2()) {
+                final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url);
+                // Exceeds Netty's 8kb default for SETTINGS_MAX_HEADER_LIST_SIZE, but fits within http.max_header_size
+                request.headers().add("x-large-header", randomAlphaOfLength(16 * 1024));
+
+                final FullHttpResponse response = client.send(remoteAddress.address(), request);
+                try {
+                    assertThat(response.status(), equalTo(HttpResponseStatus.OK));
+                } finally {
+                    response.release();
+                }
+            }
+        }
+    }
+
     private Settings createSettings() {
         return createBuilderWithPort().build();
     }


### PR DESCRIPTION
### Description

`http.max_header_size` (default 16kb) was never applied to HTTP/2. Both places in
`Netty4HttpServerTransport` that build the HTTP/2 codec used
`Http2FrameCodecBuilder.forServer().build()`, so the server advertised Netty's default
`SETTINGS_MAX_HEADER_LIST_SIZE` of 8192 bytes regardless of the configured value. Requests with
headers larger than that (commonly JWT bearer tokens) failed, while the same request succeeded over
HTTP/1.1. The 10kb figure in the reported error is Netty's
`calculateMaxHeaderListSizeGoAway(8192)` = 10240.

The fix advertises `http.max_header_size` as `SETTINGS_MAX_HEADER_LIST_SIZE` on both HTTP/2 codec
sites (the h2c upgrade codec and the default HTTP/2 pipeline, the latter also covering the
ALPN-negotiated h2 path in `SecureNetty4HttpServerTransport`). This matches what
`Netty4Http3ServerTransport` and `ReactorNetty4HttpServerTransport` already do for HTTP/3 and their
HTTP/2 support.

Verified:
- New test `Netty4HttpServerTransportTests#testLargeHeaderHttp2` (`http.max_header_size: 32kb`, 16kb
  request header) fails without the fix — the request is never answered and the client times out
  after 30s with `AssertionError: Failed to get all expected responses: 1 left` — and passes with
  it in ~2.4s.
- A control at a 4kb header passes both with and without the fix, confirming the failure is gated on
  Netty's 8kb default rather than a limitation of the HTTP/2 test client.

### Related Issues
Resolves #18846

### Check List
- [x] Functionality includes testing.
