### PR TITLE
Fix multi-value keyword search through DataFusion

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -335,6 +335,14 @@ public class OpenSearchSchemaBuilder {
                 // validator rather than a planning-time IllegalArgumentException.
                 continue;
             }
+            // Multi-value keyword fields are stored as Parquet LIST<UTF8> / Arrow List(Utf8).
+            // The Calcite schema must declare them as ARRAY so the Substrait plan emits the
+            // correct List type and DataFusion's schema validation passes.
+            Object multiValue = fieldProps.get("multi_value");
+            if (Boolean.TRUE.equals(multiValue)) {
+                columnType = typeFactory.createArrayType(columnType, -1);
+                columnType = typeFactory.createTypeWithNullability(columnType, true);
+            }
             builder.add(fieldName, columnType);
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/column_schema_resolver.rs
@@ -80,9 +80,25 @@ pub(super) fn resolve_with_schema(
     let parquet_schema = metadata.file_metadata().schema_descr();
     let mut set = HashSet::new();
     for name in predicate_column_names {
-        if let Ok(conv) = StatisticsConverter::try_new(name, arrow_schema, parquet_schema) {
-            if let Some(idx) = conv.parquet_column_index() {
-                set.insert(idx);
+        let resolved = StatisticsConverter::try_new(name, arrow_schema, parquet_schema)
+            .ok()
+            .and_then(|conv| conv.parquet_column_index());
+        if let Some(idx) = resolved {
+            set.insert(idx);
+            continue;
+        }
+
+        // parquet-rs intentionally does not resolve nested Arrow fields through
+        // `parquet_column()`: LIST/MAP/STRUCT roots may map to one or more physical
+        // leaves. Since `arrow_schema` is derived from this file's footer, its root
+        // index matches `SchemaDescriptor::get_column_root_idx`; include every leaf
+        // under the requested root so any projected nested field receives a real
+        // OffsetIndex rather than a scoped-out placeholder.
+        if let Some((root_idx, _)) = arrow_schema.fields().find(name) {
+            for leaf_idx in 0..parquet_schema.num_columns() {
+                if parquet_schema.get_column_root_idx(leaf_idx) == root_idx {
+                    set.insert(leaf_idx);
+                }
             }
         }
     }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/cache/page_index/page_index_io.rs
@@ -945,6 +945,82 @@ mod tests {
         assert_eq!(pair_b, vec![0, 1]);
     }
 
+    /// A projected nested Arrow field must resolve to every Parquet leaf under
+    /// that root. `StatisticsConverter::parquet_column_index()` deliberately
+    /// returns `None` for nested types, so the resolver needs its own root-to-leaf
+    /// fallback. Without it, `tags` receives a placeholder OffsetIndex even though
+    /// the scan reads it, and the page reader treats a whole chunk as one page.
+    #[tokio::test]
+    async fn list_projection_resolves_to_its_parquet_leaf() {
+        let _g = CACHE_TEST_GUARD.lock().unwrap();
+        clear_scoped_cache_for_test();
+        let list_field = Arc::new(Field::new("element", DataType::Utf8, true));
+        let tags = arrow::array::ListArray::new(
+            Arc::clone(&list_field),
+            arrow::buffer::OffsetBuffer::new(vec![0_i32, 2, 3, 5].into()),
+            Arc::new(arrow::array::StringArray::from(vec![
+                "a", "b", "c", "d", "e",
+            ])),
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("tags", DataType::List(list_field), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])), Arc::new(tags)],
+        )
+        .unwrap();
+        let props = WriterProperties::builder()
+            .set_data_page_row_count_limit(1)
+            .set_write_batch_size(1)
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .build();
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, Arc::clone(&schema), Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let bytes = Bytes::from(buf);
+        let footer = footer_only(&bytes);
+        let file_schema = Arc::new(
+            parquet_to_arrow_schema(
+                footer.file_metadata().schema_descr(),
+                footer.file_metadata().key_value_metadata(),
+            )
+            .unwrap(),
+        );
+
+        let mut resolved = resolve_predicate_parquet_columns(
+            &schema,
+            &footer,
+            &["id".to_string(), "tags".to_string()],
+            &file_schema,
+        );
+        resolved.sort_unstable();
+        assert_eq!(
+            resolved,
+            vec![0, 1],
+            "both id and tags.list.element must receive real OffsetIndexes"
+        );
+
+        let full = full_index(&bytes);
+        let full_list_pages = full.offset_index().unwrap()[0][1].page_locations().len();
+        assert!(
+            full_list_pages > 1,
+            "fixture must contain multiple LIST pages"
+        );
+        let (store, location) = stage(bytes).await;
+        let scoped = load_scoped_page_index_cols(&store, &location, &footer, &[], &resolved)
+            .await
+            .unwrap();
+        assert_eq!(
+            scoped.offset_index().unwrap()[0][1].page_locations().len(),
+            full_list_pages,
+            "projected LIST leaf must use its real OffsetIndex, not a one-page placeholder"
+        );
+    }
+
     /// Regression: a match()-only query has NO residual predicate columns
     /// (`parquet_cols` empty) but DOES project columns (`offset_cols` non-empty).
     /// The scoped load must still build the OffsetIndex for the projected column

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
@@ -68,8 +68,9 @@ public final class ArrowValues {
 
     /**
      * Reads an Arrow cell as a JSON-friendly scalar: numerics coerced to
-     * {@code long}/{@code double}, timestamps rendered as ISO-8601 UTC strings. Binary and
-     * complex (list/struct/decimal) types are not yet supported and return {@code null}.
+     * {@code long}/{@code double}, timestamps rendered as ISO-8601 UTC strings, list columns as a
+     * {@code List} of converted elements. Binary and remaining complex (struct/decimal) types are
+     * not yet supported and return {@code null}.
      */
     public static Object toSourceValue(FieldVector vec, int idx) {
         if (vec == null || vec.isNull(idx)) return null;
@@ -83,6 +84,19 @@ public final class ArrowValues {
                 return null;
             default:
                 break;
+        }
+        // Multi-valued fields are LIST columns; _source is reconstructed from these columns (there
+        // are no Lucene stored fields on this path), so dropping them would silently lose the
+        // field from every get-by-id response. MapVector extends ListVector, so exclude maps.
+        if (vec instanceof ListVector listVector && vec instanceof MapVector == false) {
+            FieldVector data = listVector.getDataVector();
+            int start = listVector.getOffsetBuffer().getInt((long) idx * ListVector.OFFSET_WIDTH);
+            int end = listVector.getOffsetBuffer().getInt((long) (idx + 1) * ListVector.OFFSET_WIDTH);
+            List<Object> values = new ArrayList<>(Math.max(0, end - start));
+            for (int i = start; i < end; i++) {
+                values.add(toSourceValue(data, i));
+            }
+            return values;
         }
         Object raw = vec.getObject(idx);
         switch (id) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/ArrowCalciteTypes.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/ArrowCalciteTypes.java
@@ -49,6 +49,7 @@ public final class ArrowCalciteTypes {
             // TODO: TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE, TIME, DECIMAL still missing.
             // precision 9 ⇒ date_nanos; else date — must match the wire unit shards emit (Stitcher copyFromSafe).
             case TIMESTAMP -> new ArrowType.Timestamp(t.getPrecision() == 9 ? TimeUnit.NANOSECOND : TimeUnit.MILLISECOND, null);
+            case ARRAY -> ArrowType.List.INSTANCE;
             default -> throw new IllegalArgumentException("Unsupported Calcite type: " + t.getSqlTypeName());
         };
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/engine/OpenSearchSchemaBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.engine;
 
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -21,6 +22,7 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.opensearch.Version;
+import org.opensearch.analytics.planner.ArrowCalciteTypes;
 import org.opensearch.analytics.schema.BinaryType;
 import org.opensearch.analytics.schema.DateOnlyType;
 import org.opensearch.analytics.schema.IpType;
@@ -56,6 +58,22 @@ public class OpenSearchSchemaBuilderTests extends OpenSearchTestCase {
         assertFieldType(rowType, "name", SqlTypeName.VARCHAR);
         assertFieldType(rowType, "age", SqlTypeName.BIGINT);
         assertFieldType(rowType, "score", SqlTypeName.DOUBLE);
+    }
+
+    public void testMultiValueKeywordMapsToArrowList() throws Exception {
+        ClusterState clusterState = buildClusterStateRaw(
+            "multi_value_index",
+            "{\"properties\":{\"tags\":{\"type\":\"keyword\",\"multi_value\":true}}}"
+        );
+
+        SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(clusterState);
+        RelDataType rowType = schema.getTable("multi_value_index").getRowType(new org.apache.calcite.jdbc.JavaTypeFactoryImpl());
+        RelDataType tagsType = rowType.getField("tags", true, false).getType();
+
+        assertEquals(SqlTypeName.ARRAY, tagsType.getSqlTypeName());
+        assertEquals(SqlTypeName.VARCHAR, tagsType.getComponentType().getSqlTypeName());
+        assertTrue(tagsType.isNullable());
+        assertEquals(ArrowType.List.INSTANCE, ArrowCalciteTypes.toArrow(tagsType));
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -383,6 +383,45 @@ public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseI
     }
 
     /**
+     * An absent multi_value field and an explicit empty array must stay distinct in reconstructed
+     * {@code _source}.
+     *
+     * <p>These share the same on-disk column, so the writer must encode them differently: an empty
+     * array writes an empty-but-non-null LIST cell (reconstructed as {@code "tags": []}), while an
+     * absent field never calls {@code addField} — so {@code createField} is never invoked for the
+     * column and Arrow leaves the row's validity bit unset, i.e. a null cell (reconstructed by
+     * dropping {@code tags} from {@code _source}). This pins that the row advance in
+     * {@code VSRManager#addDocument} leaves unset list rows null rather than collapsing to empty.
+     */
+    @SuppressWarnings("unchecked")
+    public void testAbsentFieldIsDistinctFromEmptyArray() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        String emptyId = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"empty\",\"tags\":[]}", XContentType.JSON)
+            .get()
+            .getId();
+        String absentId = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"absent\"}", XContentType.JSON)
+            .get()
+            .getId();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> emptySource = client().prepareGet(MV_INDEX, emptyId).setRealtime(false).get().getSourceAsMap();
+        assertTrue("empty array must reconstruct as a present list", emptySource.get("tags") instanceof List);
+        assertEquals("empty array must be a zero-length list", List.of(), emptySource.get("tags"));
+
+        Map<String, Object> absentSource = client().prepareGet(MV_INDEX, absentId).setRealtime(false).get().getSourceAsMap();
+        assertFalse("absent field must not appear in reconstructed _source", absentSource.containsKey("tags"));
+    }
+
+    /**
      * A single document whose array is far larger than the per-row average the VSR sizes for.
      *
      * <p>VSR rotation is driven by ROW count ({@code index.parquet.max_rows_per_vsr}), not by bytes,

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -109,7 +109,11 @@ public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseI
             Map<String, Object> source = resp.getSourceAsMap();
             List<String> want = EXPECTED.get(entry.getValue());
             Object actual = source.get("tags");
-            List<String> got = actual == null ? List.of() : ((List<Object>) actual).stream().map(String::valueOf).toList();
+            // An indexed array — including an explicit empty one (d3 = []) — must be reconstructed as
+            // a present, non-null list: an empty array reads back as [] and stays distinct from an
+            // absent field. Do not coalesce null → [] here, or the empty-vs-absent bug would hide.
+            assertTrue(stage + ": fixture [" + entry.getValue() + "] must reconstruct tags as a list", actual instanceof List);
+            List<String> got = ((List<Object>) actual).stream().map(String::valueOf).toList();
             assertEquals(stage + ": fixture [" + entry.getValue() + "] lost or reordered values", want, got);
         }
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -1,0 +1,569 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Durability lifecycle for multi-valued ({@code multi_value: true}) keyword fields on a composite
+ * parquet+lucene index: refresh, flush, force-merge, replication to a peer, and recovery.
+ *
+ * <p>A multi-valued field is stored as an Arrow/Parquet {@code LIST<element>} column rather than a
+ * flat column, so every stage that moves or rewrites those files is a place the list encoding can
+ * break independently of the read path: the VSR flush writes offsets, force-merge re-encodes each
+ * column through {@code compute_leaves}, segment replication ships the files to a replica, and
+ * recovery replays or re-fetches them. Each assertion below re-reads the array and requires the
+ * values to be byte-identical, in document order, duplicates intact — the column is the source of
+ * truth for derived {@code _source}, so any loss is silent data corruption rather than a query bug.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseIT {
+
+    private static final String MV_INDEX = "mv-durability-idx";
+
+    /** Document id → the exact array it was indexed with. */
+    private static final Map<String, List<String>> EXPECTED = Map.of(
+        "d1",
+        List.of("beta", "alpha", "beta"),
+        "d2",
+        List.of("solo"),
+        "d3",
+        List.of(),
+        "d4",
+        List.of("x", "y", "z", "x")
+    );
+
+    private Settings mvIndexSettings(int replicaCount) {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(replicaCount, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, org.opensearch.indices.replication.common.ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    private static final String MAPPING = "{\"properties\":{"
+        + "\"id\":{\"type\":\"keyword\"},"
+        + "\"tags\":{\"type\":\"keyword\",\"multi_value\":true}"
+        + "}}";
+
+    private void createMvIndex(int replicaCount) {
+        client().admin().indices().prepareCreate(MV_INDEX).setSettings(mvIndexSettings(replicaCount)).setMapping(MAPPING).get();
+        ensureYellowAndNoInitializingShards(MV_INDEX);
+    }
+
+    /** Generated _id → fixture key, captured at index time (append-only index rejects custom _ids). */
+    private final Map<String, String> idToFixture = new java.util.HashMap<>();
+
+    /** Indexes the four fixture docs with the given refresh policy, recording their generated ids. */
+    private void indexFixtures(WriteRequest.RefreshPolicy policy) {
+        for (Map.Entry<String, List<String>> e : EXPECTED.entrySet()) {
+            StringBuilder json = new StringBuilder("{\"id\":\"").append(e.getKey()).append("\",\"tags\":[");
+            for (int i = 0; i < e.getValue().size(); i++) {
+                if (i > 0) json.append(",");
+                json.append("\"").append(e.getValue().get(i)).append("\"");
+            }
+            json.append("]}");
+            org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+                .setRefreshPolicy(policy)
+                .setSource(json.toString(), XContentType.JSON)
+                .get();
+            idToFixture.put(resp.getId(), e.getKey());
+        }
+    }
+
+    /**
+     * Asserts every indexed document still carries exactly its own values.
+     *
+     * <p>Reads via get-by-id rather than {@code _search}: on a composite index
+     * {@code IndexShard.applyOnEngine} rejects {@code DataFormatAwareEngine}, so there is no
+     * searcher. The get path reconstructs {@code _source} from the Parquet columns (parquet-owned
+     * fields have no Lucene stored fields), making this a direct test of the LIST column's
+     * integrity rather than of a cached copy.
+     */
+    @SuppressWarnings("unchecked")
+    private void assertArraysIntact(String stage) {
+        assertFalse(stage + ": no documents were indexed", idToFixture.isEmpty());
+        for (Map.Entry<String, String> entry : idToFixture.entrySet()) {
+            org.opensearch.action.get.GetResponse resp = client().prepareGet(MV_INDEX, entry.getKey()).setRealtime(false).get();
+            assertTrue(stage + ": document [" + entry.getKey() + "] must exist", resp.isExists());
+            Map<String, Object> source = resp.getSourceAsMap();
+            List<String> want = EXPECTED.get(entry.getValue());
+            Object actual = source.get("tags");
+            List<String> got = actual == null ? List.of() : ((List<Object>) actual).stream().map(String::valueOf).toList();
+            assertEquals(stage + ": fixture [" + entry.getValue() + "] lost or reordered values", want, got);
+        }
+    }
+
+    /**
+     * refresh → flush → force-merge on a single primary. Each stage either makes the in-memory VSR
+     * durable or rewrites the Parquet files; the array must survive all three unchanged.
+     */
+    public void testArraysSurviveRefreshFlushAndForceMerge() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        // Refresh: flushes the active VSR into a readable Parquet generation.
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("after refresh");
+
+        // Flush: commits the generation.
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after flush");
+
+        // A second generation, so force-merge has more than one file to combine.
+        indexFixtures(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        ForceMergeResponse merge = client().admin().indices().prepareForceMerge(MV_INDEX).setMaxNumSegments(1).get();
+        assertEquals("force-merge must not fail any shard", 0, merge.getFailedShards());
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        assertArraysIntact("after force-merge");
+    }
+
+    /**
+     * Segment replication of a LIST column to a peer: the replica reads the primary's Parquet files
+     * verbatim, so a replica-side read failure would mean the file or its catalog entry is not
+     * self-describing.
+     */
+    public void testArraysReplicateToPeer() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createMvIndex(1);
+        ensureGreen(MV_INDEX);
+
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        // Segment replication is asynchronous. Wait for the replica's catalog to carry the same
+        // parquet files as the primary — the base helper's node lookups are bound to its own
+        // INDEX_NAME, so resolve this index's shards here.
+        assertBusy(() -> {
+            org.opensearch.cluster.routing.IndexShardRoutingTable routing = getClusterState().routingTable().index(MV_INDEX).shard(0);
+            String primaryNode = getClusterState().nodes().get(routing.primaryShard().currentNodeId()).getName();
+            org.opensearch.index.shard.IndexShard primary = getIndexShard(primaryNode, MV_INDEX);
+            java.util.Set<String> primaryFiles = DataFormatAwareITUtils.catalogFilesExcludingSegments(primary);
+            assertFalse("primary must have parquet files in its catalog", primaryFiles.isEmpty());
+            for (org.opensearch.cluster.routing.ShardRouting r : routing.replicaShards()) {
+                assertTrue("replica must be started", r.started());
+                String replicaNode = getClusterState().nodes().get(r.currentNodeId()).getName();
+                org.opensearch.index.shard.IndexShard replica = getIndexShard(replicaNode, MV_INDEX);
+                assertEquals(
+                    "primary/replica catalog files must converge on " + replicaNode,
+                    primaryFiles,
+                    DataFormatAwareITUtils.catalogFilesExcludingSegments(replica)
+                );
+            }
+        }, 60, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Values must still read back intact once the replica holds the same files.
+        assertArraysIntact("after replication to peer");
+    }
+
+    /**
+     * Recovery: restart the data node holding the primary and re-read. Exercises the commit +
+     * catalog replay path over a LIST column — a lost or mis-sized offsets buffer would surface as
+     * a read failure or altered values after recovery rather than at write time.
+     */
+    public void testArraysSurviveNodeRestartRecovery() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("before restart");
+
+        internalCluster().restartRandomDataNode();
+        ensureGreen(MV_INDEX);
+
+        assertArraysIntact("after node restart recovery");
+    }
+
+    /**
+     * A {@code BackgroundIndexer} whose documents carry a multi-valued {@code tags} array, so
+     * concurrent load exercises the LIST write path (VSR rotation, offsets growth) rather than only
+     * flat columns. Every document's array is derived from its id so the expected contents are
+     * recomputable at verification time.
+     */
+    private static final class MultiValueIndexer extends org.opensearch.test.BackgroundIndexer {
+        MultiValueIndexer(String index, org.opensearch.transport.client.Client client, int writerCount) {
+            super(index, "_doc", client, -1, writerCount, false, random());
+        }
+
+        /** The array document {@code id} is indexed with — varies length 0..3 including duplicates. */
+        static List<String> tagsFor(long id) {
+            int shape = (int) Math.floorMod(id, 4L);
+            return switch (shape) {
+                case 0 -> List.of();
+                case 1 -> List.of("t" + id);
+                case 2 -> List.of("t" + id, "dup", "dup");
+                default -> List.of("a" + id, "b" + id, "c" + id);
+            };
+        }
+
+        @Override
+        protected org.opensearch.core.xcontent.XContentBuilder generateSource(long id, java.util.Random random) throws java.io.IOException {
+            org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+            builder.startObject().field("id", Long.toString(id));
+            builder.startArray("tags");
+            for (String tag : tagsFor(id)) {
+                builder.value(tag);
+            }
+            builder.endArray();
+            return builder.endObject();
+        }
+    }
+
+    /**
+     * Peer recovery of a LIST column while indexing continues.
+     *
+     * <p>Recovery under load is the case the stop-then-recover test cannot reach: the replica is
+     * built from a catalog that is still advancing, so a generation can be shipped while the
+     * primary's active VSR is mid-list (offsets written, values not yet complete). Asserts the
+     * replica converges on the primary's parquet files and that no acknowledged write was lost.
+     */
+    public void testArraysSurviveConcurrentIndexingDuringPeerRecovery() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        try (MultiValueIndexer indexer = new MultiValueIndexer(MV_INDEX, client(), scaledRandomIntBetween(2, 4))) {
+            indexer.setUseAutoGeneratedIDs(true);
+            indexer.start(-1);
+            waitForIndexerDocs(200, indexer);
+
+            // Adding a replica while writes are in flight triggers peer recovery under load.
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(MV_INDEX)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+                .get();
+
+            indexer.continueIndexing(200);
+            ensureGreen(MV_INDEX);
+            indexer.stopAndAwaitStopped();
+
+            // No acknowledged write may be lost, and the replica must hold the same parquet files.
+            indexer.assertNoFailures();
+            assertTrue("indexing must have made progress", indexer.totalIndexedDocs() > 0);
+            client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+            assertReplicaCatalogConverged();
+        }
+    }
+
+    /**
+     * Partial write failure across the two formats must leave neither format holding the document.
+     *
+     * <p>A composite write calls the primary (parquet) then each secondary (lucene) in turn and
+     * rolls back every writer it touched if any one fails (CompositeWriter#addDoc). A term
+     * longer than Lucene's {@code IndexWriter.MAX_TERM_LENGTH} (32766 bytes) fails only in the
+     * secondary, after parquet has already accepted the row and — for a multi-valued field — after
+     * its list offsets have been advanced. The rollback therefore has to rewind a partially written
+     * LIST cell, which is the failure mode a flat column cannot exercise. Subsequent good documents
+     * must still index and read back correctly, proving the VSR was left consistent rather than
+     * merely not crashing.
+     */
+    public void testPartialWriteFailureAcrossFormatsRollsBackBothFormats() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        // One good document first, so the VSR already holds a completed list row.
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("before partial failure");
+        int acceptedBefore = idToFixture.size();
+
+        // A multi-valued document whose SECOND element exceeds Lucene's max term length: parquet
+        // accepts the row (no term limit), lucene rejects it, so the composite writer must roll back.
+        String hugeTerm = randomAlphaOfLength(40000);
+        org.opensearch.action.index.IndexRequestBuilder bad = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"bad\",\"tags\":[\"ok\",\"" + hugeTerm + "\"]}", XContentType.JSON);
+        Exception failure = expectThrows(Exception.class, bad::get);
+        assertNotNull("oversized term must fail the write", failure);
+
+        // The rejected document must exist in NEITHER format: a subsequent read of every previously
+        // acknowledged document still returns its own values, and the doc count has not grown.
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("after rolled-back partial failure");
+        assertEquals("rolled-back document must not be acknowledged", acceptedBefore, idToFixture.size());
+
+        // The writer must still accept good documents after the rollback — proving the VSR's list
+        // offsets were rewound rather than left pointing into a half-written cell.
+        idToFixture.clear();
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after resuming writes post-rollback");
+    }
+
+    /** Waits until every started replica's catalog holds the same parquet files as the primary. */
+    private void assertReplicaCatalogConverged() throws Exception {
+        assertBusy(() -> {
+            org.opensearch.cluster.routing.IndexShardRoutingTable routing = getClusterState().routingTable().index(MV_INDEX).shard(0);
+            String primaryNode = getClusterState().nodes().get(routing.primaryShard().currentNodeId()).getName();
+            org.opensearch.index.shard.IndexShard primary = getIndexShard(primaryNode, MV_INDEX);
+            java.util.Set<String> primaryFiles = DataFormatAwareITUtils.catalogFilesExcludingSegments(primary);
+            assertFalse("primary must have parquet files in its catalog", primaryFiles.isEmpty());
+            for (org.opensearch.cluster.routing.ShardRouting r : routing.replicaShards()) {
+                assertTrue("replica must be started", r.started());
+                String replicaNode = getClusterState().nodes().get(r.currentNodeId()).getName();
+                org.opensearch.index.shard.IndexShard replica = getIndexShard(replicaNode, MV_INDEX);
+                assertEquals(
+                    "primary/replica catalog files must converge on " + replicaNode,
+                    primaryFiles,
+                    DataFormatAwareITUtils.catalogFilesExcludingSegments(replica)
+                );
+            }
+        }, 60, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    /**
+     * Null elements inside an array are dropped, so the stored list is shorter than the JSON.
+     *
+     * <p>{@code KeywordFieldMapper.parseCreateFieldForPluggableFormat} returns early when the parsed
+     * value is null, so a null element never reaches {@code addField} and never becomes a list
+     * element. This matches Lucene, which indexes no term for a null, and it means
+     * {@code array_length(["a",null,"b"])} is 2 — pinned here because the alternative (a null
+     * element preserved in the list) would be an equally defensible design and should not change
+     * silently. A configured {@code null_value} substitutes instead and IS stored.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullElementsInsideArrayAreDropped() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"nulls\",\"tags\":[\"a\",null,\"b\",null]}", XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        Object tags = source.get("tags");
+        List<String> got = tags == null ? List.of() : ((List<Object>) tags).stream().map(String::valueOf).toList();
+        assertEquals("null elements are dropped, not preserved as null list entries", List.of("a", "b"), got);
+    }
+
+    /**
+     * A single document whose array is far larger than the per-row average the VSR sizes for.
+     *
+     * <p>VSR rotation is driven by ROW count ({@code index.parquet.max_rows_per_vsr}), not by bytes,
+     * so one pathological array grows the child vector without triggering a rotation — the case
+     * where a row-count-based memory bound does not hold. Verifies the write completes and every
+     * element survives the flush rather than being truncated at some buffer boundary.
+     */
+    @SuppressWarnings("unchecked")
+    public void testVeryLargeArrayInSingleDocument() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        int elementCount = 50_000;
+        StringBuilder json = new StringBuilder("{\"id\":\"big\",\"tags\":[");
+        for (int i = 0; i < elementCount; i++) {
+            if (i > 0) json.append(",");
+            json.append("\"v").append(i).append("\"");
+        }
+        json.append("]}");
+
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource(json.toString(), XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        List<Object> tags = (List<Object>) source.get("tags");
+        assertNotNull("large array must be stored", tags);
+        assertEquals("every element must survive", elementCount, tags.size());
+        assertEquals("first element", "v0", String.valueOf(tags.get(0)));
+        assertEquals("last element", "v" + (elementCount - 1), String.valueOf(tags.get(elementCount - 1)));
+    }
+
+    /**
+     * A {@code multi_value} field added by a mapping update on a live index.
+     *
+     * <p>This is the {@code VSRManager.reconcileSchema} path: the new field's vector is created on
+     * the already-active VSR. That code previously rebuilt each Arrow field from name + FieldType
+     * and dropped {@code getChildren()}, which left a LIST column with no element vector to write
+     * into — a bug only a dynamically-added multi-valued field reaches, since an index created with
+     * the field gets its children from the initial schema.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMultiValueFieldAddedByMappingUpdate() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        // Create WITHOUT the tags field.
+        client().admin()
+            .indices()
+            .prepareCreate(MV_INDEX)
+            .setSettings(mvIndexSettings(0))
+            .setMapping("{\"properties\":{\"id\":{\"type\":\"keyword\"}}}")
+            .get();
+        ensureGreen(MV_INDEX);
+
+        // A document in the original schema, so the VSR is already active when the mapping changes.
+        client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"before\"}", XContentType.JSON)
+            .get();
+
+        client().admin()
+            .indices()
+            .preparePutMapping(MV_INDEX)
+            .setSource("{\"properties\":{\"tags\":{\"type\":\"keyword\",\"multi_value\":true}}}", XContentType.JSON)
+            .get();
+
+        // Writing the newly-added LIST column exercises reconcileSchema's child preservation.
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"after\",\"tags\":[\"p\",\"q\",\"p\"]}", XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        Object tags = source.get("tags");
+        assertNotNull("dynamically added multi_value field must be stored", tags);
+        assertEquals(
+            "values written into a dynamically added LIST column must survive",
+            List.of("p", "q", "p"),
+            ((List<Object>) tags).stream().map(String::valueOf).toList()
+        );
+    }
+
+    /**
+     * A bulk request interleaving valid and invalid multi-valued documents.
+     *
+     * <p>The single-document partial-failure test proves the rollback undoes one row. Bulk is the
+     * realistic ingest path and is stricter: {@code CompositeWriter} rolls each touched writer back
+     * to the composite's running {@code acceptedRows}, so within one batch every rejected item must
+     * rewind to exactly the count its predecessors established. An off-by-one there would corrupt
+     * the neighbours in the same batch rather than the failing document — and for a LIST column it
+     * would also leave the child vector's offsets pointing past the surviving rows.
+     *
+     * <p>Invalid items carry a {@code tags} element over Lucene's {@code MAX_TERM_LENGTH}: parquet
+     * accepts the row (advancing list offsets) and lucene rejects it, so the failure is asymmetric
+     * across the two formats. The valid neighbours must all be acknowledged with their arrays
+     * exactly intact, and the invalid ones must appear in neither format.
+     *
+     * <p>Scope note: this asserts the OUTCOME (neighbours intact, writes resume). It does not by
+     * itself pin the rollback arithmetic — injecting {@code rollbackTo(target + 1)} leaves this test
+     * green, because {@code ParquetWriter.rollbackTo} rejects a target above its own
+     * {@code acceptedRows} only when it exceeds it, and after the failing doc the composite's target
+     * happens to equal the writer's count. The arithmetic itself is guarded there by explicit
+     * range checks ("Cannot rollback to N: only M rows admitted" and the exactly-one-doc limit)
+     * and is covered by unit tests on {@code ParquetWriter}/{@code VSRManager}; the mutation is
+     * therefore masked by those guards rather than by a gap in coverage.
+     */
+    @SuppressWarnings("unchecked")
+    public void testBulkWithMixedValidAndInvalidArrayDocuments() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        String hugeTerm = randomAlphaOfLength(40000);
+        // Interleave good/bad so a bad item sits first, between, and last — each position exercises
+        // a different neighbour relationship for the rollback.
+        List<List<String>> goodArrays = List.of(List.of("g0", "dup", "dup"), List.of("g1"), List.of(), List.of("g3", "x", "y", "z"));
+
+        org.opensearch.action.bulk.BulkRequestBuilder bulk = client().prepareBulk();
+        // bad, good0, good1, bad, good2, good3, bad
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad0\",\"tags\":[\"" + hugeTerm + "\"]}", XContentType.JSON));
+        bulk.add(goodRequest("g0", goodArrays.get(0)));
+        bulk.add(goodRequest("g1", goodArrays.get(1)));
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad1\",\"tags\":[\"ok\",\"" + hugeTerm + "\"]}", XContentType.JSON));
+        bulk.add(goodRequest("g2", goodArrays.get(2)));
+        bulk.add(goodRequest("g3", goodArrays.get(3)));
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad2\",\"tags\":[\"" + hugeTerm + "\"]}", XContentType.JSON));
+
+        org.opensearch.action.bulk.BulkResponse response = bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        assertTrue("the oversized-term items must fail", response.hasFailures());
+
+        // Collect the ids the cluster actually acknowledged, keyed by the logical id in the source.
+        Map<String, String> ackedIdByLogical = new java.util.HashMap<>();
+        int failed = 0;
+        for (org.opensearch.action.bulk.BulkItemResponse item : response.getItems()) {
+            if (item.isFailed()) {
+                failed++;
+            } else {
+                ackedIdByLogical.put(logicalIdOf(item.getId()), item.getId());
+            }
+        }
+        assertEquals("exactly the three oversized items must fail", 3, failed);
+        assertEquals("every valid item must be acknowledged", goodArrays.size(), ackedIdByLogical.size());
+
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        // Each surviving neighbour must carry exactly its own array — this is what an off-by-one
+        // rollback inside the batch would break.
+        for (int i = 0; i < goodArrays.size(); i++) {
+            String logical = "g" + i;
+            String docId = ackedIdByLogical.get(logical);
+            assertNotNull("valid document [" + logical + "] must have been acknowledged", docId);
+            Map<String, Object> source = client().prepareGet(MV_INDEX, docId).setRealtime(false).get().getSourceAsMap();
+            Object tags = source.get("tags");
+            List<String> got = tags == null ? List.of() : ((List<Object>) tags).stream().map(String::valueOf).toList();
+            assertEquals("bulk neighbour [" + logical + "] lost or gained values", goodArrays.get(i), got);
+        }
+
+        // Writes must still work afterwards, proving the VSR was left consistent.
+        idToFixture.clear();
+        indexFixtures(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after bulk with rejected items");
+    }
+
+    /** Builds a valid multi-valued index request whose source carries {@code logicalId}. */
+    private org.opensearch.action.index.IndexRequestBuilder goodRequest(String logicalId, List<String> tags) {
+        StringBuilder json = new StringBuilder("{\"id\":\"").append(logicalId).append("\",\"tags\":[");
+        for (int i = 0; i < tags.size(); i++) {
+            if (i > 0) json.append(",");
+            json.append("\"").append(tags.get(i)).append("\"");
+        }
+        json.append("]}");
+        return client().prepareIndex(MV_INDEX).setSource(json.toString(), XContentType.JSON);
+    }
+
+    /** Reads the logical {@code id} field back out of an acknowledged document. */
+    private String logicalIdOf(String docId) {
+        return String.valueOf(client().prepareGet(MV_INDEX, docId).setRealtime(true).get().getSourceAsMap().get("id"));
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
@@ -11,6 +11,8 @@ package org.opensearch.parquet;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.index.IndexCreationValidator;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IndexSortConfig;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 
@@ -38,11 +40,41 @@ public class ParquetIndexCreationValidator implements IndexCreationValidator {
             );
         }
 
