### PR TITLE
Enforce CPU-based transport admission control by default

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionForClusterManagerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionForClusterManagerIT.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.opensearch.ratelimitting.admissioncontrol.AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE;
 import static org.opensearch.ratelimitting.admissioncontrol.settings.CpuBasedAdmissionControllerSettings.CLUSTER_ADMIN_CPU_USAGE_LIMIT;
+import static org.opensearch.ratelimitting.admissioncontrol.settings.CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE;
 import static org.opensearch.ratelimitting.admissioncontrol.settings.NativeMemoryBasedAdmissionControllerSettings.CLUSTER_ADMIN_NATIVE_MEMORY_USAGE_LIMIT;
 import static org.opensearch.ratelimitting.admissioncontrol.settings.NativeMemoryBasedAdmissionControllerSettings.NATIVE_MEMORY_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -67,6 +68,8 @@ public class AdmissionForClusterManagerIT extends OpenSearchIntegTestCase {
 
     private static final Settings DISABLE_ADMISSION_CONTROL = Settings.builder()
         .put(ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.DISABLED.getMode())
+        // CPU admission control is enforced by default and no longer inherits the master mode, so disable it explicitly.
+        .put(CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.DISABLED.getMode())
         .put(NATIVE_MEMORY_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.DISABLED.getMode())
         .build();
 
@@ -181,8 +184,13 @@ public class AdmissionForClusterManagerIT extends OpenSearchIntegTestCase {
     }
 
     public void testAdmissionControlMonitorOnBreach() throws InterruptedException {
+        // CPU admission control is enforced by default and no longer inherits the master mode; put it in monitor
+        // mode explicitly so this "no rejection" scenario holds.
         admissionControlDisabledOnBreach(
-            Settings.builder().put(ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.MONITOR.getMode()).build()
+            Settings.builder()
+                .put(ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.MONITOR.getMode())
+                .put(CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.MONITOR.getMode())
+                .build()
         );
     }
 

--- a/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/settings/CpuBasedAdmissionControllerSettings.java
+++ b/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/settings/CpuBasedAdmissionControllerSettings.java
@@ -11,7 +11,6 @@ package org.opensearch.ratelimitting.admissioncontrol.settings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.ratelimitting.admissioncontrol.AdmissionControlSettings;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlMode;
 
 /**
@@ -35,10 +34,13 @@ public class CpuBasedAdmissionControllerSettings {
     /**
      * Feature level setting to operate in shadow-mode or in enforced-mode. If enforced field is set
      * rejection will be performed, otherwise only rejection metrics will be populated.
+     * Defaults to {@link AdmissionControlMode#ENFORCED} so CPU-based transport admission control is active
+     * out of the box; set this override to {@code disabled} or {@code monitor_only} to change that. This
+     * override no longer inherits the cluster-level admission_control.transport.mode setting.
      */
     public static final Setting<AdmissionControlMode> CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE = new Setting<>(
         "admission_control.transport.cpu_usage.mode_override",
-        AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,
+        AdmissionControlMode.ENFORCED.getMode(),
         AdmissionControlMode::fromName,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlServiceTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/AdmissionControlServiceTests.java
@@ -85,35 +85,26 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
         }
         CpuBasedAdmissionController cpuBasedAdmissionController = (CpuBasedAdmissionController) admissionControlService
             .getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER);
-        assertEquals(
-            admissionControlSettings.isTransportLayerAdmissionControlEnabled(),
-            cpuBasedAdmissionController.isEnabledForTransportLayer(
-                cpuBasedAdmissionController.settings.getTransportLayerAdmissionControllerMode()
-            )
-        );
-
-        Settings settings = Settings.builder()
-            .put(AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE.getKey(), AdmissionControlMode.DISABLED.getMode())
-            .build();
-        clusterService.getClusterSettings().applySettings(settings);
-        assertEquals(
-            admissionControlSettings.isTransportLayerAdmissionControlEnabled(),
-            cpuBasedAdmissionController.isEnabledForTransportLayer(
-                cpuBasedAdmissionController.settings.getTransportLayerAdmissionControllerMode()
-            )
-        );
+        // The master transport mode is disabled by default...
         assertFalse(admissionControlSettings.isTransportLayerAdmissionControlEnabled());
+        // ...but the CPU admission controller is enforced by default, independent of the master mode.
+        assertEquals(AdmissionControlMode.ENFORCED, cpuBasedAdmissionController.settings.getTransportLayerAdmissionControllerMode());
+        assertTrue(
+            cpuBasedAdmissionController.isEnabledForTransportLayer(
+                cpuBasedAdmissionController.settings.getTransportLayerAdmissionControllerMode()
+            )
+        );
 
