### PR TITLE
Add opt-in CPU-only transport admission control flow

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -839,6 +839,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 // Admission Control Settings
                 AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,
+                AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED,
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT,
                 CpuBasedAdmissionControllerSettings.SEARCH_CPU_USAGE_LIMIT,

--- a/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlService.java
+++ b/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlService.java
@@ -91,9 +91,21 @@ public class AdmissionControlService {
      * @param admissionControlActionType admissionControllerActionType value
      */
     public void applyTransportAdmissionControl(String action, AdmissionControlActionType admissionControlActionType) {
-        this.admissionControllers.forEach(
-            (name, admissionController) -> { admissionController.apply(action, admissionControlActionType); }
-        );
+        // Precedence: the legacy transport admission control (admission_control.transport.mode) always wins.
+        // When it is disabled and the new CPU-only flow (admission_control.transport.cpu.enabled) is enabled,
+        // enforce CPU admission control only; the IO and native-memory controllers do not participate.
+        // Otherwise run the legacy multi-controller flow, unchanged.
+        if (!this.admissionControlSettings.isTransportLayerAdmissionControlEnabled()
+            && this.admissionControlSettings.isCpuTransportLayerAdmissionControlEnabled()) {
+            AdmissionController cpuAdmissionController = this.getAdmissionController(CPU_BASED_ADMISSION_CONTROLLER);
+            if (cpuAdmissionController != null) {
+                ((CpuBasedAdmissionController) cpuAdmissionController).applyForTransportLayerEnforced(action, admissionControlActionType);
+            }
+        } else {
+            this.admissionControllers.forEach(
+                (name, admissionController) -> { admissionController.apply(action, admissionControlActionType); }
+            );
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlSettings.java
+++ b/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlSettings.java
@@ -38,7 +38,25 @@ public final class AdmissionControlSettings {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Dynamic, opt-in feature setting for the CPU-only transport layer admission control flow. Disabled by
+     * default to preserve backward compatibility. When this setting is enabled and the legacy transport
+     * admission control ({@link #ADMISSION_CONTROL_TRANSPORT_LAYER_MODE}) is disabled, only the CPU admission
+     * controller participates in admission decisions and requests are rejected (enforced) once the configured
+     * CPU usage limit is breached. The IO and native-memory admission controllers do not participate in this
+     * flow. When the legacy transport admission control is enabled, it takes precedence and this flow is
+     * bypassed.
+     */
+    public static final Setting<Boolean> ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED = Setting.boolSetting(
+        "admission_control.transport.cpu.enabled",
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
     private volatile AdmissionControlMode transportLayeradmissionControlMode;
+
+    private volatile boolean cpuTransportLayerAdmissionControlEnabled;
 
     /**
      * @param clusterSettings clusterSettings Instance
@@ -47,6 +65,11 @@ public final class AdmissionControlSettings {
     public AdmissionControlSettings(ClusterSettings clusterSettings, Settings settings) {
         this.transportLayeradmissionControlMode = ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(ADMISSION_CONTROL_TRANSPORT_LAYER_MODE, this::setAdmissionControlTransportLayerMode);
+        this.cpuTransportLayerAdmissionControlEnabled = ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(
+            ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED,
+            this::setCpuTransportLayerAdmissionControlEnabled
+        );
     }
 
     /**
@@ -55,6 +78,15 @@ public final class AdmissionControlSettings {
      */
     private void setAdmissionControlTransportLayerMode(AdmissionControlMode admissionControlMode) {
         this.transportLayeradmissionControlMode = admissionControlMode;
+    }
+
+    /**
+     *
+     * @param cpuTransportLayerAdmissionControlEnabled update the enabled state of the CPU-only transport
+     *                                                 layer admission control flow
+     */
+    private void setCpuTransportLayerAdmissionControlEnabled(boolean cpuTransportLayerAdmissionControlEnabled) {
+        this.cpuTransportLayerAdmissionControlEnabled = cpuTransportLayerAdmissionControlEnabled;
     }
 
     /**
@@ -79,5 +111,13 @@ public final class AdmissionControlSettings {
      */
     public Boolean isTransportLayerAdmissionControlEnabled() {
         return this.transportLayeradmissionControlMode != AdmissionControlMode.DISABLED;
+    }
+
+    /**
+     *
+     * @return true if the CPU-only transport layer admission control flow is enabled else false
+     */
+    public boolean isCpuTransportLayerAdmissionControlEnabled() {
+        return this.cpuTransportLayerAdmissionControlEnabled;
     }
 }

--- a/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionController.java
+++ b/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionController.java
@@ -77,6 +77,29 @@ public class CpuBasedAdmissionController extends AdmissionController {
     }
 
     /**
+     * Apply CPU based transport layer admission control in enforced mode, i.e. reject the request when the
+     * configured CPU usage limit has been breached, regardless of the configured admission control mode.
+     * Used by the CPU-only transport layer admission control flow gated by
+     * {@link org.opensearch.ratelimitting.admissioncontrol.AdmissionControlSettings#ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED}.
+     *
+     * @param actionName is the transport action
+     * @param admissionControlActionType type of the transport request
+     */
+    public void applyForTransportLayerEnforced(String actionName, AdmissionControlActionType admissionControlActionType) {
+        if (isLimitsBreached(actionName, admissionControlActionType)) {
+            this.addRejectionCount(admissionControlActionType.getType(), 1);
+            throw new OpenSearchRejectedExecutionException(
+                String.format(
+                    Locale.ROOT,
+                    "CPU usage admission controller rejected the request for action [%s] as CPU limit reached for action-type [%s]",
+                    actionName,
+                    admissionControlActionType.name()
+                )
+            );
+        }
+    }
+
+    /**
      * Check if the configured resource usage limits are breached for the action
      */
     private boolean isLimitsBreached(String actionName, AdmissionControlActionType admissionControlActionType) {

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlServiceTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlServiceTests.java
@@ -10,14 +10,19 @@ package org.opensearch.ratelimitting.admissioncontrol;
 
 import org.apache.lucene.util.Constants;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.node.IoUsageStats;
+import org.opensearch.node.NodeResourceUsageStats;
+import org.opensearch.node.ResourceUsageCollectorService;
 import org.opensearch.ratelimitting.admissioncontrol.controllers.AdmissionController;
 import org.opensearch.ratelimitting.admissioncontrol.controllers.CpuBasedAdmissionController;
+import org.opensearch.ratelimitting.admissioncontrol.controllers.IoBasedAdmissionController;
 import org.opensearch.ratelimitting.admissioncontrol.controllers.NativeMemoryBasedAdmissionController;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlActionType;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlMode;
 import org.opensearch.ratelimitting.admissioncontrol.settings.CpuBasedAdmissionControllerSettings;
+import org.opensearch.ratelimitting.admissioncontrol.settings.IoBasedAdmissionControllerSettings;
 import org.opensearch.ratelimitting.admissioncontrol.settings.NativeMemoryBasedAdmissionControllerSettings;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
@@ -25,6 +30,9 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.List;
+import java.util.Optional;
+
+import org.mockito.Mockito;
 
 public class AdmissionControlServiceTests extends OpenSearchTestCase {
     private ClusterService clusterService;
@@ -36,17 +44,14 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool("admission_controller_settings_test");
-        clusterService = ClusterServiceUtils.createClusterService(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            threadPool
-        );
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
         action = "indexing";
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
+        clusterService.close();
         threadPool.shutdownNow();
     }
 
@@ -223,5 +228,104 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
                 .getRejectionCount(AdmissionControlActionType.INDEXING.getType()),
             0
         );
+    }
+
+    /**
+     * New CPU-only flow enabled with the legacy transport mode disabled: only the CPU controller enforces and
+     * rejects; the IO controller must not participate.
+     */
+    public void testNewCpuOnlyFlowEnforcesCpuAndExcludesIo() {
+        this.action = "indices:data/write/bulk[s][p]";
+        Settings settings = Settings.builder()
+            .put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED.getKey(), true)
+            .put(CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT.getKey(), 0)
+            .put(IoBasedAdmissionControllerSettings.INDEXING_IO_USAGE_LIMIT.getKey(), 0)
+            .build();
+        ResourceUsageCollectorService rs = mockResourceCollector(50.0, 50.0);
+        admissionControlService = new AdmissionControlService(settings, clusterService, threadPool, rs, null);
+        expectThrows(
+            OpenSearchRejectedExecutionException.class,
+            () -> admissionControlService.applyTransportAdmissionControl(this.action, AdmissionControlActionType.INDEXING)
+        );
+        assertEquals(
+            1,
+            admissionControlService.getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER)
+                .getRejectionCount(AdmissionControlActionType.INDEXING.getType())
+        );
+        if (Constants.LINUX) {
+            // IO controller is registered but must NOT participate in the CPU-only flow.
+            assertEquals(
+                0,
+                admissionControlService.getAdmissionController(IoBasedAdmissionController.IO_BASED_ADMISSION_CONTROLLER)
+                    .getRejectionCount(AdmissionControlActionType.INDEXING.getType())
+            );
+        }
+    }
+
+    /**
+     * New CPU-only flow disabled (the default): the legacy multi-controller flow runs. With all legacy modes
+     * disabled, no admission control is applied even at high CPU usage - i.e. existing default behavior is preserved.
+     */
+    public void testNewCpuOnlyFlowDisabledUsesLegacyPath() {
+        this.action = "indices:data/write/bulk[s][p]";
+        ResourceUsageCollectorService rs = mockResourceCollector(100.0, 100.0);
+        admissionControlService = new AdmissionControlService(Settings.EMPTY, clusterService, threadPool, rs, null);
+        admissionControlService.applyTransportAdmissionControl(this.action, AdmissionControlActionType.INDEXING);
+        assertEquals(
+            0,
+            admissionControlService.getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER)
+                .getRejectionCount(AdmissionControlActionType.INDEXING.getType())
+        );
+    }
+
+    /**
+     * When both the legacy transport mode and the new CPU-only flow are enabled, the legacy flow takes
+     * precedence. Proven by having only the IO controller breach: a rejection from IO shows the legacy
+     * multi-controller path ran (the CPU-only flow would have skipped IO entirely).
+     */
+    public void testLegacyTakesPrecedenceWhenBothEnabled() {
+        assumeTrue("IO/native controllers are Linux-only", Constants.LINUX);
+        this.action = "indices:data/write/bulk[s][p]";
+        Settings settings = Settings.builder()
+            .put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED.getKey(), true)
+            .put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.ENFORCED.getMode())
+            .put(
+                CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(),
+                AdmissionControlMode.DISABLED.getMode()
+            )
+            .put(
+                NativeMemoryBasedAdmissionControllerSettings.NATIVE_MEMORY_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(),
+                AdmissionControlMode.DISABLED.getMode()
+            )
+            .put(IoBasedAdmissionControllerSettings.INDEXING_IO_USAGE_LIMIT.getKey(), 0)
+            .build();
+        ResourceUsageCollectorService rs = mockResourceCollector(50.0, 50.0);
+        admissionControlService = new AdmissionControlService(settings, clusterService, threadPool, rs, null);
+        expectThrows(
+            OpenSearchRejectedExecutionException.class,
+            () -> admissionControlService.applyTransportAdmissionControl(this.action, AdmissionControlActionType.INDEXING)
+        );
+        // Rejection came from the IO controller (legacy path), not CPU.
+        assertEquals(
+            1,
+            admissionControlService.getAdmissionController(IoBasedAdmissionController.IO_BASED_ADMISSION_CONTROLLER)
+                .getRejectionCount(AdmissionControlActionType.INDEXING.getType())
+        );
+        assertEquals(
+            0,
+            admissionControlService.getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER)
+                .getRejectionCount(AdmissionControlActionType.INDEXING.getType())
+        );
+    }
+
+    private ResourceUsageCollectorService mockResourceCollector(double cpuPercent, double ioPercent) {
+        ResourceUsageCollectorService rs = Mockito.mock(ResourceUsageCollectorService.class);
+        NodeResourceUsageStats stats = Mockito.mock(NodeResourceUsageStats.class);
+        Mockito.when(stats.getCpuUtilizationPercent()).thenReturn(cpuPercent);
+        IoUsageStats ioStats = Mockito.mock(IoUsageStats.class);
+        Mockito.when(ioStats.getIoUtilisationPercent()).thenReturn(ioPercent);
+        Mockito.when(stats.getIoUsageStats()).thenReturn(ioStats);
+        Mockito.when(rs.getNodeStatistics(Mockito.anyString())).thenReturn(Optional.of(stats));
+        return rs;
     }
 }

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlSettingsTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlSettingsTests.java
@@ -46,8 +46,38 @@ public class AdmissionControlSettingsTests extends OpenSearchTestCase {
         Set<Setting<?>> settings = ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
         assertTrue(
             "All the admission controller settings should be supported built in settings",
-            settings.containsAll(List.of(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE))
+            settings.containsAll(
+                List.of(
+                    AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,
+                    AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED
+                )
+            )
         );
+    }
+
+    public void testCpuTransportLayerAdmissionControlDefaultDisabled() {
+        AdmissionControlSettings admissionControlSettings = new AdmissionControlSettings(
+            clusterService.getClusterSettings(),
+            Settings.EMPTY
+        );
+        assertFalse(admissionControlSettings.isCpuTransportLayerAdmissionControlEnabled());
+    }
+
+    public void testCpuTransportLayerAdmissionControlConfiguredEnabled() {
+        Settings settings = Settings.builder().put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED.getKey(), true).build();
+        AdmissionControlSettings admissionControlSettings = new AdmissionControlSettings(clusterService.getClusterSettings(), settings);
+        assertTrue(admissionControlSettings.isCpuTransportLayerAdmissionControlEnabled());
+    }
+
+    public void testCpuTransportLayerAdmissionControlDynamicUpdate() {
+        AdmissionControlSettings admissionControlSettings = new AdmissionControlSettings(
+            clusterService.getClusterSettings(),
+            Settings.EMPTY
+        );
+        assertFalse(admissionControlSettings.isCpuTransportLayerAdmissionControlEnabled());
+        Settings settings = Settings.builder().put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED.getKey(), true).build();
+        clusterService.getClusterSettings().applySettings(settings);
+        assertTrue(admissionControlSettings.isCpuTransportLayerAdmissionControlEnabled());
     }
 
     public void testDefaultSettings() {

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionControllerTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionControllerTests.java
@@ -9,8 +9,9 @@
 package org.opensearch.ratelimitting.admissioncontrol.controllers;
 
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.node.NodeResourceUsageStats;
 import org.opensearch.node.ResourceUsageCollectorService;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlActionType;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlMode;
@@ -19,6 +20,8 @@ import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Optional;
 
 import org.mockito.Mockito;
 
@@ -32,16 +35,13 @@ public class CpuBasedAdmissionControllerTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool("admission_controller_settings_test");
-        clusterService = ClusterServiceUtils.createClusterService(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            threadPool
-        );
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
+        clusterService.close();
         threadPool.shutdownNow();
     }
 
