### PR TITLE
Stop shallow copy snapshot restore from storing every segment twice

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -11,6 +11,7 @@ package org.opensearch.remotestore;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
+import org.apache.lucene.index.IndexFileNames;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
@@ -29,6 +30,8 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.io.VersionedCodecStreamWrapper;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
@@ -39,10 +42,14 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandlerFactory;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.recovery.RecoveryState;
@@ -69,10 +76,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -224,6 +233,176 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
         indexDocuments(client, restoredIndexName1, numDocsInIndex1, numDocsInIndex1 + 2);
         ensureGreen(restoredIndexName1);
         assertDocsPresentInIndex(client, restoredIndexName1, numDocsInIndex1 + 2);
+    }
+
+    private static final VersionedCodecStreamWrapper<RemoteSegmentMetadata> METADATA_STREAM_WRAPPER = new VersionedCodecStreamWrapper<>(
+        new RemoteSegmentMetadataHandlerFactory(),
+        RemoteSegmentMetadata.VERSION_ONE,
+        RemoteSegmentMetadata.CURRENT_VERSION,
+        RemoteSegmentMetadata.METADATA_CODEC
+    );
+
+    /**
+     * Restoring a shallow copy snapshot copies the source commit into the restored shard's own remote store during
+     * recovery. That upload has to be recorded in a segment metadata file: without one, the refresh that follows the
+     * engine opening finds no remote state to reconcile against, re-uploads the identical file set under fresh UUIDs,
+     * and leaves recovery's copy named by no metadata file at all - which puts it permanently beyond the reach of
+     * deleteStaleSegments, since that only ever considers blobs it reads out of a metadata file being retired.
+     */
+    public void testRestoreShallowCopyDoesNotUploadSegmentsTwice() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataAndWarmNodes(1);
+        String indexName = "testindex1";
+        String restoredIndexName = indexName + "-restored";
+        String snapshotRepoName = "test-restore-snapshot-repo";
+        String snapshotName = "test-restore-snapshot1";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+
+        createRepository(snapshotRepoName, "fs", getRepositorySettings(absolutePath1, true));
+
+        Client client = client();
+        createIndex(indexName, getIndexSettings(1, 0).build());
+        indexDocuments(client, indexName, randomIntBetween(20, 40));
+        client.admin().indices().prepareFlush(indexName).get();
+        ensureGreen(indexName);
+
+        SnapshotInfo snapshotInfo = createSnapshot(snapshotRepoName, snapshotName, new ArrayList<>(List.of(indexName)));
+        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+        assertTrue(snapshotInfo.isRemoteStoreIndexShallowCopyEnabled());
+
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(snapshotRepoName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .setRenamePattern(indexName)
+            .setRenameReplacement(restoredIndexName)
+            .get();
+        assertEquals(RestStatus.OK, restoreSnapshotResponse.status());
+        ensureGreen(restoredIndexName);
+
+        assertTrue("no segment metadata was written for " + restoredIndexName, countSegmentMetadataFiles(restoredIndexName) > 0);
+        Map<String, Long> blobsPerFile = countSegmentBlobsPerLuceneFile(restoredIndexName);
+        assertFalse("no segment data blobs were uploaded for " + restoredIndexName, blobsPerFile.isEmpty());
+        Map<String, Long> duplicated = blobsPerFile.entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        assertEquals("segment data files uploaded more than once by the restore: " + duplicated, Map.of(), duplicated);
+        assertEverySegmentBlobIsReferenced(restoredIndexName);
+    }
+
+    /**
+     * The restore-in-place variant. {@code RestoreService} only assigns a fresh index UUID when the target name does
+     * not already exist; restoring over an existing closed index reuses that index's UUID, so the restored shard's
+     * remote path is the path the snapshot was taken from and already holds the commit's blobs. Recovery must not
+     * upload a second copy of each of them.
+     */
+    public void testRestoreShallowCopyInPlaceDoesNotUploadSegmentsTwice() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataAndWarmNodes(1);
+        String indexName = "testindex1";
+        String snapshotRepoName = "test-restore-snapshot-repo";
+        String snapshotName = "test-restore-snapshot1";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+
+        createRepository(snapshotRepoName, "fs", getRepositorySettings(absolutePath1, true));
+
+        Client client = client();
+        createIndex(indexName, getIndexSettings(1, 0).build());
+        indexDocuments(client, indexName, randomIntBetween(20, 40));
+        client.admin().indices().prepareFlush(indexName).get();
+        ensureGreen(indexName);
+
+        SnapshotInfo snapshotInfo = createSnapshot(snapshotRepoName, snapshotName, new ArrayList<>(List.of(indexName)));
+        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+        assertTrue(snapshotInfo.isRemoteStoreIndexShallowCopyEnabled());
+
+        String uuidBeforeRestore = client.admin().cluster().prepareState().get().getState().metadata().index(indexName).getIndexUUID();
+
+        // Restoring without a rename pattern requires the target index to be closed, and reuses its index UUID.
+        assertAcked(client.admin().indices().prepareClose(indexName));
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(snapshotRepoName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
+        assertEquals(RestStatus.OK, restoreSnapshotResponse.status());
+        ensureGreen(indexName);
+
+        String uuidAfterRestore = client.admin().cluster().prepareState().get().getState().metadata().index(indexName).getIndexUUID();
+        assertEquals("restore in place is expected to reuse the index UUID, and so the remote path", uuidBeforeRestore, uuidAfterRestore);
+
+        Map<String, Long> blobsPerFile = countSegmentBlobsPerLuceneFile(indexName);
+        assertFalse("no segment data blobs were uploaded for " + indexName, blobsPerFile.isEmpty());
+        Map<String, Long> duplicated = blobsPerFile.entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        assertEquals("segment data files uploaded more than once by the restore: " + duplicated, Map.of(), duplicated);
+        assertEverySegmentBlobIsReferenced(indexName);
+    }
+
+    /**
+     * Asserts that every blob under the index's remote segment data path is named by one of its metadata files. A blob
+     * that no metadata file names is unreachable rather than merely stale: {@code deleteStaleSegments} only deletes
+     * blobs it reads out of a metadata file it is retiring, so nothing will ever reclaim it.
+     * <p>
+     * Retried, because a refresh registers an uploaded blob before it writes the metadata file naming it - and
+     * {@code waitForRemoteStoreSync} gates on that in-memory registration, so the restore can report complete while
+     * the metadata file is still pending.
+     */
+    private void assertEverySegmentBlobIsReferenced(String indexName) throws Exception {
+        assertBusy(() -> {
+            Set<String> referenced = new HashSet<>();
+            try (Stream<Path> metadataFiles = Files.list(remoteSegmentPath(indexName, METADATA))) {
+                for (Path metadataFile : metadataFiles.collect(Collectors.toList())) {
+                    RemoteSegmentMetadata metadata = METADATA_STREAM_WRAPPER.readStream(
+                        new ByteArrayIndexInput(metadataFile.getFileName().toString(), Files.readAllBytes(metadataFile))
+                    );
+                    metadata.getMetadata().values().forEach(segment -> referenced.add(segment.getUploadedFilename()));
+                }
+            }
+            try (Stream<Path> blobs = Files.list(remoteSegmentPath(indexName, DATA))) {
+                Set<String> unreferenced = blobs.map(blob -> blob.getFileName().toString())
+                    .filter(blob -> referenced.contains(blob) == false)
+                    .collect(Collectors.toSet());
+                assertEquals("segment blobs named by no metadata file: " + unreferenced, Set.of(), unreferenced);
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Counts the blobs under the index's remote segment data path, grouped by the Lucene file they hold. Each blob is
+     * named {@code <lucene filename>__<uuid>}, so more than one blob per group means the same file was uploaded twice.
+     * <p>
+     * Commit files are excluded. A segment file's name is content-unique - Lucene never rewrites one - but a
+     * {@code segments_N} generation can legitimately recur with different content, notably when a restore in place
+     * rewinds the shard to the snapshot's commit and it commits forward again over a generation the closed index had
+     * already used. The UUID suffix exists to disambiguate exactly that, so the invariant for commit files is
+     * reachability, asserted by {@link #assertEverySegmentBlobIsReferenced}, not name-uniqueness.
+     */
+    private Map<String, Long> countSegmentBlobsPerLuceneFile(String indexName) throws IOException {
+        try (Stream<Path> blobs = Files.list(remoteSegmentPath(indexName, DATA))) {
+            return blobs.map(blob -> blob.getFileName().toString())
+                .map(blob -> blob.split(RemoteSegmentStoreDirectory.SEGMENT_NAME_UUID_SEPARATOR)[0])
+                .filter(luceneFile -> luceneFile.startsWith(IndexFileNames.SEGMENTS) == false)
+                .collect(Collectors.groupingBy(luceneFile -> luceneFile, Collectors.counting()));
+        }
+    }
+
+    private long countSegmentMetadataFiles(String indexName) throws IOException {
+        try (Stream<Path> metadataFiles = Files.list(remoteSegmentPath(indexName, METADATA))) {
+            return metadataFiles.count();
+        }
+    }
+
+    private Path remoteSegmentPath(String indexName, RemoteStoreEnums.DataType dataType) {
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String path = getShardLevelBlobPath(client(), indexName, new BlobPath(), "0", SEGMENTS, dataType, segmentsPathFixedPrefix)
+            .buildAsString();
+        return Path.of(remoteRepoPath + "/" + path);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -6136,6 +6136,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 overrideLocal,
                 () -> {}
             );
+            // Recovery has just written the restored commit into this shard's own remote store. Record it, so that the
+            // refresh following the engine opening does not upload the identical file set a second time and leave this
+            // copy named by no metadata file. See RemoteSegmentStoreDirectory#uploadMetadataForRestoredCommit.
+            if (remoteDirectory != null && remoteSegmentMetadata != null) {
+                remoteDirectory.uploadMetadataForRestoredCommit(
+                    remoteSegmentMetadata,
+                    shardId,
+                    getOperationPrimaryTerm(),
+                    store.directory(),
+                    getNodeId()
+                );
+            }
             if (pinnedTimestamp) {
                 final SegmentInfos infosSnapshot = store.buildSegmentInfos(
                     remoteSegmentMetadata.getSegmentInfosBytes(),

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -402,6 +402,10 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             return uploadedFilename;
         }
 
+        public int getWrittenByMajor() {
+            return writtenByMajor;
+        }
+
         public void setWrittenByMajor(int writtenByMajor) {
             if (writtenByMajor <= Version.LATEST.major && writtenByMajor >= Version.MIN_SUPPORTED_MAJOR) {
                 this.writtenByMajor = writtenByMajor;
@@ -752,12 +756,22 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     /**
      * Copies an existing src file from directory from to a non-existent file dest in this directory.
      * Once the segment is uploaded to remote segment store, update the cache accordingly.
+     * <p>
+     * The upload is skipped when this directory already holds the file under the same checksum. Restoring a snapshot
+     * over an existing closed index reuses that index's UUID, so the restored shard's remote path is the path the
+     * snapshot was taken from and already holds the commit's blobs; copying them again would store a second copy of
+     * every segment. Segment files are immutable, so a matching name and checksum means identical content - this is
+     * the same condition {@code RemoteStoreRefreshListener#skipUpload} applies on the refresh path.
      */
     @Override
     public void copyFrom(Directory from, String src, String dest, IOContext context) throws IOException {
+        String checksum = getChecksumOfLocalFile(from, src);
+        if (containsFile(src, checksum)) {
+            return;
+        }
         String remoteFilename = getNewRemoteSegmentFilename(dest);
         remoteDataDirectory.copyFrom(from, src, remoteFilename, context);
-        postUpload(from, src, remoteFilename, getChecksumOfLocalFile(from, src));
+        postUpload(from, src, remoteFilename, checksum);
     }
 
     /**
@@ -907,6 +921,86 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                             RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
                             segmentInfoSnapshotByteArray,
                             replicationCheckpoint
+                        )
+                    );
+                }
+                storeDirectory.sync(Collections.singleton(metadataFilename));
+                remoteMetadataDirectory.copyFrom(storeDirectory, metadataFilename, metadataFilename, IOContext.DEFAULT);
+            } finally {
+                tryAndDeleteLocalFile(metadataFilename, storeDirectory);
+            }
+        }
+    }
+
+    /**
+     * Writes a metadata file for a commit that was copied into this directory by a restore rather than produced by a
+     * refresh.
+     * <p>
+     * Uploads are recorded only in the in-memory {@code segmentsUploadedToRemoteStore}, which {@link #init()} replaces
+     * wholesale when it reconciles against remote state. A restored shard has no metadata file to reconcile against,
+     * so without this call the registrations made while copying are discarded when the engine opens, the first refresh
+     * uploads the identical file set again under fresh UUIDs, and the copy the restore made is left named by no
+     * metadata file - beyond the reach of {@link #deleteStaleSegments(int)}, which only deletes blobs it reads out of a
+     * metadata file being retired.
+     * <p>
+     * The metadata written here describes the same commit as {@code sourceMetadata} - the same files, the same
+     * {@code SegmentInfos} bytes and the same generation - but names the blobs this directory now holds, under the
+     * restored shard's own id and primary term so that metadata written later by the refresh listener supersedes it.
+     *
+     * @param sourceMetadata metadata of the commit that was copied into this directory
+     * @param shardId        id of the restored shard
+     * @param primaryTerm    primary term of the restored shard
+     * @param storeDirectory local directory used to stage the metadata file before upload
+     * @param nodeId         node id of the restored shard
+     * @throws IOException   if a file named by {@code sourceMetadata} was not uploaded to this directory, or if the
+     *                       metadata file could not be written
+     */
+    public void uploadMetadataForRestoredCommit(
+        RemoteSegmentMetadata sourceMetadata,
+        ShardId shardId,
+        long primaryTerm,
+        Directory storeDirectory,
+        String nodeId
+    ) throws IOException {
+        ReplicationCheckpoint source = sourceMetadata.getReplicationCheckpoint();
+        ReplicationCheckpoint checkpoint = new ReplicationCheckpoint(
+            shardId,
+            primaryTerm,
+            source.getSegmentsGen(),
+            source.getSegmentInfosVersion(),
+            source.getLength(),
+            source.getCodec(),
+            source.getMetadataMap()
+        );
+        synchronized (this) {
+            // The translog generation only groups metadata files by writer within the filename. The restored shard's
+            // translog is bootstrapped after its segments are copied, so there is no generation to record yet.
+            String metadataFilename = MetadataFilenameUtils.getMetadataFilename(
+                primaryTerm,
+                checkpoint.getSegmentsGen(),
+                0L,
+                metadataUploadCounter.incrementAndGet(),
+                RemoteSegmentMetadata.CURRENT_VERSION,
+                nodeId
+            );
+            try {
+                try (IndexOutput indexOutput = storeDirectory.createOutput(metadataFilename, IOContext.DEFAULT)) {
+                    Map<String, String> uploadedSegments = new HashMap<>();
+                    for (Map.Entry<String, UploadedSegmentMetadata> entry : sourceMetadata.getMetadata().entrySet()) {
+                        UploadedSegmentMetadata uploaded = segmentsUploadedToRemoteStore.get(entry.getKey());
+                        if (uploaded == null) {
+                            throw new NoSuchFileException(entry.getKey());
+                        }
+                        // The restore copies bytes verbatim, so the writing Lucene version carries over unchanged.
+                        uploaded.setWrittenByMajor(entry.getValue().getWrittenByMajor());
+                        uploadedSegments.put(entry.getKey(), uploaded.toString());
+                    }
+                    metadataStreamWrapper.writeStream(
+                        indexOutput,
+                        new RemoteSegmentMetadata(
+                            RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
+                            sourceMetadata.getSegmentInfosBytes(),
+                            checkpoint
                         )
                     );
                 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -757,16 +757,15 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * Copies an existing src file from directory from to a non-existent file dest in this directory.
      * Once the segment is uploaded to remote segment store, update the cache accordingly.
      * <p>
-     * The upload is skipped when this directory already holds the file under the same checksum. Restoring a snapshot
-     * over an existing closed index reuses that index's UUID, so the restored shard's remote path is the path the
-     * snapshot was taken from and already holds the commit's blobs; copying them again would store a second copy of
-     * every segment. Segment files are immutable, so a matching name and checksum means identical content - this is
-     * the same condition {@code RemoteStoreRefreshListener#skipUpload} applies on the refresh path.
+     * Skips the upload when this directory already holds the file under the same checksum, so that a restore into a
+     * remote path that already has the commit's blobs does not store a second copy of every segment. Only applies
+     * when {@code dest} equals {@code src}, since the cache is keyed by {@code src} and so says nothing about
+     * whether a differently named {@code dest} exists.
      */
     @Override
     public void copyFrom(Directory from, String src, String dest, IOContext context) throws IOException {
         String checksum = getChecksumOfLocalFile(from, src);
-        if (containsFile(src, checksum)) {
+        if (src.equals(dest) && containsFile(src, checksum)) {
             return;
         }
         String remoteFilename = getNewRemoteSegmentFilename(dest);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -45,6 +45,7 @@ import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandlerFactory;
 import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.junit.annotations.TestLogging;
 import org.opensearch.threadpool.ThreadPool;
@@ -784,6 +785,110 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
         for (String filename : expected.keySet()) {
             assertEquals(expected.get(filename).toString(), actual.get(filename).toString());
         }
+    }
+
+    /**
+     * A restore uploads the source commit's segments into the restored shard's own remote store and must then record
+     * them: the restored shard has no metadata file to reconcile against, so an unrecorded upload is discarded when
+     * the engine opens and re-done by the first refresh, leaving the first copy referenced by nothing.
+     */
+    public void testUploadMetadataForRestoredCommit() throws IOException {
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedToTarget = remoteSegmentStoreDirectory
+            .getSegmentsUploadedToRemoteStore();
+
+        // The commit as it was described in the source shard's remote store: the same Lucene files, but blobs under
+        // the source's own path and a Lucene version that must be carried across rather than re-derived.
+        Map<String, String> sourceEntries = new HashMap<>();
+        uploadedToTarget.forEach(
+            (file, uploaded) -> sourceEntries.put(
+                file,
+                String.join(
+                    "::",
+                    file,
+                    file + "__sourceuuid",
+                    uploaded.getChecksum(),
+                    String.valueOf(uploaded.getLength()),
+                    String.valueOf(Version.LATEST.major)
+                )
+            )
+        );
+        byte[] segmentInfosBytes = new byte[] { 4, 8, 15, 16, 23, 42 };
+        ReplicationCheckpoint sourceCheckpoint = new ReplicationCheckpoint(indexShard.shardId(), 5, 7, 11, 0L, "codec", Map.of());
+        RemoteSegmentMetadata sourceMetadata = new RemoteSegmentMetadata(
+            RemoteSegmentMetadata.fromMapOfStrings(sourceEntries),
+            segmentInfosBytes,
+            sourceCheckpoint
+        );
+
+        String primaryTermLong = RemoteStoreUtils.invertLong(5);
+        String generationLong = RemoteStoreUtils.invertLong(7);
+        Directory storeDirectory = mock(Directory.class);
+        BytesStreamOutput output = new BytesStreamOutput();
+        IndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
+        when(storeDirectory.createOutput(startsWith("metadata__" + primaryTermLong + "__" + generationLong), eq(IOContext.DEFAULT)))
+            .thenReturn(indexOutput);
+
+        remoteSegmentStoreDirectory.uploadMetadataForRestoredCommit(sourceMetadata, indexShard.shardId(), 5L, storeDirectory, "node-1");
+
+        verify(remoteMetadataDirectory).copyFrom(
+            eq(storeDirectory),
+            startsWith("metadata__" + primaryTermLong + "__" + generationLong),
+            startsWith("metadata__" + primaryTermLong + "__" + generationLong),
+            eq(IOContext.DEFAULT)
+        );
+
+        VersionedCodecStreamWrapper<RemoteSegmentMetadata> streamWrapper = new VersionedCodecStreamWrapper<>(
+            new RemoteSegmentMetadataHandlerFactory(),
+            RemoteSegmentMetadata.CURRENT_VERSION,
+            RemoteSegmentMetadata.CURRENT_VERSION,
+            RemoteSegmentMetadata.METADATA_CODEC
+        );
+        RemoteSegmentMetadata written = streamWrapper.readStream(
+            new ByteArrayIndexInput("written", BytesReference.toBytes(output.bytes()))
+        );
+
+        assertEquals(uploadedToTarget.keySet(), written.getMetadata().keySet());
+        for (String file : written.getMetadata().keySet()) {
+            RemoteSegmentStoreDirectory.UploadedSegmentMetadata entry = written.getMetadata().get(file);
+            assertEquals(
+                "the restored shard's own blob must be recorded, not the source's",
+                uploadedToTarget.get(file).getUploadedFilename(),
+                entry.getUploadedFilename()
+            );
+            assertEquals(uploadedToTarget.get(file).getChecksum(), entry.getChecksum());
+            assertEquals(Version.LATEST.major, entry.getWrittenByMajor());
+        }
+        assertArrayEquals(segmentInfosBytes, written.getSegmentInfosBytes());
+        assertEquals(5, written.getPrimaryTerm());
+        assertEquals(7, written.getGeneration());
+    }
+
+    public void testUploadMetadataForRestoredCommitSegmentNotUploaded() throws IOException {
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        ReplicationCheckpoint sourceCheckpoint = new ReplicationCheckpoint(indexShard.shardId(), 5, 7, 11, 0L, "codec", Map.of());
+        RemoteSegmentMetadata sourceMetadata = new RemoteSegmentMetadata(
+            RemoteSegmentMetadata.fromMapOfStrings(Map.of("_9.si", "_9.si::_9.si__sourceuuid::1234::512::" + Version.LATEST.major)),
+            new byte[0],
+            sourceCheckpoint
+        );
+
+        Directory storeDirectory = mock(Directory.class);
+        when(storeDirectory.createOutput(startsWith("metadata__"), eq(IOContext.DEFAULT))).thenReturn(mock(IndexOutput.class));
+
+        assertThrows(
+            NoSuchFileException.class,
+            () -> remoteSegmentStoreDirectory.uploadMetadataForRestoredCommit(
+                sourceMetadata,
+                indexShard.shardId(),
+                5L,
+                storeDirectory,
+                "node-1"
+            )
+        );
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Description

Restoring a remote-store-backed index from a shallow copy snapshot stores every segment **twice** in the restored
shard's remote store. In the common case the second copy is unreachable, so nothing ever reclaims it.

`IndexShard#copySegmentFiles` uploads each downloaded file into the restored shard's `RemoteSegmentStoreDirectory`.
That upload is recorded only in the in-memory `segmentsUploadedToRemoteStore` map — never in a metadata file — and it
never checks whether the target already holds the file. Two ways that surfaces:

**A — restore into a name that doesn't exist** (any rename-restore: fresh index UUID, so an empty remote path).
`RemoteStoreRefreshListener`'s constructor calls `init()`, which finds no metadata file and empties the map, so
`skipUpload` returns false for every file and the first refresh re-uploads the whole set under fresh UUIDs. Nothing
ever names the first set, and `deleteStaleSegments` only deletes blobs it reads out of a metadata file it is retiring
— so that copy is unreachable, not stale. **2N uploaded, 2N stored, N unreclaimable.**

**B — restore over an existing closed index** (reuses that index's UUID, so the path already holds the commit's
blobs). Here `init()` does find metadata and the refresh doesn't re-upload, but recovery has already written a second
copy of every file. **N uploaded redundantly, 2N stored** — reachable, so cleanup eventually reclaims it.

Introduced in #6788, released in 2.9.0. Both restore paths are affected (`recoverFromSnapshotAndRemoteStore` and
`recoverShallowSnapshotV2`), and the mechanism is in `server/`, so it is independent of repository type.

**Fix** — one part per missing check:

1. **`RemoteSegmentStoreDirectory#uploadMetadataForRestoredCommit`** (new) persists what recovery uploaded: the same
   commit as the source, same `SegmentInfos` bytes and generation, but naming the blobs this shard now holds, under
   its own shard id and primary term. Using the *restored* shard's term matters — metadata filenames sort on an
   inverted primary term, so a higher source term would shadow every later write. Fixes A.
2. **`copyFrom(Directory, String, String, IOContext)`** returns early when this directory already holds the file
   under the same checksum — the condition `skipUpload` already applies on the refresh path. Fixes B for the segment
   data files; a no-op in A (the map is empty) and on the refresh path (files only reach it after `skipUpload`
   returned false).

Not addressed: B still re-uploads the snapshot's `segments_N` — a few hundred bytes, named by the metadata written
here and so reclaimable. #18239 covers dropping `segment_n` uploads generally.

**Impact** — scenario A, single node, 1 shard / 0 replicas, `repository-s3`, ~120 MiB index:

| | before | after |
|---|---:|---:|
| objects / distinct Lucene files | 191 / 97 | 50 / 50 |
| bytes stored | 238.7 MiB | 122.7 MiB |
| bytes named by no metadata file | 119.3 MiB | 0 |
| restore wall clock | 15.2 s | 11.9 s |

Stored bytes now equal the index's primary store size, and node egress per restore drops from 2N to N.

**Testing**

- `RemoteSegmentStoreDirectoryTests#testUploadMetadataForRestoredCommit` / `…SegmentNotUploaded` — the metadata names
  this shard's blobs rather than the source's and carries over the source's `writtenByMajor` and `SegmentInfos` bytes;
  `NoSuchFileException` when a file it names was not uploaded.
- `RemoteRestoreSnapshotIT#testRestoreShallowCopyDoesNotUploadSegmentsTwice` (A) and
  `#testRestoreShallowCopyInPlaceDoesNotUploadSegmentsTwice` (B) — one blob per Lucene data file, and every blob named
  by one of the index's metadata files (parsed, not inferred from duplicates). Both confirmed to fail without the fix.
  Commit files are excluded from the uniqueness check only: a `segments_N` generation can legitimately recur with
  different content after a restore in place, which is what the blob UUID suffix disambiguates.
- Green: the above plus `RemoteStoreRefreshListenerTests`, `RemoteStoreFileDownloaderTests`, `IndexShardTests`,
  `RestoreShallowSnapshotV2IT`, `RemoteStoreRefreshListenerIT`, `:server:precommit`.
- Also verified on an S3-backed cluster: the restored index matches the source on doc counts and aggregations,
  survives close/reopen (which forces recovery from its own remote store, exercising the metadata written here), and
  a second-generation shallow snapshot of it restores cleanly.

### Related Issues

Resolves #11044 — scenario B, "There can be preexisting data, when the index is closed and we try to restore it back
in time from a snapshot". Scenario A appears unreported.

#16607 attempted #11044 by skipping the target upload wholesale whenever preexisting data is found; it has been
stalled since January 2025. This change skips per file instead, which stays correct when the snapshot's commit holds a
file the remote path does not.

Also related: #22760 (server-side copy on this path — worth little today, since the copy it would accelerate is the
one nothing references) and #18239 (above).

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. — n/a, no REST API change.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. — n/a, no user-facing behaviour or setting change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