-        Settings newSettings = Settings.builder()
-            .put(settings)
+        // Explicitly disabling the CPU override turns CPU admission control off; the master mode is unaffected.
+        Settings settings = Settings.builder()
             .put(
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(),
-                AdmissionControlMode.ENFORCED.getMode()
+                AdmissionControlMode.DISABLED.getMode()
             )
             .build();
-        clusterService.getClusterSettings().applySettings(newSettings);
+        clusterService.getClusterSettings().applySettings(settings);
         assertFalse(admissionControlSettings.isTransportLayerAdmissionControlEnabled());
-        assertTrue(
+        assertFalse(
             cpuBasedAdmissionController.isEnabledForTransportLayer(
                 cpuBasedAdmissionController.settings.getTransportLayerAdmissionControllerMode()
             )
@@ -122,7 +113,7 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
 
     public void testApplyAdmissionControllerDisabled() {
         this.action = "indices:data/write/bulk[s][p]";
-        admissionControlService = new AdmissionControlService(Settings.EMPTY, clusterService, threadPool, null, null);
+        admissionControlService = new AdmissionControlService(cpuDisabledSettings(), clusterService, threadPool, null, null);
         admissionControlService.applyTransportAdmissionControl(this.action, null);
         List<AdmissionController> admissionControllerList = admissionControlService.getAdmissionControllers();
         admissionControllerList.forEach(admissionController -> {
@@ -132,7 +123,7 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
 
     public void testApplyAdmissionControllerEnabled() {
         this.action = "indices:data/write/bulk[s][p]";
-        admissionControlService = new AdmissionControlService(Settings.EMPTY, clusterService, threadPool, null, null);
+        admissionControlService = new AdmissionControlService(cpuDisabledSettings(), clusterService, threadPool, null, null);
         admissionControlService.applyTransportAdmissionControl(this.action, null);
         assertEquals(
             admissionControlService.getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER)
@@ -157,7 +148,7 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
 
     public void testApplyAdmissionControllerEnforced() {
         this.action = "indices:data/write/bulk[s][p]";
-        admissionControlService = new AdmissionControlService(Settings.EMPTY, clusterService, threadPool, null, null);
+        admissionControlService = new AdmissionControlService(cpuDisabledSettings(), clusterService, threadPool, null, null);
         admissionControlService.applyTransportAdmissionControl(this.action, null);
         assertEquals(
             admissionControlService.getAdmissionController(CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER)
@@ -216,12 +207,22 @@ public class AdmissionControlServiceTests extends OpenSearchTestCase {
     public void testApplyNativeMemoryAdmissionControllerDisabled() {
         assumeTrue("native memory controller is Linux-only", Constants.LINUX);
         this.action = "indices:data/write/bulk[s][p]";
-        admissionControlService = new AdmissionControlService(Settings.EMPTY, clusterService, threadPool, null, null);
+        admissionControlService = new AdmissionControlService(cpuDisabledSettings(), clusterService, threadPool, null, null);
         admissionControlService.applyTransportAdmissionControl(this.action, null);
         assertEquals(
             admissionControlService.getAdmissionController(NativeMemoryBasedAdmissionController.NATIVE_MEMORY_BASED_ADMISSION_CONTROLLER)
                 .getRejectionCount(AdmissionControlActionType.INDEXING.getType()),
             0
         );
+    }
+
+    private static Settings cpuDisabledSettings() {
+        // CPU-based transport admission control is enforced by default; disable it to exercise the disabled paths.
+        return Settings.builder()
+            .put(
+                CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE.getKey(),
+                AdmissionControlMode.DISABLED.getMode()
+            )
+            .build();
     }
 }

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionControllerTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/controllers/CpuBasedAdmissionControllerTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.ratelimitting.admissioncontrol.controllers;
 
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.node.ResourceUsageCollectorService;
 import org.opensearch.ratelimitting.admissioncontrol.enums.AdmissionControlActionType;
@@ -32,16 +31,13 @@ public class CpuBasedAdmissionControllerTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool("admission_controller_settings_test");
-        clusterService = ClusterServiceUtils.createClusterService(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            threadPool
-        );
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
+        clusterService.close();
         threadPool.shutdownNow();
     }
 
@@ -54,10 +50,8 @@ public class CpuBasedAdmissionControllerTests extends OpenSearchTestCase {
         );
         assertEquals(admissionController.getName(), CpuBasedAdmissionController.CPU_BASED_ADMISSION_CONTROLLER);
         assertEquals(admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()), 0);
-        assertEquals(admissionController.settings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.DISABLED);
-        assertFalse(
-            admissionController.isEnabledForTransportLayer(admissionController.settings.getTransportLayerAdmissionControllerMode())
-        );
+        assertEquals(admissionController.settings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.ENFORCED);
+        assertTrue(admissionController.isEnabledForTransportLayer(admissionController.settings.getTransportLayerAdmissionControllerMode()));
     }
 
     public void testCheckUpdateSettings() {
@@ -90,7 +84,7 @@ public class CpuBasedAdmissionControllerTests extends OpenSearchTestCase {
             Settings.EMPTY
         );
         assertEquals(admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()), 0);
-        assertEquals(admissionController.settings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.DISABLED);
+        assertEquals(admissionController.settings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.ENFORCED);
         action = "indices:data/write/bulk[s][p]";
         admissionController.apply(action, AdmissionControlActionType.INDEXING);
         assertEquals(admissionController.getRejectionCount(AdmissionControlActionType.INDEXING.getType()), 0);

--- a/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/settings/CPUBasedAdmissionControllerSettingsTests.java
+++ b/server/src/test/java/org/opensearch/ratelimitting/admissioncontrol/settings/CPUBasedAdmissionControllerSettingsTests.java
@@ -63,7 +63,8 @@ public class CPUBasedAdmissionControllerSettingsTests extends OpenSearchTestCase
             Settings.EMPTY
         );
         long percent = 95;
-        assertEquals(cpuBasedAdmissionControllerSettings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.DISABLED);
+        // CPU-based transport admission control is enforced by default.
+        assertEquals(cpuBasedAdmissionControllerSettings.getTransportLayerAdmissionControllerMode(), AdmissionControlMode.ENFORCED);
         assertEquals(cpuBasedAdmissionControllerSettings.getIndexingCPULimit().longValue(), percent);
         assertEquals(cpuBasedAdmissionControllerSettings.getSearchCPULimit().longValue(), percent);
     }


### PR DESCRIPTION
### Description

Makes CPU-based transport-layer admission control **active by default** by changing the default of the existing per-controller setting `admission_control.transport.cpu_usage.mode_override` from *inherit the cluster-level `admission_control.transport.mode`* to **`enforced`**.

With this change, a node rejects `search` / `indexing` / `cluster_admin` transport requests once its CPU usage reaches the configured limit (`admission_control.{search,indexing,cluster.admin}.cpu_usage.limit`, default 95%), without any operator action. The IO and native-memory admission controllers remain disabled by default.

### Behavior change (breaking)

- **Before:** all admission control disabled by default (`admission_control.transport.mode = disabled`, and each per-controller override inherited it).
- **After:** CPU transport admission control is `enforced` by default; IO and native-memory remain disabled.
- To restore the previous behavior, set `admission_control.transport.cpu_usage.mode_override: disabled`.

### Semantic change: CPU override no longer inherits the master mode

Previously `cpu_usage.mode_override` fell back to `admission_control.transport.mode`. It now has an independent default (`enforced`). Consequently, changing `admission_control.transport.mode` no longer changes the CPU controller's mode — set the per-controller override explicitly.

### Changes

- `CpuBasedAdmissionControllerSettings`: default of `CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE` → `AdmissionControlMode.ENFORCED` (removed the master-mode fallback).
- Unit tests (`CpuBasedAdmissionControllerTests`, `CPUBasedAdmissionControllerSettingsTests`, `AdmissionControlServiceTests`) updated for the new default; the service tests disable CPU explicitly where they exercise the "no admission control" path.
- `AdmissionForClusterManagerIT`: its "disabled"/"monitor" states now set the CPU override explicitly (since it no longer inherits the master mode).

### Testing

- `./gradlew :server:test --tests "org.opensearch.ratelimitting.admissioncontrol.*"` passes (72 tests, 0 failures), including `AdmissionControlSingleNodeTests`. `spotlessJavaApply` applied.
- `:server:compileInternalClusterTestJava` compiles. The full `internalClusterTest` suite and `precommit` were **not** run locally (hence draft) — CI to validate.

### Known limitation / follow-up

Even with CPU enforced by default, rejections only occur once node resource stats are collected. On Linux, `NodeResourceUsageTracker.isReady()` requires the memory, cpu, io **and** native trackers to be ready (the IO tracker has a ~120s window and, if `/proc/diskstats` device I/O is unavailable, may never become ready), so there is a warmup delay and an environment-dependent edge case where CPU admission control stays inactive. Decoupling CPU-stat collection from the IO/native trackers is a recommended follow-up.

### Check List

- [x] Functionality includes tests.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