@@ -140,5 +140,43 @@ public class CpuBasedAdmissionControllerTests extends OpenSearchTestCase {
         admissionController.addRejectionCount(AdmissionControlActionType.INDEXING.getType(), 2);
         assertEquals(admissionController.getRejectionCount(AdmissionControlActionType.SEARCH.getType()), 2);
         assertEquals(admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()), 5);
+    }
+
+    public void testApplyForTransportLayerEnforcedRejectsRegardlessOfMode() {
+        // The mode-override is left at its default (DISABLED); the enforced-apply used by the CPU-only flow
+        // must still reject when the CPU usage limit is breached, i.e. it does not consult the configured mode.
+        Settings settings = Settings.builder().put(CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT.getKey(), 0).build();
+        ResourceUsageCollectorService rs = Mockito.mock(ResourceUsageCollectorService.class);
+        NodeResourceUsageStats stats = Mockito.mock(NodeResourceUsageStats.class);
+        Mockito.when(stats.getCpuUtilizationPercent()).thenReturn(50.0);
+        Mockito.when(rs.getNodeStatistics(Mockito.anyString())).thenReturn(Optional.of(stats));
+        admissionController = new CpuBasedAdmissionController(
+            CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER,
+            rs,
+            clusterService,
+            settings
+        );
+        assertEquals(AdmissionControlMode.DISABLED, admissionController.settings.getTransportLayerAdmissionControllerMode());
+        expectThrows(
+            OpenSearchRejectedExecutionException.class,
+            () -> admissionController.applyForTransportLayerEnforced(action, AdmissionControlActionType.INDEXING)
+        );
+        assertEquals(1, admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()));
+    }
+
+    public void testApplyForTransportLayerEnforcedNoRejectionBelowLimit() {
+        // Default CPU limit is 95; a usage of 10 is below it, so no rejection should occur.
+        ResourceUsageCollectorService rs = Mockito.mock(ResourceUsageCollectorService.class);
+        NodeResourceUsageStats stats = Mockito.mock(NodeResourceUsageStats.class);
+        Mockito.when(stats.getCpuUtilizationPercent()).thenReturn(10.0);
+        Mockito.when(rs.getNodeStatistics(Mockito.anyString())).thenReturn(Optional.of(stats));
+        admissionController = new CpuBasedAdmissionController(
+            CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER,
+            rs,
+            clusterService,
+            Settings.EMPTY
+        );
+        admissionController.applyForTransportLayerEnforced(action, AdmissionControlActionType.INDEXING);
+        assertEquals(0, admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()));
     }
 }


