### PR TITLE
docs: Add getting-started for pluggable data format (sandbox)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -325,6 +325,8 @@ To include sandbox modules in snapshot distributions, use the `sandbox.enabled` 
 
     ./gradlew assemble -Dsandbox.enabled=true
 
+One experimental feature currently in the sandbox is the **pluggable data format**, which lets an index be backed by non-Lucene storage engines (e.g. a Parquet primary with a Lucene secondary) via the composite engine. To spin it up from source, see [Getting Started with the Pluggable Data Format](sandbox/plugins/composite-engine/GETTING_STARTED.md).
+
 ### `qa`
 
 Honestly this is kind of in flux and we're not 100% sure where we'll end up. We welcome your thoughts and help.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -325,7 +325,7 @@ To include sandbox modules in snapshot distributions, use the `sandbox.enabled` 
 
     ./gradlew assemble -Dsandbox.enabled=true
 
-One experimental feature currently in the sandbox is the **pluggable data format**, which lets an index be backed by non-Lucene storage engines (e.g. a Parquet primary with a Lucene secondary) via the composite engine. To spin it up from source, see [Getting Started with the Pluggable Data Format](sandbox/plugins/composite-engine/GETTING_STARTED.md).
+One experimental feature currently incubating in the sandbox is the **pluggable data format**, which lets an index be backed by non-Lucene storage engines — for example a columnar Parquet primary paired with a Lucene secondary — through the composite engine. For a guided walkthrough of running it from source, creating and querying a composite-backed index, and running its test suites, see [Getting Started with the Pluggable Data Format](sandbox/plugins/composite-engine/GETTING_STARTED.md).
 
 ### `qa`
 

--- a/sandbox/plugins/composite-engine/GETTING_STARTED.md
+++ b/sandbox/plugins/composite-engine/GETTING_STARTED.md
@@ -1,70 +1,121 @@
 # Getting Started with the Pluggable Data Format
 
-> **Experimental.** The pluggable data format and every plugin described here live in
-> `sandbox/` and are marked `@ExperimentalApi`. They carry no backwards-compatibility or
-> long-term-support guarantees and may change or be removed at any time.
+> **Status: Experimental.** The pluggable data format and every plugin referenced in this
+> guide live under `sandbox/` and are annotated `@ExperimentalApi`. They provide **no**
+> backwards-compatibility or long-term-support guarantees and may change or be removed at
+> any time. Do not depend on them in production.
 
-This guide shows how to spin up OpenSearch from source with the **pluggable data format**
-enabled, create an index backed by the **composite** format (Parquet primary + Lucene
-secondary), ingest a document, and verify it.
+This guide walks you through standing up OpenSearch from source with the pluggable data
+format enabled, creating an index backed by columnar (Parquet) storage, ingesting and
+querying data, and running the associated test suites.
 
-## What the pluggable data format is
+## Contents
 