-        if (!isParquetIndex || !hasParquetSettings) {
+        if (!isParquetIndex) {
             return;
         }
 
+        validateSortFieldsAreSingleValued(mapperService, indexSettings);
+
+        // Building the schema validates the mapping's `multi_value` declarations: getSchema throws
+        // for a field whose type has no list support, turning what would otherwise be a
+        // per-document indexing failure into an immediate error at creation time.
         Schema schema = ArrowSchemaBuilder.getSchema(mapperService);
-        ParquetSettings.validateFieldConfigurations(fieldEncodings, fieldCompressions, fieldBloomFilterEnabled, schema);
+        if (hasParquetSettings) {
+            ParquetSettings.validateFieldConfigurations(fieldEncodings, fieldCompressions, fieldBloomFilterEnabled, schema);
+        }
+    }
+
+    /**
+     * Rejects {@code index.sort.field} entries that are mapped {@code multi_value: true}.
+     * <p>
+     * An index sort needs one total order over rows, but a multi-valued cell has no canonical
+     * scalar to order by — any of min/max/lexicographic would be a silent choice the user never
+     * made. Lucene rejects index sorting on multi-valued fields for the same reason; failing here
+     * keeps parity and turns what would otherwise be a merge-time failure (the native k-way merge
+     * cannot compare LIST sort keys) into an immediate, actionable error at creation time.
+     */
+    private static void validateSortFieldsAreSingleValued(MapperService mapperService, IndexSettings indexSettings) {
+        for (String sortField : IndexSortConfig.INDEX_SORT_FIELD_SETTING.get(indexSettings.getSettings())) {
+            MappedFieldType fieldType = mapperService.fieldType(sortField);
+            if (fieldType != null && fieldType.isMultiValued()) {
+                throw new IllegalArgumentException(
+                    "Cannot use field ["
+                        + sortField
+                        + "] in [index.sort.field]: the field is mapped [multi_value: true] and a "
+                        + "multi-valued field has no single value to sort on"
+                );
+            }
+        }
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -786,6 +786,18 @@ public final class ParquetSettings {
     }
 
     /**
+     * Returns the type that encoding and compression settings apply to for a field. For a LIST
+     * column that is the element type, because Parquet encodes the leaf, not the list wrapper —
+     * validating against {@code ArrowType.List} would wrongly accept every encoding.
+     */
+    private static ArrowType elementTypeOf(Field field) {
+        if (field.getType() instanceof ArrowType.List && field.getChildren().isEmpty() == false) {
+            return field.getChildren().get(0).getType();
+        }
+        return field.getType();
+    }
+
+    /**
      * Validates that field-level configurations are compatible with their Arrow types in the schema.
      */
     public static void validateFieldConfigurations(
@@ -796,7 +808,7 @@ public final class ParquetSettings {
     ) {
         Map<String, ArrowType> arrowTypes = new HashMap<>();
         for (Field field : schema.getFields()) {
-            arrowTypes.put(field.getName(), field.getType());
+            arrowTypes.put(field.getName(), elementTypeOf(field));
         }
 
         // Validate encoding configurations

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
@@ -14,9 +14,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.FieldMapper;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NestedPathFieldMapper;
@@ -39,8 +41,13 @@ public final class ArrowSchemaBuilder {
 
     /**
      * Creates an Arrow Schema from the MapperService.
-     * @param mapperService the mapper service containing field mappings
+     *
+     * <p>A field whose mapper declares {@code multi_value: true}
+     * ({@link MappedFieldType#isMultiValued()}) is emitted as a {@code LIST<element>} column;
+     * every other field keeps its scalar column.
      * TODO - Get the mapping version while creating the schema
+     *
+     * @param mapperService the mapper service containing field mappings
      */
     public static Schema getSchema(MapperService mapperService) {
         Objects.requireNonNull(mapperService, "MapperService cannot be null");
@@ -55,8 +62,18 @@ public final class ArrowSchemaBuilder {
 
                 ParquetField parquetField = ArrowFieldRegistry.getParquetField(mapper.typeName());
                 if (parquetField != null) {
-                    fields.add(new Field(mapper.name(), parquetField.getFieldType(), null));
-                    handleNormalizedField(mapper, documentMapper, fields, parquetField);
+                    boolean multiValue = isMultiValued(mapper);
+                    if (multiValue && parquetField.supportsMultiValue() == false) {
+                        throw new IllegalArgumentException(
+                            "Field ["
+                                + mapper.name()
+                                + "] of type ["
+                                + mapper.typeName()
+                                + "] does not support [multi_value] storage in the parquet data format"
+                        );
+                    }
+                    fields.add(parquetField.toArrowField(mapper.name(), multiValue));
+                    handleNormalizedField(mapper, documentMapper, fields, parquetField, multiValue);
                 } else {
                     logger.debug("No ParquetField registered for field: [{}] of type [{}]", mapper.name(), mapper.typeName());
                 }
@@ -69,13 +86,26 @@ public final class ArrowSchemaBuilder {
         return new Schema(fields);
     }
 
-    private static void handleNormalizedField(Mapper mapper, DocumentMapper documentMapper, List<Field> fields, ParquetField parquetField) {
+    private static void handleNormalizedField(
+        Mapper mapper,
+        DocumentMapper documentMapper,
+        List<Field> fields,
+        ParquetField parquetField,
+        boolean multiValue
+    ) {
         if (mapper instanceof KeywordFieldMapper keywordFieldMapper) {
             if (!documentMapper.mappers().isMultiField(mapper.name()) && keywordFieldMapper.getRawValueFieldType() != null) {
                 KeywordFieldMapper.KeywordFieldType rawValueField = keywordFieldMapper.getRawValueFieldType();
-                fields.add(new Field(rawValueField.name(), parquetField.getFieldType(), null));
+                // The raw-value companion holds the pre-normalization source for derived source, so
+                // it must mirror the parent's cardinality or source reconstruction would lose values.
+                fields.add(parquetField.toArrowField(rawValueField.name(), multiValue));
             }
         }
+    }
+
+    /** Reads the {@code multi_value} declaration from the mapper's field type. */
+    private static boolean isMultiValued(Mapper mapper) {
+        return mapper instanceof FieldMapper fieldMapper && fieldMapper.fieldType().isMultiValued();
     }
 
     private static boolean isUnsupportedMetadataField(Mapper mapper) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -8,12 +8,16 @@
 
 package org.opensearch.parquet.fields;
 
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.vsr.ManagedVSR;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -21,6 +25,12 @@ import java.util.Set;
  * between OpenSearch field types and Apache Arrow vectors.
  */
 public abstract class ParquetField {
+
+    /**
+     * Name of the child field inside a LIST column. Matches the parquet-rs convention
+     * ({@code PARQUET_LIST_ELEMENT_NAME}) so the leaf path is {@code <field>.list.element}.
+     */
+    public static final String LIST_ELEMENT_NAME = "element";
 
     /** Creates a new ParquetField. */
     public ParquetField() {}
@@ -34,6 +44,67 @@ public abstract class ParquetField {
     protected abstract void addToGroup(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue);
 
     /**
+     * Writes a single parsed value at an explicit index in the given vector.
+     * <p>
+     * Scalar columns write at the row index, so {@link #addToGroup} can derive the position from
+     * the VSR's row count. List columns write several values per row at positions in the child
+     * vector that have nothing to do with the row number, so multi-value writes need this
+     * index-explicit form instead.
+     * <p>
+     * Subclasses must override this to support being declared multi-valued; the default throws.
+     * When overridden, {@link #addToGroup} should delegate to it so the scalar and list paths
+     * share one value-coercion implementation.
+     *
+     * @param vector the target vector (the child data vector when writing into a list)
+     * @param index the position to write at
+     * @param parseValue the parsed value to write
+     */
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        throw new UnsupportedOperationException(
+            "Field type [" + getClass().getSimpleName() + "] does not support multi-valued (list) storage"
+        );
+    }
+
+    /**
+     * Returns whether this field can be stored as a Parquet LIST column, i.e. whether it
+     * implements {@link #addToVector}.
+     *
+     * @return true if multi-valued storage is supported
+     */
+    public boolean supportsMultiValue() {
+        return false;
+    }
+
+    /**
+     * Builds the Arrow field describing this column, including any child fields.
+     * <p>
+     * When {@code multiValue} is true the result is a {@code LIST<element>} whose child carries
+     * this field's element type, so the same {@link ParquetField} describes both shapes.
+     *
+     * @param name the Arrow field name
+     * @param multiValue whether to wrap the element type in a list
+     * @return the Arrow field
+     */
+    public final Field toArrowField(String name, boolean multiValue) {
+        if (multiValue == false) {
+            return new Field(name, getFieldType(), null);
+        }
+        if (supportsMultiValue() == false) {
+            throw new IllegalArgumentException(
+                "Field ["
+                    + name
+                    + "] cannot be stored as multi-valued: type ["
+                    + getClass().getSimpleName()
+                    + "] does not support list storage"
+            );
+        }
+        // The element is always nullable: a null inside an array (e.g. ["a", null]) is a legal
+        // document even when the column itself is declared non-nullable.
+        Field element = new Field(LIST_ELEMENT_NAME, FieldType.nullable(getArrowType()), null);
+        return new Field(name, FieldType.nullable(ArrowType.List.INSTANCE), List.of(element));
+    }
+
+    /**
      * Creates and processes a field entry. Throws if vector not present in VSR.
      * @param fieldType the mapped field type
      * @param managedVSR the managed vector schema root
@@ -42,7 +113,39 @@ public abstract class ParquetField {
     public final void createField(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue) {
         assert fieldType != null : "MappedFieldType cannot be null";
         assert managedVSR != null : "ManagedVSR cannot be null";
+        FieldVector vector = managedVSR.getVector(fieldType.name());
+        if (vector instanceof ListVector listVector) {
+            writeList(fieldType, managedVSR, listVector, parseValue);
+            return;
+        }
         addToGroup(fieldType, managedVSR, parseValue);
+    }
+
+    /**
+     * Writes all values collected for one document into a list column at the current row.
+     * <p>
+     * A null {@code parseValue} is written as a null list, which is how an absent field is
+     * represented. An empty list is written as a zero-length, non-null list, preserving the
+     * distinction between {@code "tags": []} and no {@code tags} at all.
+     */
+    private void writeList(MappedFieldType fieldType, ManagedVSR managedVSR, ListVector listVector, Object parseValue) {
+        int row = managedVSR.getRowCount();
+        if (parseValue == null) {
+            listVector.setNull(row);
+            return;
+        }
+        List<?> values = parseValue instanceof List<?> list ? list : List.of(parseValue);
+        int start = listVector.startNewValue(row);
+        FieldVector dataVector = listVector.getDataVector();
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
+            if (value == null) {
+                dataVector.setNull(start + i);
+            } else {
+                addToVector(dataVector, start + i, value);
+            }
+        }
+        listVector.endValue(row, values.size());
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -27,10 +28,17 @@ public class KeywordParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((VarCharVector) vector).setSafe(index, parseValue.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -192,9 +192,9 @@ public class VSRManager implements AutoCloseable {
      * Transfers collected fields from the document input into the active VSR
      * using the ArrowFieldRegistry to resolve typed vector writes.
      * <p>
-     * Single-value semantics are enforced at the {@link ParquetDocumentInput} layer:
-     * if an array field produces multiple values for the same field type, only the
-     * last value is retained (last-value-wins).
+     * Cardinality is decided at the {@link ParquetDocumentInput} layer: fields mapped with
+     * {@code multi_value: true} accumulate every value into one list-valued pair,
+     * and all other fields still reject a second value.
      *
      * @param doc the document input containing field-value pairs
      */
@@ -367,8 +367,9 @@ public class VSRManager implements AutoCloseable {
         boolean changed = false;
         for (Field schemaField : newSchema.getFields()) {
             if (activeVSR.getVector(schemaField.getName()) == null) {
-                Field field = new Field(schemaField.getName(), schemaField.getFieldType(), null);
-                activeVSR.addFieldVector(field);
+                // Pass the schema field through as-is: rebuilding it from name + FieldType alone
+                // would drop getChildren(), leaving a LIST column with no element vector.
+                activeVSR.addFieldVector(schemaField);
                 changed = true;
             }
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -10,24 +10,33 @@ package org.opensearch.parquet.writer;
 
 import org.opensearch.index.mapper.MappedFieldType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * Immutable pair of an OpenSearch {@link MappedFieldType} and its parsed value.
+ * Pair of an OpenSearch {@link MappedFieldType} and the value(s) parsed for it.
  *
  * <p>Represents a single field entry collected by {@link ParquetDocumentInput} during
  * document indexing. The field type is used to resolve the corresponding Arrow vector
  * type via {@link org.opensearch.parquet.fields.ArrowFieldRegistry}, and the value is
  * written into that vector during document transfer to the VSR.
  *
- * <p>The field type must not be null (enforced by constructor); the value may be null
+ * <p>Scalar pairs are immutable and hold exactly one value. Pairs created via
+ * {@link #multiValued} back a Parquet LIST column and accumulate values as the document parser
+ * reports each array element, so {@link #getValue()} returns a {@code List} for those — including
+ * a single-element list when the document happened to supply one value.
+ *
+ * <p>The field type must not be null (enforced by constructor); values may be null
  * for nullable fields.
  */
 public class FieldValuePair {
 
     private final MappedFieldType fieldType;
     private final Object value;
+    private final List<Object> values;
 
     /**
-     * Creates a new FieldValuePair.
+     * Creates a single-valued FieldValuePair.
      *
      * @param fieldType the mapped field type
      * @param value the parsed field value
@@ -38,6 +47,52 @@ public class FieldValuePair {
         }
         this.fieldType = fieldType;
         this.value = value;
+        this.values = null;
+    }
+
+    private FieldValuePair(MappedFieldType fieldType, List<Object> values) {
+        if (fieldType == null) {
+            throw new IllegalArgumentException("fieldType cannot be null");
+        }
+        this.fieldType = fieldType;
+        this.value = null;
+        this.values = values;
+    }
+
+    /**
+     * Creates a multi-valued FieldValuePair seeded with its first value. Further values are
+     * appended via {@link #addValue}, preserving document order and any duplicates.
+     *
+     * @param fieldType the mapped field type
+     * @param firstValue the first parsed value
+     * @return a multi-valued pair
+     */
+    public static FieldValuePair multiValued(MappedFieldType fieldType, Object firstValue) {
+        List<Object> values = new ArrayList<>(1);
+        values.add(firstValue);
+        return new FieldValuePair(fieldType, values);
+    }
+
+    /**
+     * Appends another value. Only valid on a multi-valued pair.
+     *
+     * @param nextValue the value to append
+     */
+    public void addValue(Object nextValue) {
+        if (values == null) {
+            throw new IllegalStateException("Cannot add a value to a single-valued FieldValuePair for [" + fieldType.name() + "]");
+        }
+        values.add(nextValue);
+    }
+
+    /** Returns whether this pair accumulates multiple values into a list column. */
+    public boolean isMultiValued() {
+        return values != null;
+    }
+
+    /** Returns the number of values held: always 1 for a scalar pair. */
+    public int valueCount() {
+        return values == null ? 1 : values.size();
     }
 
     /**
@@ -50,11 +105,12 @@ public class FieldValuePair {
     }
 
     /**
-     * Returns the value.
+     * Returns the value: the single parsed value, or the {@code List} of values for a
+     * multi-valued pair.
      *
-     * @return the parsed field value
+     * @return the parsed field value(s)
      */
     public Object getValue() {
-        return value;
+        return values != null ? values : value;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -22,9 +22,16 @@ import java.util.List;
  * written into that vector during document transfer to the VSR.
  *
  * <p>Scalar pairs are immutable and hold exactly one value. Pairs created via
- * {@link #multiValued} back a Parquet LIST column and accumulate values as the document parser
- * reports each array element, so {@link #getValue()} returns a {@code List} for those — including
- * a single-element list when the document happened to supply one value.
+ * {@link #multiValued} back a Parquet LIST column and are <em>mutable</em>: {@link #addValue}
+ * appends as the document parser reports each array element, so {@link #getValue()} returns a
+ * {@code List} for those — including a single-element list when the document supplied one value, or
+ * an empty list for an explicit empty array via {@link #emptyMultiValued}.
+ *
+ * <p>Because multi-valued pairs grow during parsing, a reference must not be read until the
+ * document is finalized. The sole consumer, {@code VSRManager#addDocument}, reads only through
+ * {@link ParquetDocumentInput#getFinalInput()} after the whole document has been parsed, so no
+ * caller observes a partially populated list. Do not cache or hand a pair across threads before
+ * then.
  *
  * <p>The field type must not be null (enforced by constructor); values may be null
  * for nullable fields.

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -74,6 +74,18 @@ public class FieldValuePair {
     }
 
     /**
+     * Creates a multi-valued FieldValuePair holding zero values, representing an explicit empty
+     * array ({@code "field": []}). It backs a zero-length, non-null LIST cell, which reads back as
+     * {@code []} and so stays distinct from an absent field (a null cell).
+     *
+     * @param fieldType the mapped field type
+     * @return an empty multi-valued pair
+     */
+    public static FieldValuePair emptyMultiValued(MappedFieldType fieldType) {
+        return new FieldValuePair(fieldType, new ArrayList<>(0));
+    }
+
+    /**
      * Appends another value. Only valid on a multi-valued pair.
      *
      * @param nextValue the value to append

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -21,9 +21,9 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -40,7 +40,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    private final Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Map<MappedFieldType, FieldValuePair> seen = new IdentityHashMap<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,12 +54,27 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-        if (dedup.add(fieldType) == false) {
+        FieldValuePair existing = seen.get(fieldType);
+        if (existing == null) {
+            // Fields declared `multi_value: true` in the mapping start out as a list of one so the
+            // value shape reaching the VSR is the same whether the document had one value or several.
+            FieldValuePair pair = fieldType.isMultiValued()
+                ? FieldValuePair.multiValued(fieldType, value)
+                : new FieldValuePair(fieldType, value);
+            seen.put(fieldType, pair);
+            collectedFields.add(pair);
+            return;
+        }
+        if (existing.isMultiValued() == false) {
             throw new MapperParsingException(
-                "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
+                "Cannot accept multiple values for field: ["
+                    + fieldType.name()
+                    + "] of type: ["
+                    + fieldType.typeName()
+                    + "]. Set [multi_value: true] on the field mapping to store multiple values."
             );
         }
-        collectedFields.add(new FieldValuePair(fieldType, value));
+        existing.addValue(value);
     }
 
     @Override
@@ -84,13 +99,19 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     @Override
     public long getFieldCount(String fieldName) {
-        return collectedFields.stream().filter(fvp -> fvp.getFieldType().name().equals(fieldName)).count();
+        // Counts values, not entries: a multi-valued field is one entry holding N values, and
+        // callers (single-value assertions below, the data-stream @timestamp check) mean values.
+        return collectedFields.stream()
+            .filter(fvp -> fvp.getFieldType().name().equals(fieldName))
+            .mapToLong(FieldValuePair::valueCount)
+            .sum();
     }
 
     @Override
     public void close() {
         isClosed = true;
         collectedFields.clear();
+        seen.clear();
         rowId = -1;
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -21,7 +21,7 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +40,12 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    private final Map<MappedFieldType, FieldValuePair> seen = new IdentityHashMap<>();
+    // Keyed by field name, not field-type identity: within a single document parse each logical
+    // field (including the derived-source `_ignored_source.*` companion) has a unique name, while
+    // identity would silently miss a match if the parser ever handed back a fresh wrapper per array
+    // element — degrading a multi_value field to last-value-wins or bypassing the scalar duplicate
+    // guard. Name keying makes accumulation robust to that.
+    private final Map<String, FieldValuePair> seen = new HashMap<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,7 +59,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-        FieldValuePair existing = seen.get(fieldType);
+        FieldValuePair existing = seen.get(fieldType.name());
         if (existing == null) {
             // Fields declared `multi_value: true` in the mapping start out as a list of one so the
             // value shape reaching the VSR is the same whether the document had one value or several.
@@ -68,7 +73,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             } else {
                 pair = new FieldValuePair(fieldType, value);
             }
-            seen.put(fieldType, pair);
+            seen.put(fieldType.name(), pair);
             collectedFields.add(pair);
             return;
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -58,9 +58,16 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
         if (existing == null) {
             // Fields declared `multi_value: true` in the mapping start out as a list of one so the
             // value shape reaching the VSR is the same whether the document had one value or several.
-            FieldValuePair pair = fieldType.isMultiValued()
-                ? FieldValuePair.multiValued(fieldType, value)
-                : new FieldValuePair(fieldType, value);
+            // An explicit empty array (`"field": []`) is signalled by an empty List and seeds a
+            // zero-value pair, so its LIST cell is written empty-but-non-null rather than null.
+            final FieldValuePair pair;
+            if (fieldType.isMultiValued()) {
+                pair = value instanceof List<?> list && list.isEmpty()
+                    ? FieldValuePair.emptyMultiValued(fieldType)
+                    : FieldValuePair.multiValued(fieldType, value);
+            } else {
+                pair = new FieldValuePair(fieldType, value);
+            }
             seen.put(fieldType, pair);
             collectedFields.add(pair);
             return;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -66,6 +66,34 @@ pub fn read_format_version(metadata: &FileMetaData) -> String {
 /// - **Dependency Inversion**: Depends on NativeSettings abstraction
 pub struct WriterPropertiesBuilder;
 
+/// Returns the type that column properties apply to. Parquet encodes a LIST column's leaf, not
+/// the list wrapper, so encoding/compression decisions must be made on the element type.
+fn effective_type(dt: &arrow::datatypes::DataType) -> &arrow::datatypes::DataType {
+    use arrow::datatypes::DataType::*;
+    match dt {
+        List(f) | LargeList(f) | FixedSizeList(f, _) => effective_type(f.data_type()),
+        other => other,
+    }
+}
+
+/// Builds the parquet `ColumnPath` for a top-level Arrow field.
+///
+/// `ColumnPath::from(String)` yields a single-segment path, which only matches primitive columns.
+/// A LIST column's leaf lives at `<field>.list.element`, so per-column encoding, compression, and
+/// bloom-filter settings silently no-op for lists unless the full path is spelled out. The
+/// `list`/`element` segment names match what the arrow-rs writer emits for `DataType::List`.
+fn column_path_for(field: &arrow::datatypes::Field) -> parquet::schema::types::ColumnPath {
+    use arrow::datatypes::DataType::*;
+    let mut parts = vec![field.name().clone()];
+    let mut current = field.data_type();
+    while let List(child) | LargeList(child) | FixedSizeList(child, _) = current {
+        parts.push("list".to_string());
+        parts.push(child.name().clone());
+        current = child.data_type();
+    }
+    parquet::schema::types::ColumnPath::new(parts)
+}
+
 /// Maps an Arrow DataType to a lowercase string key used for cluster-level type config lookups.
 fn arrow_type_key(dt: &arrow::datatypes::DataType) -> String {
     use arrow::datatypes::DataType::*;
@@ -196,17 +224,28 @@ impl WriterPropertiesBuilder {
         config: &NativeSettings,
         schema: &ArrowSchema,
     ) -> Result<parquet::file::properties::WriterPropertiesBuilder, String> {
-        let type_map: std::collections::HashMap<&str, (&arrow::datatypes::DataType, String)> =
-            schema
-                .fields()
-                .iter()
-                .map(|f| {
+        // Key config decisions off the element type and address the column by its full leaf path,
+        // so a LIST column is configured like the scalar column of its element type.
+        type FieldEntry<'a> = (
+            &'a arrow::datatypes::DataType,
+            String,
+            parquet::schema::types::ColumnPath,
+        );
+        let type_map: std::collections::HashMap<&str, FieldEntry<'_>> = schema
+            .fields()
+            .iter()
+            .map(|f| {
+                let element_type = effective_type(f.data_type());
+                (
+                    f.name().as_str(),
                     (
-                        f.name().as_str(),
-                        (f.data_type(), arrow_type_key(f.data_type())),
-                    )
-                })
-                .collect();
+                        element_type,
+                        arrow_type_key(element_type),
+                        column_path_for(f),
+                    ),
+                )
+            })
+            .collect();
 
         let mut field_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
         if let Some(fc) = &config.field_configs {
@@ -224,8 +263,8 @@ impl WriterPropertiesBuilder {
                 .as_ref()
                 .and_then(|m| m.get(field_name));
 
-            let (arrow_type, type_key) = match type_map.get(field_name) {
-                Some(v) => (v.0, Some(v.1.as_str())),
+            let (arrow_type, type_key, column_path) = match type_map.get(field_name) {
+                Some(v) => (v.0, Some(v.1.as_str()), v.2.clone()),
                 None => {
                     return Err(format!(
                         "Field '{}' in field_configs does not exist in schema",
@@ -284,17 +323,17 @@ impl WriterPropertiesBuilder {
                         | Encoding::RLE
                 ) {
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), false);
-                    builder = builder.set_column_encoding(field_name.to_string().into(), enc);
+                        builder.set_column_dictionary_enabled(column_path.clone(), false);
+                    builder = builder.set_column_encoding(column_path.clone(), enc);
                 } else if matches!(enc, Encoding::RLE_DICTIONARY) {
                     // RLE_DICTIONARY means use dictionary encoding - just ensure it's enabled
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), true);
+                        builder.set_column_dictionary_enabled(column_path.clone(), true);
                 } else {
                     // PLAIN: explicitly disable dictionary so the writer uses plain encoding
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), false);
-                    builder = builder.set_column_encoding(field_name.to_string().into(), enc);
+                        builder.set_column_dictionary_enabled(column_path.clone(), false);
+                    builder = builder.set_column_encoding(column_path.clone(), enc);
                 }
             }
 
@@ -326,7 +365,7 @@ impl WriterPropertiesBuilder {
                 };
 
             if let Some(comp) = compression {
-                builder = builder.set_column_compression(field_name.to_string().into(), comp);
+                builder = builder.set_column_compression(column_path.clone(), comp);
             }
 
             // Bloom filter: field-level > type-level > global. Applied per-column.
@@ -339,7 +378,7 @@ impl WriterPropertiesBuilder {
                 .unwrap_or(config.get_bloom_filter_enabled());
             if bf_enabled {
                 builder =
-                    builder.set_column_bloom_filter_enabled(field_name.to_string().into(), true);
+                    builder.set_column_bloom_filter_enabled(column_path.clone(), true);
                 let bf_fpp = index_cfg
                     .and_then(|fc| fc.bloom_filter_fpp)
                     .or_else(|| {
@@ -348,7 +387,7 @@ impl WriterPropertiesBuilder {
                     })
                     .unwrap_or(config.get_bloom_filter_fpp());
                 builder =
-                    builder.set_column_bloom_filter_fpp(field_name.to_string().into(), bf_fpp);
+                    builder.set_column_bloom_filter_fpp(column_path.clone(), bf_fpp);
                 let bf_ndv = index_cfg
                     .and_then(|fc| fc.bloom_filter_ndv)
                     .or_else(|| {
@@ -357,7 +396,7 @@ impl WriterPropertiesBuilder {
                     })
                     .unwrap_or(config.get_bloom_filter_ndv());
                 builder =
-                    builder.set_column_bloom_filter_ndv(field_name.to_string().into(), bf_ndv);
+                    builder.set_column_bloom_filter_ndv(column_path.clone(), bf_ndv);
             }
         }
         Ok(builder)
@@ -1370,5 +1409,128 @@ mod tests {
             .any(|k| k.key == WRITER_GENERATION_KEY && k.value.as_deref() == Some("42"));
         assert!(has_format, "format_version stamp missing");
         assert!(has_gen, "writer_generation stamp missing");
+    }
+
+    /// A LIST column's leaf lives at `<field>.list.element`; a single-segment path would miss it
+    /// and every per-column setting would silently fall back to defaults.
+    fn list_schema(name: &str, element: ArrowDataType) -> ArrowSchema {
+        let child = std::sync::Arc::new(Field::new("element", element, true));
+        ArrowSchema::new(vec![Field::new(name, ArrowDataType::List(child), true)])
+    }
+
+    fn list_leaf_path(name: &str) -> parquet::schema::types::ColumnPath {
+        parquet::schema::types::ColumnPath::new(vec![
+            name.to_string(),
+            "list".to_string(),
+            "element".to_string(),
+        ])
+    }
+
+    #[test]
+    fn test_list_column_uses_leaf_column_path_for_encoding() {
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "tags".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+
+        assert_eq!(
+            props.encoding(&list_leaf_path("tags")),
+            Some(Encoding::DELTA_BYTE_ARRAY),
+            "encoding must be set on the list leaf path"
+        );
+        // The single-segment path must NOT carry the setting — that was the silent-no-op bug.
+        assert_eq!(
+            props.encoding(&parquet::schema::types::ColumnPath::from("tags")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_list_column_encoding_validated_against_element_type() {
+        // DELTA_BYTE_ARRAY is valid for Utf8 but not Int64. Validation must look through the list
+        // wrapper at the element, otherwise every encoding would be accepted for a list column.
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "nums".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = list_schema("nums", ArrowDataType::Int64);
+        let err = WriterPropertiesBuilder::build(&config, &schema)
+            .expect_err("DELTA_BYTE_ARRAY must be rejected for a list of Int64");
+        assert!(err.contains("not supported"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn test_list_column_resolves_type_level_config_by_element_type() {
+        // A cluster-level `utf8` rule must apply to LIST<Utf8>: the type key is derived from the
+        // element, not from the Debug string of the list wrapper.
+        let mut type_compression = HashMap::new();
+        type_compression.insert("utf8".to_string(), "SNAPPY".to_string());
+        let config = NativeSettings {
+            type_compression_configs: Some(type_compression),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert!(matches!(
+            props.compression(&list_leaf_path("tags")),
+            Compression::SNAPPY
+        ));
+    }
+
+    #[test]
+    fn test_list_column_bloom_filter_on_leaf_path() {
+        let config = NativeSettings {
+            bloom_filter_enabled: Some(true),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert!(
+            props
+                .bloom_filter_properties(&list_leaf_path("tags"))
+                .is_some(),
+            "bloom filter must be enabled on the list leaf path"
+        );
+    }
+
+    #[test]
+    fn test_scalar_column_path_unchanged() {
+        // Regression guard: non-list columns must still be addressed by bare name.
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "name".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = schema_with(vec![("name", ArrowDataType::Utf8)]);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert_eq!(
+            props.encoding(&parquet::schema::types::ColumnPath::from("name")),
+            Some(Encoding::DELTA_BYTE_ARRAY)
+        );
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Merge coverage for multi-valued (Arrow LIST / parquet repeated) columns.
+//!
+//! A LIST column breaks the "one leaf value per row" identity every flat column satisfies, so the
+//! merge path needs its own coverage: the k-way merge slices batches by row, appends a fresh
+//! `__row_id__`, and re-encodes each column through `compute_leaves`. All of that must keep a
+//! repeated column's values grouped with their original row.
+
+use std::fs::File;
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use tempfile::tempdir;
+
+/// Schema: `id` (sort key, Int64) + `tags` (List<Utf8>) + `__row_id__`.
+fn list_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new("__row_id__", DataType::Int64, false),
+    ]))
+}
+
+/// Build a file where row i has `id = ids[i]` and `tags = rows[i]` (None ⇒ null list).
+fn write_list_file(path: &str, ids: &[i64], rows: &[Option<Vec<&str>>]) {
+    assert_eq!(ids.len(), rows.len());
+    let mut values: Vec<Option<String>> = Vec::new();
+    let mut offsets: Vec<i32> = vec![0];
+    let mut validity: Vec<bool> = Vec::new();
+    for r in rows {
+        match r {
+            Some(v) => {
+                for s in v {
+                    values.push(Some((*s).to_string()));
+                }
+                validity.push(true);
+            }
+            None => validity.push(false),
+        }
+        offsets.push(values.len() as i32);
+    }
+    let list = ListArray::new(
+        Arc::new(Field::new("element", DataType::Utf8, true)),
+        arrow::buffer::OffsetBuffer::new(offsets.into()),
+        Arc::new(StringArray::from(values)),
+        Some(arrow::buffer::NullBuffer::from(validity)),
+    );
+    let schema = list_schema();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(list) as ArrayRef,
+            Arc::new(Int64Array::from((0..ids.len() as i64).collect::<Vec<_>>())) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let file = File::create(path).unwrap();
+    let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+}
+
+/// Read back `(id, tags)` pairs in file order.
+fn read_pairs(path: &str) -> Vec<(i64, Option<Vec<String>>)> {
+    let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+    let mut out = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let ids = batch
+            .column(batch.schema().index_of("id").unwrap())
+            .as_primitive::<arrow::datatypes::Int64Type>();
+        let lists = batch
+            .column(batch.schema().index_of("tags").unwrap())
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("tags must decode as a ListArray");
+        for i in 0..batch.num_rows() {
+            let tags = if lists.is_null(i) {
+                None
+            } else {
+                let v = lists.value(i);
+                let s = v.as_any().downcast_ref::<StringArray>().unwrap();
+                Some((0..s.len()).map(|j| s.value(j).to_string()).collect())
+            };
+            out.push((ids.value(i), tags));
+        }
+    }
+    out
+}
+
+/// Borrow an owned rows-of-strings structure as the `&str` shape `write_list_file` takes.
+fn as_refs(rows: &[Option<Vec<String>>]) -> Vec<Option<Vec<&str>>> {
+    rows.iter()
+        .map(|r| r.as_ref().map(|v| v.iter().map(|s| s.as_str()).collect()))
+        .collect()
+}
+
+fn v(items: &[&str]) -> Option<Vec<String>> {
+    Some(items.iter().map(|s| (*s).to_string()).collect())
+}
+
+#[test]
+fn unsorted_merge_preserves_list_values() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // Varying list lengths, a duplicate, an empty list, and a null list.
+    write_list_file(
+        &a,
+        &[1, 2, 3],
+        &[Some(vec!["beta", "alpha", "beta"]), None, Some(vec!["solo"])],
+    );
+    write_list_file(&b, &[4, 5], &[Some(vec![]), Some(vec!["x", "y"])]);
+
+    merge_unsorted(&[a, b], &out, "merge-list-unsorted", 0).unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 5, "row count must be preserved");
+    assert_eq!(pairs[0], (1, v(&["beta", "alpha", "beta"])));
+    assert_eq!(pairs[1].0, 2);
+    assert!(pairs[1].1.is_none() || pairs[1].1 == Some(vec![]));
+    assert_eq!(pairs[2], (3, v(&["solo"])));
+    assert_eq!(pairs[3].0, 4);
+    assert_eq!(pairs[3].1, Some(vec![]), "empty list must stay empty");
+    assert_eq!(pairs[4], (5, v(&["x", "y"])));
+}
+
+#[test]
+fn sorted_merge_keeps_list_values_with_their_row() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // Interleaving sort keys force the k-way merge to alternate between cursors, so a row-vs-value
+    // confusion in the LIST column would surface as values attached to the wrong id.
+    write_list_file(
+        &a,
+        &[1, 3, 5],
+        &[Some(vec!["one"]), Some(vec!["three", "iii"]), Some(vec!["five"])],
+    );
+    write_list_file(
+        &b,
+        &[2, 4, 6],
+        &[Some(vec!["two", "ii", "2"]), None, Some(vec!["six"])],
+    );
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-sorted",
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 6);
+    // Sort order by id, and every row keeps exactly its own values.
+    assert_eq!(pairs[0], (1, v(&["one"])));
+    assert_eq!(pairs[1], (2, v(&["two", "ii", "2"])));
+    assert_eq!(pairs[2], (3, v(&["three", "iii"])));
+    assert_eq!(pairs[3].0, 4);
+    assert!(pairs[3].1.is_none() || pairs[3].1 == Some(vec![]));
+    assert_eq!(pairs[4], (5, v(&["five"])));
+    assert_eq!(pairs[5], (6, v(&["six"])));
+}
+
+#[test]
+fn sorted_merge_on_list_column_as_sort_key_errors_cleanly() {
+    // heap.rs `get_sort_value` has no arm for List, so sorting BY a list column must surface a
+    // clean MergeError rather than panicking or silently producing garbage.
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    write_list_file(&a, &[1], &[Some(vec!["a"])]);
+    write_list_file(&b, &[2], &[Some(vec!["b"])]);
+
+    let res = merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-sortkey",
+        &["tags".to_string()],
+        &[false],
+        &[false],
+        0,
+    );
+    match res {
+        Err(e) => {
+            let msg = e.to_string();
+            println!("sorting by a LIST column errored as expected: {msg}");
+            assert!(
+                msg.contains("Unsupported sort column type"),
+                "expected an explicit unsupported-sort-type error, got: {msg}"
+            );
+        }
+        Ok(_) => panic!("sorting by a LIST column should not silently succeed"),
+    }
+}
+
+/// Multi-batch cursors + deferred column decode.
+///
+/// Two settings make this the adversarial case for a repeated column:
+/// `merge_batch_size` small enough that each cursor spans several batches (so the k-way merge
+/// crosses batch boundaries mid-file, exercising `advance`/`load_next_batch` and `take_slice`), and
+/// `merge_deferred_column_threshold = 0` which forces the cursor's *deferred* mode — sort columns
+/// and data columns are read through two independent parquet readers kept in lockstep by batch
+/// index. If a LIST column's leaf desynchronised from the sort reader, the two would drift.
+#[test]
+fn sorted_merge_list_across_batches_in_deferred_mode() {
+    use opensearch_parquet_format::native_settings::NativeSettings;
+    use opensearch_parquet_format::writer::SETTINGS_STORE;
+
+    let index = "merge-list-deferred";
+    SETTINGS_STORE.insert(
+        index.to_string(),
+        NativeSettings {
+            merge_batch_size: Some(4),
+            merge_deferred_column_threshold: Some(0),
+            ..Default::default()
+        },
+    );
+
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // 40 rows total, interleaved odd/even ids, with per-row list lengths that vary 0..3 so the
+    // value count is unrelated to the row count in every batch.
+    let ids_a: Vec<i64> = (0..20).map(|i| i * 2 + 1).collect();
+    let ids_b: Vec<i64> = (0..20).map(|i| i * 2 + 2).collect();
+    let owned_a: Vec<Option<Vec<String>>> = ids_a
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 4 {
+            0 => None,
+            1 => Some(vec![]),
+            2 => Some(vec![format!("a{id}")]),
+            _ => Some(vec![format!("a{id}"), format!("a{id}b"), format!("a{id}c")]),
+        })
+        .collect();
+    let owned_b: Vec<Option<Vec<String>>> = ids_b
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 3 {
+            0 => Some(vec![format!("b{id}"), format!("b{id}x")]),
+            1 => None,
+            _ => Some(vec![format!("b{id}")]),
+        })
+        .collect();
+    write_list_file(&a, &ids_a, &as_refs(&owned_a));
+    write_list_file(&b, &ids_b, &as_refs(&owned_b));
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        index,
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 40, "all rows must survive the merge");
+
+    // Rebuild the expected (id → tags) mapping and check every row independently, so a single
+    // misattached value fails loudly with the offending id.
+    let mut expected: std::collections::HashMap<i64, Option<Vec<String>>> =
+        std::collections::HashMap::new();
+    for (id, tags) in ids_a.iter().zip(owned_a.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+    for (id, tags) in ids_b.iter().zip(owned_b.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+
+    let mut prev_id = i64::MIN;
+    for (id, tags) in &pairs {
+        assert!(*id > prev_id, "output must be sorted by id, saw {id} after {prev_id}");
+        prev_id = *id;
+        let want = expected.remove(id).unwrap_or_else(|| panic!("unexpected id {id}"));
+        // A null list and an empty list are both legitimately readable as "no values".
+        let norm = |t: &Option<Vec<String>>| t.clone().unwrap_or_default();
+        assert_eq!(
+            norm(tags),
+            norm(&want),
+            "row id={id} lost or gained values in the merge"
+        );
+    }
+    assert!(expected.is_empty(), "rows missing from output: {:?}", expected.keys());
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -28,11 +30,14 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.fields.core.data.text.KeywordParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -570,6 +575,138 @@ public class VSRManagerTests extends ParquetBaseTests {
         } finally {
             manager.close();
         }
+    }
+
+    public void testMultiValueFieldWritesListColumn() throws Exception {
+        String filePath = createTempDir().resolve("multi-value.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            // Mapping update introduces a keyword field declared multi-valued, so it arrives as a
+            // LIST<Utf8> rather than a flat Utf8 column.
+            manager.reconcileSchema(schemaWithMultiValue("tags"));
+
+            KeywordFieldMapper.KeywordFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+            tags.setMultiValued(true);
+            assignTestCapabilities(tags, PARQUET_FORMAT);
+            NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+            assignTestCapabilities(valField, PARQUET_FORMAT);
+
+            // Row 0: three values including a duplicate. Row 1: field absent entirely.
+            // Row 2: a single value. Covers the three cardinalities in one file.
+            ParquetDocumentInput doc0 = new ParquetDocumentInput();
+            populateMetadataFields(doc0);
+            doc0.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc0.addField(valField, 1);
+            doc0.addField(tags, "b");
+            doc0.addField(tags, "a");
+            doc0.addField(tags, "b");
+            manager.addDocument(doc0);
+
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+            doc1.addField(valField, 2);
+            manager.addDocument(doc1);
+
+            ParquetDocumentInput doc2 = new ParquetDocumentInput();
+            populateMetadataFields(doc2);
+            doc2.setRowId(DocumentInput.ROW_ID_FIELD, 2);
+            doc2.addField(valField, 3);
+            doc2.addField(tags, "solo");
+            manager.addDocument(doc2);
+
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertEquals(List.of("b", "a", "b"), listElements(listVector, 0));
+            assertTrue("absent field must read back as a null list", listVector.isNull(1));
+            assertEquals(List.of("solo"), listElements(listVector, 2));
+
+            ParquetFileMetadata metadata = manager.flush();
+            assertNotNull(metadata);
+            assertEquals(3, metadata.numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    public void testMultiValueFieldWritesEmptyListDistinctFromAbsent() throws Exception {
+        String filePath = createTempDir().resolve("multi-value-empty.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            manager.reconcileSchema(schemaWithMultiValue("tags"));
+            NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+            assignTestCapabilities(valField, PARQUET_FORMAT);
+
+            // An explicit "tags": [] parses to zero addField calls, so the writer never sees the
+            // field and the row is null — same as absent. Documented here so the distinction
+            // between [] and absent is a deliberate, tested choice rather than an accident.
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc.addField(valField, 1);
+            manager.addDocument(doc);
+
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertTrue(listVector.isNull(0));
+            assertEquals(1, manager.flush().numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    public void testReconcileSchemaPreservesListChildren() throws Exception {
+        String filePath = createTempDir().resolve("reconcile-children.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            assertTrue(manager.reconcileSchema(schemaWithMultiValue("tags")));
+
+            // reconcileSchema used to rebuild each Field from name + FieldType, dropping children
+            // and leaving a ListVector with no element vector to write into.
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertNotNull(listVector);
+            // A dropped child would leave the data vector as an uninitialized ZeroVector.
+            assertTrue(
+                "list vector must have a typed element vector, got " + listVector.getDataVector().getClass().getSimpleName(),
+                listVector.getDataVector() instanceof VarCharVector
+            );
+
+            // Assert on the VSR *schema* rather than the vector's own field: Arrow Java renames a
+            // list vector's child to "$data$" internally, but the schema — which is what
+            // exportSchema hands to the native writer, and therefore what determines the Parquet
+            // leaf path "tags.list.element" — keeps the declared name.
+            Field tagsField = manager.getActiveManagedVSR()
+                .getSchema()
+                .getFields()
+                .stream()
+                .filter(f -> f.getName().equals("tags"))
+                .findFirst()
+                .orElseThrow();
+            assertEquals(ArrowType.List.INSTANCE, tagsField.getType());
+            assertEquals(1, tagsField.getChildren().size());
+            assertEquals(ParquetField.LIST_ELEMENT_NAME, tagsField.getChildren().get(0).getName());
+            assertEquals(new ArrowType.Utf8(), tagsField.getChildren().get(0).getType());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /** Reads back the elements of one row of a list vector. */
+    private static List<String> listElements(ListVector listVector, int row) {
+        int start = listVector.getOffsetBuffer().getInt((long) row * 4);
+        int end = listVector.getOffsetBuffer().getInt((long) (row + 1) * 4);
+        VarCharVector data = (VarCharVector) listVector.getDataVector();
+        List<String> values = new ArrayList<>(end - start);
+        for (int i = start; i < end; i++) {
+            values.add(new String(data.get(i), StandardCharsets.UTF_8));
+        }
+        return values;
+    }
+
+    /** Test schema plus metadata fields plus a keyword field declared multi-valued. */
+    private Schema schemaWithMultiValue(String name) {
+        List<Field> fields = new ArrayList<>(schema.getFields());
+        fields.addAll(metadataFields());
+        fields.add(new KeywordParquetField().toArrowField(name, true));
+        return new Schema(fields);
     }
 
     /** Returns a copy of the test schema with one extra field appended (alongside metadata fields). */

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -147,6 +147,34 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         assertEquals(0L, input.getFieldCount("tags"));
     }
 
+    public void testMultiValueAccumulationKeyedByNameNotInstanceIdentity() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        // Two DISTINCT field-type instances that share a name, as could arise if the parse path ever
+        // handed back a fresh wrapper per array element. Accumulation keys on the name, so both
+        // elements must land in the SAME list rather than the second creating a new pair (which
+        // would silently degrade multi_value to last-value-wins).
+        MappedFieldType first = new KeywordFieldMapper.KeywordFieldType("tags");
+        first.setMultiValued(true);
+        assignTestCapabilities(first, PARQUET_FORMAT);
+        MappedFieldType second = new KeywordFieldMapper.KeywordFieldType("tags");
+        second.setMultiValued(true);
+        assignTestCapabilities(second, PARQUET_FORMAT);
+        assertNotSame(first, second);
+
+        input.addField(first, "a");
+        input.addField(second, "b");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        assertEquals(
+            "both elements must accumulate into one pair",
+            1,
+            input.getFinalInput().stream().filter(p -> p.getFieldType().name().equals("tags")).count()
+        );
+        FieldValuePair pair = findPair(input, "tags");
+        assertEquals(List.of("a", "b"), pair.getValue());
+    }
+
     public void testUndeclaredFieldStillRejectsMultipleValues() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         populateMetadataFields(input);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -86,4 +86,99 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         input.addField(valField, 10);
         expectThrows(MapperParsingException.class, () -> input.addField(valField, 20));
     }
+
+    public void testDeclaredMultiValueFieldAccumulatesValuesInOrder() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        // The document parser reports one addField call per array element.
+        input.addField(tags, "b");
+        input.addField(tags, "a");
+        input.addField(tags, "b");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        // Document order and duplicates are preserved: the values are the source of truth for
+        // derived _source, so they must not be sorted or deduplicated.
+        assertEquals(List.of("b", "a", "b"), pair.getValue());
+        assertEquals(3, pair.valueCount());
+        assertEquals(3L, input.getFieldCount("tags"));
+    }
+
+    public void testDeclaredMultiValueFieldWithSingleValueIsStillAList() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        input.addField(tags, "solo");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        // A scalar JSON value on a declared list column still writes a one-element list, so the
+        // column type stays consistent across documents.
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of("solo"), pair.getValue());
+    }
+
+    public void testUndeclaredFieldStillRejectsMultipleValues() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType other = new KeywordFieldMapper.KeywordFieldType("other");
+        assignTestCapabilities(other, PARQUET_FORMAT);
+
+        input.addField(other, "one");
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> input.addField(other, "two"));
+        assertTrue(e.getMessage().contains("multi_value"));
+    }
+
+    public void testMultiValueFieldCountIsValueCountNotEntryCount() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+        input.addField(tags, "x");
+        input.addField(tags, "y");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        // Metadata fields must still count as exactly one so getFinalInput's assertions hold.
+        assertEquals(1L, input.getFieldCount(org.opensearch.index.mapper.IdFieldMapper.NAME));
+        assertEquals(2L, input.getFieldCount("tags"));
+        // One collected entry holding two values.
+        assertEquals(5, input.getFinalInput().size());
+    }
+
+    public void testDerivedSourceCompanionFieldFollowsParentCardinality() {
+        // KeywordFieldMapper emits "_ignored_source.<field>" alongside the parent when a normalizer
+        // or ignore_above alters the value, and buildRawKeywordValueFieldType copies the parent's
+        // multi_value flag onto it, so the document input must accumulate its values too —
+        // otherwise it would reject the second value while its own column expects a list.
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType rawValue = new KeywordFieldMapper.KeywordFieldType("_ignored_source.tags");
+        rawValue.setMultiValued(true);
+        assignTestCapabilities(rawValue, PARQUET_FORMAT);
+
+        input.addField(rawValue, "RAW-ONE");
+        input.addField(rawValue, "RAW-TWO");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "_ignored_source.tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of("RAW-ONE", "RAW-TWO"), pair.getValue());
+    }
+
+    private static FieldValuePair findPair(ParquetDocumentInput input, String fieldName) {
+        return input.getFinalInput()
+            .stream()
+            .filter(p -> p.getFieldType().name().equals(fieldName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no collected field named " + fieldName));
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -126,6 +126,27 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         assertEquals(List.of("solo"), pair.getValue());
     }
 
+    public void testDeclaredMultiValueFieldWithEmptyArrayIsPresentEmptyList() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        // The parser signals an explicit empty array ("tags": []) with an empty List value. It must
+        // seed a present, zero-value list (written as an empty-but-non-null LIST cell) rather than
+        // being dropped, so an empty array stays distinct from an absent field in reconstructed
+        // _source.
+        input.addField(tags, List.of());
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of(), pair.getValue());
+        assertEquals(0, pair.valueCount());
+        assertEquals(0L, input.getFieldCount("tags"));
+    }
+
     public void testUndeclaredFieldStillRejectsMultipleValues() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         populateMetadataFields(input);

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1234,6 +1234,12 @@ final class DocumentParser {
      *
      * <p>Strictly gated: no-op unless the pluggable data format is enabled and the resolved leaf is
      * a {@code multi_value} {@link FieldMapper}, so stock indexing is unaffected.
+     *
+     * <p>Reached from every scalar-leaf array route — top-level, nested, and disable_objects arrays
+     * all funnel through {@link #parseNonDynamicArray}. The only array route that bypasses it is a
+     * mapper with {@link FieldMapper#parsesArrayValue()} true (geo/completion), which no
+     * {@code multi_value} type currently is; if that ever changes, that route needs equivalent
+     * empty-array handling or {@code []} would collapse to an absent field there.
      */
     private static void registerEmptyMultiValueArray(ParseContext context, ObjectMapper mapper, String lastFieldName, String[] paths) {
         if (context.indexSettings().isPluggableDataFormatEnabled() == false) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1197,7 +1197,9 @@ final class DocumentParser {
             );
         }
         final String[] paths = resolvePathForParsing(mapper, lastFieldName);
+        boolean sawElement = false;
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            sawElement = true;
             if (token == XContentParser.Token.START_OBJECT) {
                 parseObject(context, mapper, lastFieldName, paths);
             } else if (token == XContentParser.Token.START_ARRAY) {
@@ -1216,6 +1218,30 @@ final class DocumentParser {
                 assert token.isValue();
                 parseValue(context, mapper, lastFieldName, token, paths);
             }
+        }
+        if (sawElement == false) {
+            registerEmptyMultiValueArray(context, mapper, lastFieldName, paths);
+        }
+    }
+
+    /**
+     * Records an empty array ({@code "field": []}) for a pluggable-data-format field mapped with
+     * {@code multi_value: true}. The element loop above never fires for an empty array, so without
+     * this the field would be absent from the document input and its LIST column cell would be
+     * written null — collapsing the distinction between {@code []} and a missing field when
+     * {@code _source} is later reconstructed from the columns. Registering an empty list lets the
+     * writer emit a zero-length, non-null list instead.
+     *
+     * <p>Strictly gated: no-op unless the pluggable data format is enabled and the resolved leaf is
+     * a {@code multi_value} {@link FieldMapper}, so stock indexing is unaffected.
+     */
+    private static void registerEmptyMultiValueArray(ParseContext context, ObjectMapper mapper, String lastFieldName, String[] paths) {
+        if (context.indexSettings().isPluggableDataFormatEnabled() == false) {
+            return;
+        }
+        Mapper leaf = getMapper(context, mapper, lastFieldName, paths);
+        if (leaf instanceof FieldMapper fieldMapper && fieldMapper.fieldType().isMultiValued()) {
+            context.documentInput().addField(fieldMapper.fieldType(), List.of());
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
@@ -270,6 +270,16 @@ public abstract class FilterFieldType extends MappedFieldType {
     }
 
     @Override
+    public boolean isMultiValued() {
+        return delegate.isMultiValued();
+    }
+
+    @Override
+    public void setMultiValued(boolean multiValued) {
+        delegate.setMultiValued(multiValued);
+    }
+
+    @Override
     public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
         return delegate.docValueFormat(format, timeZone);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -175,6 +175,14 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
         private final Parameter<Float> boost = Parameter.boostParam();
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Lucene is inherently multi-valued, so the flag matters only to consumers projecting a fixed
+         * schema — e.g. a pluggable format whose column type is fixed per file (Parquet stores a
+         * declared field as {@code LIST<element>}). Not updateable: arity is baked into written data.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         private final IndexAnalyzers indexAnalyzers;
         private final boolean canConsumeRawValueForSource;
 
@@ -224,7 +232,8 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
                 normalizer,
                 splitQueriesOnWhitespace,
                 boost,
-                meta
+                meta,
+                multiValue
             );
         }
 
@@ -343,6 +352,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
             setEagerGlobalOrdinals(builder.eagerGlobalOrdinals.getValue());
             setIndexAnalyzer(normalizer);
             setBoost(builder.boost.getValue());
+            setMultiValued(builder.multiValue.getValue());
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
             this.useSimilarity = builder.useSimilarity.getValue();
@@ -830,6 +840,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     private final boolean useSimilarity;
     private final String normalizerName;
     private final boolean splitQueriesOnWhitespace;
+    private final boolean multiValued;
     private final KeywordFieldType rawKeywordValueFieldType;
 
     private final IndexAnalyzers indexAnalyzers;
@@ -856,6 +867,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         this.useSimilarity = builder.useSimilarity.getValue();
         this.normalizerName = builder.normalizer.getValue();
         this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace.getValue();
+        this.multiValued = builder.multiValue.getValue();
         this.indexAnalyzers = builder.indexAnalyzers;
         this.canConsumeRawValueForSource = builder.canConsumeRawValueForSource;
         this.rawKeywordValueFieldType = buildRawKeywordValueFieldType();
@@ -886,7 +898,18 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
      */
     private KeywordFieldType buildRawKeywordValueFieldType() {
         if (isIneligibleForGeneratingSource() && canConsumeRawValueForSource) {
-            return new KeywordFieldType("_ignored_source." + fieldType().name(), false, true, false, false, fieldType().meta());
+            KeywordFieldType rawValueType = new KeywordFieldType(
+                "_ignored_source." + fieldType().name(),
+                false,
+                true,
+                false,
+                false,
+                fieldType().meta()
+            );
+            // The companion carries the pre-normalization values for derived source, so it must
+            // mirror the parent's cardinality or source reconstruction would lose values.
+            rawValueType.setMultiValued(multiValued);
+            return rawValueType;
         }
         return null;
     }

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -97,6 +97,7 @@ public abstract class MappedFieldType {
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
+    private boolean multiValued;
 
     /**
      * Capability map assigning each registered {@link DataFormat} to the set of capabilities it owns for this field type.
@@ -476,6 +477,30 @@ public abstract class MappedFieldType {
 
     public void setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+    }
+
+    /**
+     * Whether this field is declared to hold multiple values per document in columnar data
+     * formats ({@code multi_value} mapping parameter). Lucene is inherently multi-valued, so
+     * this flag only matters to pluggable formats whose column type is fixed per file (e.g.
+     * Parquet, where a declared field is stored as {@code LIST<element>}).
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public boolean isMultiValued() {
+        return multiValued;
+    }
+
+    /**
+     * Declares this field multi-valued for columnar data formats. Set during mapping build by
+     * mappers exposing the {@code multi_value} parameter.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public void setMultiValued(boolean multiValued) {
+        this.multiValued = multiValued;
     }
 
     @ExperimentalApi

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -189,6 +189,9 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     @PublicApi(since = "1.0.0")
     public static final class Parameter<T> implements Supplier<T> {
 
+        /** Name of the shared {@code multi_value} arity parameter; see {@link #multiValueParam()}. */
+        public static final String MULTI_VALUE_PARAM_NAME = "multi_value";
+
         public final String name;
         private final List<String> deprecatedNames = new ArrayList<>();
         private final Supplier<T> defaultValue;
@@ -394,6 +397,23 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 (n, c, o) -> new Explicit<>(XContentMapValues.nodeBooleanValue(o), true),
                 initializer
             ).setSerializer((b, n, v) -> b.field(n, v.value()), v -> Boolean.toString(v.value()));
+        }
+
+        /**
+         * Defines the shared {@code multi_value} mapping parameter, declaring whether a field holds a
+         * single value or an array. This captures field <em>arity</em> — distinct from the number of
+         * distinct values a field has, and unrelated to the {@code cardinality} aggregation.
+         *
+         * <p>Field types that can hold arrays should register this in {@code getParameters()} and
+         * stamp its value onto the built field type via {@link MappedFieldType#setMultiValued(boolean)}.
+         * Consumers that project a fixed schema (columnar data formats, SQL/PPL, join) read it back via
+         * {@link MappedFieldType#isMultiValued()}. It defaults to {@code false} and is not updateable —
+         * a field's arity is fixed once data is written.
+         *
+         * @return a {@code Parameter<Boolean>} named {@value #MULTI_VALUE_PARAM_NAME}
+         */
+        public static Parameter<Boolean> multiValueParam() {
+            return Parameter.boolParam(MULTI_VALUE_PARAM_NAME, false, m -> m.fieldType().isMultiValued(), false);
         }
 
         /**

--- a/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
@@ -55,6 +55,8 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
@@ -197,6 +199,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "foo"));
         checker.registerConflictCheck("similarity", b -> b.field("similarity", "boolean"));
         checker.registerConflictCheck("normalizer", b -> b.field("normalizer", "lowercase"));
+        // Not updateable: the column type is baked into every parquet file the index has written.
+        checker.registerConflictCheck("multi_value", b -> b.field("multi_value", true));
 
         checker.registerUpdateCheck(b -> b.field("eager_global_ordinals", true), m -> assertTrue(m.fieldType().eagerGlobalOrdinals()));
         checker.registerUpdateCheck(b -> b.field("ignore_above", 256), m -> assertEquals(256, ((KeywordFieldMapper) m).ignoreAbove()));
@@ -281,6 +285,20 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
         assertTrue(fields[0].fieldType().stored());
+    }
+
+    public void testMultiValueParameter() throws IOException {
+        // Default is single-valued and, being the default, is not serialized.
+        DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        FieldMapper defaultField = (FieldMapper) defaultMapper.mappers().getMapper("field");
+        assertFalse(defaultField.fieldType().isMultiValued());
+        assertFalse(Strings.toString(MediaTypeRegistry.JSON, defaultField).contains("multi_value"));
+
+        // multi_value: true reaches the field type and round-trips through serialization.
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword").field("multi_value", true)));
+        FieldMapper field = (FieldMapper) mapper.mappers().getMapper("field");
+        assertTrue(field.fieldType().isMultiValued());
+        assertTrue(Strings.toString(MediaTypeRegistry.JSON, field).contains("\"multi_value\":true"));
     }
 
     public void testDisableIndex() throws IOException {


### PR DESCRIPTION
### Description

> **Stacked on [#22703](https://github.com/opensearch-project/OpenSearch/pull/22703) by [@Bukhtawar](https://github.com/Bukhtawar).** This PR builds on the multi-value keyword indexing and Parquet `LIST` storage work from that earlier PR. It implements the query-side follow-up that #22703 intentionally deferred and should be reviewed/merged after #22703. Until then, the GitHub diff against `main` also contains the dependency commits; the incremental change is the five analytics files in commit `22454cb1763`.

A `keyword` field mapped with `multi_value: true` is stored as Parquet `LIST<UTF8>`, but search had two independent schema/page-index gaps:

1. `OpenSearchSchemaBuilder` exposed the field to Calcite as scalar `VARCHAR`, so Substrait expected `Utf8` while DataFusion read `List<Utf8>`. The field is now declared as nullable `ARRAY<VARCHAR>`, and `ArrowCalciteTypes` converts Calcite `ARRAY` to Arrow `List`.
2. Scoped page-index loading resolved scalar columns through `StatisticsConverter::parquet_column_index()`, which intentionally returns `None` for nested Arrow roots. A projected `LIST` field could therefore retain a placeholder `OffsetIndex`, causing mixed scalar/LIST projections to fail with `Src size is incorrect`. The resolver now maps a requested nested root to every physical Parquet leaf under that root.

The nested fallback is generic for `LIST`, `MAP`, and `STRUCT` roots and uses the Arrow schema derived from each file footer, preserving correctness across schema evolution.

### Testing

- `cargo fmt -p opensearch-datafusion -- --check`
- `cargo test -p opensearch-datafusion --lib cache::page_index` — 42 passed, including `list_projection_resolves_to_its_parquet_leaf`
- `:sandbox:libs:analytics-api:compileJava` and `:sandbox:plugins:analytics-engine:compileJava`
- Focused `OpenSearchSchemaBuilderTests`, including `testMultiValueKeywordMapsToArrowList`
- `spotlessJavaCheck` for analytics-api and analytics-engine
- Local end-to-end PPL with scoped page indexes enabled: mixed `fields id, tags` passed 40/40; reversed, `head`, scalar-only, and LIST-only controls passed 20/20 each; no `Src size is incorrect` errors

### Check List

- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.