### PR DESCRIPTION
### Description

Adds a new dynamic cluster setting `admission_control.transport.cpu.enabled` (default `false`, opt-in) that enables a CPU-only Transport Layer admission control flow.

When this setting is enabled **and** the legacy transport admission control (`admission_control.transport.mode`) is disabled, only the CPU admission controller participates in admission decisions and enforces rejection once the configured CPU usage limit is breached. The IO and native-memory admission controllers do not participate in this flow. When the legacy transport admission control is enabled, it takes precedence and the CPU-only flow is bypassed, so existing behavior is fully preserved.

The setting is `Dynamic` + `NodeScope`, consistent with the existing admission control settings, and reuses the existing CPU usage limit settings (`admission_control.{search,indexing,cluster.admin}.cpu_usage.limit`, default 95).

### Behavior matrix

| `admission_control.transport.mode` | `admission_control.transport.cpu.enabled` | Result |
|---|---|---|
| disabled (default) | false (default) | Existing behavior — no admission control |
| disabled | true | CPU-only transport admission control, enforced; IO and native-memory excluded |
| monitor / enforced | false | Legacy behavior, unchanged |
| monitor / enforced | true | Legacy takes precedence; CPU-only flow bypassed |

### Changes

- `AdmissionControlSettings`: new `ADMISSION_CONTROL_TRANSPORT_CPU_ENABLED` setting, backing field, dynamic update consumer, and getter.
- `ClusterSettings`: register the new setting.
- `AdmissionControlService#applyTransportAdmissionControl`: precedence branch selecting the CPU-only enforced path or the legacy multi-controller loop (the legacy loop is preserved verbatim in the `else`).
- `CpuBasedAdmissionController#applyForTransportLayerEnforced`: enforced CPU apply that reuses the existing breach-detection logic.

### Testing

- New unit tests cover: setting default/configured/dynamic-update, the CPU enforced-apply path (rejects regardless of mode; no rejection below limit), and flow precedence (CPU-only enforces and excludes IO; disabled falls back to legacy; legacy wins when both enabled).
- `./gradlew :server:test --tests "org.opensearch.ratelimitting.admissioncontrol.*"` passes (all admission-control suites, 0 failures/errors). `spotlessJavaApply` applied.
- Full `precommit` and `internalClusterTest` have not yet been run — this PR is opened as a draft for that reason.

### Notes

- Opt-in by default to preserve backward compatibility; no behavior change on upgrade.
- Precedence keys on the master `admission_control.transport.mode`. If legacy admission control is enabled only via a per-controller `*_mode_override` while the master mode is left disabled and this setting is on, the CPU-only flow takes precedence.

### Check List

- [x] Functionality includes tests.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