-Classic OpenSearch stores every index in Lucene. The pluggable data format lets an index
-be backed by one or more *data format* engines instead. The engine that ties them together
-is the **composite** format, which writes each document to:
+- [Overview](#overview)
+- [Architecture at a glance](#architecture-at-a-glance)
+- [Key concepts](#key-concepts)
+- [Prerequisites](#prerequisites)
+- [Quick start: run the storage layer](#quick-start-run-the-storage-layer)
+- [Create a composite-backed index](#create-a-composite-backed-index)
+- [Ingest and verify](#ingest-and-verify)
+- [Query with PPL (full analytics stack)](#query-with-ppl-full-analytics-stack)
+- [Running the tests](#running-the-tests)
+- [Configuration reference](#configuration-reference)
+- [Troubleshooting](#troubleshooting)
+- [Extending: authoring a new data format](#extending-authoring-a-new-data-format)
+- [Further reading](#further-reading)
 
-- a **primary** format — the authoritative store used for merges and commit coordination
-  (default: `parquet`), and
+## Overview
+
+By default, every OpenSearch index is stored in Lucene. The **pluggable data format**
+decouples an index from that assumption, allowing a shard to be backed by one or more
+alternative storage engines. The engine that coordinates them is the **composite** data
+format, which fans each document out to:
+
+- a **primary** format — the authoritative store that owns merges and commit coordination
+  (default `parquet`, a columnar format well suited to analytical scans), and
 - zero or more **secondary** formats that receive the same writes (commonly `lucene`, so
-  text/keyword predicates still resolve).
+  full-text and term predicates continue to resolve).
 
-Each format is contributed by a `DataFormatPlugin` (see the SPI in
-`server/.../index/engine/dataformat/` and the architecture notes in
-[`README.md`](README.md)). The composite plugin discovers the format plugins at node
-startup via the `ExtensiblePlugin` SPI.
+Each storage engine is contributed by a `DataFormatPlugin` and discovered at node startup
+through the `ExtensiblePlugin` SPI. Analytical queries over the columnar data are served by
+a separate query stack (a DataFusion execution backend fronted by a PPL/SQL interface).
+
+## Architecture at a glance
+
+```
+                    ┌──────────────────────────────────────────────┐
+   PPL / SQL  ─────▶│  analytics-engine (hub)                       │
+   query            │  discovers backends + front ends via SPI      │
+                    └───────────────┬──────────────────────────────┘
+                                    │ query plan fragments
+                     ┌──────────────┴───────────────┐
+                     ▼                               ▼
+        ┌───────────────────────┐        ┌───────────────────────┐
+        │ analytics-backend-    │        │ analytics-backend-     │
+        │ datafusion (Parquet)  │        │ lucene (text/terms)    │
+        └───────────────────────┘        └───────────────────────┘
+
+   Indexing path:
+        document ──▶ composite-engine ──┬──▶ parquet  (primary: merges, commits)
+                                        └──▶ lucene   (secondary: text/term index)
+```
+
+The composite engine (`sandbox/plugins/composite-engine`) owns the write path; the
+analytics engine (`sandbox/plugins/analytics-engine`) and its backends own the read path.
+See [`README.md`](README.md) for the composite engine's internal design.
+
+## Key concepts
+
+| Term | Meaning |
+|---|---|
+| **Data format** | A pluggable storage engine for a shard (e.g. `parquet`, `lucene`), contributed by a `DataFormatPlugin` and identified by a unique `name()`. |
+| **Composite format** | A data format that writes each document to a primary plus zero or more secondary formats, presenting them behind a single indexing engine. |
+| **Primary format** | The authoritative format for a composite index; owns segment merges and commit coordination. Defaults to `parquet`. |
+| **Secondary format** | An additional format that receives the same writes (e.g. `lucene` for text/term queries). |
+| **Analytics engine** | The query hub that routes PPL/SQL query plans to execution backends (DataFusion for Parquet, Lucene for text). |
 
 ## Prerequisites
 
-- The standard OpenSearch build prerequisites (JDK 21+, and **Rust + protoc** — the
-  Parquet/DataFusion plugins compile a native Rust component). See the
-  [Developer Guide](../../../DEVELOPER_GUIDE.md#install-prerequisites).
-- `JAVA_HOME` set to your JDK.
+| Requirement | Notes |
+|---|---|
+| **JDK** | The data-format plugins (`composite-engine`, `parquet-data-format`, `analytics-backend-datafusion`) compile and test against **JDK 25**, above the repo-wide JDK 21 minimum. Point `JAVA_HOME` at a JDK 25 when building or testing them. |
+| **Rust + Cargo** | The Parquet and DataFusion engines include a native Rust component (`sandbox/libs/dataformat-native`). Install a recent stable toolchain via [rustup](https://rustup.rs/). |
+| **protoc** | Required by the OpenSearch build. See the [Developer Guide](../../../DEVELOPER_GUIDE.md#install-prerequisites). |
 
-## 1. Run OpenSearch with the data-format plugins
+## Quick start: run the storage layer
 
-From the repository root, launch a single node with the composite stack installed. The
-`run` task automatically enables the pluggable data format feature flag and sets the native
-library path whenever `parquet-data-format` or `analytics-backend-datafusion` is in the
-plugin list (see `gradle/run.gradle`):
+From the repository root, launch a single node with the composite storage stack. The Gradle
+`run` task automatically enables the pluggable data format feature flag and configures the
+native library path whenever `parquet-data-format` or `analytics-backend-datafusion` is in
+the plugin list (see `gradle/run.gradle`):
 
 ```bash
 ./gradlew run -PinstalledPlugins='["arrow-base","arrow-flight-rpc","composite-engine","parquet-data-format","analytics-backend-lucene"]'
 ```
 
-- `composite-engine` — orchestrates primary + secondary formats.
-- `parquet-data-format` — the default primary format (native Rust component).
-- `analytics-backend-lucene` — provides the `lucene` secondary format.
-- `arrow-base` / `arrow-flight-rpc` — Arrow runtime the native path depends on. `arrow-base`
-  must be listed **before** any plugin that extends it.
+| Plugin | Role |
+|---|---|
+| `arrow-base` | Apache Arrow runtime. **Must be listed first** — plugins that extend it fail the install jarHell check otherwise. |
+| `arrow-flight-rpc` | Arrow Flight transport used by the native path. |
+| `composite-engine` | Orchestrates the primary and secondary formats. |
+| `parquet-data-format` | The default primary (columnar) format; ships the native Rust component. |
+| `analytics-backend-lucene` | Provides the `lucene` secondary format. |
 
-This corresponds to setting, on a manually-configured node:
+Wait for `[node-1] started` in the console. This node can create composite indices, ingest,
+and merge data. To also run analytical **queries**, see
+[Query with PPL](#query-with-ppl-full-analytics-stack).
 
-```yaml
-# opensearch.yml
-opensearch.experimental.feature.pluggable.dataformat.enabled: true
-```
+## Create a composite-backed index
 
-Wait for `[node-1] started` in the console.
-
-## 2. Create a composite-backed index
-
-The two index settings that turn on the pluggable data format are **final** — they can only
-be set at index-creation time:
+The two settings that activate the pluggable data format are **final** — they can only be
+set at index-creation time and cannot be updated afterward:
 
 ```bash
 curl -X PUT "http://localhost:9200/logs-parquet" -H 'Content-Type: application/json' -d '{
   "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
     "index.pluggable.dataformat.enabled": true,
     "index.pluggable.dataformat": "composite",
     "index.composite.primary_data_format": "parquet",
@@ -72,26 +123,21 @@ curl -X PUT "http://localhost:9200/logs-parquet" -H 'Content-Type: application/j
   },
   "mappings": {
     "properties": {
-      "message":   { "type": "text" },
-      "level":     { "type": "keyword" },
-      "@timestamp":{ "type": "date" }
+      "message":    { "type": "text" },
+      "level":      { "type": "keyword" },
+      "@timestamp": { "type": "date" }
     }
   }
 }'
 ```
 
-| Setting | Default | Notes |
-|---|---|---|
-| `index.pluggable.dataformat.enabled` | `false` | Final. Master switch for the index. |
-| `index.pluggable.dataformat` | `""` | Final. Set to `composite` to use the composite engine. |
-| `index.composite.primary_data_format` | `parquet` | Final. Authoritative / merge format. |
-| `index.composite.secondary_data_formats` | `[]` | Final. Extra formats written alongside the primary. |
+> `secondary_data_formats` accepts either a JSON array (`["lucene"]`) or a single string
+> (`"lucene"`).
 
-You can also set cluster-wide defaults so new indices pick up the format automatically
-(`cluster.pluggable.dataformat.enabled`, `cluster.pluggable.dataformat`,
-`cluster.composite.primary_data_format`, `cluster.composite.secondary_data_formats`).
+To make every new index use the composite format without specifying it per request, set the
+cluster-scoped defaults instead (see the [Configuration reference](#configuration-reference)).
 
-## 3. Index a document
+## Ingest and verify
 
 ```bash
 curl -X POST "http://localhost:9200/logs-parquet/_doc?refresh=true" -H 'Content-Type: application/json' -d '{
@@ -101,149 +147,203 @@ curl -X POST "http://localhost:9200/logs-parquet/_doc?refresh=true" -H 'Content-
 }'
 ```
 
-## 4. Verify
-
-> **Gotcha:** `_count` and `_search` hit the **Lucene secondary** index, which does not
-> materialize the Parquet-primary rows — so on a parquet-primary index `_count` reports
-> **0 docs even after a successful ingest**. That is expected, not data loss.
-
-Confirm the shard is healthy and the format took effect:
+Confirm the shard is healthy and the format is in effect:
 
 ```bash
-# Index exists and is green/yellow
 curl "http://localhost:9200/_cat/indices/logs-parquet?v"
-
-# Settings reflect the composite format
 curl "http://localhost:9200/logs-parquet/_settings?pretty"
 ```
 
-To actually **query** the Parquet data you need the analytics query stack (DataFusion
-backend + a PPL/SQL front end). Add those plugins when launching:
+> **Expected behavior — `_count` reports 0.** The `_count` and `_search` APIs read through
+> the **Lucene secondary** index, which does not materialize the Parquet-primary rows. On a
+> parquet-primary index these APIs return **0 documents even after a successful ingest**.
+> This is expected, not data loss — query the columnar data through the analytics/PPL path
+> described below.
+
+## Query with PPL (full analytics stack)
+
+Analytical queries over Parquet data are served by the analytics engine and its DataFusion
+backend, fronted by a PPL interface. This path requires the query plugins **and** the
+streaming transport feature flag in addition to the storage layer:
+
+- **Plugins:** `arrow-base`, `arrow-flight-rpc`, `composite-engine`, `parquet-data-format`,
+  `analytics-backend-lucene`, `analytics-backend-datafusion`, `analytics-engine`,
+  `dsl-query-executor` (and the `opensearch-sql` plugin, which serves `/_plugins/_ppl`).
+- **Feature flags:**
+  - `opensearch.experimental.feature.pluggable.dataformat.enabled=true`
+  - `opensearch.experimental.feature.transport.stream.enabled=true` (fragment dispatch is
+    streaming-only)
+- **JVM configuration:** the Netty unsafe flags and the DataFusion native library path
+  (`-Djava.library.path=<repo>/sandbox/libs/dataformat-native/rust/target/release`).
+
+Once configured, run a query:
 
 ```bash
-./gradlew run -PinstalledPlugins='["arrow-base","arrow-flight-rpc","composite-engine","parquet-data-format","analytics-backend-lucene","analytics-backend-datafusion","analytics-engine","dsl-query-executor"]'
+curl -X POST "http://localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' -d '{
+  "query": "source = logs-parquet | stats count() by level"
+}'
 ```
 
-The analytics engine additionally requires the streaming transport feature flag
-(`opensearch.experimental.feature.transport.stream.enabled=true`). For a fully-wired,
-ready-to-run example of the complete stack — plugin order, JVM flags, and cluster settings
-— see the QA harness at
-[`sandbox/qa/analytics-engine-rest/build.gradle`](../../qa/analytics-engine-rest/build.gradle)
-and the [`analytics-engine`](../analytics-engine/README.md) README.
+The single authoritative, always-current reference for the exact plugin ordering, JVM
+arguments, and cluster settings this stack needs is the QA build definition at
+[`sandbox/qa/analytics-engine-rest/build.gradle`](../../qa/analytics-engine-rest/build.gradle).
+The fastest way to see the complete stack running end to end is to execute that QA suite
+(see [Running the tests](#running-the-tests)). For component-level detail, see the
+[`analytics-engine`](../analytics-engine/README.md) and
+[`analytics-backend-datafusion`](../analytics-backend-datafusion/README.md) READMEs.
 
-## Running tests
+## Running the tests
 
-Sandbox plugins use the same test tiers as the rest of OpenSearch. There is **no special
-`sandbox.enabled` flag for tests** — that flag only controls whether sandbox artifacts are
-bundled into a *distribution* (`./gradlew assemble -Dsandbox.enabled=true`). Test tasks run
-per-project directly.
+Sandbox plugins use the same test tiers as the rest of OpenSearch. Test tasks run per
+project and are **not** gated by the `sandbox.enabled` system property — that flag only
+controls whether sandbox artifacts are bundled into a *distribution*
+(`./gradlew assemble -Dsandbox.enabled=true`).
 
-> **JDK note:** the data-format plugins (`composite-engine`, `parquet-data-format`,
-> `analytics-backend-datafusion`) compile and test against **JDK 25**, not the repo-wide
-> JDK 21 minimum. Point `JAVA_HOME` (or the Gradle runtime JDK) at a JDK 25 before running
-> their tests. Any task that touches the native path also depends on
-> `:sandbox:libs:dataformat-native:buildRustLibrary`, so **Rust/Cargo must be installed**.
+> **Before you run:** ensure `JAVA_HOME` points at a **JDK 25** and that **Rust/Cargo** is
+> installed — the data-format test tasks depend on
+> `:sandbox:libs:dataformat-native:buildRustLibrary`.
 
-### Unit tests (`src/test`, class names end in `Tests`)
+### Unit tests
+
+Located in `src/test`; class names end in `Tests`.
 
 ```bash
-# One plugin's unit tests
+# All unit tests for a plugin
 ./gradlew :sandbox:plugins:composite-engine:test
-./gradlew :sandbox:plugins:analytics-backend-datafusion:test
 
-# A single test class or method
+# A single class or method
 ./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests"
 ./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests.testRollback"
 
-# Reproduce a failure with its seed, or repeat to shake out flakiness
+# Reproduce with a seed, or repeat to surface flakiness
 ./gradlew :sandbox:plugins:composite-engine:test -Dtests.seed=DEADBEEF
 ./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests.testRollback" -Dtests.iters=50
 ```
 
-### Internal cluster tests (`src/internalClusterTest`, class names end in `IT`)
+### Internal cluster tests
 
-These spin up an in-memory multi-node cluster. Enabled by
-`apply plugin: 'opensearch.internal-cluster-test'` in the plugin's `build.gradle`; the
-data-format plugins add the Netty/native JVM flags and the Rust build dependency for you.
+Located in `src/internalClusterTest`; class names end in `IT`. These run an in-memory
+multi-node cluster and are enabled by `apply plugin: 'opensearch.internal-cluster-test'`.
 
 ```bash
 ./gradlew :sandbox:plugins:composite-engine:internalClusterTest
 ./gradlew :sandbox:plugins:composite-engine:internalClusterTest --tests "*.CompositeParquetIndexIT"
 ```
 
-Plugins with `internalClusterTest` sources today: `composite-engine`,
-`analytics-engine`, `analytics-backend-datafusion`, `dsl-query-executor`,
-`block-cache-foyer`, and the `native-repository-*` plugins.
+Plugins with internal cluster tests today: `composite-engine`, `analytics-engine`,
+`analytics-backend-datafusion`, `dsl-query-executor`, `block-cache-foyer`, and the
+`native-repository-*` plugins.
 
-### REST / QA integration tests (`sandbox/qa`)
+### REST / QA integration tests
 
-The end-to-end analytics stack (composite + Parquet + DataFusion + PPL) is exercised from
-the QA modules, which stand up a real test cluster with the full plugin set and JVM flags:
+The end-to-end analytics stack is exercised from the QA modules, which stand up a real test
+cluster with the full plugin set and JVM configuration.
 
 ```bash
-# Full analytics REST suite (default 2-node cluster)
+# Full analytics REST suite (default two-node cluster)
 ./gradlew :sandbox:qa:analytics-engine-rest:integTest
 
-# Named variants (each configures the cluster differently — see the build.gradle)
-./gradlew :sandbox:qa:analytics-engine-rest:integTestNoMerge      # parquet merge disabled
-./gradlew :sandbox:qa:analytics-engine-rest:integTestStreaming    # Arrow Flight streaming
-./gradlew :sandbox:qa:analytics-engine-rest:integTestMemtable
+# Purpose-built variants (each configures the cluster differently)
+./gradlew :sandbox:qa:analytics-engine-rest:integTestNoMerge     # Parquet segment merge disabled
+./gradlew :sandbox:qa:analytics-engine-rest:integTestStreaming   # Arrow Flight streaming
+./gradlew :sandbox:qa:analytics-engine-rest:integTestMemtable    # memtable reduce sink
 
-# Coordinator-reduce internal cluster tests
+# Coordinator internal cluster tests
 ./gradlew :sandbox:qa:analytics-engine-coordinator:internalClusterTest
 
-# Run the REST tests against an already-running external cluster
+# Run REST tests against an already-running external cluster
 ./gradlew :sandbox:qa:analytics-engine-rest:restTest -PrestCluster=localhost:9200
 ```
 
-`sandbox/qa/analytics-engine-rest/build.gradle` is the authoritative reference for the exact
-plugin order, JVM flags, and cluster settings the stack needs.
-
 ### Rust tests
 
-The DataFusion native crate has Rust unit + fuzz tests wired into Gradle `check` via a
-`cargoTest` task:
+The DataFusion native crate has Rust unit and fuzz tests wired into Gradle `check` via a
+`cargoTest` task. The fuzz seed follows the build-wide `-Dtests.seed`, so a failing Java
+seed reproduces the Rust failure.
 
 ```bash
-# Via Gradle (runs `cargo test -p opensearch-datafusion --lib`)
+# Through Gradle (runs `cargo test -p opensearch-datafusion --lib`)
 ./gradlew :sandbox:plugins:analytics-backend-datafusion:cargoTest
 
-# The fuzz seed follows -Dtests.seed (or override explicitly)
+# With an explicit seed
 ./gradlew :sandbox:plugins:analytics-backend-datafusion:cargoTest -PindexedE2eSeed=<hex>
 
-# Or run cargo directly in the crate
+# Or directly in the crate
 cd sandbox/libs/dataformat-native/rust && cargo test -p opensearch-datafusion --lib
 ```
 
-### Everything for one plugin
+### Verification and formatting
 
 ```bash
-# Unit tests + static analysis (spotless, forbidden APIs, etc.); for
+# Unit tests + static analysis (Spotless, forbidden APIs, ...); for
 # analytics-backend-datafusion this also runs cargoTest.
 ./gradlew :sandbox:plugins:composite-engine:check
 
-# Static/format checks only
+# Static / format checks only, and auto-fix formatting
 ./gradlew :sandbox:plugins:composite-engine:precommit
-./gradlew spotlessApply        # auto-fix formatting
+./gradlew spotlessApply
 ```
 
-Note: `check` does **not** run `internalClusterTest` — run that task explicitly (it is heavy).
+> `check` does **not** include `internalClusterTest` — invoke that task explicitly, as it is
+> comparatively heavy.
 
-## Where to go next
+## Configuration reference
 
-- [`composite-engine/README.md`](README.md) — architecture and key classes of the composite engine.
-- `server/.../index/engine/dataformat/DataFormatPlugin.java` — the SPI to implement if you
-  want to contribute a **new** data format.
-- Declare `extendedPlugins = ['composite-engine']` in your format plugin's `build.gradle` so
-  the composite engine discovers it at startup.
+### Index settings (set at creation; final)
+
+| Setting | Default | Description |
+|---|---|---|
+| `index.pluggable.dataformat.enabled` | `false` | Master switch enabling the pluggable data format for the index. |
+| `index.pluggable.dataformat` | `""` | Data format to use; set to `composite` for primary + secondary. |
+| `index.composite.primary_data_format` | `parquet` | Authoritative format that owns merges and commits. |
+| `index.composite.secondary_data_formats` | `[]` | Additional formats written alongside the primary (array or single string). |
+
+### Cluster settings (dynamic defaults for new indices)
+
+| Setting | Description |
+|---|---|
+| `cluster.pluggable.dataformat.enabled` | Cluster-wide default for `index.pluggable.dataformat.enabled`. |
+| `cluster.pluggable.dataformat` | Cluster-wide default data format (e.g. `composite`). |
+| `cluster.composite.primary_data_format` | Default primary format for new composite indices. |
+| `cluster.composite.secondary_data_formats` | Default secondary formats for new composite indices. |
+
+### Feature flags (node JVM system properties)
+
+| Property | Required for |
+|---|---|
+| `opensearch.experimental.feature.pluggable.dataformat.enabled` | Any composite / pluggable data format index. |
+| `opensearch.experimental.feature.transport.stream.enabled` | The analytics query path (streaming fragment dispatch). |
 
 ## Troubleshooting
 
-- **`UnsatisfiedLinkError` / missing native library** — the Parquet/DataFusion plugins need
-  their Rust component built and `java.library.path` pointed at it. `./gradlew run` handles
-  this automatically; a manually-started node must set `-Djava.library.path` to
-  `sandbox/libs/dataformat-native/rust/target/release`.
-- **`IllegalArgumentException` changing `index.pluggable.dataformat*`** — these settings are
-  final; recreate the index rather than updating them.
-- **`_count` returns 0** — expected on a parquet-primary index (see step 4); query via the
-  analytics/PPL path instead.
+| Symptom | Cause and resolution |
+|---|---|
+| `UnsatisfiedLinkError` or missing native library at startup | The Parquet/DataFusion native library is not built or not on `java.library.path`. `./gradlew run` and the test tasks build it automatically; a manually started node must build it (`./gradlew :sandbox:libs:dataformat-native:buildRustLibrary`) and set `-Djava.library.path=<repo>/sandbox/libs/dataformat-native/rust/target/release`. |
+| `IllegalArgumentException` when updating `index.pluggable.dataformat*` | These settings are **final**. Recreate the index rather than updating them. |
+| `_count` / `_search` returns 0 documents | Expected on a parquet-primary index — those APIs read the Lucene secondary. Query via the analytics/PPL path. |
+| Compilation errors referencing FFM or newer APIs | The data-format plugins require **JDK 25**; verify `JAVA_HOME`. |
+| PPL query fails or the analytics endpoint is unavailable | The query stack needs the analytics plugins **and** `opensearch.experimental.feature.transport.stream.enabled=true`. Compare your node against `sandbox/qa/analytics-engine-rest/build.gradle`. |
+
+## Extending: authoring a new data format
+
+To contribute a new storage engine:
+
+1. Implement `DataFormatPlugin`
+   (`server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java`):
+   - `getDataFormat()` returns your `DataFormat` (unique `name()`, `priority()`, and
+     `supportedFields()`),
+   - `indexingEngine(IndexingEngineConfig)` returns a per-shard `IndexingExecutionEngine`.
+2. Declare `extendedPlugins = ['composite-engine']` in your plugin's `build.gradle` so the
+   composite engine discovers your format through the `ExtensiblePlugin` SPI.
+3. Register the format name in the index settings above to route data to it.
+
+The SPI contracts (`DataFormat`, `IndexingExecutionEngine`, `Writer`, and the failure model)
+are described in detail in [`README.md`](README.md).
+
+## Further reading
+
+- [`composite-engine/README.md`](README.md) — composite engine architecture and key classes.
+- [`analytics-engine/README.md`](../analytics-engine/README.md) — query hub and SPI wiring.
+- [`analytics-backend-datafusion/README.md`](../analytics-backend-datafusion/README.md) — native execution backend.
+- [`sandbox/qa/analytics-engine-rest/build.gradle`](../../qa/analytics-engine-rest/build.gradle) — authoritative end-to-end cluster configuration.
+- [Developer Guide](../../../DEVELOPER_GUIDE.md) — building, testing, and the `sandbox` layout.

--- a/sandbox/plugins/composite-engine/GETTING_STARTED.md
+++ b/sandbox/plugins/composite-engine/GETTING_STARTED.md
@@ -1,0 +1,249 @@
+# Getting Started with the Pluggable Data Format
+
+> **Experimental.** The pluggable data format and every plugin described here live in
+> `sandbox/` and are marked `@ExperimentalApi`. They carry no backwards-compatibility or
+> long-term-support guarantees and may change or be removed at any time.
+
+This guide shows how to spin up OpenSearch from source with the **pluggable data format**
+enabled, create an index backed by the **composite** format (Parquet primary + Lucene
+secondary), ingest a document, and verify it.
+
+## What the pluggable data format is
+
+Classic OpenSearch stores every index in Lucene. The pluggable data format lets an index
+be backed by one or more *data format* engines instead. The engine that ties them together
+is the **composite** format, which writes each document to:
+
+- a **primary** format — the authoritative store used for merges and commit coordination
+  (default: `parquet`), and
+- zero or more **secondary** formats that receive the same writes (commonly `lucene`, so
+  text/keyword predicates still resolve).
+
+Each format is contributed by a `DataFormatPlugin` (see the SPI in
+`server/.../index/engine/dataformat/` and the architecture notes in
+[`README.md`](README.md)). The composite plugin discovers the format plugins at node
+startup via the `ExtensiblePlugin` SPI.
+
+## Prerequisites
+
+- The standard OpenSearch build prerequisites (JDK 21+, and **Rust + protoc** — the
+  Parquet/DataFusion plugins compile a native Rust component). See the
+  [Developer Guide](../../../DEVELOPER_GUIDE.md#install-prerequisites).
+- `JAVA_HOME` set to your JDK.
+
+## 1. Run OpenSearch with the data-format plugins
+
+From the repository root, launch a single node with the composite stack installed. The
+`run` task automatically enables the pluggable data format feature flag and sets the native
+library path whenever `parquet-data-format` or `analytics-backend-datafusion` is in the
+plugin list (see `gradle/run.gradle`):
+
+```bash
+./gradlew run -PinstalledPlugins='["arrow-base","arrow-flight-rpc","composite-engine","parquet-data-format","analytics-backend-lucene"]'
+```
+
+- `composite-engine` — orchestrates primary + secondary formats.
+- `parquet-data-format` — the default primary format (native Rust component).
+- `analytics-backend-lucene` — provides the `lucene` secondary format.
+- `arrow-base` / `arrow-flight-rpc` — Arrow runtime the native path depends on. `arrow-base`
+  must be listed **before** any plugin that extends it.
+
+This corresponds to setting, on a manually-configured node:
+
+```yaml
+# opensearch.yml
+opensearch.experimental.feature.pluggable.dataformat.enabled: true
+```
+
+Wait for `[node-1] started` in the console.
+
+## 2. Create a composite-backed index
+
+The two index settings that turn on the pluggable data format are **final** — they can only
+be set at index-creation time:
+
+```bash
+curl -X PUT "http://localhost:9200/logs-parquet" -H 'Content-Type: application/json' -d '{
+  "settings": {
+    "index.pluggable.dataformat.enabled": true,
+    "index.pluggable.dataformat": "composite",
+    "index.composite.primary_data_format": "parquet",
+    "index.composite.secondary_data_formats": ["lucene"]
+  },
+  "mappings": {
+    "properties": {
+      "message":   { "type": "text" },
+      "level":     { "type": "keyword" },
+      "@timestamp":{ "type": "date" }
+    }
+  }
+}'
+```
+
+| Setting | Default | Notes |
+|---|---|---|
+| `index.pluggable.dataformat.enabled` | `false` | Final. Master switch for the index. |
+| `index.pluggable.dataformat` | `""` | Final. Set to `composite` to use the composite engine. |
+| `index.composite.primary_data_format` | `parquet` | Final. Authoritative / merge format. |
+| `index.composite.secondary_data_formats` | `[]` | Final. Extra formats written alongside the primary. |
+
+You can also set cluster-wide defaults so new indices pick up the format automatically
+(`cluster.pluggable.dataformat.enabled`, `cluster.pluggable.dataformat`,
+`cluster.composite.primary_data_format`, `cluster.composite.secondary_data_formats`).
+
+## 3. Index a document
+
+```bash
+curl -X POST "http://localhost:9200/logs-parquet/_doc?refresh=true" -H 'Content-Type: application/json' -d '{
+  "message": "connection reset by peer",
+  "level": "ERROR",
+  "@timestamp": "2026-01-01T00:00:00Z"
+}'
+```
+
+## 4. Verify
+
+> **Gotcha:** `_count` and `_search` hit the **Lucene secondary** index, which does not
+> materialize the Parquet-primary rows — so on a parquet-primary index `_count` reports
+> **0 docs even after a successful ingest**. That is expected, not data loss.
+
+Confirm the shard is healthy and the format took effect:
+
+```bash
+# Index exists and is green/yellow
+curl "http://localhost:9200/_cat/indices/logs-parquet?v"
+
+# Settings reflect the composite format
+curl "http://localhost:9200/logs-parquet/_settings?pretty"
+```
+
+To actually **query** the Parquet data you need the analytics query stack (DataFusion
+backend + a PPL/SQL front end). Add those plugins when launching:
+
+```bash
+./gradlew run -PinstalledPlugins='["arrow-base","arrow-flight-rpc","composite-engine","parquet-data-format","analytics-backend-lucene","analytics-backend-datafusion","analytics-engine","dsl-query-executor"]'
+```
+
+The analytics engine additionally requires the streaming transport feature flag
+(`opensearch.experimental.feature.transport.stream.enabled=true`). For a fully-wired,
+ready-to-run example of the complete stack — plugin order, JVM flags, and cluster settings
+— see the QA harness at
+[`sandbox/qa/analytics-engine-rest/build.gradle`](../../qa/analytics-engine-rest/build.gradle)
+and the [`analytics-engine`](../analytics-engine/README.md) README.
+
+## Running tests
+
+Sandbox plugins use the same test tiers as the rest of OpenSearch. There is **no special
+`sandbox.enabled` flag for tests** — that flag only controls whether sandbox artifacts are
+bundled into a *distribution* (`./gradlew assemble -Dsandbox.enabled=true`). Test tasks run
+per-project directly.
+
+> **JDK note:** the data-format plugins (`composite-engine`, `parquet-data-format`,
+> `analytics-backend-datafusion`) compile and test against **JDK 25**, not the repo-wide
+> JDK 21 minimum. Point `JAVA_HOME` (or the Gradle runtime JDK) at a JDK 25 before running
+> their tests. Any task that touches the native path also depends on
+> `:sandbox:libs:dataformat-native:buildRustLibrary`, so **Rust/Cargo must be installed**.
+
+### Unit tests (`src/test`, class names end in `Tests`)
+
+```bash
+# One plugin's unit tests
+./gradlew :sandbox:plugins:composite-engine:test
+./gradlew :sandbox:plugins:analytics-backend-datafusion:test
+
+# A single test class or method
+./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests"
+./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests.testRollback"
+
+# Reproduce a failure with its seed, or repeat to shake out flakiness
+./gradlew :sandbox:plugins:composite-engine:test -Dtests.seed=DEADBEEF
+./gradlew :sandbox:plugins:composite-engine:test --tests "*.CompositeWriterTests.testRollback" -Dtests.iters=50
+```
+
+### Internal cluster tests (`src/internalClusterTest`, class names end in `IT`)
+
+These spin up an in-memory multi-node cluster. Enabled by
+`apply plugin: 'opensearch.internal-cluster-test'` in the plugin's `build.gradle`; the
+data-format plugins add the Netty/native JVM flags and the Rust build dependency for you.
+
+```bash
+./gradlew :sandbox:plugins:composite-engine:internalClusterTest
+./gradlew :sandbox:plugins:composite-engine:internalClusterTest --tests "*.CompositeParquetIndexIT"
+```
+
+Plugins with `internalClusterTest` sources today: `composite-engine`,
+`analytics-engine`, `analytics-backend-datafusion`, `dsl-query-executor`,
+`block-cache-foyer`, and the `native-repository-*` plugins.
+
+### REST / QA integration tests (`sandbox/qa`)
+
+The end-to-end analytics stack (composite + Parquet + DataFusion + PPL) is exercised from
+the QA modules, which stand up a real test cluster with the full plugin set and JVM flags:
+
+```bash
+# Full analytics REST suite (default 2-node cluster)
+./gradlew :sandbox:qa:analytics-engine-rest:integTest
+
+# Named variants (each configures the cluster differently — see the build.gradle)
+./gradlew :sandbox:qa:analytics-engine-rest:integTestNoMerge      # parquet merge disabled
+./gradlew :sandbox:qa:analytics-engine-rest:integTestStreaming    # Arrow Flight streaming
+./gradlew :sandbox:qa:analytics-engine-rest:integTestMemtable
+
+# Coordinator-reduce internal cluster tests
+./gradlew :sandbox:qa:analytics-engine-coordinator:internalClusterTest
+
+# Run the REST tests against an already-running external cluster
+./gradlew :sandbox:qa:analytics-engine-rest:restTest -PrestCluster=localhost:9200
+```
+
+`sandbox/qa/analytics-engine-rest/build.gradle` is the authoritative reference for the exact
+plugin order, JVM flags, and cluster settings the stack needs.
+
+### Rust tests
+
+The DataFusion native crate has Rust unit + fuzz tests wired into Gradle `check` via a
+`cargoTest` task:
+
+```bash
+# Via Gradle (runs `cargo test -p opensearch-datafusion --lib`)
+./gradlew :sandbox:plugins:analytics-backend-datafusion:cargoTest
+
+# The fuzz seed follows -Dtests.seed (or override explicitly)
+./gradlew :sandbox:plugins:analytics-backend-datafusion:cargoTest -PindexedE2eSeed=<hex>
+
+# Or run cargo directly in the crate
+cd sandbox/libs/dataformat-native/rust && cargo test -p opensearch-datafusion --lib
+```
+
+### Everything for one plugin
+
+```bash
+# Unit tests + static analysis (spotless, forbidden APIs, etc.); for
+# analytics-backend-datafusion this also runs cargoTest.
+./gradlew :sandbox:plugins:composite-engine:check
+
+# Static/format checks only
+./gradlew :sandbox:plugins:composite-engine:precommit
+./gradlew spotlessApply        # auto-fix formatting
+```
+
+Note: `check` does **not** run `internalClusterTest` — run that task explicitly (it is heavy).
+
+## Where to go next
+
+- [`composite-engine/README.md`](README.md) — architecture and key classes of the composite engine.
+- `server/.../index/engine/dataformat/DataFormatPlugin.java` — the SPI to implement if you
+  want to contribute a **new** data format.
+- Declare `extendedPlugins = ['composite-engine']` in your format plugin's `build.gradle` so
+  the composite engine discovers it at startup.
+
+## Troubleshooting
+
+- **`UnsatisfiedLinkError` / missing native library** — the Parquet/DataFusion plugins need
+  their Rust component built and `java.library.path` pointed at it. `./gradlew run` handles
+  this automatically; a manually-started node must set `-Djava.library.path` to
+  `sandbox/libs/dataformat-native/rust/target/release`.
+- **`IllegalArgumentException` changing `index.pluggable.dataformat*`** — these settings are
+  final; recreate the index rather than updating them.
+- **`_count` returns 0** — expected on a parquet-primary index (see step 4); query via the
+  analytics/PPL path instead.


### PR DESCRIPTION
### Description

Adds a basic **Getting Started** guide for the experimental pluggable data format
(sandbox), and links it from the main Developer Guide so it is discoverable.

The new guide (`sandbox/plugins/composite-engine/GETTING_STARTED.md`) covers:

- What the pluggable data format is (the composite engine = Parquet primary + Lucene secondary).
- Running OpenSearch from source with the data-format plugins via
  `./gradlew run -PinstalledPlugins='[...]'` (which auto-enables the
  `opensearch.experimental.feature.pluggable.dataformat.enabled` flag and the native lib path).
- Creating a composite-backed index using the `index.pluggable.dataformat*` /
  `index.composite.*` settings, ingesting, and verifying (including the
  `_count`-returns-0 gotcha on a parquet-primary index).
- Running the sandbox test tiers: unit (`test`), internal cluster
  (`internalClusterTest`), REST/QA (`sandbox/qa/analytics-engine-rest`), and the
  Rust `cargoTest`, plus the JDK 25 / Rust prerequisites.

`DEVELOPER_GUIDE.md` gains a short pointer to the guide in the existing `sandbox` section.

Documentation-only change; no functional code is modified.

### Check List
- [x] Documentation update.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.