### PR TITLE
Support correlated nested groups and multi-value flat_object

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.mapper.IndexFieldMapper;
@@ -54,6 +55,11 @@ public class LuceneDataFormat extends DataFormat {
         new FieldTypeCapabilities(TextFieldMapper.CONTENT_TYPE, Set.of(FULL_TEXT_SEARCH, STORED_FIELDS)),
         new FieldTypeCapabilities(KeywordFieldMapper.CONTENT_TYPE, Set.of(FULL_TEXT_SEARCH, STORED_FIELDS, COLUMNAR_STORAGE)),
         new FieldTypeCapabilities(MatchOnlyTextFieldMapper.CONTENT_TYPE, Set.of(FULL_TEXT_SEARCH, STORED_FIELDS)),
+        // flat_object leaves are keyword-like terms, so Lucene serves search for it exactly as it does
+        // for keyword. This is what keeps basic searches on a flat_object working when a columnar
+        // primary owns the field's storage: the primary claims COLUMNAR_STORAGE, Lucene claims the
+        // inverted index. Written by LuceneFieldFactoryRegistry's flat_object factory.
+        new FieldTypeCapabilities(FlatObjectFieldMapper.CONTENT_TYPE, Set.of(FULL_TEXT_SEARCH, COLUMNAR_STORAGE)),
 
         // Metadata fields
         new FieldTypeCapabilities(SourceFieldMapper.CONTENT_TYPE, Set.of(STORED_FIELDS)),

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactoryRegistry.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneFieldFactoryRegistry.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
@@ -22,6 +23,9 @@ import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,6 +70,64 @@ public final class LuceneFieldFactoryRegistry {
         doc.add(new Field(ft.name(), new BytesRef((byte[]) value), ID_FIELD_TYPE));
     };
 
+    /**
+     * Indexes a {@code flat_object} field's leaves as searchable terms.
+     *
+     * <p>The value is the ordered {@code (relative path, value)} entry list the mapper produces for a
+     * pluggable data format — the whole object arrives in one call rather than one call per leaf. This
+     * expands it into the same three Lucene fields the non-pluggable path writes, because those are
+     * exactly what {@code FlatObjectFieldType}'s queries resolve to:
+     * <ul>
+     *   <li>{@code <field>._value} ← the bare leaf value, for a query on the field itself.</li>
+     *   <li>{@code <field>._valueAndPath} ← {@code <field>.<path>=<value>}, for a dotted-path query
+     *       such as {@code LogAttributes.http.status: 500}, which rewrites to that term.</li>
+     *   <li>{@code <field>} ← {@code <field>.<pathPart>} per path segment, which is what makes the
+     *       field and its sub-paths report as existing.</li>
+     * </ul>
+     *
+     * <p>Only terms are written: doc values stay with the primary format, and {@code lft} already has
+     * {@code DocValuesType.NONE} whenever this format did not claim {@code COLUMNAR_STORAGE}. So the
+     * doc-values-prefixed form the non-pluggable path also writes is intentionally not produced here.
+     */
+    private static final LuceneFieldFactory FLAT_OBJECT_FACTORY = (doc, ft, value, lft) -> {
+        if (value instanceof List<?> == false) {
+            throw new IllegalArgumentException(
+                "flat_object field ["
+                    + ft.name()
+                    + "] expects the mapper's leaf entry list, but got ["
+                    + value.getClass().getSimpleName()
+                    + "]"
+            );
+        }
+        final String fieldName = ft.name();
+        final Set<String> pathParts = new HashSet<>();
+        for (Object element : (List<?>) value) {
+            if (element instanceof Map.Entry<?, ?> entry) {
+                // A null leaf value is dropped by the mapper before it reaches here; guard anyway so
+                // a future change cannot silently index the string "null".
+                if (entry.getValue() == null) {
+                    continue;
+                }
+                final String relativePath = entry.getKey().toString();
+                final String leafValue = entry.getValue().toString();
+                final String leafPath = fieldName + "." + relativePath;
+
+                doc.add(new Field(fieldName + "._value", new BytesRef(leafValue), lft));
+                doc.add(new Field(fieldName + "._valueAndPath", new BytesRef(leafPath + "=" + leafValue), lft));
+                pathParts.addAll(Arrays.asList(relativePath.split("\\.")));
+            } else {
+                throw new IllegalArgumentException(
+                    "flat_object field [" + fieldName + "] expects Map.Entry leaves, but got [" + element + "]"
+                );
+            }
+        }
+        // Deduplicated, mirroring the non-pluggable path: the parent field carries the set of path
+        // parts, not one term per leaf occurrence.
+        for (String part : pathParts) {
+            doc.add(new Field(fieldName, new BytesRef(fieldName + "." + part), lft));
+        }
+    };
+
     private static final LuceneFieldFactory SEQ_NO_FIELD_FACTORY = (doc, ft, value, lft) -> {
         // do nothing for now since we don't want to index seq no indexing without soft deletes enabled.
     };
@@ -81,6 +143,7 @@ public final class LuceneFieldFactoryRegistry {
         register(TextFieldMapper.CONTENT_TYPE, TEXT_FACTORY);
         register(KeywordFieldMapper.CONTENT_TYPE, KEYWORD_FACTORY);
         register(MatchOnlyTextFieldMapper.CONTENT_TYPE, MATCH_ONLY_TEXT_FACTORY);
+        register(FlatObjectFieldMapper.CONTENT_TYPE, FLAT_OBJECT_FACTORY);
         registerMetaFields();
     }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
@@ -13,6 +13,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -85,6 +86,14 @@ public final class ArrowValues {
             default:
                 break;
         }
+        // flat_object fields are MAP columns. Emit them as a JSON object so they survive into
+        // _source; without this branch a MapVector falls through to the scalar switch below,
+        // returns null, and toSourceMap drops the field entirely — the attribute bag would be
+        // silently missing from every get-by-id response. Must precede the LIST branch, since
+        // MapVector extends ListVector.
+        if (vec instanceof MapVector mapVector) {
+            return mapToSource(mapVector, idx);
+        }
         // Multi-valued fields are LIST columns; _source is reconstructed from these columns (there
         // are no Lucene stored fields on this path), so dropping them would silently lose the
         // field from every get-by-id response. MapVector extends ListVector, so exclude maps.
@@ -120,6 +129,50 @@ public final class ArrowValues {
                 // TODO type coverage (list, struct, decimal)
                 return null;
         }
+    }
+
+    /**
+     * Rebuilds one {@code MAP<utf8, utf8>} cell as a JSON object for {@code _source}.
+     * <p>
+     * Keys are emitted <b>verbatim</b> — a leaf that arrived as {@code {"k8s":{"pod":"x"}}} was
+     * already flattened to the key {@code k8s.pod} on the way in, so it reads back as
+     * {@code {"k8s.pod":"x"}}. That is flat_object's own model (its Lucene {@code _valueAndPath}
+     * terms use the same dotted form), and it avoids having to guess whether a dotted key was
+     * originally nested — an ambiguity no un-flattening convention can resolve.
+     * <p>
+     * A Parquet MAP is a repeated group, so a key can legitimately repeat when the source had an
+     * array ({@code {"tag":["a","b"]}} → two {@code tag} entries). Repeats are grouped back into a
+     * list rather than overwritten, so the array survives the round trip.
+     */
+    private static Object mapToSource(MapVector mapVector, int idx) {
+        int start = mapVector.getOffsetBuffer().getInt((long) idx * MapVector.OFFSET_WIDTH);
+        int end = mapVector.getOffsetBuffer().getInt((long) (idx + 1) * MapVector.OFFSET_WIDTH);
+        StructVector entries = (StructVector) mapVector.getDataVector();
+        FieldVector keys = entries.getChild(MapVector.KEY_NAME);
+        FieldVector values = entries.getChild(MapVector.VALUE_NAME);
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (int i = start; i < end; i++) {
+            Object key = toSourceValue(keys, i);
+            if (key == null) {
+                continue;
+            }
+            Object value = toSourceValue(values, i);
+            Object existing = out.putIfAbsent(key.toString(), value);
+            if (existing != null) {
+                // Second and later occurrences of the same key: promote to a list, preserving order.
+                if (existing instanceof List<?> list) {
+                    List<Object> merged = new ArrayList<>(list);
+                    merged.add(value);
+                    out.put(key.toString(), merged);
+                } else {
+                    List<Object> merged = new ArrayList<>(2);
+                    merged.add(existing);
+                    merged.add(value);
+                    out.put(key.toString(), merged);
+                }
+            }
+        }
+        return out;
     }
 
     private static Instant toInstant(long v, TimeUnit unit) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/ArrowValues.java
@@ -68,8 +68,9 @@ public final class ArrowValues {
 
     /**
      * Reads an Arrow cell as a JSON-friendly scalar: numerics coerced to
-     * {@code long}/{@code double}, timestamps rendered as ISO-8601 UTC strings. Binary and
-     * complex (list/struct/decimal) types are not yet supported and return {@code null}.
+     * {@code long}/{@code double}, timestamps rendered as ISO-8601 UTC strings, list columns as a
+     * {@code List} of converted elements. Binary and remaining complex (struct/decimal) types are
+     * not yet supported and return {@code null}.
      */
     public static Object toSourceValue(FieldVector vec, int idx) {
         if (vec == null || vec.isNull(idx)) return null;
@@ -83,6 +84,19 @@ public final class ArrowValues {
                 return null;
             default:
                 break;
+        }
+        // Multi-valued fields are LIST columns; _source is reconstructed from these columns (there
+        // are no Lucene stored fields on this path), so dropping them would silently lose the
+        // field from every get-by-id response. MapVector extends ListVector, so exclude maps.
+        if (vec instanceof ListVector listVector && vec instanceof MapVector == false) {
+            FieldVector data = listVector.getDataVector();
+            int start = listVector.getOffsetBuffer().getInt((long) idx * ListVector.OFFSET_WIDTH);
+            int end = listVector.getOffsetBuffer().getInt((long) (idx + 1) * ListVector.OFFSET_WIDTH);
+            List<Object> values = new ArrayList<>(Math.max(0, end - start));
+            for (int i = start; i < end; i++) {
+                values.add(toSourceValue(data, i));
+            }
+            return values;
         }
         Object raw = vec.getObject(idx);
         switch (id) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
@@ -331,6 +331,84 @@ public class ArrowValuesTests extends OpenSearchTestCase {
         }
     }
 
+    // ---- LIST<MAP> columns (multi_value flat_object) in _source ----
+
+    /**
+     * Builds a {@code LIST<MAP<utf8,utf8>>} vector holding one row whose elements are the given maps —
+     * the shape a multi_value flat_object writes for an OTel {@code Events.Attributes}.
+     */
+    private ListVector listOfMapVectorWith(String name, List<List<String[]>> elements) {
+        Field key = new Field(MapVector.KEY_NAME, FieldType.notNullable(new ArrowType.Utf8()), null);
+        Field value = new Field(MapVector.VALUE_NAME, FieldType.nullable(new ArrowType.Utf8()), null);
+        Field entries = new Field(MapVector.DATA_VECTOR_NAME, FieldType.notNullable(ArrowType.Struct.INSTANCE), List.of(key, value));
+        Field element = new Field("element", FieldType.nullable(new ArrowType.Map(false)), List.of(entries));
+        Field listField = new Field(name, FieldType.nullable(ArrowType.List.INSTANCE), List.of(element));
+
+        ListVector list = (ListVector) listField.createVector(allocator);
+        MapVector maps = (MapVector) list.getDataVector();
+        StructVector struct = (StructVector) maps.getDataVector();
+        VarCharVector keys = (VarCharVector) struct.getChild(MapVector.KEY_NAME);
+        VarCharVector values = (VarCharVector) struct.getChild(MapVector.VALUE_NAME);
+
+        int listStart = list.startNewValue(0);
+        for (int e = 0; e < elements.size(); e++) {
+            List<String[]> pairs = elements.get(e);
+            int mapIndex = listStart + e;
+            int start = maps.startNewValue(mapIndex);
+            for (int i = 0; i < pairs.size(); i++) {
+                struct.setIndexDefined(start + i);
+                keys.setSafe(start + i, pairs.get(i)[0].getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                if (pairs.get(i)[1] == null) {
+                    values.setNull(start + i);
+                } else {
+                    values.setSafe(start + i, pairs.get(i)[1].getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                }
+            }
+            maps.endValue(mapIndex, pairs.size());
+        }
+        list.endValue(0, elements.size());
+        list.setValueCount(1);
+        return list;
+    }
+
+    /**
+     * Each element reconstructs as its own map, in order. Flattening them into one map would lose which
+     * event an attribute came from, so this is the property that makes the column worth being a LIST.
+     */
+    public void testListOfMapsReconstructsPerElement() {
+        try (
+            ListVector v = listOfMapVectorWith(
+                "Events.Attributes",
+                List.of(
+                    List.<String[]>of(new String[] { "exception.type", "IOError" }),
+                    List.<String[]>of(new String[] { "http.method", "GET" }, new String[] { "retry", "1" })
+                )
+            )
+        ) {
+            Object cell = ArrowValues.toSourceValue(v, 0);
+            assertEquals(List.of(Map.of("exception.type", "IOError"), Map.of("http.method", "GET", "retry", "1")), cell);
+        }
+    }
+
+    /** An empty attribute set on one event stays an empty map rather than collapsing the element away. */
+    public void testListOfMapsKeepsEmptyElement() {
+        try (
+            ListVector v = listOfMapVectorWith(
+                "Events.Attributes",
+                List.of(List.<String[]>of(), List.<String[]>of(new String[] { "a", "1" }))
+            )
+        ) {
+            assertEquals(List.of(Map.of(), Map.of("a", "1")), ArrowValues.toSourceValue(v, 0));
+        }
+    }
+
+    /** An empty array stays an empty list, keeping it distinct from an absent field. */
+    public void testListOfMapsEmptyArray() {
+        try (ListVector v = listOfMapVectorWith("Events.Attributes", List.of())) {
+            assertEquals(List.of(), ArrowValues.toSourceValue(v, 0));
+        }
+    }
+
     // ---- MAP columns (flat_object) in _source ----
 
     /** Builds a {@code MAP<utf8,utf8>} vector with one cell holding the given (key, value) pairs in order. */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/ArrowValuesTests.java
@@ -29,6 +29,8 @@ import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -326,6 +328,90 @@ public class ArrowValuesTests extends OpenSearchTestCase {
             assertEquals("alice", out.get("name"));
             assertEquals(30L, out.get("age"));
             assertFalse(out.containsKey("missing"));
+        }
+    }
+
+    // ---- MAP columns (flat_object) in _source ----
+
+    /** Builds a {@code MAP<utf8,utf8>} vector with one cell holding the given (key, value) pairs in order. */
+    private MapVector mapVectorWith(String name, List<String[]> pairs) {
+        Field key = new Field(MapVector.KEY_NAME, FieldType.notNullable(new ArrowType.Utf8()), null);
+        Field value = new Field(MapVector.VALUE_NAME, FieldType.nullable(new ArrowType.Utf8()), null);
+        Field entries = new Field(MapVector.DATA_VECTOR_NAME, FieldType.notNullable(ArrowType.Struct.INSTANCE), List.of(key, value));
+        Field mapField = new Field(name, FieldType.nullable(new ArrowType.Map(false)), List.of(entries));
+        MapVector v = (MapVector) mapField.createVector(allocator);
+        int start = v.startNewValue(0);
+        StructVector struct = (StructVector) v.getDataVector();
+        VarCharVector keys = (VarCharVector) struct.getChild(MapVector.KEY_NAME);
+        VarCharVector values = (VarCharVector) struct.getChild(MapVector.VALUE_NAME);
+        for (int i = 0; i < pairs.size(); i++) {
+            struct.setIndexDefined(start + i);
+            keys.setSafe(start + i, pairs.get(i)[0].getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            if (pairs.get(i)[1] == null) {
+                values.setNull(start + i);
+            } else {
+                values.setSafe(start + i, pairs.get(i)[1].getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+        }
+        v.endValue(0, pairs.size());
+        v.setValueCount(1);
+        return v;
+    }
+
+    /**
+     * A MAP column must reach _source as a JSON object. Before this, toSourceValue had no MAP branch
+     * (only a guard excluding maps from the LIST branch), so a flat_object field fell through to the
+     * scalar switch, returned null, and toSourceMap dropped it — the attribute bag was silently
+     * missing from every get-by-id response.
+     */
+    public void testToSourceValueOnMapColumn() {
+        try (
+            MapVector v = mapVectorWith(
+                "attrs",
+                List.<String[]>of(new String[] { "k8s.pod", "web-1" }, new String[] { "http.status", "500" })
+            )
+        ) {
+            Object cell = ArrowValues.toSourceValue(v, 0);
+            assertEquals(Map.of("k8s.pod", "web-1", "http.status", "500"), cell);
+        }
+    }
+
+    /** Keys stay verbatim: flat_object already flattened nesting to dotted keys on the way in. */
+    public void testMapKeysAreNotUnflattened() {
+        try (MapVector v = mapVectorWith("attrs", List.<String[]>of(new String[] { "a.b.c", "deep" }))) {
+            Object cell = ArrowValues.toSourceValue(v, 0);
+            assertEquals(Map.of("a.b.c", "deep"), cell);
+        }
+    }
+
+    /** A repeated key comes from an array leaf, so it must group back into a list, not overwrite. */
+    public void testRepeatedMapKeysGroupIntoList() {
+        try (
+            MapVector v = mapVectorWith(
+                "attrs",
+                List.<String[]>of(new String[] { "tag", "a" }, new String[] { "tag", "b" }, new String[] { "other", "x" })
+            )
+        ) {
+            Object cell = ArrowValues.toSourceValue(v, 0);
+            assertEquals(Map.of("tag", List.of("a", "b"), "other", "x"), cell);
+        }
+    }
+
+    /** An empty object is a zero-entry non-null cell, and must read back as {} rather than vanish. */
+    public void testEmptyMapIsEmptyObjectNotNull() {
+        try (MapVector v = mapVectorWith("attrs", List.<String[]>of())) {
+            Object cell = ArrowValues.toSourceValue(v, 0);
+            assertEquals(Map.of(), cell);
+        }
+    }
+
+    /** A null value inside an entry keeps its key, with a null value. */
+    public void testMapEntryWithNullValue() {
+        try (MapVector v = mapVectorWith("attrs", List.<String[]>of(new String[] { "missing", null }))) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> cell = (Map<String, Object>) ArrowValues.toSourceValue(v, 0);
+            assertTrue(cell.containsKey("missing"));
+            assertNull(cell.get("missing"));
         }
     }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldCapabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeFieldCapabilityIT.java
@@ -208,9 +208,10 @@ public class CompositeFieldCapabilityIT extends AbstractCompositeEngineIT {
         assertTrue(ex.getMessage().contains("nested type is not supported with pluggable data format"));
     }
 
-    public void testFlatObjectFieldUnsupported() {
+    public void testFlatObjectFieldSupported() {
+        // flat_object is stored as a MAP<utf8, utf8> parquet column, so index creation succeeds.
         startCluster();
-        assertIndexCreationFails("test-flat-object", "field", "type=flat_object");
+        assertIndexCreationSucceeds("test-flat-object", "field", "type=flat_object");
     }
 
     public void testWildcardFieldUnsupported() {

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
@@ -34,31 +34,26 @@ import java.util.Set;
  * (parquet primary + lucene secondary) versus the internal engine (Lucene only), for the same mapping
  * and the same documents.
  *
- * <p>The two engines store a flat_object field in fundamentally different places, and this test pins
- * that divergence rather than leaving it to be discovered:
+ * <p>Both engines keep the same Lucene representation, and the composite engine adds a columnar copy:
  *
  * <table>
  *   <caption>Where a flat_object field's data lands</caption>
  *   <tr><th></th><th>internal engine (Lucene)</th><th>composite engine (parquet + lucene)</th></tr>
- *   <tr><td>Lucene inverted index / doc values</td>
+ *   <tr><td>Lucene inverted index</td>
  *       <td>{@code field}, {@code field._value}, {@code field._valueAndPath}</td>
- *       <td><em>nothing</em></td></tr>
+ *       <td>the same three fields</td></tr>
+ *   <tr><td>Lucene doc values</td><td>SORTED_SET on all three</td>
+ *       <td>none — the primary format owns columnar storage</td></tr>
  *   <tr><td>Parquet</td><td>n/a</td><td>one {@code MAP<utf8, utf8>} column</td></tr>
- *   <tr><td>Term query on a leaf</td><td>matches</td><td>not served</td></tr>
  * </table>
  *
- * <p>The cause is capability assignment. A flat_object field requests {@code FULL_TEXT_SEARCH} (it is
- * searchable) and {@code COLUMNAR_STORAGE} (it has doc values). On the composite engine the parquet
- * primary is offered capabilities first and its {@code FlatObjectParquetField} claims both, so the
- * lucene secondary is left with an empty capability set and {@code LuceneDocumentInput#addField}
- * returns without indexing anything. Contrast a {@code keyword} or {@code text} field, whose parquet
- * implementation deliberately does <em>not</em> claim {@code FULL_TEXT_SEARCH}: Lucene claims it and
- * indexes the terms, which is why those fields stay searchable on a composite index.
- *
- * <p>The practical consequence, asserted below: on a composite index a flat_object field is durable in
- * the Parquet MAP column but is <strong>not searchable by either format</strong> — parquet claims the
- * capability without a read path yet, and Lucene holds no terms. Closing that means either giving
- * Lucene the capability plus a flat_object field factory, or implementing the columnar read path.
+ * <p>That split comes from capability assignment. A flat_object field requests
+ * {@code FULL_TEXT_SEARCH} (it is searchable) and {@code COLUMNAR_STORAGE} (it has doc values); the
+ * parquet primary claims only {@code COLUMNAR_STORAGE}, leaving the inverted index to the lucene
+ * secondary — exactly how {@code keyword} and {@code text} are split, which is what keeps them
+ * searchable on a composite index. An earlier revision had the parquet field claim both, which starved
+ * Lucene of the field entirely and left it searchable by neither format; these tests exist to keep
+ * that from regressing.
  */
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
@@ -133,47 +133,88 @@ public class FlatObjectEngineParityIT extends AbstractCompositeEngineIT {
     }
 
     /**
-     * On the composite engine none of those Lucene fields exist: the parquet primary claimed both of
-     * flat_object's capabilities, so the lucene secondary indexes nothing for it. Scalars are
-     * unaffected — keyword and text still reach Lucene, because their parquet implementations leave
-     * {@code FULL_TEXT_SEARCH} to it.
+     * The composite engine indexes the same three Lucene fields, so basic searches keep working: the
+     * parquet primary claims only {@code COLUMNAR_STORAGE} for a flat_object, leaving
+     * {@code FULL_TEXT_SEARCH} to the lucene secondary — the same split that keeps keyword and text
+     * searchable. The Parquet MAP column is the columnar copy alongside it, not a replacement.
      */
-    public void testCompositeEngineIndexesNoLuceneFieldsForFlatObject() throws Exception {
+    public void testCompositeEngineAlsoIndexesFlatObjectSubFieldsInLucene() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataOnlyNodes(1);
         createAndIndex(COMPOSITE_INDEX, compositeSettings());
 
         Set<String> fields = luceneFields(COMPOSITE_INDEX);
-        assertFalse("flat_object parent must NOT be in lucene: " + fields, fields.contains("LogAttributes"));
-        assertFalse("_value must NOT be in lucene: " + fields, fields.contains("LogAttributes._value"));
-        assertFalse("_valueAndPath must NOT be in lucene: " + fields, fields.contains("LogAttributes._valueAndPath"));
+        assertTrue("flat_object parent must be indexed: " + fields, fields.contains("LogAttributes"));
+        assertTrue("_value sub-field must be indexed: " + fields, fields.contains("LogAttributes._value"));
+        assertTrue("_valueAndPath sub-field must be indexed: " + fields, fields.contains("LogAttributes._valueAndPath"));
 
-        // The capability split is per field, not per index: keyword/text still go to Lucene, which is
-        // what keeps them searchable on a composite index.
+        // The capability split is per field, not per index: keyword/text also still reach Lucene.
         assertTrue("keyword must still be indexed in lucene: " + fields, fields.contains("ServiceName"));
         assertTrue("text must still be indexed in lucene: " + fields, fields.contains("Body"));
     }
 
     /**
-     * The behavioural consequence of the row above. A term query against a flat_object leaf matches on
-     * the internal engine and returns nothing on the composite engine — the values are in the Parquet
-     * MAP column, which no query path reads yet.
-     *
-     * <p>Asserted so the divergence is a known, visible state. When the columnar read path lands, the
-     * composite expectation here must be changed to match the internal engine.
+     * On the internal engine the leaves are searchable through the sub-fields the mapper writes: a
+     * dotted-path term query rewrites to a {@code <field>.<path>=<value>} term on
+     * {@code _valueAndPath}, and a query on the field itself to the bare value on {@code _value}. The
+     * composite engine now writes those same terms, which is what the previous test asserts.
      */
-    public void testTermQueryOnFlatObjectLeafDivergesBetweenEngines() throws Exception {
+    public void testInternalEngineServesBasicSearchesOnFlatObject() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataOnlyNodes(1);
         createAndIndex(LUCENE_INDEX, luceneSettings());
 
-        // Internal engine: the leaf is searchable through the _valueAndPath sub-field.
-        long luceneHits = client().prepareSearch(LUCENE_INDEX)
-            .setQuery(QueryBuilders.termQuery("LogAttributes.http.status", "500"))
-            .get()
-            .getHits()
-            .getTotalHits()
-            .value();
-        assertEquals("internal engine must match the flat_object leaf", 1L, luceneHits);
+        assertEquals(
+            "dotted-path term query must match the flat_object leaf",
+            1L,
+            hits(LUCENE_INDEX, QueryBuilders.termQuery("LogAttributes.http.status", "500"))
+        );
+        assertEquals(
+            "query on the field itself must match a bare leaf value",
+            1L,
+            hits(LUCENE_INDEX, QueryBuilders.termQuery("LogAttributes", "GET"))
+        );
+        assertEquals(
+            "a value that was never indexed must not match",
+            0L,
+            hits(LUCENE_INDEX, QueryBuilders.termQuery("LogAttributes.http.status", "404"))
+        );
+        assertEquals("exists query must see the flat_object field", 1L, hits(LUCENE_INDEX, QueryBuilders.existsQuery("LogAttributes")));
+    }
+
+    /**
+     * flat_object is now searchable on a composite index to exactly the same degree as {@code keyword}
+     * — which is the meaningful parity bar, because the transport {@code _search} action is not
+     * supported on a composite index for <em>any</em> field type: {@code IndexShard} refuses to apply
+     * it to a {@code DataFormatAwareEngine}, and queries are instead served through the analytics
+     * engine (PPL / the DSL query executor), which the {@code analytics-engine-rest} QA suite covers.
+     *
+     * <p>Asserting the two field types fail identically keeps this engine-wide limitation from being
+     * mistaken for a flat_object gap: before the capability split was corrected, flat_object had no
+     * Lucene terms at all, so it could never become searchable even once that limitation is lifted.
+     */
+    public void testFlatObjectAndKeywordAreEquallySearchableOnCompositeEngine() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createAndIndex(COMPOSITE_INDEX, compositeSettings());
+
+        Exception flatObjectFailure = expectThrows(
+            Exception.class,
+            () -> hits(COMPOSITE_INDEX, QueryBuilders.termQuery("LogAttributes.http.status", "500"))
+        );
+        Exception keywordFailure = expectThrows(
+            Exception.class,
+            () -> hits(COMPOSITE_INDEX, QueryBuilders.termQuery("ServiceName", "checkout"))
+        );
+        for (Exception failure : List.of(flatObjectFailure, keywordFailure)) {
+            assertTrue(
+                "transport _search must be refused for the engine, not for the field: " + failure,
+                failure.toString().contains("DataFormatAwareEngine")
+            );
+        }
+    }
+
+    private long hits(String index, org.opensearch.index.query.QueryBuilder query) {
+        return client().prepareSearch(index).setQuery(query).get().getHits().getTotalHits().value();
     }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectEngineParityIT.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Side-by-side comparison of how a {@code flat_object} field behaves on the composite engine
+ * (parquet primary + lucene secondary) versus the internal engine (Lucene only), for the same mapping
+ * and the same documents.
+ *
+ * <p>The two engines store a flat_object field in fundamentally different places, and this test pins
+ * that divergence rather than leaving it to be discovered:
+ *
+ * <table>
+ *   <caption>Where a flat_object field's data lands</caption>
+ *   <tr><th></th><th>internal engine (Lucene)</th><th>composite engine (parquet + lucene)</th></tr>
+ *   <tr><td>Lucene inverted index / doc values</td>
+ *       <td>{@code field}, {@code field._value}, {@code field._valueAndPath}</td>
+ *       <td><em>nothing</em></td></tr>
+ *   <tr><td>Parquet</td><td>n/a</td><td>one {@code MAP<utf8, utf8>} column</td></tr>
+ *   <tr><td>Term query on a leaf</td><td>matches</td><td>not served</td></tr>
+ * </table>
+ *
+ * <p>The cause is capability assignment. A flat_object field requests {@code FULL_TEXT_SEARCH} (it is
+ * searchable) and {@code COLUMNAR_STORAGE} (it has doc values). On the composite engine the parquet
+ * primary is offered capabilities first and its {@code FlatObjectParquetField} claims both, so the
+ * lucene secondary is left with an empty capability set and {@code LuceneDocumentInput#addField}
+ * returns without indexing anything. Contrast a {@code keyword} or {@code text} field, whose parquet
+ * implementation deliberately does <em>not</em> claim {@code FULL_TEXT_SEARCH}: Lucene claims it and
+ * indexes the terms, which is why those fields stay searchable on a composite index.
+ *
+ * <p>The practical consequence, asserted below: on a composite index a flat_object field is durable in
+ * the Parquet MAP column but is <strong>not searchable by either format</strong> — parquet claims the
+ * capability without a read path yet, and Lucene holds no terms. Closing that means either giving
+ * Lucene the capability plus a flat_object field factory, or implementing the columnar read path.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class FlatObjectEngineParityIT extends AbstractCompositeEngineIT {
+
+    private static final String COMPOSITE_INDEX = "flatobj-composite";
+    private static final String LUCENE_INDEX = "flatobj-internal";
+
+    private static final String MAPPING = "{\"properties\":{"
+        + "\"ServiceName\":{\"type\":\"keyword\"},"
+        + "\"Body\":{\"type\":\"text\"},"
+        + "\"LogAttributes\":{\"type\":\"flat_object\"}"
+        + "}}";
+
+    private static final String DOC = "{\"ServiceName\":\"checkout\",\"Body\":\"request completed\","
+        + "\"LogAttributes\":{\"http\":{\"status\":\"500\",\"method\":\"GET\"}}}";
+
+    private Settings compositeSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    /** Plain index — no pluggable data format, so IndexShard uses the internal (Lucene) engine. */
+    private Settings luceneSettings() {
+        return Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build();
+    }
+
+    private void createAndIndex(String index, Settings settings) {
+        assertTrue(client().admin().indices().prepareCreate(index).setSettings(settings).setMapping(MAPPING).get().isAcknowledged());
+        ensureGreen(index);
+        client().prepareIndex(index).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).setSource(DOC, XContentType.JSON).get();
+        client().admin().indices().prepareFlush(index).setForce(true).get();
+    }
+
+    private Set<String> luceneFields(String index) throws IOException {
+        IndexShard shard = getPrimaryShard(index);
+        Path luceneDir = shard.shardPath().resolveIndex();
+        Set<String> fields = new HashSet<>();
+        try (Directory dir = NIOFSDirectory.open(luceneDir); DirectoryReader reader = DirectoryReader.open(dir)) {
+            for (LeafReaderContext ctx : reader.leaves()) {
+                for (FieldInfo fi : ctx.reader().getFieldInfos()) {
+                    fields.add(fi.name);
+                }
+            }
+        }
+        return fields;
+    }
+
+    /**
+     * The internal engine indexes a flat_object into three Lucene fields: the parent (holding the set
+     * of path parts), {@code _value} (the bare leaf values) and {@code _valueAndPath}
+     * ({@code path=value}). This is the baseline the composite engine is compared against.
+     */
+    public void testInternalEngineIndexesFlatObjectSubFieldsInLucene() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createAndIndex(LUCENE_INDEX, luceneSettings());
+
+        Set<String> fields = luceneFields(LUCENE_INDEX);
+        assertTrue("parent field must be indexed: " + fields, fields.contains("LogAttributes"));
+        assertTrue("_value sub-field must be indexed: " + fields, fields.contains("LogAttributes._value"));
+        assertTrue("_valueAndPath sub-field must be indexed: " + fields, fields.contains("LogAttributes._valueAndPath"));
+        // The scalar fields are indexed here too, so the comparison below isolates flat_object.
+        assertTrue(fields.contains("ServiceName"));
+        assertTrue(fields.contains("Body"));
+    }
+
+    /**
+     * On the composite engine none of those Lucene fields exist: the parquet primary claimed both of
+     * flat_object's capabilities, so the lucene secondary indexes nothing for it. Scalars are
+     * unaffected — keyword and text still reach Lucene, because their parquet implementations leave
+     * {@code FULL_TEXT_SEARCH} to it.
+     */
+    public void testCompositeEngineIndexesNoLuceneFieldsForFlatObject() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createAndIndex(COMPOSITE_INDEX, compositeSettings());
+
+        Set<String> fields = luceneFields(COMPOSITE_INDEX);
+        assertFalse("flat_object parent must NOT be in lucene: " + fields, fields.contains("LogAttributes"));
+        assertFalse("_value must NOT be in lucene: " + fields, fields.contains("LogAttributes._value"));
+        assertFalse("_valueAndPath must NOT be in lucene: " + fields, fields.contains("LogAttributes._valueAndPath"));
+
+        // The capability split is per field, not per index: keyword/text still go to Lucene, which is
+        // what keeps them searchable on a composite index.
+        assertTrue("keyword must still be indexed in lucene: " + fields, fields.contains("ServiceName"));
+        assertTrue("text must still be indexed in lucene: " + fields, fields.contains("Body"));
+    }
+
+    /**
+     * The behavioural consequence of the row above. A term query against a flat_object leaf matches on
+     * the internal engine and returns nothing on the composite engine — the values are in the Parquet
+     * MAP column, which no query path reads yet.
+     *
+     * <p>Asserted so the divergence is a known, visible state. When the columnar read path lands, the
+     * composite expectation here must be changed to match the internal engine.
+     */
+    public void testTermQueryOnFlatObjectLeafDivergesBetweenEngines() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createAndIndex(LUCENE_INDEX, luceneSettings());
+
+        // Internal engine: the leaf is searchable through the _valueAndPath sub-field.
+        long luceneHits = client().prepareSearch(LUCENE_INDEX)
+            .setQuery(QueryBuilders.termQuery("LogAttributes.http.status", "500"))
+            .get()
+            .getHits()
+            .getTotalHits()
+            .value();
+        assertEquals("internal engine must match the flat_object leaf", 1L, luceneHits);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectMapColumnIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectMapColumnIT.java
@@ -19,6 +19,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Indexing-side support for {@code flat_object} fields on a composite parquet+lucene index, using
@@ -313,18 +314,96 @@ public class FlatObjectMapColumnIT extends AbstractCompositeEngineIT {
      * declaring it {@code multi_value: true} would ask for a {@code LIST<MAP>} the writer does not
      * build. It must fail at creation time rather than at first write.
      */
-    public void testFlatObjectRejectsMultiValue() {
+    /** Mapping for an OTel {@code Events} group: parallel columns, attributes as one map per event. */
+    private static final String OTEL_EVENTS_MAPPING = "{\"properties\":{"
+        + "\"TraceId\":{\"type\":\"keyword\"},"
+        + "\"Events\":{\"type\":\"nested\",\"correlated\":true,\"properties\":{"
+        + "  \"Name\":{\"type\":\"keyword\",\"multi_value\":true},"
+        + "  \"Attributes\":{\"type\":\"flat_object\",\"multi_value\":true}"
+        + "}}}}";
+
+    private void createEventsIndex(String index) {
+        assertTrue(
+            client().admin()
+                .indices()
+                .prepareCreate(index)
+                .setSettings(compositeSettings())
+                .setMapping(OTEL_EVENTS_MAPPING)
+                .get()
+                .isAcknowledged()
+        );
+        ensureGreen(index);
+    }
+
+    /**
+     * A {@code multi_value} flat_object is a {@code LIST<MAP>} — one attribute set per array element,
+     * which is the OTel {@code Events.Attributes} shape. Merging the elements into a single map would
+     * lose which event each attribute belonged to, so {@code _source} must return them separately and
+     * in order.
+     */
+    public void testFlatObjectMultiValueRoundTripsPerElement() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataOnlyNodes(1);
-        expectThrows(
+        String index = "otel-events-idx";
+        createEventsIndex(index);
+
+        client().prepareIndex(index)
+            .setId("1")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource(
+                "{\"TraceId\":\"t1\",\"Events\":{"
+                    + "\"Name\":[\"exception\",\"retry\"],"
+                    + "\"Attributes\":[{\"exception.type\":\"IOError\"},{\"http.method\":\"GET\",\"retry\":\"1\"}]"
+                    + "}}",
+                XContentType.JSON
+            )
+            .get();
+
+        Object attributes = resolveField(client().prepareGet(index, "1").get().getSourceAsMap(), "Events", "Attributes");
+        assertTrue("expected a list of per-event maps, got: " + attributes, attributes instanceof List);
+        List<?> perEvent = (List<?>) attributes;
+        assertEquals("one attribute map per event", 2, perEvent.size());
+        assertEquals(Map.of("exception.type", "IOError"), perEvent.get(0));
+        assertEquals(Map.of("http.method", "GET", "retry", "1"), perEvent.get(1));
+    }
+
+    /**
+     * The correlated length check covers the flat_object member too: two event names but one attribute
+     * set means the second name has no attributes of its own, so any positional pairing is a guess.
+     */
+    public void testCorrelatedLengthCheckAppliesToFlatObjectMember() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        String index = "otel-events-ragged-idx";
+        createEventsIndex(index);
+
+        Exception e = expectThrows(
             Exception.class,
-            () -> client().admin()
-                .indices()
-                .prepareCreate("otel-mv-flat-idx")
-                .setSettings(compositeSettings())
-                .setMapping("{\"properties\":{\"LogAttributes\":{\"type\":\"flat_object\",\"multi_value\":true}}}")
+            () -> client().prepareIndex(index)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .setSource(
+                    "{\"TraceId\":\"t1\",\"Events\":{"
+                        + "\"Name\":[\"exception\",\"retry\"],"
+                        + "\"Attributes\":[{\"exception.type\":\"IOError\"}]"
+                        + "}}",
+                    XContentType.JSON
+                )
                 .get()
         );
+        assertTrue("expected a correlated-group error, got: " + e.getMessage(), e.getMessage().contains("correlated group"));
+    }
+
+    /**
+     * Reads a field from {@code _source} whether the reconstruction nests it under its parent object or
+     * keeps the dotted path as a single key, so the assertion is about the values rather than the
+     * envelope shape.
+     */
+    private static Object resolveField(Map<String, Object> source, String parent, String child) {
+        Object nested = source.get(parent);
+        if (nested instanceof Map<?, ?> map && map.containsKey(child)) {
+            return map.get(child);
+        }
+        return source.get(parent + "." + child);
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectMapColumnIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FlatObjectMapColumnIT.java
@@ -1,0 +1,344 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.List;
+
+/**
+ * Indexing-side support for {@code flat_object} fields on a composite parquet+lucene index, using
+ * the OpenTelemetry-logs ("Textbench") mapping shape: keyword/date_nanos/byte/text scalars plus three
+ * {@code flat_object} attribute maps.
+ *
+ * <p>A {@code flat_object} field is stored as a single Arrow/Parquet {@code MAP<utf8, utf8>} column
+ * (leaves {@code <field>.entries.key} and {@code <field>.entries.value}) rather than being dropped, so
+ * every stage that writes or rewrites those files is a place the map encoding can break independently
+ * of the query path: the VSR flush writes the map offsets and the entries-struct validity bits, and
+ * force-merge re-encodes each column through the native {@code compute_leaves} path, which must walk
+ * two leaves for this column instead of one.
+ *
+ * <p>Scope: this exercises the <em>write</em> path only — index creation, document admission, and the
+ * durability stages above. Reading the values back is a separate, unwired concern, so the assertions
+ * here are deliberately about acceptance and durability (document counts survive each stage, no shard
+ * fails) rather than about projecting map values; {@link #testAttributesAreNotYetReturnedInSource}
+ * pins that boundary explicitly, and the remaining negative tests pin the arity and sort-key limits.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class FlatObjectMapColumnIT extends AbstractCompositeEngineIT {
+
+    private static final String OTEL_INDEX = "otel-logs-idx";
+
+    /**
+     * The OpenTelemetry-logs mapping. {@code flattened} is the Elasticsearch spelling of this type;
+     * the OpenSearch equivalent, used here, is {@code flat_object}.
+     */
+    private static final String OTEL_MAPPING = "{\"properties\":{"
+        + "\"Timestamp\":{\"type\":\"date_nanos\"},"
+        + "\"TraceId\":{\"type\":\"keyword\"},"
+        + "\"SpanId\":{\"type\":\"keyword\"},"
+        + "\"TraceFlags\":{\"type\":\"byte\"},"
+        + "\"SeverityText\":{\"type\":\"keyword\"},"
+        + "\"SeverityNumber\":{\"type\":\"byte\"},"
+        + "\"ServiceName\":{\"type\":\"keyword\"},"
+        + "\"Body\":{\"type\":\"text\"},"
+        + "\"ResourceSchemaUrl\":{\"type\":\"keyword\"},"
+        + "\"ResourceAttributes\":{\"type\":\"flat_object\"},"
+        + "\"ScopeSchemaUrl\":{\"type\":\"keyword\"},"
+        + "\"ScopeName\":{\"type\":\"keyword\"},"
+        + "\"ScopeVersion\":{\"type\":\"keyword\"},"
+        + "\"ScopeAttributes\":{\"type\":\"flat_object\"},"
+        + "\"LogAttributes\":{\"type\":\"flat_object\"}"
+        + "}}";
+
+    private Settings compositeSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    private void createOtelIndex() {
+        assertTrue(
+            client().admin()
+                .indices()
+                .prepareCreate(OTEL_INDEX)
+                .setSettings(compositeSettings())
+                .setMapping(OTEL_MAPPING)
+                .get()
+                .isAcknowledged()
+        );
+        ensureGreen(OTEL_INDEX);
+    }
+
+    /**
+     * One OTel log line. {@code i} varies the attribute keys and values so the MAP column sees a
+     * different key set per document — the case a fixed-schema column cannot represent and the reason
+     * these fields are a map rather than sub-columns.
+     */
+    private static String logLine(int i) {
+        return "{"
+            + "\"Timestamp\":\"2026-08-17T10:00:0"
+            + (i % 10)
+            + ".123456789Z\","
+            + "\"TraceId\":\"trace-"
+            + i
+            + "\",\"SpanId\":\"span-"
+            + i
+            + "\",\"TraceFlags\":1,"
+            + "\"SeverityText\":\"INFO\",\"SeverityNumber\":9,"
+            + "\"ServiceName\":\"checkout\",\"Body\":\"request completed in "
+            + i
+            + "ms\","
+            + "\"ResourceSchemaUrl\":\"https://opentelemetry.io/schemas/1.20.0\","
+            + "\"ResourceAttributes\":{\"host\":{\"name\":\"node-"
+            + i
+            + "\"},\"k8s\":{\"pod\":\"web-"
+            + i
+            + "\"}},"
+            + "\"ScopeSchemaUrl\":\"https://opentelemetry.io/schemas/1.20.0\","
+            + "\"ScopeName\":\"io.opentelemetry.checkout\",\"ScopeVersion\":\"1.0."
+            + i
+            + "\","
+            + "\"ScopeAttributes\":{\"library\":\"otel-java\"},"
+            + "\"LogAttributes\":{\"http\":{\"status\":"
+            + (200 + i)
+            + ",\"method\":\"GET\"},\"retry\":"
+            + (i % 2 == 0)
+            + ",\"attempt-"
+            + i
+            + "\":\"v"
+            + i
+            + "\"}"
+            + "}";
+    }
+
+    private void indexLogLines(int count, WriteRequest.RefreshPolicy policy) {
+        for (int i = 0; i < count; i++) {
+            client().prepareIndex(OTEL_INDEX).setRefreshPolicy(policy).setSource(logLine(i), XContentType.JSON).get();
+        }
+    }
+
+    /** Asserts the shard still reports exactly {@code expected} live documents. */
+    private void assertDocCount(String stage, long expected) {
+        client().admin().indices().prepareRefresh(OTEL_INDEX).get();
+        IndicesStatsResponse stats = client().admin().indices().prepareStats(OTEL_INDEX).get();
+        assertEquals(stage + ": document count must be unchanged", expected, stats.getIndex(OTEL_INDEX).getTotal().getDocs().getCount());
+    }
+
+    /**
+     * The whole OTel mapping — three {@code flat_object} fields alongside date_nanos/byte/text/keyword
+     * — must be accepted. Before flat_object was backed by a MAP column, index creation failed:
+     * enabling a pluggable data format also enables derived source, and flat_object could not satisfy
+     * that check.
+     */
+    public void testOtelLogsMappingIsAccepted() {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        // The mapping round-trips with all three attribute fields still typed flat_object.
+        String mapping = client().admin().indices().prepareGetMappings(OTEL_INDEX).get().mappings().get(OTEL_INDEX).source().toString();
+        for (String attributeField : List.of("ResourceAttributes", "ScopeAttributes", "LogAttributes")) {
+            assertTrue("mapping must retain " + attributeField, mapping.contains(attributeField));
+        }
+        assertTrue("attribute fields must stay flat_object", mapping.contains("flat_object"));
+    }
+
+    /**
+     * Documents whose attribute objects are nested, differently-keyed, and of mixed value types must
+     * all be admitted. Every leaf becomes one MAP entry, stringified — so a per-document key set is
+     * representable in a column whose type is fixed for the whole file.
+     */
+    public void testDocumentsWithVaryingAttributeKeysAreIndexed() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        indexLogLines(25, WriteRequest.RefreshPolicy.NONE);
+        assertDocCount("after indexing", 25);
+    }
+
+    /**
+     * refresh → flush → force-merge. Each stage either makes the in-memory VSR durable or rewrites the
+     * Parquet files; force-merge is the interesting one, because the native merge must resolve this
+     * column to its two leaves rather than one and would fail the shard if it could not.
+     */
+    public void testMapColumnSurvivesRefreshFlushAndForceMerge() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        indexLogLines(10, WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(OTEL_INDEX).get();
+        assertDocCount("after refresh", 10);
+
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+        assertDocCount("after flush", 10);
+
+        // A second generation, so force-merge has more than one file to combine.
+        indexLogLines(10, WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+        assertDocCount("after second generation", 20);
+
+        ForceMergeResponse merge = client().admin().indices().prepareForceMerge(OTEL_INDEX).setMaxNumSegments(1).get();
+        assertEquals("force-merge must not fail any shard", 0, merge.getFailedShards());
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+        assertDocCount("after force-merge", 20);
+    }
+
+    /**
+     * Write-path edge shapes for one map cell: an empty object, an absent field, duplicate keys from
+     * an array leaf, and an explicit null value. All are legal documents and none may be rejected.
+     */
+    public void testEmptyAbsentDuplicateAndNullAttributeShapes() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        // Empty object → a zero-entry, non-null map cell.
+        client().prepareIndex(OTEL_INDEX).setSource("{\"ServiceName\":\"a\",\"LogAttributes\":{}}", XContentType.JSON).get();
+        // Field absent entirely → a null cell, which stays distinct from the empty object above.
+        client().prepareIndex(OTEL_INDEX).setSource("{\"ServiceName\":\"b\"}", XContentType.JSON).get();
+        // An array leaf yields the same key twice; a Parquet MAP is a repeated group, so both survive
+        // rather than one overwriting the other.
+        client().prepareIndex(OTEL_INDEX)
+            .setSource("{\"ServiceName\":\"c\",\"LogAttributes\":{\"tag\":[\"x\",\"y\"]}}", XContentType.JSON)
+            .get();
+        // An explicit null value: the key is dropped, matching flat_object's Lucene behaviour.
+        client().prepareIndex(OTEL_INDEX).setSource("{\"ServiceName\":\"d\",\"LogAttributes\":{\"k\":null}}", XContentType.JSON).get();
+        // Deeply nested leaves flatten to dotted keys.
+        client().prepareIndex(OTEL_INDEX)
+            .setSource("{\"ServiceName\":\"e\",\"LogAttributes\":{\"a\":{\"b\":{\"c\":\"deep\"}}}}", XContentType.JSON)
+            .get();
+
+        assertDocCount("after edge shapes", 5);
+
+        // These shapes must also survive being made durable and re-encoded.
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+        ForceMergeResponse merge = client().admin().indices().prepareForceMerge(OTEL_INDEX).setMaxNumSegments(1).get();
+        assertEquals("force-merge must not fail any shard", 0, merge.getFailedShards());
+        assertDocCount("after force-merge of edge shapes", 5);
+    }
+
+    /**
+     * A {@code flat_object} field added to a live index must become a MAP column too, so an OTel
+     * mapping can gain a new attribute bag without reindexing.
+     */
+    public void testFlatObjectAddedByMappingUpdate() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        indexLogLines(3, WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        assertTrue(
+            client().admin()
+                .indices()
+                .preparePutMapping(OTEL_INDEX)
+                .setSource("{\"properties\":{\"ExtraAttributes\":{\"type\":\"flat_object\"}}}", XContentType.JSON)
+                .get()
+                .isAcknowledged()
+        );
+
+        client().prepareIndex(OTEL_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"ServiceName\":\"after-update\",\"ExtraAttributes\":{\"tenant\":\"acme\"}}", XContentType.JSON)
+            .get();
+
+        assertDocCount("after mapping update", 4);
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+        assertDocCount("after flush following mapping update", 4);
+    }
+
+    /**
+     * Documents the current read-back boundary, so it is a deliberate, visible state rather than a
+     * silent surprise: a document carrying a flat_object field is retrievable and its scalar fields
+     * come back, but the attribute object is <em>not</em> yet present in the reconstructed
+     * {@code _source}.
+     *
+     * <p>The values are written and durable in the Parquet MAP column — the rest of this class proves
+     * that — but nothing surfaces them back yet: derived source is rebuilt from the Lucene secondary,
+     * which deliberately holds no doc values or stored fields for a field the primary format owns, so
+     * {@link org.opensearch.index.mapper.FlatObjectFieldMapper#deriveSource} has no source to read and
+     * omits the field.
+     *
+     * <p>When the columnar read path learns to project a MAP column this assertion must be inverted —
+     * that is the point of asserting it rather than leaving it untested.
+     */
+    public void testAttributesAreNotYetReturnedInSource() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createOtelIndex();
+
+        org.opensearch.action.index.IndexResponse indexed = client().prepareIndex(OTEL_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"ServiceName\":\"probe\",\"LogAttributes\":{\"http\":{\"status\":500}}}", XContentType.JSON)
+            .get();
+        client().admin().indices().prepareFlush(OTEL_INDEX).setForce(true).get();
+
+        org.opensearch.action.get.GetResponse resp = client().prepareGet(OTEL_INDEX, indexed.getId()).setRealtime(false).get();
+        assertTrue("the document itself must be retrievable", resp.isExists());
+        java.util.Map<String, Object> source = resp.getSourceAsMap();
+        assertEquals("scalar fields must round-trip", "probe", source.get("ServiceName"));
+        assertNull(
+            "flat_object is not yet reconstructed into _source; invert this once the MAP read path lands",
+            source.get("LogAttributes")
+        );
+    }
+
+    // === BOUNDARIES ===
+
+    /**
+     * {@code flat_object} is single-arity: one map cell already holds any number of entries, so
+     * declaring it {@code multi_value: true} would ask for a {@code LIST<MAP>} the writer does not
+     * build. It must fail at creation time rather than at first write.
+     */
+    public void testFlatObjectRejectsMultiValue() {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        expectThrows(
+            Exception.class,
+            () -> client().admin()
+                .indices()
+                .prepareCreate("otel-mv-flat-idx")
+                .setSettings(compositeSettings())
+                .setMapping("{\"properties\":{\"LogAttributes\":{\"type\":\"flat_object\",\"multi_value\":true}}}")
+                .get()
+        );
+    }
+
+    /**
+     * A MAP column has no single value to sort on, so it cannot be an {@code index.sort.field}. The
+     * native k-way merge can only build a sort key from a primitive leaf and would otherwise fail on
+     * the first merge, long after the index started accepting writes.
+     */
+    public void testFlatObjectRejectedAsIndexSortField() {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        Settings sorted = Settings.builder().put(compositeSettings()).put("index.sort.field", "LogAttributes").build();
+        expectThrows(
+            Exception.class,
+            () -> client().admin().indices().prepareCreate("otel-sorted-idx").setSettings(sorted).setMapping(OTEL_MAPPING).get()
+        );
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -383,6 +383,45 @@ public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseI
     }
 
     /**
+     * An absent multi_value field and an explicit empty array must stay distinct in reconstructed
+     * {@code _source}.
+     *
+     * <p>These share the same on-disk column, so the writer must encode them differently: an empty
+     * array writes an empty-but-non-null LIST cell (reconstructed as {@code "tags": []}), while an
+     * absent field never calls {@code addField} — so {@code createField} is never invoked for the
+     * column and Arrow leaves the row's validity bit unset, i.e. a null cell (reconstructed by
+     * dropping {@code tags} from {@code _source}). This pins that the row advance in
+     * {@code VSRManager#addDocument} leaves unset list rows null rather than collapsing to empty.
+     */
+    @SuppressWarnings("unchecked")
+    public void testAbsentFieldIsDistinctFromEmptyArray() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        String emptyId = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"empty\",\"tags\":[]}", XContentType.JSON)
+            .get()
+            .getId();
+        String absentId = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"absent\"}", XContentType.JSON)
+            .get()
+            .getId();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> emptySource = client().prepareGet(MV_INDEX, emptyId).setRealtime(false).get().getSourceAsMap();
+        assertTrue("empty array must reconstruct as a present list", emptySource.get("tags") instanceof List);
+        assertEquals("empty array must be a zero-length list", List.of(), emptySource.get("tags"));
+
+        Map<String, Object> absentSource = client().prepareGet(MV_INDEX, absentId).setRealtime(false).get().getSourceAsMap();
+        assertFalse("absent field must not appear in reconstructed _source", absentSource.containsKey("tags"));
+    }
+
+    /**
      * A single document whose array is far larger than the per-row average the VSR sizes for.
      *
      * <p>VSR rotation is driven by ROW count ({@code index.parquet.max_rows_per_vsr}), not by bytes,

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -109,7 +109,11 @@ public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseI
             Map<String, Object> source = resp.getSourceAsMap();
             List<String> want = EXPECTED.get(entry.getValue());
             Object actual = source.get("tags");
-            List<String> got = actual == null ? List.of() : ((List<Object>) actual).stream().map(String::valueOf).toList();
+            // An indexed array — including an explicit empty one (d3 = []) — must be reconstructed as
+            // a present, non-null list: an empty array reads back as [] and stays distinct from an
+            // absent field. Do not coalesce null → [] here, or the empty-vs-absent bug would hide.
+            assertTrue(stage + ": fixture [" + entry.getValue() + "] must reconstruct tags as a list", actual instanceof List);
+            List<String> got = ((List<Object>) actual).stream().map(String::valueOf).toList();
             assertEquals(stage + ": fixture [" + entry.getValue() + "] lost or reordered values", want, got);
         }
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/MultiValueFieldDurabilityIT.java
@@ -1,0 +1,569 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Durability lifecycle for multi-valued ({@code multi_value: true}) keyword fields on a composite
+ * parquet+lucene index: refresh, flush, force-merge, replication to a peer, and recovery.
+ *
+ * <p>A multi-valued field is stored as an Arrow/Parquet {@code LIST<element>} column rather than a
+ * flat column, so every stage that moves or rewrites those files is a place the list encoding can
+ * break independently of the read path: the VSR flush writes offsets, force-merge re-encodes each
+ * column through {@code compute_leaves}, segment replication ships the files to a replica, and
+ * recovery replays or re-fetches them. Each assertion below re-reads the array and requires the
+ * values to be byte-identical, in document order, duplicates intact — the column is the source of
+ * truth for derived {@code _source}, so any loss is silent data corruption rather than a query bug.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class MultiValueFieldDurabilityIT extends DataFormatAwareReplicationBaseIT {
+
+    private static final String MV_INDEX = "mv-durability-idx";
+
+    /** Document id → the exact array it was indexed with. */
+    private static final Map<String, List<String>> EXPECTED = Map.of(
+        "d1",
+        List.of("beta", "alpha", "beta"),
+        "d2",
+        List.of("solo"),
+        "d3",
+        List.of(),
+        "d4",
+        List.of("x", "y", "z", "x")
+    );
+
+    private Settings mvIndexSettings(int replicaCount) {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(replicaCount, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, org.opensearch.indices.replication.common.ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    private static final String MAPPING = "{\"properties\":{"
+        + "\"id\":{\"type\":\"keyword\"},"
+        + "\"tags\":{\"type\":\"keyword\",\"multi_value\":true}"
+        + "}}";
+
+    private void createMvIndex(int replicaCount) {
+        client().admin().indices().prepareCreate(MV_INDEX).setSettings(mvIndexSettings(replicaCount)).setMapping(MAPPING).get();
+        ensureYellowAndNoInitializingShards(MV_INDEX);
+    }
+
+    /** Generated _id → fixture key, captured at index time (append-only index rejects custom _ids). */
+    private final Map<String, String> idToFixture = new java.util.HashMap<>();
+
+    /** Indexes the four fixture docs with the given refresh policy, recording their generated ids. */
+    private void indexFixtures(WriteRequest.RefreshPolicy policy) {
+        for (Map.Entry<String, List<String>> e : EXPECTED.entrySet()) {
+            StringBuilder json = new StringBuilder("{\"id\":\"").append(e.getKey()).append("\",\"tags\":[");
+            for (int i = 0; i < e.getValue().size(); i++) {
+                if (i > 0) json.append(",");
+                json.append("\"").append(e.getValue().get(i)).append("\"");
+            }
+            json.append("]}");
+            org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+                .setRefreshPolicy(policy)
+                .setSource(json.toString(), XContentType.JSON)
+                .get();
+            idToFixture.put(resp.getId(), e.getKey());
+        }
+    }
+
+    /**
+     * Asserts every indexed document still carries exactly its own values.
+     *
+     * <p>Reads via get-by-id rather than {@code _search}: on a composite index
+     * {@code IndexShard.applyOnEngine} rejects {@code DataFormatAwareEngine}, so there is no
+     * searcher. The get path reconstructs {@code _source} from the Parquet columns (parquet-owned
+     * fields have no Lucene stored fields), making this a direct test of the LIST column's
+     * integrity rather than of a cached copy.
+     */
+    @SuppressWarnings("unchecked")
+    private void assertArraysIntact(String stage) {
+        assertFalse(stage + ": no documents were indexed", idToFixture.isEmpty());
+        for (Map.Entry<String, String> entry : idToFixture.entrySet()) {
+            org.opensearch.action.get.GetResponse resp = client().prepareGet(MV_INDEX, entry.getKey()).setRealtime(false).get();
+            assertTrue(stage + ": document [" + entry.getKey() + "] must exist", resp.isExists());
+            Map<String, Object> source = resp.getSourceAsMap();
+            List<String> want = EXPECTED.get(entry.getValue());
+            Object actual = source.get("tags");
+            List<String> got = actual == null ? List.of() : ((List<Object>) actual).stream().map(String::valueOf).toList();
+            assertEquals(stage + ": fixture [" + entry.getValue() + "] lost or reordered values", want, got);
+        }
+    }
+
+    /**
+     * refresh → flush → force-merge on a single primary. Each stage either makes the in-memory VSR
+     * durable or rewrites the Parquet files; the array must survive all three unchanged.
+     */
+    public void testArraysSurviveRefreshFlushAndForceMerge() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        // Refresh: flushes the active VSR into a readable Parquet generation.
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("after refresh");
+
+        // Flush: commits the generation.
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after flush");
+
+        // A second generation, so force-merge has more than one file to combine.
+        indexFixtures(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        ForceMergeResponse merge = client().admin().indices().prepareForceMerge(MV_INDEX).setMaxNumSegments(1).get();
+        assertEquals("force-merge must not fail any shard", 0, merge.getFailedShards());
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        assertArraysIntact("after force-merge");
+    }
+
+    /**
+     * Segment replication of a LIST column to a peer: the replica reads the primary's Parquet files
+     * verbatim, so a replica-side read failure would mean the file or its catalog entry is not
+     * self-describing.
+     */
+    public void testArraysReplicateToPeer() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createMvIndex(1);
+        ensureGreen(MV_INDEX);
+
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        // Segment replication is asynchronous. Wait for the replica's catalog to carry the same
+        // parquet files as the primary — the base helper's node lookups are bound to its own
+        // INDEX_NAME, so resolve this index's shards here.
+        assertBusy(() -> {
+            org.opensearch.cluster.routing.IndexShardRoutingTable routing = getClusterState().routingTable().index(MV_INDEX).shard(0);
+            String primaryNode = getClusterState().nodes().get(routing.primaryShard().currentNodeId()).getName();
+            org.opensearch.index.shard.IndexShard primary = getIndexShard(primaryNode, MV_INDEX);
+            java.util.Set<String> primaryFiles = DataFormatAwareITUtils.catalogFilesExcludingSegments(primary);
+            assertFalse("primary must have parquet files in its catalog", primaryFiles.isEmpty());
+            for (org.opensearch.cluster.routing.ShardRouting r : routing.replicaShards()) {
+                assertTrue("replica must be started", r.started());
+                String replicaNode = getClusterState().nodes().get(r.currentNodeId()).getName();
+                org.opensearch.index.shard.IndexShard replica = getIndexShard(replicaNode, MV_INDEX);
+                assertEquals(
+                    "primary/replica catalog files must converge on " + replicaNode,
+                    primaryFiles,
+                    DataFormatAwareITUtils.catalogFilesExcludingSegments(replica)
+                );
+            }
+        }, 60, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Values must still read back intact once the replica holds the same files.
+        assertArraysIntact("after replication to peer");
+    }
+
+    /**
+     * Recovery: restart the data node holding the primary and re-read. Exercises the commit +
+     * catalog replay path over a LIST column — a lost or mis-sized offsets buffer would surface as
+     * a read failure or altered values after recovery rather than at write time.
+     */
+    public void testArraysSurviveNodeRestartRecovery() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("before restart");
+
+        internalCluster().restartRandomDataNode();
+        ensureGreen(MV_INDEX);
+
+        assertArraysIntact("after node restart recovery");
+    }
+
+    /**
+     * A {@code BackgroundIndexer} whose documents carry a multi-valued {@code tags} array, so
+     * concurrent load exercises the LIST write path (VSR rotation, offsets growth) rather than only
+     * flat columns. Every document's array is derived from its id so the expected contents are
+     * recomputable at verification time.
+     */
+    private static final class MultiValueIndexer extends org.opensearch.test.BackgroundIndexer {
+        MultiValueIndexer(String index, org.opensearch.transport.client.Client client, int writerCount) {
+            super(index, "_doc", client, -1, writerCount, false, random());
+        }
+
+        /** The array document {@code id} is indexed with — varies length 0..3 including duplicates. */
+        static List<String> tagsFor(long id) {
+            int shape = (int) Math.floorMod(id, 4L);
+            return switch (shape) {
+                case 0 -> List.of();
+                case 1 -> List.of("t" + id);
+                case 2 -> List.of("t" + id, "dup", "dup");
+                default -> List.of("a" + id, "b" + id, "c" + id);
+            };
+        }
+
+        @Override
+        protected org.opensearch.core.xcontent.XContentBuilder generateSource(long id, java.util.Random random) throws java.io.IOException {
+            org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+            builder.startObject().field("id", Long.toString(id));
+            builder.startArray("tags");
+            for (String tag : tagsFor(id)) {
+                builder.value(tag);
+            }
+            builder.endArray();
+            return builder.endObject();
+        }
+    }
+
+    /**
+     * Peer recovery of a LIST column while indexing continues.
+     *
+     * <p>Recovery under load is the case the stop-then-recover test cannot reach: the replica is
+     * built from a catalog that is still advancing, so a generation can be shipped while the
+     * primary's active VSR is mid-list (offsets written, values not yet complete). Asserts the
+     * replica converges on the primary's parquet files and that no acknowledged write was lost.
+     */
+    public void testArraysSurviveConcurrentIndexingDuringPeerRecovery() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        try (MultiValueIndexer indexer = new MultiValueIndexer(MV_INDEX, client(), scaledRandomIntBetween(2, 4))) {
+            indexer.setUseAutoGeneratedIDs(true);
+            indexer.start(-1);
+            waitForIndexerDocs(200, indexer);
+
+            // Adding a replica while writes are in flight triggers peer recovery under load.
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(MV_INDEX)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+                .get();
+
+            indexer.continueIndexing(200);
+            ensureGreen(MV_INDEX);
+            indexer.stopAndAwaitStopped();
+
+            // No acknowledged write may be lost, and the replica must hold the same parquet files.
+            indexer.assertNoFailures();
+            assertTrue("indexing must have made progress", indexer.totalIndexedDocs() > 0);
+            client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+            assertReplicaCatalogConverged();
+        }
+    }
+
+    /**
+     * Partial write failure across the two formats must leave neither format holding the document.
+     *
+     * <p>A composite write calls the primary (parquet) then each secondary (lucene) in turn and
+     * rolls back every writer it touched if any one fails (CompositeWriter#addDoc). A term
+     * longer than Lucene's {@code IndexWriter.MAX_TERM_LENGTH} (32766 bytes) fails only in the
+     * secondary, after parquet has already accepted the row and — for a multi-valued field — after
+     * its list offsets have been advanced. The rollback therefore has to rewind a partially written
+     * LIST cell, which is the failure mode a flat column cannot exercise. Subsequent good documents
+     * must still index and read back correctly, proving the VSR was left consistent rather than
+     * merely not crashing.
+     */
+    public void testPartialWriteFailureAcrossFormatsRollsBackBothFormats() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        // One good document first, so the VSR already holds a completed list row.
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("before partial failure");
+        int acceptedBefore = idToFixture.size();
+
+        // A multi-valued document whose SECOND element exceeds Lucene's max term length: parquet
+        // accepts the row (no term limit), lucene rejects it, so the composite writer must roll back.
+        String hugeTerm = randomAlphaOfLength(40000);
+        org.opensearch.action.index.IndexRequestBuilder bad = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"bad\",\"tags\":[\"ok\",\"" + hugeTerm + "\"]}", XContentType.JSON);
+        Exception failure = expectThrows(Exception.class, bad::get);
+        assertNotNull("oversized term must fail the write", failure);
+
+        // The rejected document must exist in NEITHER format: a subsequent read of every previously
+        // acknowledged document still returns its own values, and the doc count has not grown.
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        assertArraysIntact("after rolled-back partial failure");
+        assertEquals("rolled-back document must not be acknowledged", acceptedBefore, idToFixture.size());
+
+        // The writer must still accept good documents after the rollback — proving the VSR's list
+        // offsets were rewound rather than left pointing into a half-written cell.
+        idToFixture.clear();
+        indexFixtures(WriteRequest.RefreshPolicy.NONE);
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after resuming writes post-rollback");
+    }
+
+    /** Waits until every started replica's catalog holds the same parquet files as the primary. */
+    private void assertReplicaCatalogConverged() throws Exception {
+        assertBusy(() -> {
+            org.opensearch.cluster.routing.IndexShardRoutingTable routing = getClusterState().routingTable().index(MV_INDEX).shard(0);
+            String primaryNode = getClusterState().nodes().get(routing.primaryShard().currentNodeId()).getName();
+            org.opensearch.index.shard.IndexShard primary = getIndexShard(primaryNode, MV_INDEX);
+            java.util.Set<String> primaryFiles = DataFormatAwareITUtils.catalogFilesExcludingSegments(primary);
+            assertFalse("primary must have parquet files in its catalog", primaryFiles.isEmpty());
+            for (org.opensearch.cluster.routing.ShardRouting r : routing.replicaShards()) {
+                assertTrue("replica must be started", r.started());
+                String replicaNode = getClusterState().nodes().get(r.currentNodeId()).getName();
+                org.opensearch.index.shard.IndexShard replica = getIndexShard(replicaNode, MV_INDEX);
+                assertEquals(
+                    "primary/replica catalog files must converge on " + replicaNode,
+                    primaryFiles,
+                    DataFormatAwareITUtils.catalogFilesExcludingSegments(replica)
+                );
+            }
+        }, 60, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    /**
+     * Null elements inside an array are dropped, so the stored list is shorter than the JSON.
+     *
+     * <p>{@code KeywordFieldMapper.parseCreateFieldForPluggableFormat} returns early when the parsed
+     * value is null, so a null element never reaches {@code addField} and never becomes a list
+     * element. This matches Lucene, which indexes no term for a null, and it means
+     * {@code array_length(["a",null,"b"])} is 2 — pinned here because the alternative (a null
+     * element preserved in the list) would be an equally defensible design and should not change
+     * silently. A configured {@code null_value} substitutes instead and IS stored.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullElementsInsideArrayAreDropped() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"nulls\",\"tags\":[\"a\",null,\"b\",null]}", XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        Object tags = source.get("tags");
+        List<String> got = tags == null ? List.of() : ((List<Object>) tags).stream().map(String::valueOf).toList();
+        assertEquals("null elements are dropped, not preserved as null list entries", List.of("a", "b"), got);
+    }
+
+    /**
+     * A single document whose array is far larger than the per-row average the VSR sizes for.
+     *
+     * <p>VSR rotation is driven by ROW count ({@code index.parquet.max_rows_per_vsr}), not by bytes,
+     * so one pathological array grows the child vector without triggering a rotation — the case
+     * where a row-count-based memory bound does not hold. Verifies the write completes and every
+     * element survives the flush rather than being truncated at some buffer boundary.
+     */
+    @SuppressWarnings("unchecked")
+    public void testVeryLargeArrayInSingleDocument() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        int elementCount = 50_000;
+        StringBuilder json = new StringBuilder("{\"id\":\"big\",\"tags\":[");
+        for (int i = 0; i < elementCount; i++) {
+            if (i > 0) json.append(",");
+            json.append("\"v").append(i).append("\"");
+        }
+        json.append("]}");
+
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource(json.toString(), XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        List<Object> tags = (List<Object>) source.get("tags");
+        assertNotNull("large array must be stored", tags);
+        assertEquals("every element must survive", elementCount, tags.size());
+        assertEquals("first element", "v0", String.valueOf(tags.get(0)));
+        assertEquals("last element", "v" + (elementCount - 1), String.valueOf(tags.get(elementCount - 1)));
+    }
+
+    /**
+     * A {@code multi_value} field added by a mapping update on a live index.
+     *
+     * <p>This is the {@code VSRManager.reconcileSchema} path: the new field's vector is created on
+     * the already-active VSR. That code previously rebuilt each Arrow field from name + FieldType
+     * and dropped {@code getChildren()}, which left a LIST column with no element vector to write
+     * into — a bug only a dynamically-added multi-valued field reaches, since an index created with
+     * the field gets its children from the initial schema.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMultiValueFieldAddedByMappingUpdate() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        // Create WITHOUT the tags field.
+        client().admin()
+            .indices()
+            .prepareCreate(MV_INDEX)
+            .setSettings(mvIndexSettings(0))
+            .setMapping("{\"properties\":{\"id\":{\"type\":\"keyword\"}}}")
+            .get();
+        ensureGreen(MV_INDEX);
+
+        // A document in the original schema, so the VSR is already active when the mapping changes.
+        client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"before\"}", XContentType.JSON)
+            .get();
+
+        client().admin()
+            .indices()
+            .preparePutMapping(MV_INDEX)
+            .setSource("{\"properties\":{\"tags\":{\"type\":\"keyword\",\"multi_value\":true}}}", XContentType.JSON)
+            .get();
+
+        // Writing the newly-added LIST column exercises reconcileSchema's child preservation.
+        org.opensearch.action.index.IndexResponse resp = client().prepareIndex(MV_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.NONE)
+            .setSource("{\"id\":\"after\",\"tags\":[\"p\",\"q\",\"p\"]}", XContentType.JSON)
+            .get();
+        client().admin().indices().prepareRefresh(MV_INDEX).get();
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        Map<String, Object> source = client().prepareGet(MV_INDEX, resp.getId()).setRealtime(false).get().getSourceAsMap();
+        Object tags = source.get("tags");
+        assertNotNull("dynamically added multi_value field must be stored", tags);
+        assertEquals(
+            "values written into a dynamically added LIST column must survive",
+            List.of("p", "q", "p"),
+            ((List<Object>) tags).stream().map(String::valueOf).toList()
+        );
+    }
+
+    /**
+     * A bulk request interleaving valid and invalid multi-valued documents.
+     *
+     * <p>The single-document partial-failure test proves the rollback undoes one row. Bulk is the
+     * realistic ingest path and is stricter: {@code CompositeWriter} rolls each touched writer back
+     * to the composite's running {@code acceptedRows}, so within one batch every rejected item must
+     * rewind to exactly the count its predecessors established. An off-by-one there would corrupt
+     * the neighbours in the same batch rather than the failing document — and for a LIST column it
+     * would also leave the child vector's offsets pointing past the surviving rows.
+     *
+     * <p>Invalid items carry a {@code tags} element over Lucene's {@code MAX_TERM_LENGTH}: parquet
+     * accepts the row (advancing list offsets) and lucene rejects it, so the failure is asymmetric
+     * across the two formats. The valid neighbours must all be acknowledged with their arrays
+     * exactly intact, and the invalid ones must appear in neither format.
+     *
+     * <p>Scope note: this asserts the OUTCOME (neighbours intact, writes resume). It does not by
+     * itself pin the rollback arithmetic — injecting {@code rollbackTo(target + 1)} leaves this test
+     * green, because {@code ParquetWriter.rollbackTo} rejects a target above its own
+     * {@code acceptedRows} only when it exceeds it, and after the failing doc the composite's target
+     * happens to equal the writer's count. The arithmetic itself is guarded there by explicit
+     * range checks ("Cannot rollback to N: only M rows admitted" and the exactly-one-doc limit)
+     * and is covered by unit tests on {@code ParquetWriter}/{@code VSRManager}; the mutation is
+     * therefore masked by those guards rather than by a gap in coverage.
+     */
+    @SuppressWarnings("unchecked")
+    public void testBulkWithMixedValidAndInvalidArrayDocuments() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createMvIndex(0);
+        ensureGreen(MV_INDEX);
+
+        String hugeTerm = randomAlphaOfLength(40000);
+        // Interleave good/bad so a bad item sits first, between, and last — each position exercises
+        // a different neighbour relationship for the rollback.
+        List<List<String>> goodArrays = List.of(List.of("g0", "dup", "dup"), List.of("g1"), List.of(), List.of("g3", "x", "y", "z"));
+
+        org.opensearch.action.bulk.BulkRequestBuilder bulk = client().prepareBulk();
+        // bad, good0, good1, bad, good2, good3, bad
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad0\",\"tags\":[\"" + hugeTerm + "\"]}", XContentType.JSON));
+        bulk.add(goodRequest("g0", goodArrays.get(0)));
+        bulk.add(goodRequest("g1", goodArrays.get(1)));
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad1\",\"tags\":[\"ok\",\"" + hugeTerm + "\"]}", XContentType.JSON));
+        bulk.add(goodRequest("g2", goodArrays.get(2)));
+        bulk.add(goodRequest("g3", goodArrays.get(3)));
+        bulk.add(client().prepareIndex(MV_INDEX).setSource("{\"id\":\"bad2\",\"tags\":[\"" + hugeTerm + "\"]}", XContentType.JSON));
+
+        org.opensearch.action.bulk.BulkResponse response = bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        assertTrue("the oversized-term items must fail", response.hasFailures());
+
+        // Collect the ids the cluster actually acknowledged, keyed by the logical id in the source.
+        Map<String, String> ackedIdByLogical = new java.util.HashMap<>();
+        int failed = 0;
+        for (org.opensearch.action.bulk.BulkItemResponse item : response.getItems()) {
+            if (item.isFailed()) {
+                failed++;
+            } else {
+                ackedIdByLogical.put(logicalIdOf(item.getId()), item.getId());
+            }
+        }
+        assertEquals("exactly the three oversized items must fail", 3, failed);
+        assertEquals("every valid item must be acknowledged", goodArrays.size(), ackedIdByLogical.size());
+
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+
+        // Each surviving neighbour must carry exactly its own array — this is what an off-by-one
+        // rollback inside the batch would break.
+        for (int i = 0; i < goodArrays.size(); i++) {
+            String logical = "g" + i;
+            String docId = ackedIdByLogical.get(logical);
+            assertNotNull("valid document [" + logical + "] must have been acknowledged", docId);
+            Map<String, Object> source = client().prepareGet(MV_INDEX, docId).setRealtime(false).get().getSourceAsMap();
+            Object tags = source.get("tags");
+            List<String> got = tags == null ? List.of() : ((List<Object>) tags).stream().map(String::valueOf).toList();
+            assertEquals("bulk neighbour [" + logical + "] lost or gained values", goodArrays.get(i), got);
+        }
+
+        // Writes must still work afterwards, proving the VSR was left consistent.
+        idToFixture.clear();
+        indexFixtures(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().admin().indices().prepareFlush(MV_INDEX).setForce(true).get();
+        assertArraysIntact("after bulk with rejected items");
+    }
+
+    /** Builds a valid multi-valued index request whose source carries {@code logicalId}. */
+    private org.opensearch.action.index.IndexRequestBuilder goodRequest(String logicalId, List<String> tags) {
+        StringBuilder json = new StringBuilder("{\"id\":\"").append(logicalId).append("\",\"tags\":[");
+        for (int i = 0; i < tags.size(); i++) {
+            if (i > 0) json.append(",");
+            json.append("\"").append(tags.get(i)).append("\"");
+        }
+        json.append("]}");
+        return client().prepareIndex(MV_INDEX).setSource(json.toString(), XContentType.JSON);
+    }
+
+    /** Reads the logical {@code id} field back out of an acknowledged document. */
+    private String logicalIdOf(String docId) {
+        return String.valueOf(client().prepareGet(MV_INDEX, docId).setRealtime(true).get().getSourceAsMap().get("id"));
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/NestedGroupCorrelationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/NestedGroupCorrelationIT.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.List;
+
+/**
+ * Positional correlation across the parallel arrays of a ClickHouse-style {@code Nested} group.
+ *
+ * <p>OTel traces model events as parallel arrays — {@code Events.Timestamp}, {@code Events.Name},
+ * {@code Events.Attributes} — where index {@code i} of each describes the same event. Each is stored
+ * as its own Parquet {@code LIST} column with independent offsets, so nothing in the storage layer
+ * couples them: a document whose arrays differ in length writes cleanly and reads back with values
+ * from different events paired together.
+ *
+ * <p>ClickHouse prevents this by rejecting the insert ("elements of Nested type have different array
+ * sizes"). Declaring the object {@code nested} with {@code correlated: true} applies the same rule at
+ * parse time, turning a silently mispaired row into a rejected document.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class NestedGroupCorrelationIT extends AbstractCompositeEngineIT {
+
+    /** Correlated: the group is declared {@code nested}, stored as parallel position-paired columns. */
+    private static final String CORRELATED_MAPPING = "{\"properties\":{"
+        + "\"TraceId\":{\"type\":\"keyword\"},"
+        + "\"Events\":{\"type\":\"nested\",\"correlated\":true,\"properties\":{"
+        + "  \"Name\":{\"type\":\"keyword\",\"multi_value\":true},"
+        + "  \"Kind\":{\"type\":\"keyword\",\"multi_value\":true}"
+        + "}}}}";
+
+    /** The same fields as a plain object: no group, so nothing couples the columns. */
+    private static final String PLAIN_MAPPING = "{\"properties\":{"
+        + "\"TraceId\":{\"type\":\"keyword\"},"
+        + "\"Events\":{\"properties\":{"
+        + "  \"Name\":{\"type\":\"keyword\",\"multi_value\":true},"
+        + "  \"Kind\":{\"type\":\"keyword\",\"multi_value\":true}"
+        + "}}}}";
+
+    private Settings settings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    private void createIndex(String name, String mapping) {
+        assertTrue(client().admin().indices().prepareCreate(name).setSettings(settings()).setMapping(mapping).get().isAcknowledged());
+        ensureGreen(name);
+    }
+
+    private Exception indexRagged(String index) {
+        // 2 names but only 1 kind: name[1] has no kind of its own, so any positional pairing is a guess.
+        return expectThrows(
+            Exception.class,
+            () -> client().prepareIndex(index)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .setSource("{\"TraceId\":\"t\",\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\"]}}", XContentType.JSON)
+                .get()
+        );
+    }
+
+    /** Equal lengths are the correlated case and must be accepted. */
+    public void testEqualLengthsAccepted() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-ok", CORRELATED_MAPPING);
+
+        client().prepareIndex("grp-ok")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"TraceId\":\"t\",\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\",\"k2\"]}}", XContentType.JSON)
+            .get();
+
+        assertEquals(1, client().admin().indices().prepareStats("grp-ok").get().getIndex("grp-ok").getTotal().getDocs().getCount());
+    }
+
+    /** Ragged arrays in a correlated group are rejected rather than stored mispaired. */
+    public void testUnequalLengthsRejectedWhenCorrelated() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-strict", CORRELATED_MAPPING);
+
+        Exception e = indexRagged("grp-strict");
+        assertTrue(
+            "expected a nested-group length error, got: " + e.getMessage(),
+            e.getMessage().contains("correlated group") || e.getMessage().contains("Events")
+        );
+        assertEquals(
+            "the rejected document must not be indexed",
+            0,
+            client().admin().indices().prepareStats("grp-strict").get().getIndex("grp-strict").getTotal().getDocs().getCount()
+        );
+    }
+
+    /**
+     * As a plain object the same document is accepted, so existing indices are unaffected. This is the
+     * silently-mispaired state that [correlated: true] exists to opt out of.
+     */
+    public void testUnequalLengthsAcceptedWhenNotCorrelated() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-default", PLAIN_MAPPING);
+
+        client().prepareIndex("grp-default")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"TraceId\":\"t\",\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\"]}}", XContentType.JSON)
+            .get();
+
+        assertEquals(
+            1,
+            client().admin().indices().prepareStats("grp-default").get().getIndex("grp-default").getTotal().getDocs().getCount()
+        );
+    }
+
+    /**
+     * A {@code nested} query over a correlated group fails loudly. There is no document per element for
+     * its block join to match, so it would otherwise return nothing at all and read as "no such event"
+     * rather than "this engine cannot scope a query to one element".
+     */
+    public void testNestedQueryOnCorrelatedGroupIsRejected() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-query", CORRELATED_MAPPING);
+
+        client().prepareIndex("grp-query")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"TraceId\":\"t\",\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\",\"k2\"]}}", XContentType.JSON)
+            .get();
+
+        Exception e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("grp-query")
+                .setQuery(QueryBuilders.nestedQuery("Events", QueryBuilders.termQuery("Events.Name", "a"), ScoreMode.None))
+                .get()
+        );
+        assertTrue("expected a correlated-group explanation, got: " + e.getMessage(), e.getMessage().contains("correlated"));
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/NestedGroupCorrelationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/NestedGroupCorrelationIT.java
@@ -16,6 +16,9 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.sort.NestedSortBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.List;
@@ -154,5 +157,49 @@ public class NestedGroupCorrelationIT extends AbstractCompositeEngineIT {
                 .get()
         );
         assertTrue("expected a correlated-group explanation, got: " + e.getMessage(), e.getMessage().contains("correlated"));
+    }
+
+    /**
+     * A {@code nested} aggregation buckets the per-element documents. A correlated group has none, so
+     * its child filter matches nothing and every bucket would come back empty — a plausible-looking
+     * zero rather than an unsupported operation.
+     */
+    public void testNestedAggregationOnCorrelatedGroupIsRejected() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-agg", CORRELATED_MAPPING);
+        indexOneSpan("grp-agg");
+
+        Exception e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("grp-agg").addAggregation(AggregationBuilders.nested("ev", "Events")).get()
+        );
+        assertTrue("expected a correlated-group explanation, got: " + e.getMessage(), e.getMessage().contains("correlated"));
+    }
+
+    /**
+     * Nested sorting picks a value from the matching child documents. With none, the sort would
+     * silently fall back to the missing value for every hit instead of reporting that it cannot work.
+     */
+    public void testNestedSortOnCorrelatedGroupIsRejected() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex("grp-sort", CORRELATED_MAPPING);
+        indexOneSpan("grp-sort");
+
+        Exception e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("grp-sort")
+                .addSort(SortBuilders.fieldSort("Events.Name").setNestedSort(new NestedSortBuilder("Events")))
+                .get()
+        );
+        assertTrue("expected a correlated-group explanation, got: " + e.getMessage(), e.getMessage().contains("correlated"));
+    }
+
+    private void indexOneSpan(String index) {
+        client().prepareIndex(index)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .setSource("{\"TraceId\":\"t\",\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\",\"k2\"]}}", XContentType.JSON)
+            .get();
     }
 }

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/README.md
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/README.md
@@ -36,21 +36,28 @@ writer — so the artifact is what an index with this mapping actually produces.
 Both properties are read by the **forked test JVM**, hence `-Dtests.jvm.argline`; a bare `-D` on the
 Gradle command line does not reach it.
 
-The mapping under test, restricted to what is accepted today:
+The mapping under test:
 
 ```json
 "Events": {
   "type": "nested", "correlated": true,
   "properties": {
+    "Timestamp":  { "type": "date_nanos",  "multi_value": true },
     "Name":       { "type": "keyword",     "multi_value": true },
     "Attributes": { "type": "flat_object", "multi_value": true }
   }
 }
 ```
 
-`Events.Timestamp` as `date_nanos` + `multi_value` is **rejected** — only `KeywordParquetField` and
-`FlatObjectParquetField` override `supportsMultiValue()`. The second test in the class pins that, so it
-starts failing when the remaining type overrides land.
+All three member types are expressible: `Timestamp` writes as `LIST<int64>` nanos, `Name` as
+`LIST<utf8>`, `Attributes` as `LIST<MAP<utf8,utf8>>` — the full ClickHouse `Events` column set. The
+second test in the class asserts `date_nanos` supports list storage, so a regression that reverts it
+fails here.
+
+Note the latency figures below were measured **before** `Events.Timestamp` was added, so the benchmark
+file carried two members per group rather than three. Re-running the generator now produces a third
+column; the JSON side gains a corresponding field, and the ratios should be re-derived rather than
+assumed to carry over.
 
 Data shape: 3 spans per trace; every 4th span errored; errored spans carry two events (`exception` then
 `retry`), others one (`cache.hit`); every third span carries one link. Attribute cardinality is

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/README.md
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/README.md
@@ -1,0 +1,189 @@
+# OTel traces: representation evaluation
+
+Tooling to evaluate how the composite engine's Parquet output behaves when read by **external** query
+engines, using an OTel-traces workload. Two things are measured:
+
+1. **Correctness** — do ClickHouse and DataFusion agree on the same file, and does the correlated-group
+   invariant hold in the written output? (`compare_engines.py`)
+2. **Cost** — how do parallel `LIST` columns compare against the same data flattened into JSON strings?
+   (`bench_ch.sh`, `bench_df.sh`)
+
+Nothing here runs in CI. It is reproduction tooling for a one-off evaluation, kept so the numbers can be
+re-derived rather than trusted.
+
+## 1. Generate the Parquet file
+
+`OtelTracesParquetGeneratorTests` writes an OTel-traces file through the **real write path** — the same
+`ParquetField` implementations the mapping uses, the same `VSRManager`, and the same native arrow-rs
+writer — so the artifact is what an index with this mapping actually produces.
+
+```bash
+# 12 rows into the test temp dir; this is what runs as a normal test
+./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:test \
+  --tests "*OtelTracesParquetGeneratorTests*"
+
+# 10M rows to a durable path, for benchmarking
+./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:test \
+  --tests "*OtelTracesParquetGeneratorTests*" -Dtests.security.manager=false \
+  -Dtests.jvm.argline="-Dotel.parquet.out=/tmp/otel_10m.parquet -Dotel.parquet.rows=10000000"
+```
+
+| Property | Default | Notes |
+| --- | --- | --- |
+| `otel.parquet.out` | test temp dir | An external path also needs `-Dtests.security.manager=false` |
+| `otel.parquet.rows` | `12` | 10M takes ~45 s and produces ~102 MiB |
+
+Both properties are read by the **forked test JVM**, hence `-Dtests.jvm.argline`; a bare `-D` on the
+Gradle command line does not reach it.
+
+The mapping under test, restricted to what is accepted today:
+
+```json
+"Events": {
+  "type": "nested", "correlated": true,
+  "properties": {
+    "Name":       { "type": "keyword",     "multi_value": true },
+    "Attributes": { "type": "flat_object", "multi_value": true }
+  }
+}
+```
+
+`Events.Timestamp` as `date_nanos` + `multi_value` is **rejected** — only `KeywordParquetField` and
+`FlatObjectParquetField` override `supportsMultiValue()`. The second test in the class pins that, so it
+starts failing when the remaining type overrides land.
+
+Data shape: 3 spans per trace; every 4th span errored; errored spans carry two events (`exception` then
+`retry`), others one (`cache.hit`); every third span carries one link. Attribute cardinality is
+deliberately low (3 hosts, 3 SDK languages), which **flatters compression on both sides** — treat any
+size figure from this fixture with suspicion.
+
+## 2. Engines
+
+```bash
+# ClickHouse (single static binary, reads Parquet directly)
+curl -sL -o /tmp/clickhouse https://builds.clickhouse.com/master/macos-aarch64/clickhouse
+chmod +x /tmp/clickhouse
+
+# DataFusion
+cargo install datafusion-cli
+```
+
+Lambda syntax (`array_any_match(arr, e -> ...)`) needs DataFusion **55.0+**, plus
+`set datafusion.sql_parser.dialect = databricks`, and that dialect makes `"Events.Name"` a *string
+literal* — identifiers need backticks. `UNNEST` works on 54.1 and is the `ARRAY JOIN` equivalent, so it
+is the portable choice.
+
+## 3. Cross-engine correctness
+
+```bash
+python3 compare_engines.py
+```
+
+Runs ~19 query pairs and compares normalised output (`\N`→`NULL`, timestamp separator, trailing `.0`).
+Each case declares whether a match or a divergence is expected, so an unexplained difference fails
+rather than being absorbed. Notable cases:
+
+- **A vs B** — element-scoped versus document-scoped evaluation of the same predicate. Differs by one
+  token (`unnest("Events.Name")` versus `"Events.Name"`) and flips `0` → `3`. Both engines agree on
+  both answers, so the false positive is a property of document-granularity evaluation, not of either
+  implementation.
+- **I** — asserts zero ragged rows in either correlated group, i.e. the parse-time invariant validated
+  in the written output rather than in a unit test.
+- **F / F2** — on a deliberately ragged file, ClickHouse throws `SIZES_OF_ARRAYS_DONT_MATCH` when both
+  arrays are projected but **not** under `count(*)` (the optimizer prunes them, and it then pads to the
+  longer array). DataFusion never errors — `arrays_zip` documents "shorter arrays are padded with
+  NULLs". Hence write-time enforcement is the only guarantee that does not depend on the query plan.
+
+Harness gotchas, all learned the hard way:
+
+- DataFusion's `--format tsv` emits a header row; ClickHouse's does not. Strip it.
+- `set ... dialect` must go in a `-f` script, not `-c`; with `-c` the whole string is parsed before the
+  `set` takes effect.
+- `array_agg` returns a `List`, which TSV/CSV cannot render — wrap in `array_to_string`.
+- Do not detect engine errors by searching output for `"Error"`; the data contains `IOError`.
+
+## 4. Representation benchmark
+
+Build the JSON-string variant of the same data (~3 s, no Rust needed):
+
+```bash
+/tmp/clickhouse local -q "
+INSERT INTO FUNCTION file('/tmp/otel_10m_json.parquet', Parquet)
+SELECT Timestamp, TraceId, SpanId, ParentSpanId, SpanName, SpanKind, ServiceName, StatusCode,
+       Duration, ResourceAttributes, SpanAttributes,
+       toJSONString(arrayMap((n,a) -> map('name',n,'attributes',toJSONString(a)),
+                    \`Events.Name\`, \`Events.Attributes\`)) AS events,
+       toJSONString(arrayMap((t,s,a) -> map('traceId',t,'spanId',s,'attributes',toJSONString(a)),
+                    \`Links.TraceId\`, \`Links.SpanId\`, \`Links.Attributes\`)) AS links
+FROM file('/tmp/otel_10m.parquet', Parquet)
+SETTINGS engine_file_truncate_on_insert=1, max_threads=8"
+```
+
+Stock `datafusion-cli` has no JSON UDFs, so the DataFusion side needs a small binary that registers
+`datafusion-functions-json`. `df-json.rs` and `df-json.Cargo.toml` are that binary:
+
+```bash
+mkdir -p /tmp/dfjson/src
+cp df-json.Cargo.toml /tmp/dfjson/Cargo.toml
+cp df-json.rs         /tmp/dfjson/src/main.rs
+cargo build --release --manifest-path /tmp/dfjson/Cargo.toml
+```
+
+Note the registration call needs the guard dereferenced —
+`register_all(&mut *ctx.state_ref().write())` — since `RwLockWriteGuard` itself does not satisfy
+`FunctionRegistry`.
+
+```bash
+./bench_ch.sh   # ClickHouse, both representations, medians of 5
+./bench_df.sh   # DataFusion,  both representations, medians of 5
+```
+
+### Results as measured (10M spans, aarch64 macOS)
+
+| Workload | DF: ours | DF: JSON | CH: ours | CH: JSON |
+| --- | --- | --- | --- | --- |
+| Presence check over all 10M rows | **138 ms** | 294 ms | **272 ms** | 561 ms |
+| First link fields, LIMIT 100 | 8 ms | **4 ms** | **218 ms** | 239 ms |
+| First event fields, LIMIT 100 | **3 ms** | 4 ms | **172 ms** | 221 ms |
+| Explode all events, group by name | **49 ms** | 482 ms | **203 ms** | 1341 ms |
+| Element-scoped conjunction | **240 ms** | 598 ms | **400 ms** | 1516 ms |
+
+Parallel `LIST` columns win on four of five workloads, by up to **9.8×**. The mechanism is column
+pruning *inside* the group: `unnest("Events.Name")` touches one Parquet leaf and never opens
+`Events.Attributes`, whereas `json_get_array(events)` must parse every element — attributes included —
+before one key can be read. The gap is widest on explode-and-aggregate and vanishes on `LIMIT 100`
+point lookups, where both engines short-circuit and per-column setup dominates.
+
+### On storage — read this before quoting any size
+
+Scoped to the `events`/`links` columns the two representations are at **parity**: 15.65 MB compressed
+versus 15.63 MB. A raw file-size comparison (107,101,263 B vs 187,295,500 B) is **not** attributable to
+the representation, for two reasons:
+
+1. The files use **different codecs**. Our writer emitted `LZ4_RAW` for `Duration` (62.9 MB) where
+   ClickHouse used `ZSTD(1)` (27.8 MB) for identical values — ~35 MB of the gap, on a span-level column
+   unrelated to events or links, and 59% of our whole file. Worth investigating independently.
+2. The low-cardinality fixture gives the JSON column a **92×** compression ratio (895.9 MB → 9.7 MB)
+   that real attribute cardinality would not reproduce.
+
+The real cost of JSON here is not storage but the **4.2× more bytes that must be materialised and
+parsed** (306 MB versus 1293 MB uncompressed) — which compresses away on disk and does not in the CPU.
+
+### Caveats
+
+- Only the methodology is shared with the prior JSON-vs-nested comparison that motivated this: that one
+  used `List<Struct<...>>` as its "native" side, which cannot prune within the group the way parallel
+  columns can. These numbers do not refute it; they refute generalising it.
+- Rows 2 and 3 are at the noise floor (3–8 ms).
+- The JSON variant nests `attributes` as a JSON string inside each element, costing it a second parse.
+  OpenObserve's Serde-flatten layout puts attributes as direct keys, which would be somewhat faster.
+- Neither file carries real link/event attributes, so this is not an attributes benchmark.
+- **The JSON representation needs no correlation invariant at all** — both fields live inside one
+  element object, so a ragged row is unrepresentable. That is a genuine advantage of the blob form. What
+  it costs is per-field typing, encoding and statistics, plus the parse cost above.
+
+## 5. Known deviations visible in the output
+
+- Our MAP child group is named `entries`; the Parquet spec requires **`key_value`** (ClickHouse writes
+  `key_value`). Both engines read our form, but it is a conformance gap.
+- `Timestamp` carries no timezone, i.e. `isAdjustedToUTC=false`.

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/bench_ch.sh
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/bench_ch.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+CH=${CLICKHOUSE:-/tmp/clickhouse}
+NAT=${OTEL_NATIVE:-/tmp/otel_10m.parquet}
+JSN=${OTEL_JSON:-/tmp/otel_10m_json.parquet}
+
+run() {  # label, file, sql  -> median of 5 in ms
+  local label=$1 file=$2 sql=$3
+  local -a t
+  for i in 1 2 3 4 5; do
+    local s=$(( $(date +%s%N) ))
+    $CH local -q "$sql" --path /tmp/chtmp > /dev/null 2>&1
+    local e=$(( $(date +%s%N) ))
+    t+=$(( (e - s) / 1000000 ))
+  done
+  printf "%-46s %6s ms\n" "$label" "$(print -l ${t[@]} | sort -n | sed -n 3p)"
+}
+
+echo "=== 1. Presence check over all 10M rows ==="
+run "  ours (parallel LIST)" $NAT "SELECT count(*), sum(length(\`Events.Name\`)>0), sum(length(\`Links.SpanId\`)>0) FROM file('$NAT',Parquet)"
+run "  json strings" $JSN "SELECT count(*), sum(JSONLength(events)>0), sum(JSONLength(links)>0) FROM file('$JSN',Parquet)"
+
+echo "=== 2. First link fields, LIMIT 100 ==="
+run "  ours (parallel LIST)" $NAT "SELECT SpanId, \`Links.TraceId\`[1], \`Links.SpanId\`[1], \`Links.Attributes\`[1]['link.kind'] FROM file('$NAT',Parquet) WHERE length(\`Links.SpanId\`)>0 LIMIT 100"
+run "  json strings" $JSN "SELECT SpanId, JSONExtractString(links,1,'traceId'), JSONExtractString(links,1,'spanId'), JSONExtractString(JSONExtractString(links,1,'attributes'),'link.kind') FROM file('$JSN',Parquet) WHERE JSONLength(links)>0 LIMIT 100"
+
+echo "=== 3. First event fields, LIMIT 100 ==="
+run "  ours (parallel LIST)" $NAT "SELECT \`Events.Name\`[1], \`Events.Attributes\`[1]['exception.type'] FROM file('$NAT',Parquet) WHERE length(\`Events.Name\`)>0 LIMIT 100"
+run "  json strings" $JSN "SELECT JSONExtractString(events,1,'name'), JSONExtractString(JSONExtractString(events,1,'attributes'),'exception.type') FROM file('$JSN',Parquet) WHERE JSONLength(events)>0 LIMIT 100"
+
+echo "=== 4. Explode all events, group by name ==="
+run "  ours (parallel LIST)" $NAT "SELECT name, count(*) FROM file('$NAT',Parquet) ARRAY JOIN \`Events.Name\` AS name GROUP BY name ORDER BY 2 DESC"
+run "  json strings" $JSN "SELECT JSONExtractString(e,'name') AS name, count(*) FROM file('$JSN',Parquet) ARRAY JOIN JSONExtractArrayRaw(events) AS e GROUP BY name ORDER BY 2 DESC"
+
+echo "=== 5. Element-scoped: event named exception WITH exception.type=IOError ==="
+run "  ours (parallel LIST)" $NAT "SELECT count(DISTINCT SpanId) FROM file('$NAT',Parquet) ARRAY JOIN \`Events.Name\` AS n, \`Events.Attributes\` AS a WHERE n='exception' AND a['exception.type']='IOError'"
+run "  json strings" $JSN "SELECT count(DISTINCT SpanId) FROM file('$JSN',Parquet) ARRAY JOIN JSONExtractArrayRaw(events) AS e WHERE JSONExtractString(e,'name')='exception' AND JSONExtractString(JSONExtractString(e,'attributes'),'exception.type')='IOError'"

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/bench_df.sh
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/bench_df.sh
@@ -1,0 +1,35 @@
+#!/bin/zsh
+DFJ=${DF_JSON:-/tmp/dfjson/target/release/df-json}
+NAT=${OTEL_NATIVE:-/tmp/otel_10m.parquet}
+JSN=${OTEL_JSON:-/tmp/otel_10m_json.parquet}
+
+run() {  # label, file, sql -> median of 5 from ELAPSED_MS (excludes startup+registration)
+  local label=$1 file=$2 sql=$3
+  local -a t
+  for i in 1 2 3 4 5; do
+    local ms=$($DFJ -p $file -c "$sql" 2>&1 >/dev/null | sed -n 's/.*ELAPSED_MS=\([0-9.]*\).*/\1/p')
+    [[ -z "$ms" ]] && { printf "%-46s  ERROR\n" "$label"; $DFJ -p $file -c "$sql" 2>&1 >/dev/null | head -2; return; }
+    t+=${ms%.*}
+  done
+  printf "%-46s %6s ms\n" "$label" "$(print -l ${t[@]} | sort -n | sed -n 3p)"
+}
+
+echo "=== 1. Presence check over all 10M rows ==="
+run "  ours (parallel LIST)" $NAT "SELECT count(*), sum(CASE WHEN array_length(\"Events.Name\")>0 THEN 1 ELSE 0 END), sum(CASE WHEN array_length(\"Links.SpanId\")>0 THEN 1 ELSE 0 END) FROM traces"
+run "  json strings" $JSN "SELECT count(*), sum(CASE WHEN json_length(events)>0 THEN 1 ELSE 0 END), sum(CASE WHEN json_length(links)>0 THEN 1 ELSE 0 END) FROM traces"
+
+echo "=== 2. First link fields, LIMIT 100 ==="
+run "  ours (parallel LIST)" $NAT "SELECT \"SpanId\", \"Links.TraceId\"[1], \"Links.SpanId\"[1] FROM traces WHERE array_length(\"Links.SpanId\")>0 LIMIT 100"
+run "  json strings" $JSN "SELECT \"SpanId\", json_get_str(links,0,'traceId'), json_get_str(links,0,'spanId') FROM traces WHERE json_length(links)>0 LIMIT 100"
+
+echo "=== 3. First event fields, LIMIT 100 ==="
+run "  ours (parallel LIST)" $NAT "SELECT \"Events.Name\"[1] FROM traces WHERE array_length(\"Events.Name\")>0 LIMIT 100"
+run "  json strings" $JSN "SELECT json_get_str(events,0,'name') FROM traces WHERE json_length(events)>0 LIMIT 100"
+
+echo "=== 4. Explode all events, group by name ==="
+run "  ours (parallel LIST)" $NAT "SELECT name, count(*) FROM (SELECT unnest(\"Events.Name\") AS name FROM traces) GROUP BY name ORDER BY 2 DESC"
+run "  json strings" $JSN "SELECT json_get_str(e,'name') AS name, count(*) FROM (SELECT unnest(json_get_array(events)) AS e FROM traces) GROUP BY name ORDER BY 2 DESC"
+
+echo "=== 5. Element-scoped: name=exception AND exception.type=IOError ==="
+run "  ours (parallel LIST)" $NAT "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\", unnest(\"Events.Name\") AS n, unnest(\"Events.Attributes\") AS a FROM traces) WHERE n='exception' AND map_extract(a,'exception.type')[1]='IOError'"
+run "  json strings" $JSN "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\", unnest(json_get_array(events)) AS e FROM traces) WHERE json_get_str(e,'name')='exception' AND json_get_str(json_get(e,'attributes'),'exception.type')='IOError'"

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/compare_engines.py
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/compare_engines.py
@@ -1,0 +1,117 @@
+import subprocess, re, os
+
+CH   = os.environ.get("CLICKHOUSE", "/tmp/clickhouse")
+DF   = os.environ.get("DATAFUSION_CLI", "datafusion-cli")
+DF55 = os.environ.get("DATAFUSION_CLI_55", "datafusion-cli")
+MAIN = os.environ.get("OTEL_PARQUET", "/tmp/otel_traces.parquet")
+RAG  = os.environ.get("OTEL_RAGGED", "/tmp/ragged.parquet")
+
+def run_ch(sql, src):
+    pre = f"CREATE VIEW spans AS SELECT * FROM file('{src}', Parquet);\n"
+    p = subprocess.run([CH, "local", "--format", "TSV", "-q", pre + sql], capture_output=True, text=True)
+    out = (p.stdout or p.stderr).strip()
+    m = re.search(r"Code: (\d+).*?\((\w+)\)", out, re.S)
+    return f"ERROR {m.group(2)}" if m else out
+
+def run_df(sql, src, dialect=None):
+    pre = ("set datafusion.sql_parser.dialect = databricks;\n" if dialect else "")
+    pre += f"CREATE EXTERNAL TABLE spans STORED AS PARQUET LOCATION '{src}';\n"
+    open("/tmp/_c.sql","w").write(pre + sql + ";\n")
+    p = subprocess.run([DF55 if dialect else DF, "--format","tsv","-q","-f","/tmp/_c.sql"],
+                       capture_output=True, text=True)
+    out = (p.stdout or p.stderr).strip()
+    if p.returncode != 0 or re.match(r"^(Error|.*Exception:)", out):
+        return "ERROR " + re.sub(r"\s+"," ",out)[:70]
+    lines = [l for l in out.splitlines() if l.strip() and not l.startswith(("+","|")) and "row(s)" not in l]
+    return "\n".join(lines[1:]) if lines else ""   # strip datafusion's TSV header
+
+def norm(s):
+    s = s.strip().replace("\\N","NULL").replace("null","NULL")
+    s = re.sub(r"\bT(\d\d:)", r" \1", s)
+    s = re.sub(r"(\d)\.0+\b", r"\1", s)
+    s = re.sub(r"(:\d\d)\.0+\b", r"\1", s)
+    return re.sub(r"\s+"," ",s).strip()
+
+# (label, ch_sql, df_sql, src, dialect, expectation)
+CASES = [
+ ("Q2  sample span",
+  "SELECT TraceId,SpanId,ServiceName,Duration,arrayStringConcat(`Events.Name`,',') FROM spans ORDER BY SpanId LIMIT 1",
+  "SELECT \"TraceId\",\"SpanId\",\"ServiceName\",\"Duration\",array_to_string(\"Events.Name\",',') FROM spans ORDER BY \"SpanId\" LIMIT 1", MAIN, None, "match"),
+ ("Q9  trace lookup",
+  "SELECT count(*),arrayStringConcat(groupArray(SpanId),',') FROM (SELECT SpanId FROM spans WHERE TraceId='trace-01' ORDER BY Timestamp)",
+  "SELECT count(*),array_to_string(array_agg(\"SpanId\" ORDER BY \"Timestamp\"),',') FROM spans WHERE \"TraceId\"='trace-01'", MAIN, None, "match"),
+ ("Q10 trace lookup bounded",
+  "WITH (SELECT min(Timestamp) FROM spans WHERE TraceId='trace-01') AS s,(SELECT max(Timestamp) FROM spans WHERE TraceId='trace-01') AS e SELECT count(*) FROM spans WHERE TraceId='trace-01' AND Timestamp>=s AND Timestamp<=e",
+  "SELECT count(*) FROM spans WHERE \"TraceId\"='trace-01' AND \"Timestamp\">=(SELECT min(\"Timestamp\") FROM spans WHERE \"TraceId\"='trace-01') AND \"Timestamp\"<=(SELECT max(\"Timestamp\") FROM spans WHERE \"TraceId\"='trace-01')", MAIN, None, "match"),
+ ("Q11 count+avg by lang",
+  "SELECT ResourceAttributes['telemetry.sdk.language'],count(*),avg(Duration) FROM spans WHERE ResourceAttributes['host.name']='host-0' GROUP BY 1",
+  "SELECT \"ResourceAttributes\"['telemetry.sdk.language'],count(*),avg(\"Duration\") FROM spans WHERE \"ResourceAttributes\"['host.name']='host-0' GROUP BY 1", MAIN, None, "match"),
+ ("Q11b p90",
+  "SELECT quantile(0.9)(Duration) FROM spans WHERE ResourceAttributes['host.name']='host-0'",
+  "SELECT approx_percentile_cont(\"Duration\",0.9) FROM spans WHERE \"ResourceAttributes\"['host.name']='host-0'", MAIN, None, "diff: exact quantile vs t-digest"),
+ ("Q12 attribute keys",
+  "SELECT arrayStringConcat(arraySort(groupArrayDistinctArray(mapKeys(ResourceAttributes))),',') FROM spans",
+  "SELECT array_to_string(array_sort(array_distinct(flatten(array_agg(map_keys(\"ResourceAttributes\"))))),',') FROM spans", MAIN, None, "match"),
+ ("Q13 grafana tags",
+  "SELECT SpanId,arrayStringConcat(arrayMap(k -> concat(k,'=',SpanAttributes[k]),mapKeys(SpanAttributes)),',') FROM spans ORDER BY SpanId LIMIT 2",
+  "SELECT \"SpanId\",array_to_string(array_agg(concat(k,'=',v)),',') FROM (SELECT \"SpanId\",unnest(map_keys(\"SpanAttributes\")) AS k,unnest(map_values(\"SpanAttributes\")) AS v FROM spans) GROUP BY \"SpanId\" ORDER BY \"SpanId\" LIMIT 2", MAIN, None, "match"),
+ ("Q16 total compression",
+  f"SELECT sum(c.total_compressed_size),sum(c.total_uncompressed_size) FROM file('{MAIN}',ParquetMetadata) ARRAY JOIN row_groups AS rg ARRAY JOIN rg.columns AS c",
+  f"SELECT sum(total_compressed_size),sum(total_uncompressed_size) FROM parquet_metadata('{MAIN}')", MAIN, None, "match"),
+ ("Q17 top leaf by size",
+  f"SELECT c.path,c.total_compressed_size FROM file('{MAIN}',ParquetMetadata) ARRAY JOIN row_groups AS rg ARRAY JOIN rg.columns AS c ORDER BY c.total_compressed_size DESC, c.name LIMIT 1",
+  f"SELECT replace(path_in_schema,'\"',''),total_compressed_size FROM parquet_metadata('{MAIN}') ORDER BY total_compressed_size DESC, path_in_schema LIMIT 1", MAIN, None, "match"),
+ ("A   correlated element-scoped",
+  "SELECT count(DISTINCT SpanId) FROM spans ARRAY JOIN `Events.Name` AS name,`Events.Attributes` AS attrs WHERE name='retry' AND attrs['exception.type']='IOError'",
+  "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\",unnest(\"Events.Name\") AS name,unnest(\"Events.Attributes\") AS attrs FROM spans) WHERE name='retry' AND map_extract(attrs,'exception.type')[1]='IOError'", MAIN, None, "match"),
+ ("B   uncorrelated document-scoped",
+  "SELECT count(DISTINCT SpanId) FROM spans WHERE has(`Events.Name`,'retry') AND arrayExists(a -> a['exception.type']='IOError',`Events.Attributes`)",
+  "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\",\"Events.Name\" AS names,unnest(\"Events.Attributes\") AS attrs FROM spans) WHERE array_has(names,'retry') AND map_extract(attrs,'exception.type')[1]='IOError'", MAIN, None, "match"),
+ ("C   correlated lambda",
+  "SELECT count(DISTINCT SpanId) FROM spans WHERE arrayExists((n,a) -> n='retry' AND a['exception.type']='IOError',`Events.Name`,`Events.Attributes`)",
+  "SELECT count(*) FROM spans WHERE array_any_match(arrays_zip(`Events.Name`,`Events.Attributes`), e -> e['1']='retry' AND map_extract(e['2'],'exception.type')[1]='IOError')", MAIN, "databricks", "match"),
+ ("D   positive control",
+  "SELECT count(DISTINCT SpanId) FROM spans ARRAY JOIN `Events.Name` AS name,`Events.Attributes` AS attrs WHERE name='exception' AND attrs['exception.type']='IOError'",
+  "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\",unnest(\"Events.Name\") AS name,unnest(\"Events.Attributes\") AS attrs FROM spans) WHERE name='exception' AND map_extract(attrs,'exception.type')[1]='IOError'", MAIN, None, "match"),
+ ("E   zip made visible",
+  "SELECT arrayStringConcat(groupArray(concat(name,':',ifNull(attrs['exception.type'],'-'))),' | ') FROM (SELECT name,attrs FROM spans ARRAY JOIN `Events.Name` AS name,`Events.Attributes` AS attrs WHERE SpanId='span-00')",
+  "SELECT array_to_string(array_agg(concat(name,':',coalesce(map_extract(attrs,'exception.type')[1],'-'))),' | ') FROM (SELECT unnest(\"Events.Name\") AS name,unnest(\"Events.Attributes\") AS attrs FROM spans WHERE \"SpanId\"='span-00')", MAIN, None, "match"),
+ ("H   Links group correlated",
+  "SELECT count(DISTINCT SpanId) FROM spans ARRAY JOIN `Links.SpanId` AS lsid,`Links.Attributes` AS lattrs WHERE lattrs['link.kind']='follows_from'",
+  "SELECT count(DISTINCT \"SpanId\") FROM (SELECT \"SpanId\",unnest(\"Links.SpanId\") AS lsid,unnest(\"Links.Attributes\") AS lattrs FROM spans) WHERE map_extract(lattrs,'link.kind')[1]='follows_from'", MAIN, None, "match"),
+ ("I   INVARIANT: group lengths equal",
+  "SELECT countIf(length(`Events.Name`)!=length(`Events.Attributes`)) AS ragged_events, countIf(length(`Links.SpanId`)!=length(`Links.Attributes`)) AS ragged_links FROM spans",
+  "SELECT sum(CASE WHEN array_length(\"Events.Name\")!=array_length(\"Events.Attributes\") THEN 1 ELSE 0 END), sum(CASE WHEN array_length(\"Links.SpanId\")!=array_length(\"Links.Attributes\") THEN 1 ELSE 0 END) FROM spans", MAIN, None, "match"),
+ ("J   total element count",
+  "SELECT sum(length(`Events.Name`)),sum(length(`Events.Attributes`)) FROM spans",
+  "SELECT sum(array_length(\"Events.Name\")),sum(array_length(\"Events.Attributes\")) FROM spans", MAIN, None, "match"),
+ ("F   RAGGED element expansion",
+  "SELECT arrayStringConcat(groupArray(concat(name,':',ifNull(attrs['exception.type'],'-'))),' | ') FROM spans ARRAY JOIN `Events.Name` AS name,`Events.Attributes` AS attrs",
+  "SELECT array_to_string(array_agg(concat(name,':',coalesce(map_extract(attrs,'exception.type')[1],'-'))),' | ') FROM (SELECT unnest(\"Events.Name\") AS name,unnest(\"Events.Attributes\") AS attrs FROM spans)", RAG, None, "diff: CH rejects when both arrays are projected, DF pads with NULL"),
+ ("F2  RAGGED count(*) only",
+  "SELECT count(*) FROM spans ARRAY JOIN `Events.Name` AS name,`Events.Attributes` AS attrs",
+  "SELECT count(*) FROM (SELECT unnest(\"Events.Name\") AS name,unnest(\"Events.Attributes\") AS attrs FROM spans)", RAG, None, "match"),
+]
+# Dropped: per-leaf max_definition_level / max_repetition_level. ClickHouse exposes them via the
+# ParquetMetadata format but neither the aliased nor the positional tuple projection resolves them
+# correctly, and DataFusion's parquet_metadata() does not expose them at all -- so it was never a
+# cross-engine case.
+
+rows=[]
+for label, chq, dfq, src, dialect, expect in CASES:
+    c, d = norm(run_ch(chq, src)), norm(run_df(dfq, src, dialect))
+    same = (c == d)
+    if expect == "match":
+        verdict = "MATCH" if same else "FAIL"
+    else:
+        verdict = "DIFF-OK" if not same else "FAIL"
+    rows.append((verdict, label, c, d, expect))
+
+w=max(len(r[1]) for r in rows)
+for v,label,c,d,expect in rows:
+    print(f"{v:8} {label:<{w}}  CH={c!r}")
+    if c != d:
+        print(f"{'':8} {'':<{w}}  DF={d!r}" + (f"   [{expect}]" if expect!="match" else ""))
+print()
+ok=sum(1 for r in rows if r[0] in ("MATCH","DIFF-OK"))
+print(f"{ok}/{len(rows)} as expected  ({sum(1 for r in rows if r[0]=='MATCH')} identical, {sum(1 for r in rows if r[0]=='DIFF-OK')} expected-diff, {sum(1 for r in rows if r[0]=='FAIL')} unexpected)")

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/df-json.Cargo.toml
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/df-json.Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "df-json"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+datafusion = "54.1"
+datafusion-functions-json = "0.54"
+tokio = { version = "1", features = ["full"] }

--- a/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/df-json.rs
+++ b/sandbox/plugins/parquet-data-format/benchmarks/otel-representation/df-json.rs
@@ -1,0 +1,33 @@
+use datafusion::prelude::*;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> datafusion::error::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut path = String::new();
+    let mut sql = String::new();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-p" => { path = args[i + 1].clone(); i += 2; }
+            "-c" => { sql = args[i + 1].clone(); i += 2; }
+            _ => { i += 1; }
+        }
+    }
+    let ctx = SessionContext::new();
+    {
+        let state_ref = ctx.state_ref();
+        let mut guard = state_ref.write();
+        datafusion_functions_json::register_all(&mut *guard)?;
+    }
+    ctx.register_parquet("traces", &path, ParquetReadOptions::default()).await?;
+    let t = Instant::now();
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    let ms = t.elapsed().as_secs_f64() * 1000.0;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    eprintln!("ELAPSED_MS={:.1} ROWS={}", ms, rows);
+    if let Some(b) = batches.first() {
+        print!("{}", datafusion::arrow::util::pretty::pretty_format_batches(&[b.clone()])?);
+    }
+    Ok(())
+}

--- a/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/AdvanceExactBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/AdvanceExactBenchmark.java
@@ -1,0 +1,211 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.benchmark;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.nativebridge.spi.ArrowExport;
+import org.opensearch.parquet.bridge.NativeParquetWriter;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+import org.opensearch.parquet.bridge.ParquetSortConfig;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.codec.ParquetPhysicalType;
+import org.opensearch.parquet.codec.cache.BufferPool;
+import org.opensearch.parquet.codec.iter.ParquetNumericDocValues;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark for the {@link ParquetNumericDocValues#advanceExact} hot path over a
+ * single-valued INT64 Parquet column ("price").
+ *
+ * <p>Each invocation is one full pass over the column:
+ * <ul>
+ *   <li>{@code sequentialScan} — calls {@code advanceExact(d)} for every doc
+ *       {@code 0..maxDoc-1}. Almost every call is a resident {@code PageCache} hit; a page
+ *       miss (FFM decode crossing) happens only at page boundaries, so this measures the
+ *       Layer 1/2 bit-test + array-lookup fast path.</li>
+ *   <li>{@code stridedScan} — calls {@code advanceExact(d)} for every {@code stride}-th doc.
+ *       Larger strides skip more rows per resident page (and eventually a whole page per
+ *       call), shifting the hit/miss mix toward the page-decode cold path.</li>
+ * </ul>
+ *
+ * <p>The reader is opened once per trial ({@link Setup} at {@link Level#Trial}), so
+ * measurements reflect warm scans over an already-open column reader; the file open and
+ * page-index load are excluded from the measured region.
+ *
+ * <p>Run with:
+ * <pre>
+ * ./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:benchmarks:run \
+ *   --args 'AdvanceExactBenchmark'
+ * </pre>
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class AdvanceExactBenchmark {
+
+    /** Rows per Arrow batch handed to the native writer during setup. */
+    private static final int BATCH_ROWS = 100_000;
+
+    /**
+     * Shared per-trial state: the Parquet file, the open column reader, and the doc-values
+     * iterator. Parameterized on {@code numDocs} only, so {@code sequentialScan} does not
+     * re-run per stride value.
+     */
+    @State(Scope.Benchmark)
+    public static class ScanState {
+
+        @Param({ "100000", "1000000" })
+        int numDocs;
+
+        BufferAllocator allocator;
+        Path dir;
+        Path file;
+        BufferPool bufferPool;
+        ParquetColumnReader reader;
+        ParquetNumericDocValues docValues;
+
+        @Setup(Level.Trial)
+        public void setupTrial() throws Exception {
+            RustBridge.initLogger();
+            allocator = new RootAllocator();
+            dir = Files.createTempDirectory("advance-exact-bench");
+            file = dir.resolve("bench.parquet");
+            writeFile();
+
+            bufferPool = new BufferPool();
+            reader = ParquetColumnReader.open(file, "price", ParquetPhysicalType.INT64, false, bufferPool);
+            docValues = new ParquetNumericDocValues(reader, numDocs);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDownTrial() throws Exception {
+            if (reader != null) {
+                reader.close();
+            }
+            if (bufferPool != null) {
+                bufferPool.close();
+            }
+            if (allocator != null) {
+                allocator.close();
+            }
+            if (file != null) {
+                Files.deleteIfExists(file);
+            }
+            if (dir != null) {
+                Files.deleteIfExists(dir);
+            }
+        }
+
+        // ── data generation ──
+
+        private void writeFile() throws Exception {
+            Schema schema = new Schema(List.of(new Field("price", FieldType.nullable(new ArrowType.Int(64, true)), null)));
+
+            NativeParquetWriter writer = new NativeParquetWriter(file.toString());
+            try (ArrowExport schemaExport = exportSchema(schema)) {
+                writer.initialize("advance-exact-bench-index", schemaExport.getSchemaAddress(), ParquetSortConfig.empty(), 0L);
+            }
+
+            // Deterministic values so every fork/param combination measures identical data.
+            Random random = new Random(42);
+            for (int start = 0; start < numDocs; start += BATCH_ROWS) {
+                int batch = Math.min(BATCH_ROWS, numDocs - start);
+                try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+                    BigIntVector priceVec = (BigIntVector) root.getVector("price");
+                    for (int i = 0; i < batch; i++) {
+                        priceVec.setSafe(i, random.nextLong());
+                    }
+                    root.setRowCount(batch);
+
+                    ArrowArray array = ArrowArray.allocateNew(allocator);
+                    ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+                    Data.exportVectorSchemaRoot(allocator, root, null, array, arrowSchema);
+                    try (ArrowExport export = new ArrowExport(array, arrowSchema)) {
+                        writer.write(export.getArrayAddress(), export.getSchemaAddress());
+                    }
+                }
+            }
+            writer.flush();
+        }
+
+        private ArrowExport exportSchema(Schema schema) {
+            ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+            Data.exportSchema(allocator, schema, null, arrowSchema);
+            return new ArrowExport(null, arrowSchema);
+        }
+    }
+
+    /** Stride between consecutive advanceExact targets; only applies to {@link #stridedScan}. */
+    @State(Scope.Benchmark)
+    public static class StrideParam {
+
+        @Param({ "1", "100", "10000" })
+        int stride;
+    }
+
+    /**
+     * Full ascending scan: exercises the page-hit fast path heavily — the only page misses
+     * are at page boundaries (~rows/page_row_limit FFM decodes per scan).
+     */
+    @Benchmark
+    public void sequentialScan(ScanState state, Blackhole bh) throws IOException {
+        ParquetNumericDocValues dv = state.docValues;
+        for (int d = 0; d < state.numDocs; d++) {
+            if (dv.advanceExact(d)) {
+                bh.consume(dv.longValue());
+            }
+        }
+    }
+
+    /**
+     * Ascending scan visiting every {@code stride}-th doc: fewer hits are amortized over each
+     * page decode, raising the page-miss share of the per-call cost.
+     */
+    @Benchmark
+    public void stridedScan(ScanState state, StrideParam strideParam, Blackhole bh) throws IOException {
+        ParquetNumericDocValues dv = state.docValues;
+        for (int d = 0; d < state.numDocs; d += strideParam.stride) {
+            if (dv.advanceExact(d)) {
+                bh.consume(dv.longValue());
+            }
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet;
 
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.index.IndexCreationValidator;
 import org.opensearch.index.IndexSettings;
@@ -55,6 +56,7 @@ public class ParquetIndexCreationValidator implements IndexCreationValidator {
         // for a field whose type has no list support, turning what would otherwise be a
         // per-document indexing failure into an immediate error at creation time.
         Schema schema = ArrowSchemaBuilder.getSchema(mapperService);
+        validateSortFieldsAreNotNested(schema, indexSettings);
         ParquetSettings.validateFieldConfigurations(
             fieldEncodings,
             fieldCompressions,
@@ -63,6 +65,30 @@ public class ParquetIndexCreationValidator implements IndexCreationValidator {
             schema,
             mapperService
         );
+    }
+
+    /**
+     * Rejects {@code index.sort.field} entries whose Parquet column is a nested type.
+     * <p>
+     * Complements {@link #validateSortFieldsAreSingleValued}: that check catches a field the mapping
+     * declared {@code multi_value: true}, this one catches a type that is nested regardless of its
+     * declared arity — today {@code flat_object}, which is stored as a {@code MAP} column. The native
+     * k-way merge can only extract a sort key from a primitive column and otherwise fails with
+     * {@code Unsupported sort column type} on the first merge, long after the index accepted writes.
+     */
+    private static void validateSortFieldsAreNotNested(Schema schema, IndexSettings indexSettings) {
+        for (String sortField : IndexSortConfig.INDEX_SORT_FIELD_SETTING.get(indexSettings.getSettings())) {
+            Field field = schema.findField(sortField);
+            if (field != null && field.getChildren().isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "Cannot use field ["
+                        + sortField
+                        + "] in [index.sort.field]: it is stored as a nested ["
+                        + field.getType()
+                        + "] parquet column, which has no single value to sort on"
+                );
+            }
+        }
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetIndexCreationValidator.java
@@ -11,6 +11,8 @@ package org.opensearch.parquet;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.index.IndexCreationValidator;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IndexSortConfig;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 
@@ -43,10 +45,15 @@ public class ParquetIndexCreationValidator implements IndexCreationValidator {
             );
         }
 
-        if (!isParquetIndex || !hasParquetSettings) {
+        if (!isParquetIndex) {
             return;
         }
 
+        validateSortFieldsAreSingleValued(mapperService, indexSettings);
+
+        // Building the schema validates the mapping's `multi_value` declarations: getSchema throws
+        // for a field whose type has no list support, turning what would otherwise be a
+        // per-document indexing failure into an immediate error at creation time.
         Schema schema = ArrowSchemaBuilder.getSchema(mapperService);
         ParquetSettings.validateFieldConfigurations(
             fieldEncodings,
@@ -56,5 +63,28 @@ public class ParquetIndexCreationValidator implements IndexCreationValidator {
             schema,
             mapperService
         );
+    }
+
+    /**
+     * Rejects {@code index.sort.field} entries that are mapped {@code multi_value: true}.
+     * <p>
+     * An index sort needs one total order over rows, but a multi-valued cell has no canonical
+     * scalar to order by — any of min/max/lexicographic would be a silent choice the user never
+     * made. Lucene rejects index sorting on multi-valued fields for the same reason; failing here
+     * keeps parity and turns what would otherwise be a merge-time failure (the native k-way merge
+     * cannot compare LIST sort keys) into an immediate, actionable error at creation time.
+     */
+    private static void validateSortFieldsAreSingleValued(MapperService mapperService, IndexSettings indexSettings) {
+        for (String sortField : IndexSortConfig.INDEX_SORT_FIELD_SETTING.get(indexSettings.getSettings())) {
+            MappedFieldType fieldType = mapperService.fieldType(sortField);
+            if (fieldType != null && fieldType.isMultiValued()) {
+                throw new IllegalArgumentException(
+                    "Cannot use field ["
+                        + sortField
+                        + "] in [index.sort.field]: the field is mapped [multi_value: true] and a "
+                        + "multi-valued field has no single value to sort on"
+                );
+            }
+        }
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -835,6 +835,18 @@ public final class ParquetSettings {
     }
 
     /**
+     * Returns the type that encoding and compression settings apply to for a field. For a LIST
+     * column that is the element type, because Parquet encodes the leaf, not the list wrapper —
+     * validating against {@code ArrowType.List} would wrongly accept every encoding.
+     */
+    private static ArrowType elementTypeOf(Field field) {
+        if (field.getType() instanceof ArrowType.List && field.getChildren().isEmpty() == false) {
+            return field.getChildren().get(0).getType();
+        }
+        return field.getType();
+    }
+
+    /**
      * Validates that field-level configurations are compatible with their Arrow types in the schema.
      * Only keyword and text field types are accepted for low_cardinality_enable.
      */
@@ -848,7 +860,7 @@ public final class ParquetSettings {
     ) {
         Map<String, ArrowType> arrowTypes = new HashMap<>();
         for (Field field : schema.getFields()) {
-            arrowTypes.put(field.getName(), field.getType());
+            arrowTypes.put(field.getName(), elementTypeOf(field));
         }
 
         // Validate encoding configurations

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowSchemaBuilder.java
@@ -14,9 +14,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.FieldMapper;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NestedPathFieldMapper;
@@ -39,8 +41,13 @@ public final class ArrowSchemaBuilder {
 
     /**
      * Creates an Arrow Schema from the MapperService.
-     * @param mapperService the mapper service containing field mappings
+     *
+     * <p>A field whose mapper declares {@code multi_value: true}
+     * ({@link MappedFieldType#isMultiValued()}) is emitted as a {@code LIST<element>} column;
+     * every other field keeps its scalar column.
      * TODO - Get the mapping version while creating the schema
+     *
+     * @param mapperService the mapper service containing field mappings
      */
     public static Schema getSchema(MapperService mapperService) {
         Objects.requireNonNull(mapperService, "MapperService cannot be null");
@@ -55,8 +62,18 @@ public final class ArrowSchemaBuilder {
 
                 ParquetField parquetField = ArrowFieldRegistry.getParquetField(mapper.typeName());
                 if (parquetField != null) {
-                    fields.add(new Field(mapper.name(), parquetField.getFieldType(), null));
-                    handleNormalizedField(mapper, documentMapper, fields, parquetField);
+                    boolean multiValue = isMultiValued(mapper);
+                    if (multiValue && parquetField.supportsMultiValue() == false) {
+                        throw new IllegalArgumentException(
+                            "Field ["
+                                + mapper.name()
+                                + "] of type ["
+                                + mapper.typeName()
+                                + "] does not support [multi_value] storage in the parquet data format"
+                        );
+                    }
+                    fields.add(parquetField.toArrowField(mapper.name(), multiValue));
+                    handleNormalizedField(mapper, documentMapper, fields, parquetField, multiValue);
                 } else {
                     logger.debug("No ParquetField registered for field: [{}] of type [{}]", mapper.name(), mapper.typeName());
                 }
@@ -69,13 +86,26 @@ public final class ArrowSchemaBuilder {
         return new Schema(fields);
     }
 
-    private static void handleNormalizedField(Mapper mapper, DocumentMapper documentMapper, List<Field> fields, ParquetField parquetField) {
+    private static void handleNormalizedField(
+        Mapper mapper,
+        DocumentMapper documentMapper,
+        List<Field> fields,
+        ParquetField parquetField,
+        boolean multiValue
+    ) {
         if (mapper instanceof KeywordFieldMapper keywordFieldMapper) {
             if (!documentMapper.mappers().isMultiField(mapper.name()) && keywordFieldMapper.getRawValueFieldType() != null) {
                 KeywordFieldMapper.KeywordFieldType rawValueField = keywordFieldMapper.getRawValueFieldType();
-                fields.add(new Field(rawValueField.name(), parquetField.getFieldType(), null));
+                // The raw-value companion holds the pre-normalization source for derived source, so
+                // it must mirror the parent's cardinality or source reconstruction would lose values.
+                fields.add(parquetField.toArrowField(rawValueField.name(), multiValue));
             }
         }
+    }
+
+    /** Reads the {@code multi_value} declaration from the mapper's field type. */
+    private static boolean isMultiValued(Mapper mapper) {
+        return mapper instanceof FieldMapper fieldMapper && fieldMapper.fieldType().isMultiValued();
     }
 
     private static boolean isUnsupportedMetadataField(Mapper mapper) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -114,7 +114,12 @@ public abstract class ParquetField {
         }
         // The element is always nullable: a null inside an array (e.g. ["a", null]) is a legal
         // document even when the column itself is declared non-nullable.
-        Field element = new Field(LIST_ELEMENT_NAME, FieldType.nullable(getArrowType()), null);
+        //
+        // The element carries getChildren() for the same reason the scalar branch above does: a nested
+        // element type is not fully described by its ArrowType alone. A MAP element needs its
+        // `entries` struct, and passing null here yields a childless MAP that allocates as an empty
+        // vector, so writes land nowhere. Primitive elements return null and are unaffected.
+        Field element = new Field(LIST_ELEMENT_NAME, FieldType.nullable(getArrowType()), getChildren());
         return new Field(name, FieldType.nullable(ArrowType.List.INSTANCE), List.of(element));
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -10,6 +10,7 @@ package org.opensearch.parquet.fields;
 
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -76,6 +77,19 @@ public abstract class ParquetField {
     }
 
     /**
+     * Returns the child fields of this column's own Arrow type, or null for a primitive column.
+     * <p>
+     * Only nested types (e.g. a {@code MAP<key, value>} column, whose Arrow type requires an
+     * {@code entries} struct child) override this. It describes the field's <em>intrinsic</em>
+     * structure and is unrelated to the {@code LIST} wrapper {@code multi_value} adds.
+     *
+     * @return the child fields, or null if this column is primitive
+     */
+    protected List<Field> getChildren() {
+        return null;
+    }
+
+    /**
      * Builds the Arrow field describing this column, including any child fields.
      * <p>
      * When {@code multiValue} is true the result is a {@code LIST<element>} whose child carries
@@ -87,7 +101,7 @@ public abstract class ParquetField {
      */
     public final Field toArrowField(String name, boolean multiValue) {
         if (multiValue == false) {
-            return new Field(name, getFieldType(), null);
+            return new Field(name, getFieldType(), getChildren());
         }
         if (supportsMultiValue() == false) {
             throw new IllegalArgumentException(
@@ -114,7 +128,10 @@ public abstract class ParquetField {
         assert fieldType != null : "MappedFieldType cannot be null";
         assert managedVSR != null : "ManagedVSR cannot be null";
         FieldVector vector = managedVSR.getVector(fieldType.name());
-        if (vector instanceof ListVector listVector) {
+        // MapVector extends ListVector but carries a (key, value) struct child instead of a plain
+        // element, so it must not go through the LIST writer. Its owning ParquetField writes it in
+        // addToGroup, where the key/value shape of the parsed value is known.
+        if (vector instanceof ListVector listVector && vector instanceof MapVector == false) {
             writeList(fieldType, managedVSR, listVector, parseValue);
             return;
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -8,12 +8,16 @@
 
 package org.opensearch.parquet.fields;
 
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.vsr.ManagedVSR;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -21,6 +25,12 @@ import java.util.Set;
  * between OpenSearch field types and Apache Arrow vectors.
  */
 public abstract class ParquetField {
+
+    /**
+     * Name of the child field inside a LIST column. Matches the parquet-rs convention
+     * ({@code PARQUET_LIST_ELEMENT_NAME}) so the leaf path is {@code <field>.list.element}.
+     */
+    public static final String LIST_ELEMENT_NAME = "element";
 
     /** Creates a new ParquetField. */
     public ParquetField() {}
@@ -34,6 +44,67 @@ public abstract class ParquetField {
     protected abstract void addToGroup(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue);
 
     /**
+     * Writes a single parsed value at an explicit index in the given vector.
+     * <p>
+     * Scalar columns write at the row index, so {@link #addToGroup} can derive the position from
+     * the VSR's row count. List columns write several values per row at positions in the child
+     * vector that have nothing to do with the row number, so multi-value writes need this
+     * index-explicit form instead.
+     * <p>
+     * Subclasses must override this to support being declared multi-valued; the default throws.
+     * When overridden, {@link #addToGroup} should delegate to it so the scalar and list paths
+     * share one value-coercion implementation.
+     *
+     * @param vector the target vector (the child data vector when writing into a list)
+     * @param index the position to write at
+     * @param parseValue the parsed value to write
+     */
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        throw new UnsupportedOperationException(
+            "Field type [" + getClass().getSimpleName() + "] does not support multi-valued (list) storage"
+        );
+    }
+
+    /**
+     * Returns whether this field can be stored as a Parquet LIST column, i.e. whether it
+     * implements {@link #addToVector}.
+     *
+     * @return true if multi-valued storage is supported
+     */
+    public boolean supportsMultiValue() {
+        return false;
+    }
+
+    /**
+     * Builds the Arrow field describing this column, including any child fields.
+     * <p>
+     * When {@code multiValue} is true the result is a {@code LIST<element>} whose child carries
+     * this field's element type, so the same {@link ParquetField} describes both shapes.
+     *
+     * @param name the Arrow field name
+     * @param multiValue whether to wrap the element type in a list
+     * @return the Arrow field
+     */
+    public final Field toArrowField(String name, boolean multiValue) {
+        if (multiValue == false) {
+            return new Field(name, getFieldType(), null);
+        }
+        if (supportsMultiValue() == false) {
+            throw new IllegalArgumentException(
+                "Field ["
+                    + name
+                    + "] cannot be stored as multi-valued: type ["
+                    + getClass().getSimpleName()
+                    + "] does not support list storage"
+            );
+        }
+        // The element is always nullable: a null inside an array (e.g. ["a", null]) is a legal
+        // document even when the column itself is declared non-nullable.
+        Field element = new Field(LIST_ELEMENT_NAME, FieldType.nullable(getArrowType()), null);
+        return new Field(name, FieldType.nullable(ArrowType.List.INSTANCE), List.of(element));
+    }
+
+    /**
      * Creates and processes a field entry. Throws if vector not present in VSR.
      * @param fieldType the mapped field type
      * @param managedVSR the managed vector schema root
@@ -42,7 +113,39 @@ public abstract class ParquetField {
     public final void createField(MappedFieldType fieldType, ManagedVSR managedVSR, Object parseValue) {
         assert fieldType != null : "MappedFieldType cannot be null";
         assert managedVSR != null : "ManagedVSR cannot be null";
+        FieldVector vector = managedVSR.getVector(fieldType.name());
+        if (vector instanceof ListVector listVector) {
+            writeList(fieldType, managedVSR, listVector, parseValue);
+            return;
+        }
         addToGroup(fieldType, managedVSR, parseValue);
+    }
+
+    /**
+     * Writes all values collected for one document into a list column at the current row.
+     * <p>
+     * A null {@code parseValue} is written as a null list, which is how an absent field is
+     * represented. An empty list is written as a zero-length, non-null list, preserving the
+     * distinction between {@code "tags": []} and no {@code tags} at all.
+     */
+    private void writeList(MappedFieldType fieldType, ManagedVSR managedVSR, ListVector listVector, Object parseValue) {
+        int row = managedVSR.getRowCount();
+        if (parseValue == null) {
+            listVector.setNull(row);
+            return;
+        }
+        List<?> values = parseValue instanceof List<?> list ? list : List.of(parseValue);
+        int start = listVector.startNewValue(row);
+        FieldVector dataVector = listVector.getDataVector();
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
+            if (value == null) {
+                dataVector.setNull(start + i);
+            } else {
+                addToVector(dataVector, start + i, value);
+            }
+        }
+        listVector.endValue(row, values.size());
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BinaryParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BinaryParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -28,7 +29,17 @@ public class BinaryParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarBinaryVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (byte[]) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((VarBinaryVector) vector).setSafe(index, (byte[]) parseValue);
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/BooleanParquetField.java
@@ -9,6 +9,7 @@
 package org.opensearch.parquet.fields.core.data;
 
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
@@ -28,7 +29,17 @@ public class BooleanParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((BitVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Boolean) parseValue ? 1 : 0);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((BitVector) vector).setSafe(index, (Boolean) parseValue ? 1 : 0);
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
@@ -108,9 +108,13 @@ public class FlatObjectParquetField extends ParquetField {
 
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
-        // Matches what FlatObjectFieldType requests: it is searchable and has doc values, and the MAP
-        // column serves both from the same storage. No BLOOM_FILTER — a bloom filter would have to be
-        // configured against the nested key/value leaves, which field-level settings cannot address.
-        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH);
+        // Columnar storage only — deliberately NOT FULL_TEXT_SEARCH, so the Lucene secondary claims it
+        // and indexes the object's leaves as terms, keeping basic searches working exactly as they do
+        // for keyword and text (whose parquet fields leave that capability to Lucene for the same
+        // reason). Claiming it here would starve Lucene of the field and make it unsearchable, since
+        // the columnar read path cannot project a MAP column yet.
+        // No BLOOM_FILTER either — that would have to be configured against the nested key/value
+        // leaves, which field-level settings cannot address.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.fields.core.data;
+
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.vsr.ManagedVSR;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parquet field for {@code flat_object} values, stored as a single Arrow {@code MAP<utf8, utf8>}
+ * column ({@link MapVector}) that Parquet writes as a {@code MAP} logical type over a repeated
+ * {@code entries: STRUCT<key, value>} group.
+ *
+ * <p>One document contributes one map cell holding however many leaves its object had, so the
+ * attribute set stays in a single column no matter how many distinct keys the index sees. This is why
+ * the field is single-arity and does not support {@code multi_value}: a {@code LIST<MAP>} has no
+ * meaning here, and the per-document entry count is already variable.
+ *
+ * <p>Values arrive from {@code FlatObjectFieldMapper} as an ordered {@code List<Map.Entry>} of
+ * {@code (relative path, value)} pairs — see
+ * {@code FlatObjectFieldMapper#parseCreateFieldForPluggableFormat}. Everything is stored as UTF-8
+ * text, mirroring flat_object's Lucene representation, which also stringifies numbers and booleans.
+ * Document order and duplicate keys are preserved: a Parquet MAP is physically a repeated group, so
+ * {@code {"a": [1, 2]}} keeps both {@code a} entries rather than collapsing them.
+ */
+public class FlatObjectParquetField extends ParquetField {
+
+    /** Creates a new FlatObjectParquetField. */
+    public FlatObjectParquetField() {}
+
+    /**
+     * Writes one map cell at the current row.
+     * <p>
+     * A null value is written as a null cell, which is how an absent field is represented. An empty
+     * entry list becomes a zero-entry, non-null map, keeping {@code "attrs": {}} distinct from no
+     * {@code attrs} at all.
+     */
+    @Override
+    protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
+        MapVector mapVector = (MapVector) managedVSR.getVector(mappedFieldType.name());
+        int row = managedVSR.getRowCount();
+        if (parseValue == null) {
+            mapVector.setNull(row);
+            return;
+        }
+        List<?> entries = (List<?>) parseValue;
+        StructVector entriesVector = (StructVector) mapVector.getDataVector();
+        VarCharVector keyVector = (VarCharVector) entriesVector.getChild(MapVector.KEY_NAME);
+        VarCharVector valueVector = (VarCharVector) entriesVector.getChild(MapVector.VALUE_NAME);
+        int start = mapVector.startNewValue(row);
+        for (int i = 0; i < entries.size(); i++) {
+            Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entries.get(i);
+            int index = start + i;
+            // The entries struct is non-nullable per the Arrow MAP spec, so every slot written must
+            // have its validity bit set; without this the child values read back as null.
+            entriesVector.setIndexDefined(index);
+            keyVector.setSafe(index, entry.getKey().toString().getBytes(StandardCharsets.UTF_8));
+            Object value = entry.getValue();
+            if (value == null) {
+                valueVector.setNull(index);
+            } else {
+                valueVector.setSafe(index, value.toString().getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        mapVector.endValue(row, entries.size());
+    }
+
+    /**
+     * Builds the {@code entries: STRUCT<key, value>} child the Arrow MAP type requires. Per the Arrow
+     * spec the entries struct and its {@code key} are non-nullable; only {@code value} may be null.
+     */
+    @Override
+    protected List<Field> getChildren() {
+        Field key = new Field(MapVector.KEY_NAME, FieldType.notNullable(new ArrowType.Utf8()), null);
+        Field value = new Field(MapVector.VALUE_NAME, FieldType.nullable(new ArrowType.Utf8()), null);
+        Field entries = new Field(MapVector.DATA_VECTOR_NAME, FieldType.notNullable(ArrowType.Struct.INSTANCE), List.of(key, value));
+        return List.of(entries);
+    }
+
+    @Override
+    public ArrowType getArrowType() {
+        // keysSorted = false: entries keep document order rather than being sorted by key.
+        return new ArrowType.Map(false);
+    }
+
+    @Override
+    public FieldType getFieldType() {
+        return FieldType.nullable(getArrowType());
+    }
+
+    @Override
+    public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
+        // Matches what FlatObjectFieldType requests: it is searchable and has doc values, and the MAP
+        // column serves both from the same storage. No BLOOM_FILTER — a bloom filter would have to be
+        // configured against the nested key/value leaves, which field-level settings cannot address.
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
@@ -30,9 +31,14 @@ import java.util.Set;
  * {@code entries: STRUCT<key, value>} group.
  *
  * <p>One document contributes one map cell holding however many leaves its object had, so the
- * attribute set stays in a single column no matter how many distinct keys the index sees. This is why
- * the field is single-arity and does not support {@code multi_value}: a {@code LIST<MAP>} has no
- * meaning here, and the per-document entry count is already variable.
+ * attribute set stays in a single column no matter how many distinct keys the index sees. A variable
+ * entry count therefore needs no {@code multi_value} declaration.
+ *
+ * <p>Declaring {@code multi_value: true} means something different and is supported: the column becomes
+ * {@code LIST<MAP>}, one map per array element. That is the shape an OTel {@code Events.Attributes}
+ * needs — {@code [{...}, {...}]}, one attribute set per event — where merging the elements into a
+ * single map would lose which event each attribute belonged to. The document parser hands each array
+ * element to this mapper separately, so every element arrives as its own entry list.
  *
  * <p>Values arrive from {@code FlatObjectFieldMapper} as an ordered {@code List<Map.Entry>} of
  * {@code (relative path, value)} pairs — see
@@ -61,26 +67,52 @@ public class FlatObjectParquetField extends ParquetField {
             mapVector.setNull(row);
             return;
         }
+        addToVector(mapVector, row, parseValue);
+    }
+
+    /**
+     * Writes one map cell at an explicit index.
+     * <p>
+     * Used for both shapes of this column. A single-arity MAP writes at the row index; a
+     * {@code LIST<MAP>} writes at a position in the child MapVector that has nothing to do with the
+     * row, so the index has to be passed in rather than derived from the VSR row count.
+     *
+     * @param vector the MapVector to write into — the list's child vector when multi-valued
+     * @param index the map value index to write at
+     * @param parseValue the entry list for this map cell
+     */
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        MapVector mapVector = (MapVector) vector;
         List<?> entries = (List<?>) parseValue;
         StructVector entriesVector = (StructVector) mapVector.getDataVector();
         VarCharVector keyVector = (VarCharVector) entriesVector.getChild(MapVector.KEY_NAME);
         VarCharVector valueVector = (VarCharVector) entriesVector.getChild(MapVector.VALUE_NAME);
-        int start = mapVector.startNewValue(row);
+        int start = mapVector.startNewValue(index);
         for (int i = 0; i < entries.size(); i++) {
             Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entries.get(i);
-            int index = start + i;
+            int at = start + i;
             // The entries struct is non-nullable per the Arrow MAP spec, so every slot written must
             // have its validity bit set; without this the child values read back as null.
-            entriesVector.setIndexDefined(index);
-            keyVector.setSafe(index, entry.getKey().toString().getBytes(StandardCharsets.UTF_8));
+            entriesVector.setIndexDefined(at);
+            keyVector.setSafe(at, entry.getKey().toString().getBytes(StandardCharsets.UTF_8));
             Object value = entry.getValue();
             if (value == null) {
-                valueVector.setNull(index);
+                valueVector.setNull(at);
             } else {
-                valueVector.setSafe(index, value.toString().getBytes(StandardCharsets.UTF_8));
+                valueVector.setSafe(at, value.toString().getBytes(StandardCharsets.UTF_8));
             }
         }
-        mapVector.endValue(row, entries.size());
+        mapVector.endValue(index, entries.size());
+    }
+
+    /**
+     * Supported: the column becomes {@code LIST<MAP>}, one map per array element. {@link #addToVector}
+     * is implemented, which is the contract the base class requires.
+     */
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateNanosParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.date;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -29,7 +30,17 @@ public class DateNanosParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TimeStampNanoVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (long) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((TimeStampNanoVector) vector).setSafe(index, (long) parseValue);
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/date/DateParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.date;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -29,7 +30,17 @@ public class DateParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TimeStampMilliVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (long) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((TimeStampMilliVector) vector).setSafe(index, (long) parseValue);
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ByteParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -24,7 +25,12 @@ public class ByteParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((TinyIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).byteValue());
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((TinyIntVector) vector).setSafe(index, ((Number) parseValue).byteValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/DoubleParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/DoubleParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -25,7 +26,12 @@ public class DoubleParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float8Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Double) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((Float8Vector) vector).setSafe(index, (Double) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/FloatParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/FloatParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -25,7 +26,12 @@ public class FloatParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((Float4Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Float) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((Float4Vector) vector).setSafe(index, (Float) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/IntegerParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/IntegerParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -24,7 +25,12 @@ public class IntegerParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((IntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Integer) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((IntVector) vector).setSafe(index, (Integer) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/LongParquetField.java
@@ -9,6 +9,7 @@
 package org.opensearch.parquet.fields.core.data.number;
 
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -32,7 +33,12 @@ public class LongParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((BigIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Long) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((BigIntVector) vector).setSafe(index, (Long) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/NumericParquetField.java
@@ -18,6 +18,12 @@ import java.util.Set;
  */
 public abstract class NumericParquetField extends ParquetField {
 
+    /** Every numeric field writes a fixed-width slot, so all of them implement {@link #addToVector}. */
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
+    }
+
     @Override
     public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
         return Set.of(

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ShortParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/ShortParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -24,7 +25,12 @@ public class ShortParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((SmallIntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Short) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((SmallIntVector) vector).setSafe(index, (Short) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/TokenCountParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/TokenCountParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -24,7 +25,12 @@ public class TokenCountParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((IntVector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), (Integer) parseValue);
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((IntVector) vector).setSafe(index, (Integer) parseValue);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/UnsignedLongParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/number/UnsignedLongParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.number;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -24,7 +25,12 @@ public class UnsignedLongParquetField extends NumericParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((UInt8Vector) managedVSR.getVector(mappedFieldType.name())).setSafe(managedVSR.getRowCount(), ((Number) parseValue).longValue());
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((UInt8Vector) vector).setSafe(index, ((Number) parseValue).longValue());
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/IpParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -31,9 +32,18 @@ public class IpParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        VarBinaryVector vector = (VarBinaryVector) managedVSR.getVector(mappedFieldType.name());
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
         BytesRef bytesRef = new BytesRef(InetAddressPoint.encode((InetAddress) parseValue));
-        vector.setSafe(managedVSR.getRowCount(), bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        ((VarBinaryVector) vector).setSafe(index, bytesRef.bytes, bytesRef.offset, bytesRef.length);
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/KeywordParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -27,10 +28,17 @@ public class KeywordParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((VarCharVector) vector).setSafe(index, parseValue.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/TextParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/core/data/text/TextParquetField.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet.fields.core.data.text;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -29,10 +30,17 @@ public class TextParquetField extends ParquetField {
 
     @Override
     protected void addToGroup(MappedFieldType mappedFieldType, ManagedVSR managedVSR, Object parseValue) {
-        ((VarCharVector) managedVSR.getVector(mappedFieldType.name())).setSafe(
-            managedVSR.getRowCount(),
-            parseValue.toString().getBytes(StandardCharsets.UTF_8)
-        );
+        addToVector(managedVSR.getVector(mappedFieldType.name()), managedVSR.getRowCount(), parseValue);
+    }
+
+    @Override
+    protected void addToVector(FieldVector vector, int index, Object parseValue) {
+        ((VarCharVector) vector).setSafe(index, parseValue.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public boolean supportsMultiValue() {
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPlugin.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.fields.plugins;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
 import org.opensearch.index.mapper.IpFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
@@ -19,6 +20,7 @@ import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.fields.core.data.BinaryParquetField;
 import org.opensearch.parquet.fields.core.data.BooleanParquetField;
+import org.opensearch.parquet.fields.core.data.FlatObjectParquetField;
 import org.opensearch.parquet.fields.core.data.date.DateNanosParquetField;
 import org.opensearch.parquet.fields.core.data.date.DateParquetField;
 import org.opensearch.parquet.fields.core.data.number.ByteParquetField;
@@ -53,6 +55,7 @@ public class CoreDataFieldPlugin implements ParquetFieldPlugin {
         registerBooleanFields(fieldMap);
         registerTextFields(fieldMap);
         registerBinaryFields(fieldMap);
+        registerObjectFields(fieldMap);
         return fieldMap;
     }
 
@@ -87,5 +90,9 @@ public class CoreDataFieldPlugin implements ParquetFieldPlugin {
 
     private static void registerBinaryFields(Map<String, ParquetField> fieldMap) {
         fieldMap.put(BinaryFieldMapper.CONTENT_TYPE, new BinaryParquetField());
+    }
+
+    private static void registerObjectFields(Map<String, ParquetField> fieldMap) {
+        fieldMap.put(FlatObjectFieldMapper.CONTENT_TYPE, new FlatObjectParquetField());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -192,9 +192,9 @@ public class VSRManager implements AutoCloseable {
      * Transfers collected fields from the document input into the active VSR
      * using the ArrowFieldRegistry to resolve typed vector writes.
      * <p>
-     * Single-value semantics are enforced at the {@link ParquetDocumentInput} layer:
-     * if an array field produces multiple values for the same field type, only the
-     * last value is retained (last-value-wins).
+     * Cardinality is decided at the {@link ParquetDocumentInput} layer: fields mapped with
+     * {@code multi_value: true} accumulate every value into one list-valued pair,
+     * and all other fields still reject a second value.
      *
      * @param doc the document input containing field-value pairs
      */
@@ -367,8 +367,9 @@ public class VSRManager implements AutoCloseable {
         boolean changed = false;
         for (Field schemaField : newSchema.getFields()) {
             if (activeVSR.getVector(schemaField.getName()) == null) {
-                Field field = new Field(schemaField.getName(), schemaField.getFieldType(), null);
-                activeVSR.addFieldVector(field);
+                // Pass the schema field through as-is: rebuilding it from name + FieldType alone
+                // would drop getChildren(), leaving a LIST column with no element vector.
+                activeVSR.addFieldVector(schemaField);
                 changed = true;
             }
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -10,24 +10,33 @@ package org.opensearch.parquet.writer;
 
 import org.opensearch.index.mapper.MappedFieldType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * Immutable pair of an OpenSearch {@link MappedFieldType} and its parsed value.
+ * Pair of an OpenSearch {@link MappedFieldType} and the value(s) parsed for it.
  *
  * <p>Represents a single field entry collected by {@link ParquetDocumentInput} during
  * document indexing. The field type is used to resolve the corresponding Arrow vector
  * type via {@link org.opensearch.parquet.fields.ArrowFieldRegistry}, and the value is
  * written into that vector during document transfer to the VSR.
  *
- * <p>The field type must not be null (enforced by constructor); the value may be null
+ * <p>Scalar pairs are immutable and hold exactly one value. Pairs created via
+ * {@link #multiValued} back a Parquet LIST column and accumulate values as the document parser
+ * reports each array element, so {@link #getValue()} returns a {@code List} for those — including
+ * a single-element list when the document happened to supply one value.
+ *
+ * <p>The field type must not be null (enforced by constructor); values may be null
  * for nullable fields.
  */
 public class FieldValuePair {
 
     private final MappedFieldType fieldType;
     private final Object value;
+    private final List<Object> values;
 
     /**
-     * Creates a new FieldValuePair.
+     * Creates a single-valued FieldValuePair.
      *
      * @param fieldType the mapped field type
      * @param value the parsed field value
@@ -38,6 +47,52 @@ public class FieldValuePair {
         }
         this.fieldType = fieldType;
         this.value = value;
+        this.values = null;
+    }
+
+    private FieldValuePair(MappedFieldType fieldType, List<Object> values) {
+        if (fieldType == null) {
+            throw new IllegalArgumentException("fieldType cannot be null");
+        }
+        this.fieldType = fieldType;
+        this.value = null;
+        this.values = values;
+    }
+
+    /**
+     * Creates a multi-valued FieldValuePair seeded with its first value. Further values are
+     * appended via {@link #addValue}, preserving document order and any duplicates.
+     *
+     * @param fieldType the mapped field type
+     * @param firstValue the first parsed value
+     * @return a multi-valued pair
+     */
+    public static FieldValuePair multiValued(MappedFieldType fieldType, Object firstValue) {
+        List<Object> values = new ArrayList<>(1);
+        values.add(firstValue);
+        return new FieldValuePair(fieldType, values);
+    }
+
+    /**
+     * Appends another value. Only valid on a multi-valued pair.
+     *
+     * @param nextValue the value to append
+     */
+    public void addValue(Object nextValue) {
+        if (values == null) {
+            throw new IllegalStateException("Cannot add a value to a single-valued FieldValuePair for [" + fieldType.name() + "]");
+        }
+        values.add(nextValue);
+    }
+
+    /** Returns whether this pair accumulates multiple values into a list column. */
+    public boolean isMultiValued() {
+        return values != null;
+    }
+
+    /** Returns the number of values held: always 1 for a scalar pair. */
+    public int valueCount() {
+        return values == null ? 1 : values.size();
     }
 
     /**
@@ -50,11 +105,12 @@ public class FieldValuePair {
     }
 
     /**
-     * Returns the value.
+     * Returns the value: the single parsed value, or the {@code List} of values for a
+     * multi-valued pair.
      *
-     * @return the parsed field value
+     * @return the parsed field value(s)
      */
     public Object getValue() {
-        return value;
+        return values != null ? values : value;
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -22,9 +22,16 @@ import java.util.List;
  * written into that vector during document transfer to the VSR.
  *
  * <p>Scalar pairs are immutable and hold exactly one value. Pairs created via
- * {@link #multiValued} back a Parquet LIST column and accumulate values as the document parser
- * reports each array element, so {@link #getValue()} returns a {@code List} for those — including
- * a single-element list when the document happened to supply one value.
+ * {@link #multiValued} back a Parquet LIST column and are <em>mutable</em>: {@link #addValue}
+ * appends as the document parser reports each array element, so {@link #getValue()} returns a
+ * {@code List} for those — including a single-element list when the document supplied one value, or
+ * an empty list for an explicit empty array via {@link #emptyMultiValued}.
+ *
+ * <p>Because multi-valued pairs grow during parsing, a reference must not be read until the
+ * document is finalized. The sole consumer, {@code VSRManager#addDocument}, reads only through
+ * {@link ParquetDocumentInput#getFinalInput()} after the whole document has been parsed, so no
+ * caller observes a partially populated list. Do not cache or hand a pair across threads before
+ * then.
  *
  * <p>The field type must not be null (enforced by constructor); values may be null
  * for nullable fields.

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/FieldValuePair.java
@@ -74,6 +74,18 @@ public class FieldValuePair {
     }
 
     /**
+     * Creates a multi-valued FieldValuePair holding zero values, representing an explicit empty
+     * array ({@code "field": []}). It backs a zero-length, non-null LIST cell, which reads back as
+     * {@code []} and so stays distinct from an absent field (a null cell).
+     *
+     * @param fieldType the mapped field type
+     * @return an empty multi-valued pair
+     */
+    public static FieldValuePair emptyMultiValued(MappedFieldType fieldType) {
+        return new FieldValuePair(fieldType, new ArrayList<>(0));
+    }
+
+    /**
      * Appends another value. Only valid on a multi-valued pair.
      *
      * @param nextValue the value to append

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -95,9 +95,62 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
         this.rowId = rowId;
     }
 
+    /**
+     * Rejects a document whose correlated group has sub-fields of differing array length.
+     * <p>
+     * Each field is written as its own {@code LIST} column with independent offsets, so unequal
+     * lengths mean index {@code i} of one field no longer describes the same element as index
+     * {@code i} of its siblings — a document that writes cleanly and reads back mispaired. Mirrors
+     * ClickHouse, which refuses such an insert into a {@code Nested} column rather than storing a
+     * misaligned row.
+     * <p>
+     * Group membership comes from {@link MappedFieldType#correlationGroup()}, stamped at mapping build
+     * time on the children of an object declared {@code nested} with {@code correlated: true}.
+     * <p>
+     * Only fields <em>present</em> in the document are compared. A sub-field the document never
+     * mentions has nothing to mispair — every element of it is absent — so requiring it to be
+     * present would reject legitimate documents (an event batch carrying no attributes at all).
+     */
+    private void validateCorrelatedGroups() {
+        // Tracks the first present, multi-valued field seen per group and the count it established.
+        Map<String, FieldValuePair> firstInGroup = null;
+        for (FieldValuePair pair : collectedFields) {
+            String group = pair.getFieldType().correlationGroup();
+            if (group == null || pair.isMultiValued() == false) {
+                continue;
+            }
+            if (firstInGroup == null) {
+                firstInGroup = new HashMap<>();
+            }
+            FieldValuePair first = firstInGroup.putIfAbsent(group, pair);
+            if (first == null) {
+                continue;
+            }
+            int expected = first.valueCount();
+            int count = pair.valueCount();
+            if (count != expected) {
+                throw new MapperParsingException(
+                    "Fields in correlated group ["
+                        + group
+                        + "] must have the same number of values in a document, but ["
+                        + first.getFieldType().name()
+                        + "] has "
+                        + expected
+                        + " and ["
+                        + pair.getFieldType().name()
+                        + "] has "
+                        + count
+                        + ". Correlated arrays are paired by position, so differing lengths would "
+                        + "associate values from different elements."
+                );
+            }
+        }
+    }
+
     @Override
     public List<FieldValuePair> getFinalInput() {
         if (!isClosed) {
+            validateCorrelatedGroups();
             assert rowId >= 0 : "Row ID must be set before calling getFinalInput";
             // assertions for parquet primary
             // TODO: once parquet is supported in secondary mode, this assertion would change

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -21,9 +21,9 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -40,7 +40,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    private final Set<MappedFieldType> dedup = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Map<MappedFieldType, FieldValuePair> seen = new IdentityHashMap<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,12 +54,27 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-        if (dedup.add(fieldType) == false) {
+        FieldValuePair existing = seen.get(fieldType);
+        if (existing == null) {
+            // Fields declared `multi_value: true` in the mapping start out as a list of one so the
+            // value shape reaching the VSR is the same whether the document had one value or several.
+            FieldValuePair pair = fieldType.isMultiValued()
+                ? FieldValuePair.multiValued(fieldType, value)
+                : new FieldValuePair(fieldType, value);
+            seen.put(fieldType, pair);
+            collectedFields.add(pair);
+            return;
+        }
+        if (existing.isMultiValued() == false) {
             throw new MapperParsingException(
-                "Cannot accept multiple values for field: [" + fieldType.name() + "] of type: [" + fieldType.typeName() + "]."
+                "Cannot accept multiple values for field: ["
+                    + fieldType.name()
+                    + "] of type: ["
+                    + fieldType.typeName()
+                    + "]. Set [multi_value: true] on the field mapping to store multiple values."
             );
         }
-        collectedFields.add(new FieldValuePair(fieldType, value));
+        existing.addValue(value);
     }
 
     @Override
@@ -84,13 +99,19 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     @Override
     public long getFieldCount(String fieldName) {
-        return collectedFields.stream().filter(fvp -> fvp.getFieldType().name().equals(fieldName)).count();
+        // Counts values, not entries: a multi-valued field is one entry holding N values, and
+        // callers (single-value assertions below, the data-stream @timestamp check) mean values.
+        return collectedFields.stream()
+            .filter(fvp -> fvp.getFieldType().name().equals(fieldName))
+            .mapToLong(FieldValuePair::valueCount)
+            .sum();
     }
 
     @Override
     public void close() {
         isClosed = true;
         collectedFields.clear();
+        seen.clear();
         rowId = -1;
     }
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -21,7 +21,7 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +40,12 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
 
     private static final Logger logger = LogManager.getLogger(ParquetDocumentInput.class);
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
-    private final Map<MappedFieldType, FieldValuePair> seen = new IdentityHashMap<>();
+    // Keyed by field name, not field-type identity: within a single document parse each logical
+    // field (including the derived-source `_ignored_source.*` companion) has a unique name, while
+    // identity would silently miss a match if the parser ever handed back a fresh wrapper per array
+    // element — degrading a multi_value field to last-value-wins or bypassing the scalar duplicate
+    // guard. Name keying makes accumulation robust to that.
+    private final Map<String, FieldValuePair> seen = new HashMap<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
@@ -54,7 +59,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             logger.trace("Ignored to add field: {} {}", fieldType.name(), fieldType.getCapabilityMap());
             return;
         }
-        FieldValuePair existing = seen.get(fieldType);
+        FieldValuePair existing = seen.get(fieldType.name());
         if (existing == null) {
             // Fields declared `multi_value: true` in the mapping start out as a list of one so the
             // value shape reaching the VSR is the same whether the document had one value or several.
@@ -68,7 +73,7 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
             } else {
                 pair = new FieldValuePair(fieldType, value);
             }
-            seen.put(fieldType, pair);
+            seen.put(fieldType.name(), pair);
             collectedFields.add(pair);
             return;
         }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -58,9 +58,16 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
         if (existing == null) {
             // Fields declared `multi_value: true` in the mapping start out as a list of one so the
             // value shape reaching the VSR is the same whether the document had one value or several.
-            FieldValuePair pair = fieldType.isMultiValued()
-                ? FieldValuePair.multiValued(fieldType, value)
-                : new FieldValuePair(fieldType, value);
+            // An explicit empty array (`"field": []`) is signalled by an empty List and seeds a
+            // zero-value pair, so its LIST cell is written empty-but-non-null rather than null.
+            final FieldValuePair pair;
+            if (fieldType.isMultiValued()) {
+                pair = value instanceof List<?> list && list.isEmpty()
+                    ? FieldValuePair.emptyMultiValued(fieldType)
+                    : FieldValuePair.multiValued(fieldType, value);
+            } else {
+                pair = new FieldValuePair(fieldType, value);
+            }
             seen.put(fieldType, pair);
             collectedFields.add(pair);
             return;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_baseline_only.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_baseline_only.rs
@@ -1,0 +1,89 @@
+use std::fs;
+use std::sync::Arc;
+use std::time::Instant;
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use opensearch_parquet_format::merge::merge_sorted;
+use opensearch_parquet_format::native_settings::NativeSettings;
+use opensearch_parquet_format::writer::SETTINGS_STORE;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+// Realistic OTel workload: time-partitioned files with overlapping tails.
+// Each file covers a 10-minute window with ~80% sequential, ~20% overlap with neighbors.
+const ROWS_PER_FILE: usize = 1_000_000;
+const NUM_FILES: usize = 10;
+const NUM_STRING_COLUMNS: usize = 30;
+const STRING_VALUE_LEN: usize = 150;
+const ROW_GROUP_ROWS: usize = 500_000; // 2 RGs per file
+
+fn generate_parquet_file(path: &str, num_rows: usize, file_id: usize) {
+    let mut fields = vec![Field::new("@timestamp", DataType::Int64, false)];
+    for i in 0..NUM_STRING_COLUMNS {
+        fields.push(Field::new(format!("field_{}", i), DataType::Utf8, true));
+    }
+    let schema = Arc::new(ArrowSchema::new(fields));
+    let file = fs::File::create(path).unwrap();
+    let props = WriterProperties::builder().set_max_row_group_row_count(Some(ROW_GROUP_ROWS)).build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+    let batch_size = 8192;
+    let mut rows_written = 0;
+
+    // Each file covers a time range with 20% overlap with the next file.
+    // File 0: timestamps 0..1_000_000
+    // File 1: timestamps 800_000..1_800_000 (200K overlap with file 0)
+    // etc.
+    let file_start = (file_id as i64) * (num_rows as i64 * 80 / 100);
+
+    while rows_written < num_rows {
+        let batch_len = batch_size.min(num_rows - rows_written);
+        // Sorted within each file (realistic: ingestion order = time order)
+        let timestamps: Vec<i64> = (0..batch_len)
+            .map(|i| file_start + (rows_written + i) as i64)
+            .collect();
+        let mut columns: Vec<Arc<dyn arrow::array::Array>> = vec![Arc::new(Int64Array::from(timestamps))];
+        for col_idx in 0..NUM_STRING_COLUMNS {
+            let values: Vec<String> = (0..batch_len)
+                .map(|row| format!("{:0>width$}", (rows_written + row) * 31 + col_idx * 7, width = STRING_VALUE_LEN))
+                .collect();
+            columns.push(Arc::new(StringArray::from(values)));
+        }
+        writer.write(&RecordBatch::try_new(schema.clone(), columns).unwrap()).unwrap();
+        rows_written += batch_len;
+    }
+    writer.close().unwrap();
+}
+
+fn main() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    eprintln!("Generating {} files × {} rows × {} string cols ({}B)...",
+        NUM_FILES, ROWS_PER_FILE, NUM_STRING_COLUMNS, STRING_VALUE_LEN);
+    let mut input_paths = Vec::new();
+    for i in 0..NUM_FILES {
+        let path = tmp_dir.path().join(format!("input_{}.parquet", i));
+        generate_parquet_file(path.to_str().unwrap(), ROWS_PER_FILE, i);
+        input_paths.push(path.to_str().unwrap().to_string());
+    }
+    let input_size: u64 = input_paths.iter().map(|p| fs::metadata(p).map(|m| m.len()).unwrap_or(0)).sum();
+    eprintln!("Input ready: {:.1} MB", input_size as f64 / 1024.0 / 1024.0);
+
+    // BASELINE: threshold=999 forces eager mode (all columns decoded upfront)
+    SETTINGS_STORE.insert("bench".to_string(), NativeSettings {
+        merge_batch_size: Some(8192),
+        merge_deferred_column_threshold: Some(999),
+        ..Default::default()
+    });
+
+    let output = tmp_dir.path().join("out.parquet");
+    let start = Instant::now();
+    let result = merge_sorted(&input_paths, output.to_str().unwrap(), "bench",
+        &["@timestamp".to_string()], &[false], &[false], 1).unwrap();
+    let elapsed = start.elapsed();
+
+    let total_rows = ROWS_PER_FILE * NUM_FILES;
+    eprintln!("BASELINE (eager): {:.2?}, {} rows/sec, {} output rows, {} RGs",
+        elapsed,
+        (total_rows as f64 / elapsed.as_secs_f64()) as u64,
+        result.metadata.file_metadata().num_rows(),
+        result.metadata.num_row_groups());
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_optimized_only.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/benches/merge_optimized_only.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::sync::Arc;
+use std::time::Instant;
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use opensearch_parquet_format::merge::merge_sorted;
+use opensearch_parquet_format::native_settings::NativeSettings;
+use opensearch_parquet_format::writer::SETTINGS_STORE;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+const ROWS_PER_FILE: usize = 1_000_000;
+const NUM_FILES: usize = 10;
+const NUM_STRING_COLUMNS: usize = 30;
+const STRING_VALUE_LEN: usize = 150;
+const ROW_GROUP_ROWS: usize = 500_000;
+
+fn generate_parquet_file(path: &str, num_rows: usize, file_id: usize) {
+    let mut fields = vec![Field::new("@timestamp", DataType::Int64, false)];
+    for i in 0..NUM_STRING_COLUMNS {
+        fields.push(Field::new(format!("field_{}", i), DataType::Utf8, true));
+    }
+    let schema = Arc::new(ArrowSchema::new(fields));
+    let file = fs::File::create(path).unwrap();
+    let props = WriterProperties::builder().set_max_row_group_row_count(Some(ROW_GROUP_ROWS)).build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+    let batch_size = 8192;
+    let mut rows_written = 0;
+
+    let file_start = (file_id as i64) * (num_rows as i64 * 80 / 100);
+
+    while rows_written < num_rows {
+        let batch_len = batch_size.min(num_rows - rows_written);
+        let timestamps: Vec<i64> = (0..batch_len)
+            .map(|i| file_start + (rows_written + i) as i64)
+            .collect();
+        let mut columns: Vec<Arc<dyn arrow::array::Array>> = vec![Arc::new(Int64Array::from(timestamps))];
+        for col_idx in 0..NUM_STRING_COLUMNS {
+            let values: Vec<String> = (0..batch_len)
+                .map(|row| format!("{:0>width$}", (rows_written + row) * 31 + col_idx * 7, width = STRING_VALUE_LEN))
+                .collect();
+            columns.push(Arc::new(StringArray::from(values)));
+        }
+        writer.write(&RecordBatch::try_new(schema.clone(), columns).unwrap()).unwrap();
+        rows_written += batch_len;
+    }
+    writer.close().unwrap();
+}
+
+fn main() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    eprintln!("Generating {} files × {} rows × {} string cols ({}B)...",
+        NUM_FILES, ROWS_PER_FILE, NUM_STRING_COLUMNS, STRING_VALUE_LEN);
+    let mut input_paths = Vec::new();
+    for i in 0..NUM_FILES {
+        let path = tmp_dir.path().join(format!("input_{}.parquet", i));
+        generate_parquet_file(path.to_str().unwrap(), ROWS_PER_FILE, i);
+        input_paths.push(path.to_str().unwrap().to_string());
+    }
+    let input_size: u64 = input_paths.iter().map(|p| fs::metadata(p).map(|m| m.len()).unwrap_or(0)).sum();
+    eprintln!("Input ready: {:.1} MB", input_size as f64 / 1024.0 / 1024.0);
+
+    // OPTIMIZED: threshold=3 enables deferred for wide schemas
+    SETTINGS_STORE.insert("bench".to_string(), NativeSettings {
+        merge_batch_size: Some(8192),
+        merge_deferred_column_threshold: Some(3),
+        ..Default::default()
+    });
+
+    let output = tmp_dir.path().join("out.parquet");
+    let start = Instant::now();
+    let result = merge_sorted(&input_paths, output.to_str().unwrap(), "bench",
+        &["@timestamp".to_string()], &[false], &[false], 1).unwrap();
+    let elapsed = start.elapsed();
+
+    let total_rows = ROWS_PER_FILE * NUM_FILES;
+    eprintln!("OPTIMIZED (deferred): {:.2?}, {} rows/sec, {} output rows, {} RGs",
+        elapsed,
+        (total_rows as f64 / elapsed.as_secs_f64()) as u64,
+        result.metadata.file_metadata().num_rows(),
+        result.metadata.num_row_groups());
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -66,32 +66,64 @@ pub fn read_format_version(metadata: &FileMetaData) -> String {
 /// - **Dependency Inversion**: Depends on NativeSettings abstraction
 pub struct WriterPropertiesBuilder;
 
-/// Returns the type that column properties apply to. Parquet encodes a LIST column's leaf, not
-/// the list wrapper, so encoding/compression decisions must be made on the element type.
-fn effective_type(dt: &arrow::datatypes::DataType) -> &arrow::datatypes::DataType {
-    use arrow::datatypes::DataType::*;
-    match dt {
-        List(f) | LargeList(f) | FixedSizeList(f, _) => effective_type(f.data_type()),
-        other => other,
-    }
+/// A primitive parquet leaf of a top-level Arrow field: its full column path and the Arrow type
+/// that encoding/compression decisions should be keyed off.
+type Leaf<'a> = (
+    parquet::schema::types::ColumnPath,
+    &'a arrow::datatypes::DataType,
+);
+
+/// Collects every primitive parquet leaf of a top-level Arrow field, each with its full column path.
+///
+/// Per-column encoding, compression, and bloom-filter settings address *leaves*, not the nested
+/// wrapper: `ColumnPath::from(String)` yields a single-segment path, which only matches a primitive
+/// column, so settings on a nested column silently no-op unless the full path is spelled out. The
+/// path segments mirror what the arrow-rs writer emits for the corresponding Arrow type:
+///
+/// - primitive `n`         → `n`
+/// - `LIST<element>` `n`   → `n.list.element`
+/// - `MAP<k, v>` `n`       → `n.entries.key` and `n.entries.value` (two leaves)
+///
+/// Nested group names come from the Arrow child field names rather than being hardcoded, so they
+/// track whatever the schema actually declares. `nested_leaf_paths_match_arrow_rs_writer` pins this
+/// against the paths arrow-rs really produces.
+fn leaves_for(field: &arrow::datatypes::Field) -> Vec<Leaf<'_>> {
+    let mut leaves = Vec::new();
+    collect_leaves(vec![field.name().clone()], field.data_type(), &mut leaves);
+    leaves
 }
 
-/// Builds the parquet `ColumnPath` for a top-level Arrow field.
-///
-/// `ColumnPath::from(String)` yields a single-segment path, which only matches primitive columns.
-/// A LIST column's leaf lives at `<field>.list.element`, so per-column encoding, compression, and
-/// bloom-filter settings silently no-op for lists unless the full path is spelled out. The
-/// `list`/`element` segment names match what the arrow-rs writer emits for `DataType::List`.
-fn column_path_for(field: &arrow::datatypes::Field) -> parquet::schema::types::ColumnPath {
+fn collect_leaves<'a>(
+    prefix: Vec<String>,
+    dt: &'a arrow::datatypes::DataType,
+    out: &mut Vec<Leaf<'a>>,
+) {
     use arrow::datatypes::DataType::*;
-    let mut parts = vec![field.name().clone()];
-    let mut current = field.data_type();
-    while let List(child) | LargeList(child) | FixedSizeList(child, _) = current {
-        parts.push("list".to_string());
-        parts.push(child.name().clone());
-        current = child.data_type();
+    match dt {
+        List(child) | LargeList(child) | FixedSizeList(child, _) => {
+            let mut parts = prefix;
+            parts.push("list".to_string());
+            parts.push(child.name().clone());
+            collect_leaves(parts, child.data_type(), out);
+        }
+        // A MAP's single child is the repeated entries group; its struct children are the leaves.
+        Map(entries, _) => {
+            let mut parts = prefix;
+            parts.push(entries.name().clone());
+            collect_leaves(parts, entries.data_type(), out);
+        }
+        Struct(children) => {
+            for child in children {
+                let mut parts = prefix.clone();
+                parts.push(child.name().clone());
+                collect_leaves(parts, child.data_type(), out);
+            }
+        }
+        primitive => out.push((
+            parquet::schema::types::ColumnPath::new(prefix),
+            primitive,
+        )),
     }
-    parquet::schema::types::ColumnPath::new(parts)
 }
 
 /// Maps an Arrow DataType to a lowercase string key used for cluster-level type config lookups.
@@ -224,27 +256,13 @@ impl WriterPropertiesBuilder {
         config: &NativeSettings,
         schema: &ArrowSchema,
     ) -> Result<parquet::file::properties::WriterPropertiesBuilder, String> {
-        // Key config decisions off the element type and address the column by its full leaf path,
-        // so a LIST column is configured like the scalar column of its element type.
-        type FieldEntry<'a> = (
-            &'a arrow::datatypes::DataType,
-            String,
-            parquet::schema::types::ColumnPath,
-        );
-        let type_map: std::collections::HashMap<&str, FieldEntry<'_>> = schema
+        // Key config decisions off each leaf's own type and address it by its full leaf path, so a
+        // LIST column is configured like the scalar column of its element type and a MAP column's
+        // key and value leaves are each configured like the scalar column of their type.
+        let type_map: std::collections::HashMap<&str, Vec<Leaf<'_>>> = schema
             .fields()
             .iter()
-            .map(|f| {
-                let element_type = effective_type(f.data_type());
-                (
-                    f.name().as_str(),
-                    (
-                        element_type,
-                        arrow_type_key(element_type),
-                        column_path_for(f),
-                    ),
-                )
-            })
+            .map(|f| (f.name().as_str(), leaves_for(f)))
             .collect();
 
         let mut field_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
@@ -263,8 +281,8 @@ impl WriterPropertiesBuilder {
                 .as_ref()
                 .and_then(|m| m.get(field_name));
 
-            let (arrow_type, type_key, column_path) = match type_map.get(field_name) {
-                Some(v) => (v.0, Some(v.1.as_str()), v.2.clone()),
+            let leaves = match type_map.get(field_name) {
+                Some(v) => v,
                 None => {
                     return Err(format!(
                         "Field '{}' in field_configs does not exist in schema",
@@ -273,6 +291,39 @@ impl WriterPropertiesBuilder {
                 }
             };
 
+            // A nested field has more than one leaf (a MAP has key and value); the field's settings
+            // apply to each of them independently.
+            for (column_path, arrow_type) in leaves {
+                let column_path = column_path.clone();
+                let arrow_type = *arrow_type;
+                let type_key_owned = arrow_type_key(arrow_type);
+                let type_key = Some(type_key_owned.as_str());
+                builder = Self::apply_leaf_config(
+                    builder,
+                    config,
+                    field_name,
+                    index_cfg,
+                    column_path,
+                    arrow_type,
+                    type_key,
+                )?;
+            }
+        }
+        Ok(builder)
+    }
+
+    /// Applies encoding, compression, and bloom-filter settings to a single parquet leaf.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_leaf_config(
+        mut builder: parquet::file::properties::WriterPropertiesBuilder,
+        config: &NativeSettings,
+        field_name: &str,
+        index_cfg: Option<&crate::field_config::FieldConfig>,
+        column_path: parquet::schema::types::ColumnPath,
+        arrow_type: &arrow::datatypes::DataType,
+        type_key: Option<&str>,
+    ) -> Result<parquet::file::properties::WriterPropertiesBuilder, String> {
+        {
             // Encoding: parse once, validate, apply. Skip if nothing set.
             let encoding: Option<Encoding> =
                 if let Some(enc) = index_cfg.and_then(|fc| fc.encoding_type.as_deref()) {
@@ -1509,6 +1560,129 @@ mod tests {
                 .is_some(),
             "bloom filter must be enabled on the list leaf path"
         );
+    }
+
+    /// A `flat_object` column is a `MAP<Utf8, Utf8>`: one Arrow field, two parquet leaves.
+    fn map_schema(name: &str) -> ArrowSchema {
+        let key = std::sync::Arc::new(Field::new("key", ArrowDataType::Utf8, false));
+        let value = std::sync::Arc::new(Field::new("value", ArrowDataType::Utf8, true));
+        let entries = std::sync::Arc::new(Field::new(
+            "entries",
+            ArrowDataType::Struct(vec![key, value].into()),
+            false,
+        ));
+        ArrowSchema::new(vec![Field::new(
+            name,
+            ArrowDataType::Map(entries, false),
+            true,
+        )])
+    }
+
+    fn map_leaf_path(name: &str, leaf: &str) -> parquet::schema::types::ColumnPath {
+        parquet::schema::types::ColumnPath::new(vec![
+            name.to_string(),
+            "entries".to_string(),
+            leaf.to_string(),
+        ])
+    }
+
+    /// The leaf paths `leaves_for` derives are only useful if they are the paths arrow-rs actually
+    /// writes. Deriving them from the arrow schema and asserting against the converted parquet
+    /// schema pins that correspondence, so a change in arrow-rs's nested naming fails here rather
+    /// than silently turning every per-column setting on a nested field back into a no-op.
+    #[test]
+    fn nested_leaf_paths_match_arrow_rs_writer() {
+        for schema in [map_schema("attrs"), list_schema("tags", ArrowDataType::Utf8)] {
+            let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
+                .convert(&schema)
+                .expect("schema converts");
+            let actual: std::collections::HashSet<String> = parquet_schema
+                .columns()
+                .iter()
+                .map(|c| c.path().string())
+                .collect();
+            let derived: std::collections::HashSet<String> = schema
+                .fields()
+                .iter()
+                .flat_map(|f| leaves_for(f))
+                .map(|(path, _)| path.string())
+                .collect();
+            assert_eq!(
+                derived, actual,
+                "derived leaf paths must match the parquet schema arrow-rs produces"
+            );
+        }
+    }
+
+    #[test]
+    fn test_map_column_applies_config_to_both_leaves() {
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "attrs".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let props = WriterPropertiesBuilder::build(&config, &map_schema("attrs")).unwrap();
+
+        for leaf in ["key", "value"] {
+            assert_eq!(
+                props.encoding(&map_leaf_path("attrs", leaf)),
+                Some(Encoding::DELTA_BYTE_ARRAY),
+                "encoding must be set on the map's {} leaf",
+                leaf
+            );
+        }
+        // The wrapper path carries nothing — it is not a column.
+        assert_eq!(
+            props.encoding(&parquet::schema::types::ColumnPath::from("attrs")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_map_column_resolves_type_level_config_by_leaf_type() {
+        // A MAP's leaves are Utf8, so a cluster-level `utf8` rule must reach them. Before leaf-wise
+        // resolution the type key came from the Debug string of the whole Map type and matched
+        // nothing, so string leaves silently lost their compression default.
+        let mut type_compression = HashMap::new();
+        type_compression.insert("utf8".to_string(), "SNAPPY".to_string());
+        let config = NativeSettings {
+            type_compression_configs: Some(type_compression),
+            ..Default::default()
+        };
+        let props = WriterPropertiesBuilder::build(&config, &map_schema("attrs")).unwrap();
+        for leaf in ["key", "value"] {
+            assert!(matches!(
+                props.compression(&map_leaf_path("attrs", leaf)),
+                Compression::SNAPPY
+            ));
+        }
+    }
+
+    #[test]
+    fn test_map_column_encoding_validated_against_leaf_type() {
+        // DELTA_BINARY_PACKED is invalid for Utf8; validation must see the leaf type, not the Map.
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "attrs".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BINARY_PACKED".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let err = WriterPropertiesBuilder::build(&config, &map_schema("attrs"))
+            .expect_err("DELTA_BINARY_PACKED must be rejected for Utf8 map leaves");
+        assert!(err.contains("not supported"), "unexpected error: {}", err);
     }
 
     #[test]

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -1578,6 +1578,28 @@ mod tests {
         )])
     }
 
+    /// A multi_value `flat_object` column is a `LIST<MAP<Utf8, Utf8>>`: one Arrow field, still two
+    /// parquet leaves, but nested one level deeper (an OTel `Events.Attributes`).
+    fn list_of_map_schema(name: &str) -> ArrowSchema {
+        let key = std::sync::Arc::new(Field::new("key", ArrowDataType::Utf8, false));
+        let value = std::sync::Arc::new(Field::new("value", ArrowDataType::Utf8, true));
+        let entries = std::sync::Arc::new(Field::new(
+            "entries",
+            ArrowDataType::Struct(vec![key, value].into()),
+            false,
+        ));
+        let element = std::sync::Arc::new(Field::new(
+            "element",
+            ArrowDataType::Map(entries, false),
+            true,
+        ));
+        ArrowSchema::new(vec![Field::new(
+            name,
+            ArrowDataType::List(element),
+            true,
+        )])
+    }
+
     fn map_leaf_path(name: &str, leaf: &str) -> parquet::schema::types::ColumnPath {
         parquet::schema::types::ColumnPath::new(vec![
             name.to_string(),
@@ -1592,7 +1614,11 @@ mod tests {
     /// than silently turning every per-column setting on a nested field back into a no-op.
     #[test]
     fn nested_leaf_paths_match_arrow_rs_writer() {
-        for schema in [map_schema("attrs"), list_schema("tags", ArrowDataType::Utf8)] {
+        for schema in [
+            map_schema("attrs"),
+            list_schema("tags", ArrowDataType::Utf8),
+            list_of_map_schema("Events.Attributes"),
+        ] {
             let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
                 .convert(&schema)
                 .expect("schema converts");

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer_properties_builder.rs
@@ -66,6 +66,34 @@ pub fn read_format_version(metadata: &FileMetaData) -> String {
 /// - **Dependency Inversion**: Depends on NativeSettings abstraction
 pub struct WriterPropertiesBuilder;
 
+/// Returns the type that column properties apply to. Parquet encodes a LIST column's leaf, not
+/// the list wrapper, so encoding/compression decisions must be made on the element type.
+fn effective_type(dt: &arrow::datatypes::DataType) -> &arrow::datatypes::DataType {
+    use arrow::datatypes::DataType::*;
+    match dt {
+        List(f) | LargeList(f) | FixedSizeList(f, _) => effective_type(f.data_type()),
+        other => other,
+    }
+}
+
+/// Builds the parquet `ColumnPath` for a top-level Arrow field.
+///
+/// `ColumnPath::from(String)` yields a single-segment path, which only matches primitive columns.
+/// A LIST column's leaf lives at `<field>.list.element`, so per-column encoding, compression, and
+/// bloom-filter settings silently no-op for lists unless the full path is spelled out. The
+/// `list`/`element` segment names match what the arrow-rs writer emits for `DataType::List`.
+fn column_path_for(field: &arrow::datatypes::Field) -> parquet::schema::types::ColumnPath {
+    use arrow::datatypes::DataType::*;
+    let mut parts = vec![field.name().clone()];
+    let mut current = field.data_type();
+    while let List(child) | LargeList(child) | FixedSizeList(child, _) = current {
+        parts.push("list".to_string());
+        parts.push(child.name().clone());
+        current = child.data_type();
+    }
+    parquet::schema::types::ColumnPath::new(parts)
+}
+
 /// Maps an Arrow DataType to a lowercase string key used for cluster-level type config lookups.
 fn arrow_type_key(dt: &arrow::datatypes::DataType) -> String {
     use arrow::datatypes::DataType::*;
@@ -196,17 +224,28 @@ impl WriterPropertiesBuilder {
         config: &NativeSettings,
         schema: &ArrowSchema,
     ) -> Result<parquet::file::properties::WriterPropertiesBuilder, String> {
-        let type_map: std::collections::HashMap<&str, (&arrow::datatypes::DataType, String)> =
-            schema
-                .fields()
-                .iter()
-                .map(|f| {
+        // Key config decisions off the element type and address the column by its full leaf path,
+        // so a LIST column is configured like the scalar column of its element type.
+        type FieldEntry<'a> = (
+            &'a arrow::datatypes::DataType,
+            String,
+            parquet::schema::types::ColumnPath,
+        );
+        let type_map: std::collections::HashMap<&str, FieldEntry<'_>> = schema
+            .fields()
+            .iter()
+            .map(|f| {
+                let element_type = effective_type(f.data_type());
+                (
+                    f.name().as_str(),
                     (
-                        f.name().as_str(),
-                        (f.data_type(), arrow_type_key(f.data_type())),
-                    )
-                })
-                .collect();
+                        element_type,
+                        arrow_type_key(element_type),
+                        column_path_for(f),
+                    ),
+                )
+            })
+            .collect();
 
         let mut field_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
         if let Some(fc) = &config.field_configs {
@@ -224,8 +263,8 @@ impl WriterPropertiesBuilder {
                 .as_ref()
                 .and_then(|m| m.get(field_name));
 
-            let (arrow_type, type_key) = match type_map.get(field_name) {
-                Some(v) => (v.0, Some(v.1.as_str())),
+            let (arrow_type, type_key, column_path) = match type_map.get(field_name) {
+                Some(v) => (v.0, Some(v.1.as_str()), v.2.clone()),
                 None => {
                     return Err(format!(
                         "Field '{}' in field_configs does not exist in schema",
@@ -284,17 +323,17 @@ impl WriterPropertiesBuilder {
                         | Encoding::RLE
                 ) {
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), false);
-                    builder = builder.set_column_encoding(field_name.to_string().into(), enc);
+                        builder.set_column_dictionary_enabled(column_path.clone(), false);
+                    builder = builder.set_column_encoding(column_path.clone(), enc);
                 } else if matches!(enc, Encoding::RLE_DICTIONARY) {
                     // RLE_DICTIONARY means use dictionary encoding - just ensure it's enabled
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), true);
+                        builder.set_column_dictionary_enabled(column_path.clone(), true);
                 } else {
                     // PLAIN: explicitly disable dictionary so the writer uses plain encoding
                     builder =
-                        builder.set_column_dictionary_enabled(field_name.to_string().into(), false);
-                    builder = builder.set_column_encoding(field_name.to_string().into(), enc);
+                        builder.set_column_dictionary_enabled(column_path.clone(), false);
+                    builder = builder.set_column_encoding(column_path.clone(), enc);
                 }
             }
 
@@ -326,7 +365,7 @@ impl WriterPropertiesBuilder {
                 };
 
             if let Some(comp) = compression {
-                builder = builder.set_column_compression(field_name.to_string().into(), comp);
+                builder = builder.set_column_compression(column_path.clone(), comp);
             }
 
             // Bloom filter: field-level > type-level > global. Applied per-column.
@@ -339,7 +378,7 @@ impl WriterPropertiesBuilder {
                 .unwrap_or(config.get_bloom_filter_enabled());
             if bf_enabled {
                 builder =
-                    builder.set_column_bloom_filter_enabled(field_name.to_string().into(), true);
+                    builder.set_column_bloom_filter_enabled(column_path.clone(), true);
                 let bf_fpp = index_cfg
                     .and_then(|fc| fc.bloom_filter_fpp)
                     .or_else(|| {
@@ -348,7 +387,7 @@ impl WriterPropertiesBuilder {
                     })
                     .unwrap_or(config.get_bloom_filter_fpp());
                 builder =
-                    builder.set_column_bloom_filter_fpp(field_name.to_string().into(), bf_fpp);
+                    builder.set_column_bloom_filter_fpp(column_path.clone(), bf_fpp);
                 let bf_ndv = index_cfg
                     .and_then(|fc| fc.bloom_filter_ndv)
                     .or_else(|| {
@@ -357,7 +396,7 @@ impl WriterPropertiesBuilder {
                     })
                     .unwrap_or(config.get_bloom_filter_ndv());
                 builder =
-                    builder.set_column_bloom_filter_ndv(field_name.to_string().into(), bf_ndv);
+                    builder.set_column_bloom_filter_ndv(column_path.clone(), bf_ndv);
             }
         }
         Ok(builder)
@@ -1370,5 +1409,128 @@ mod tests {
             .any(|k| k.key == WRITER_GENERATION_KEY && k.value.as_deref() == Some("42"));
         assert!(has_format, "format_version stamp missing");
         assert!(has_gen, "writer_generation stamp missing");
+    }
+
+    /// A LIST column's leaf lives at `<field>.list.element`; a single-segment path would miss it
+    /// and every per-column setting would silently fall back to defaults.
+    fn list_schema(name: &str, element: ArrowDataType) -> ArrowSchema {
+        let child = std::sync::Arc::new(Field::new("element", element, true));
+        ArrowSchema::new(vec![Field::new(name, ArrowDataType::List(child), true)])
+    }
+
+    fn list_leaf_path(name: &str) -> parquet::schema::types::ColumnPath {
+        parquet::schema::types::ColumnPath::new(vec![
+            name.to_string(),
+            "list".to_string(),
+            "element".to_string(),
+        ])
+    }
+
+    #[test]
+    fn test_list_column_uses_leaf_column_path_for_encoding() {
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "tags".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+
+        assert_eq!(
+            props.encoding(&list_leaf_path("tags")),
+            Some(Encoding::DELTA_BYTE_ARRAY),
+            "encoding must be set on the list leaf path"
+        );
+        // The single-segment path must NOT carry the setting — that was the silent-no-op bug.
+        assert_eq!(
+            props.encoding(&parquet::schema::types::ColumnPath::from("tags")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_list_column_encoding_validated_against_element_type() {
+        // DELTA_BYTE_ARRAY is valid for Utf8 but not Int64. Validation must look through the list
+        // wrapper at the element, otherwise every encoding would be accepted for a list column.
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "nums".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = list_schema("nums", ArrowDataType::Int64);
+        let err = WriterPropertiesBuilder::build(&config, &schema)
+            .expect_err("DELTA_BYTE_ARRAY must be rejected for a list of Int64");
+        assert!(err.contains("not supported"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn test_list_column_resolves_type_level_config_by_element_type() {
+        // A cluster-level `utf8` rule must apply to LIST<Utf8>: the type key is derived from the
+        // element, not from the Debug string of the list wrapper.
+        let mut type_compression = HashMap::new();
+        type_compression.insert("utf8".to_string(), "SNAPPY".to_string());
+        let config = NativeSettings {
+            type_compression_configs: Some(type_compression),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert!(matches!(
+            props.compression(&list_leaf_path("tags")),
+            Compression::SNAPPY
+        ));
+    }
+
+    #[test]
+    fn test_list_column_bloom_filter_on_leaf_path() {
+        let config = NativeSettings {
+            bloom_filter_enabled: Some(true),
+            ..Default::default()
+        };
+        let schema = list_schema("tags", ArrowDataType::Utf8);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert!(
+            props
+                .bloom_filter_properties(&list_leaf_path("tags"))
+                .is_some(),
+            "bloom filter must be enabled on the list leaf path"
+        );
+    }
+
+    #[test]
+    fn test_scalar_column_path_unchanged() {
+        // Regression guard: non-list columns must still be addressed by bare name.
+        let mut field_configs = HashMap::new();
+        field_configs.insert(
+            "name".to_string(),
+            FieldConfig {
+                encoding_type: Some("DELTA_BYTE_ARRAY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = NativeSettings {
+            field_configs: Some(field_configs),
+            ..Default::default()
+        };
+        let schema = schema_with(vec![("name", ArrowDataType::Utf8)]);
+        let props = WriterPropertiesBuilder::build(&config, &schema).unwrap();
+        assert_eq!(
+            props.encoding(&parquet::schema::types::ColumnPath::from("name")),
+            Some(Encoding::DELTA_BYTE_ARRAY)
+        );
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/cursor_verify_tmp.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/cursor_verify_tmp.rs
@@ -1,0 +1,178 @@
+// Temporary verification test for the parquet_decode_page_at_row retained cursor.
+// Verifies sequential page decode (cursor reuse), row-group transitions, and
+// backwards seeks (cursor invalidation) all return values identical to the
+// row-by-row slow path.
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+use opensearch_parquet_format::ffm::{
+    parquet_close_column_reader, parquet_decode_page_at_row, parquet_open_column_reader,
+    parquet_read_value_at_row,
+};
+
+const N_ROWS: i64 = 5000;
+
+fn expected(i: i64) -> Option<i64> {
+    if i % 7 == 0 {
+        None
+    } else {
+        Some(i * 3)
+    }
+}
+
+fn write_test_file(path: &str) {
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+    let props = WriterProperties::builder()
+        .set_data_page_row_count_limit(100)
+        .set_write_batch_size(100)
+        .set_max_row_group_size(2000) // 3 row groups: 2000 + 2000 + 1000
+        .build();
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+    // Write in small batches so data_page_row_count_limit takes effect.
+    let mut i = 0i64;
+    while i < N_ROWS {
+        let end = (i + 100).min(N_ROWS);
+        let vals: Int64Array = (i..end).map(expected).collect();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vals)]).unwrap();
+        writer.write(&batch).unwrap();
+        i = end;
+    }
+    writer.close().unwrap();
+}
+
+unsafe fn open_reader(path: &str) -> i64 {
+    let col = "v";
+    let h = parquet_open_column_reader(
+        path.as_ptr(),
+        path.len() as i64,
+        col.as_ptr(),
+        col.len() as i64,
+        1, // TYPE_INT64
+    );
+    assert!(h >= 0, "open failed: {}", h);
+    h
+}
+
+/// Decodes the page containing `row`; returns (first_row, last_row, values, presence_bits).
+unsafe fn decode_page(handle: i64, row: i64) -> (i64, i64, Vec<i64>, Vec<i64>) {
+    let mut first = 0i64;
+    let mut last = 0i64;
+    let mut actual_len = 0i64;
+    let cap_rows = 8192usize;
+    let mut values = vec![0i64; cap_rows];
+    let mut presence = vec![0i64; (cap_rows + 63) / 64];
+    let rc = parquet_decode_page_at_row(
+        handle,
+        row,
+        &mut first,
+        &mut last,
+        values.as_mut_ptr() as *mut u8,
+        (values.len() * 8) as i64,
+        &mut actual_len,
+        std::ptr::null_mut(),
+        0,
+        presence.as_mut_ptr(),
+        presence.len() as i64,
+    );
+    assert_eq!(rc, 0, "decode failed rc={} at row {}", rc, row);
+    let rows = (last - first + 1) as usize;
+    values.truncate(rows);
+    presence.truncate((rows + 63) / 64);
+    (first, last, values, presence)
+}
+
+unsafe fn assert_page_correct(first: i64, last: i64, values: &[i64], presence: &[i64]) {
+    for (k, g) in (first..=last).enumerate() {
+        let present = (presence[k / 64] >> (k % 64)) & 1 == 1;
+        match expected(g) {
+            Some(v) => {
+                assert!(present, "row {} should be present", g);
+                assert_eq!(values[k], v, "row {} value mismatch", g);
+            }
+            None => {
+                assert!(!present, "row {} should be null", g);
+                assert_eq!(values[k], 0, "null row {} slot must be 0", g);
+            }
+        }
+    }
+}
+
+#[test]
+fn cursor_sequential_backward_and_slowpath_consistency() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("cursor_verify.parquet");
+    let path = path.to_str().unwrap().to_string();
+    write_test_file(&path);
+
+    unsafe {
+        let h = open_reader(&path);
+
+        // 1. Full sequential sweep (the hot path): decode every page in order,
+        //    crossing row-group boundaries. Cursor should be reused within each
+        //    row group and rebuilt across groups; values must be exact.
+        let mut row = 0i64;
+        let mut n_pages = 0;
+        while row < N_ROWS {
+            let (first, last, values, presence) = decode_page(h, row);
+            assert_eq!(first, row, "pages must tile the row space");
+            assert_page_correct(first, last, &values, &presence);
+            row = last + 1;
+            n_pages += 1;
+        }
+        assert!(
+            n_pages > 3,
+            "expected page-granular layout (page index), got {} pages",
+            n_pages
+        );
+
+        // 2. Backwards seek: re-decode an early page after the sweep (cursor is
+        //    positioned at EOF — must fall back to a fresh reader, not garbage).
+        let (first, last, values, presence) = decode_page(h, 150);
+        assert!(first <= 150 && last >= 150);
+        assert_page_correct(first, last, &values, &presence);
+
+        // 3. Re-decode the SAME page again (cursor position == last+1 > first — miss).
+        let (f2, l2, v2, p2) = decode_page(h, 150);
+        assert_eq!((f2, l2), (first, last));
+        assert_eq!(v2, values);
+        assert_eq!(p2, presence);
+
+        // 4. Skip-ahead within the same row group (cursor hit with skip > 0):
+        //    jump from the page after row 150 to a page much later in the same group.
+        let (f3, l3, v3, p3) = decode_page(h, 1900); // still in rg 0 (rows 0..2000)
+        assert!(f3 <= 1900 && l3 >= 1900);
+        assert_page_correct(f3, l3, &v3, &p3);
+
+        // 5. Cross-check random rows against the slow path (fresh reader per call).
+        for &r in &[0i64, 1, 6, 7, 99, 100, 1999, 2000, 2001, 3999, 4000, 4999] {
+            let mut present = 0i64;
+            let mut long = 0i64;
+            let rc = parquet_read_value_at_row(
+                h,
+                r,
+                &mut present,
+                &mut long,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+            );
+            assert_eq!(rc, 0);
+            match expected(r) {
+                Some(v) => {
+                    assert_eq!(present, 1, "slow path row {}", r);
+                    assert_eq!(long, v, "slow path row {}", r);
+                }
+                None => assert_eq!(present, 0, "slow path row {}", r),
+            }
+        }
+
+        assert_eq!(parquet_close_column_reader(h), 0);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Merge coverage for multi-valued (Arrow LIST / parquet repeated) columns.
+//!
+//! A LIST column breaks the "one leaf value per row" identity every flat column satisfies, so the
+//! merge path needs its own coverage: the k-way merge slices batches by row, appends a fresh
+//! `__row_id__`, and re-encodes each column through `compute_leaves`. All of that must keep a
+//! repeated column's values grouped with their original row.
+
+use std::fs::File;
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use tempfile::tempdir;
+
+/// Schema: `id` (sort key, Int64) + `tags` (List<Utf8>) + `__row_id__`.
+fn list_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new("__row_id__", DataType::Int64, false),
+    ]))
+}
+
+/// Build a file where row i has `id = ids[i]` and `tags = rows[i]` (None ⇒ null list).
+fn write_list_file(path: &str, ids: &[i64], rows: &[Option<Vec<&str>>]) {
+    assert_eq!(ids.len(), rows.len());
+    let mut values: Vec<Option<String>> = Vec::new();
+    let mut offsets: Vec<i32> = vec![0];
+    let mut validity: Vec<bool> = Vec::new();
+    for r in rows {
+        match r {
+            Some(v) => {
+                for s in v {
+                    values.push(Some((*s).to_string()));
+                }
+                validity.push(true);
+            }
+            None => validity.push(false),
+        }
+        offsets.push(values.len() as i32);
+    }
+    let list = ListArray::new(
+        Arc::new(Field::new("element", DataType::Utf8, true)),
+        arrow::buffer::OffsetBuffer::new(offsets.into()),
+        Arc::new(StringArray::from(values)),
+        Some(arrow::buffer::NullBuffer::from(validity)),
+    );
+    let schema = list_schema();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(list) as ArrayRef,
+            Arc::new(Int64Array::from((0..ids.len() as i64).collect::<Vec<_>>())) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let file = File::create(path).unwrap();
+    let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+}
+
+/// Read back `(id, tags)` pairs in file order.
+fn read_pairs(path: &str) -> Vec<(i64, Option<Vec<String>>)> {
+    let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+    let mut out = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let ids = batch
+            .column(batch.schema().index_of("id").unwrap())
+            .as_primitive::<arrow::datatypes::Int64Type>();
+        let lists = batch
+            .column(batch.schema().index_of("tags").unwrap())
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("tags must decode as a ListArray");
+        for i in 0..batch.num_rows() {
+            let tags = if lists.is_null(i) {
+                None
+            } else {
+                let v = lists.value(i);
+                let s = v.as_any().downcast_ref::<StringArray>().unwrap();
+                Some((0..s.len()).map(|j| s.value(j).to_string()).collect())
+            };
+            out.push((ids.value(i), tags));
+        }
+    }
+    out
+}
+
+/// Borrow an owned rows-of-strings structure as the `&str` shape `write_list_file` takes.
+fn as_refs(rows: &[Option<Vec<String>>]) -> Vec<Option<Vec<&str>>> {
+    rows.iter()
+        .map(|r| r.as_ref().map(|v| v.iter().map(|s| s.as_str()).collect()))
+        .collect()
+}
+
+fn v(items: &[&str]) -> Option<Vec<String>> {
+    Some(items.iter().map(|s| (*s).to_string()).collect())
+}
+
+#[test]
+fn unsorted_merge_preserves_list_values() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // Varying list lengths, a duplicate, an empty list, and a null list.
+    write_list_file(
+        &a,
+        &[1, 2, 3],
+        &[Some(vec!["beta", "alpha", "beta"]), None, Some(vec!["solo"])],
+    );
+    write_list_file(&b, &[4, 5], &[Some(vec![]), Some(vec!["x", "y"])]);
+
+    merge_unsorted(&[a, b], &out, "merge-list-unsorted", 0).unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 5, "row count must be preserved");
+    assert_eq!(pairs[0], (1, v(&["beta", "alpha", "beta"])));
+    assert_eq!(pairs[1].0, 2);
+    assert!(pairs[1].1.is_none() || pairs[1].1 == Some(vec![]));
+    assert_eq!(pairs[2], (3, v(&["solo"])));
+    assert_eq!(pairs[3].0, 4);
+    assert_eq!(pairs[3].1, Some(vec![]), "empty list must stay empty");
+    assert_eq!(pairs[4], (5, v(&["x", "y"])));
+}
+
+#[test]
+fn sorted_merge_keeps_list_values_with_their_row() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // Interleaving sort keys force the k-way merge to alternate between cursors, so a row-vs-value
+    // confusion in the LIST column would surface as values attached to the wrong id.
+    write_list_file(
+        &a,
+        &[1, 3, 5],
+        &[Some(vec!["one"]), Some(vec!["three", "iii"]), Some(vec!["five"])],
+    );
+    write_list_file(
+        &b,
+        &[2, 4, 6],
+        &[Some(vec!["two", "ii", "2"]), None, Some(vec!["six"])],
+    );
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-sorted",
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 6);
+    // Sort order by id, and every row keeps exactly its own values.
+    assert_eq!(pairs[0], (1, v(&["one"])));
+    assert_eq!(pairs[1], (2, v(&["two", "ii", "2"])));
+    assert_eq!(pairs[2], (3, v(&["three", "iii"])));
+    assert_eq!(pairs[3].0, 4);
+    assert!(pairs[3].1.is_none() || pairs[3].1 == Some(vec![]));
+    assert_eq!(pairs[4], (5, v(&["five"])));
+    assert_eq!(pairs[5], (6, v(&["six"])));
+}
+
+#[test]
+fn sorted_merge_on_list_column_as_sort_key_errors_cleanly() {
+    // heap.rs `get_sort_value` has no arm for List, so sorting BY a list column must surface a
+    // clean MergeError rather than panicking or silently producing garbage.
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+    write_list_file(&a, &[1], &[Some(vec!["a"])]);
+    write_list_file(&b, &[2], &[Some(vec!["b"])]);
+
+    let res = merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-sortkey",
+        &["tags".to_string()],
+        &[false],
+        &[false],
+        0,
+    );
+    match res {
+        Err(e) => {
+            let msg = e.to_string();
+            println!("sorting by a LIST column errored as expected: {msg}");
+            assert!(
+                msg.contains("Unsupported sort column type"),
+                "expected an explicit unsupported-sort-type error, got: {msg}"
+            );
+        }
+        Ok(_) => panic!("sorting by a LIST column should not silently succeed"),
+    }
+}
+
+/// Multi-batch cursors + deferred column decode.
+///
+/// Two settings make this the adversarial case for a repeated column:
+/// `merge_batch_size` small enough that each cursor spans several batches (so the k-way merge
+/// crosses batch boundaries mid-file, exercising `advance`/`load_next_batch` and `take_slice`), and
+/// `merge_deferred_column_threshold = 0` which forces the cursor's *deferred* mode — sort columns
+/// and data columns are read through two independent parquet readers kept in lockstep by batch
+/// index. If a LIST column's leaf desynchronised from the sort reader, the two would drift.
+#[test]
+fn sorted_merge_list_across_batches_in_deferred_mode() {
+    use opensearch_parquet_format::native_settings::NativeSettings;
+    use opensearch_parquet_format::writer::SETTINGS_STORE;
+
+    let index = "merge-list-deferred";
+    SETTINGS_STORE.insert(
+        index.to_string(),
+        NativeSettings {
+            merge_batch_size: Some(4),
+            merge_deferred_column_threshold: Some(0),
+            ..Default::default()
+        },
+    );
+
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp.path().join("merged.parquet").to_string_lossy().to_string();
+
+    // 40 rows total, interleaved odd/even ids, with per-row list lengths that vary 0..3 so the
+    // value count is unrelated to the row count in every batch.
+    let ids_a: Vec<i64> = (0..20).map(|i| i * 2 + 1).collect();
+    let ids_b: Vec<i64> = (0..20).map(|i| i * 2 + 2).collect();
+    let owned_a: Vec<Option<Vec<String>>> = ids_a
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 4 {
+            0 => None,
+            1 => Some(vec![]),
+            2 => Some(vec![format!("a{id}")]),
+            _ => Some(vec![format!("a{id}"), format!("a{id}b"), format!("a{id}c")]),
+        })
+        .collect();
+    let owned_b: Vec<Option<Vec<String>>> = ids_b
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 3 {
+            0 => Some(vec![format!("b{id}"), format!("b{id}x")]),
+            1 => None,
+            _ => Some(vec![format!("b{id}")]),
+        })
+        .collect();
+    write_list_file(&a, &ids_a, &as_refs(&owned_a));
+    write_list_file(&b, &ids_b, &as_refs(&owned_b));
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        index,
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 40, "all rows must survive the merge");
+
+    // Rebuild the expected (id → tags) mapping and check every row independently, so a single
+    // misattached value fails loudly with the offending id.
+    let mut expected: std::collections::HashMap<i64, Option<Vec<String>>> =
+        std::collections::HashMap::new();
+    for (id, tags) in ids_a.iter().zip(owned_a.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+    for (id, tags) in ids_b.iter().zip(owned_b.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+
+    let mut prev_id = i64::MIN;
+    for (id, tags) in &pairs {
+        assert!(*id > prev_id, "output must be sorted by id, saw {id} after {prev_id}");
+        prev_id = *id;
+        let want = expected.remove(id).unwrap_or_else(|| panic!("unexpected id {id}"));
+        // A null list and an empty list are both legitimately readable as "no values".
+        let norm = |t: &Option<Vec<String>>| t.clone().unwrap_or_default();
+        assert_eq!(
+            norm(tags),
+            norm(&want),
+            "row id={id} lost or gained values in the merge"
+        );
+    }
+    assert!(expected.is_empty(), "rows missing from output: {:?}", expected.keys());
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/OtelTracesParquetGeneratorTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/OtelTracesParquetGeneratorTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.parquet;
 
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.opensearch.Version;
@@ -119,7 +120,16 @@ public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
     }
 
     private MappedFieldType dateNanos(String name) {
+        return dateNanos(name, false, null);
+    }
+
+    /** A date_nanos column, optionally multi_value and stamped into a correlated group. */
+    private MappedFieldType dateNanos(String name, boolean multiValue, String group) {
         MappedFieldType ft = new DateFieldMapper.DateFieldType(name, DateFieldMapper.Resolution.NANOSECONDS);
+        if (multiValue) {
+            ft.setMultiValued(true);
+            ft.setCorrelationGroup(group);
+        }
         assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
         return ft;
     }
@@ -170,6 +180,7 @@ public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
         MappedFieldType duration = lng("Duration");
         MappedFieldType resourceAttrs = flat("ResourceAttributes", false, null);
         MappedFieldType spanAttrs = flat("SpanAttributes", false, null);
+        MappedFieldType eventsTimestamp = dateNanos("Events.Timestamp", true, "Events");
         MappedFieldType eventsName = kwList("Events.Name", "Events");
         MappedFieldType eventsAttrs = flat("Events.Attributes", true, "Events");
         MappedFieldType linksTraceId = kwList("Links.TraceId", "Links");
@@ -188,6 +199,7 @@ public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
             duration,
             resourceAttrs,
             spanAttrs,
+            eventsTimestamp,
             eventsName,
             eventsAttrs,
             linksTraceId,
@@ -232,11 +244,14 @@ public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
                 // Two events per errored span, one otherwise. Each addField call is one element, which
                 // is how the document parser hands over the elements of a JSON array.
                 if (errored) {
+                    doc.addField(eventsTimestamp, base + row * 1_000_000_000L + 1L);
                     doc.addField(eventsName, "exception");
                     doc.addField(eventsAttrs, attrs("exception.type", "IOError", "exception.message", "disk full"));
+                    doc.addField(eventsTimestamp, base + row * 1_000_000_000L + 2L);
                     doc.addField(eventsName, "retry");
                     doc.addField(eventsAttrs, attrs("retry.count", "3"));
                 } else {
+                    doc.addField(eventsTimestamp, base + row * 1_000_000_000L + 1L);
                     doc.addField(eventsName, "cache.hit");
                     doc.addField(eventsAttrs, attrs("cache.key", "k" + row));
                 }
@@ -263,18 +278,17 @@ public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
     }
 
     /**
-     * {@code Events.Timestamp} as {@code date_nanos, multi_value: true} is rejected: only
-     * {@code KeywordParquetField} and {@code FlatObjectParquetField} override
-     * {@link ParquetField#supportsMultiValue()}. This pins the gap that keeps the generated file from
-     * matching the ClickHouse column list exactly.
+     * {@code Events.Timestamp} as {@code date_nanos, multi_value: true} is a {@code LIST<int64>} of
+     * nanos, so the generated file now matches the ClickHouse column list for the whole group.
      */
-    public void testEventsTimestampMultiValueStillUnsupported() {
+    public void testEventsTimestampSupportsMultiValue() {
         ParquetField dateNanosField = ArrowFieldRegistry.getParquetField(DateFieldMapper.DATE_NANOS_CONTENT_TYPE);
-        assertFalse(dateNanosField.supportsMultiValue());
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> dateNanosField.toArrowField("Events.Timestamp", true)
+        assertTrue(dateNanosField.supportsMultiValue());
+        Field arrowField = dateNanosField.toArrowField("Events.Timestamp", true);
+        assertEquals(ArrowType.List.INSTANCE, arrowField.getType());
+        assertEquals(
+            new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.NANOSECOND, null),
+            arrowField.getChildren().get(0).getType()
         );
-        assertTrue(e.getMessage().contains("Events.Timestamp"));
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/OtelTracesParquetGeneratorTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/OtelTracesParquetGeneratorTests.java
@@ -1,0 +1,280 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.arrow.allocator.ArrowNativeAllocator;
+import org.opensearch.arrow.spi.NativeAllocatorPoolConfig;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.fields.ArrowFieldRegistry;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.memory.ArrowBufferPool;
+import org.opensearch.parquet.vsr.VSRManager;
+import org.opensearch.parquet.writer.ParquetDocumentInput;
+import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.index.engine.dataformat.DataFormatTestUtils.assignTestCapabilities;
+import static org.opensearch.parquet.ParquetDataFormatPlugin.PARQUET_DATA_FORMAT;
+
+/**
+ * Writes an OTel-traces Parquet file through the real write path — the same
+ * {@link ParquetField} implementations the mapping uses, the same {@link VSRManager}, and the same
+ * native arrow-rs writer — so the file is byte-for-byte what an index with this mapping produces.
+ *
+ * <p>Not a unit test: it exists to produce an artifact for inspection with external tools. The output
+ * path is taken from {@code -Dotel.parquet.out}, defaulting to {@code /tmp/otel_traces.parquet}.
+ */
+public class OtelTracesParquetGeneratorTests extends ParquetBaseTests {
+
+    private ArrowNativeAllocator nativeAllocator;
+    private ArrowBufferPool bufferPool;
+    private ThreadPool threadPool;
+    private IndexSettings indexSettings;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        nativeAllocator = new ArrowNativeAllocator();
+        nativeAllocator.getOrCreatePool(NativeAllocatorPoolConfig.POOL_INGEST, 0L, Long.MAX_VALUE, null);
+        bufferPool = new ArrowBufferPool(Settings.EMPTY, nativeAllocator);
+        IndexMetadata meta = IndexMetadata.builder("otel-traces")
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .build()
+            )
+            .build();
+        indexSettings = new IndexSettings(meta, Settings.EMPTY);
+        Settings nodeSettings = Settings.builder().put("node.name", "otel-gen").build();
+        threadPool = new ThreadPool(
+            nodeSettings,
+            new FixedExecutorBuilder(
+                nodeSettings,
+                ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME,
+                1,
+                -1,
+                "thread_pool." + ParquetDataFormatPlugin.PARQUET_THREAD_POOL_NAME
+            )
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        terminate(threadPool);
+        bufferPool.close();
+        if (nativeAllocator != null) {
+            nativeAllocator.close();
+            nativeAllocator = null;
+        }
+        super.tearDown();
+    }
+
+    /** A scalar keyword column. */
+    private MappedFieldType kw(String name) {
+        MappedFieldType ft = new KeywordFieldMapper.KeywordFieldType(name);
+        assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
+        return ft;
+    }
+
+    /** A multi_value keyword column, optionally stamped into a correlated group. */
+    private MappedFieldType kwList(String name, String group) {
+        MappedFieldType ft = new KeywordFieldMapper.KeywordFieldType(name);
+        ft.setMultiValued(true);
+        ft.setCorrelationGroup(group);
+        assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
+        return ft;
+    }
+
+    private MappedFieldType lng(String name) {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.LONG);
+        assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
+        return ft;
+    }
+
+    private MappedFieldType dateNanos(String name) {
+        MappedFieldType ft = new DateFieldMapper.DateFieldType(name, DateFieldMapper.Resolution.NANOSECONDS);
+        assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
+        return ft;
+    }
+
+    /** A flat_object column: {@code MAP<utf8,utf8>}, or {@code LIST<MAP>} when multi-valued. */
+    private MappedFieldType flat(String name, boolean multiValue, String group) {
+        MappedFieldType ft = new FlatObjectFieldMapper.FlatObjectFieldType(name, null, true, true);
+        if (multiValue) {
+            ft.setMultiValued(true);
+            ft.setCorrelationGroup(group);
+        }
+        assignTestCapabilities(ft, PARQUET_DATA_FORMAT);
+        return ft;
+    }
+
+    private static Field arrow(MappedFieldType ft) {
+        ParquetField pf = ArrowFieldRegistry.getParquetField(ft.typeName());
+        return pf.toArrowField(ft.name(), ft.isMultiValued());
+    }
+
+    private static List<Map.Entry<String, String>> attrs(String... kv) {
+        List<Map.Entry<String, String>> out = new ArrayList<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            out.add(Map.entry(kv[i], kv[i + 1]));
+        }
+        return out;
+    }
+
+    public void testGenerateOtelTracesParquet() throws Exception {
+        // Defaults to the test temp directory so the suite passes under the test security manager with
+        // no extra flags. Point [otel.parquet.out] somewhere durable to keep the file for inspection,
+        // which also needs -Dtests.security.manager=false since that path is outside the sandbox.
+        String configured = System.getProperty("otel.parquet.out");
+        Path out = configured != null ? Path.of(configured) : createTempDir().resolve("otel_traces.parquet");
+        int rowCount = Integer.getInteger("otel.parquet.rows", 12);
+        Files.deleteIfExists(out);
+
+        // The span-level columns, then the two correlated groups. Mirrors the ClickHouse otel_traces
+        // column list, restricted to what the mapping accepts today (see the note printed at the end).
+        MappedFieldType timestamp = dateNanos("Timestamp");
+        MappedFieldType traceId = kw("TraceId");
+        MappedFieldType spanId = kw("SpanId");
+        MappedFieldType parentSpanId = kw("ParentSpanId");
+        MappedFieldType spanName = kw("SpanName");
+        MappedFieldType spanKind = kw("SpanKind");
+        MappedFieldType serviceName = kw("ServiceName");
+        MappedFieldType statusCode = kw("StatusCode");
+        MappedFieldType duration = lng("Duration");
+        MappedFieldType resourceAttrs = flat("ResourceAttributes", false, null);
+        MappedFieldType spanAttrs = flat("SpanAttributes", false, null);
+        MappedFieldType eventsName = kwList("Events.Name", "Events");
+        MappedFieldType eventsAttrs = flat("Events.Attributes", true, "Events");
+        MappedFieldType linksTraceId = kwList("Links.TraceId", "Links");
+        MappedFieldType linksSpanId = kwList("Links.SpanId", "Links");
+        MappedFieldType linksAttrs = flat("Links.Attributes", true, "Links");
+
+        List<MappedFieldType> columns = List.of(
+            timestamp,
+            traceId,
+            spanId,
+            parentSpanId,
+            spanName,
+            spanKind,
+            serviceName,
+            statusCode,
+            duration,
+            resourceAttrs,
+            spanAttrs,
+            eventsName,
+            eventsAttrs,
+            linksTraceId,
+            linksSpanId,
+            linksAttrs
+        );
+
+        List<Field> fields = new ArrayList<>();
+        for (MappedFieldType ft : columns) {
+            fields.add(arrow(ft));
+        }
+        fields.addAll(metadataFields());
+        Schema schema = new Schema(fields);
+
+        VSRManager manager = new VSRManager(out.toString(), indexSettings, schema, bufferPool, 50000, threadPool, 0L);
+        try {
+            long base = 1755684000000000000L; // 2025-08-20T10:00:00Z in epoch nanos
+            String[] services = { "checkout", "payment", "cart" };
+            String[] spans = { "GET /checkout", "POST /pay", "GET /cart" };
+            String[] langs = { "java", "python", "go" };
+
+            for (int row = 0; row < rowCount; row++) {
+                ParquetDocumentInput doc = new ParquetDocumentInput();
+                populateMetadataFields(doc);
+                doc.setRowId(DocumentInput.ROW_ID_FIELD, row);
+
+                int svc = row % 3;
+                boolean errored = row % 4 == 0;
+                doc.addField(timestamp, base + row * 1_000_000_000L);
+                // Three spans per trace, so a trace lookup returns several rows.
+                doc.addField(traceId, String.format(java.util.Locale.ROOT, "trace-%08d", row / 3));
+                doc.addField(spanId, String.format(java.util.Locale.ROOT, "span-%08d", row));
+                doc.addField(parentSpanId, row % 3 == 0 ? "" : String.format(java.util.Locale.ROOT, "span-%08d", row - 1));
+                doc.addField(spanName, spans[svc]);
+                doc.addField(spanKind, "SPAN_KIND_SERVER");
+                doc.addField(serviceName, services[svc]);
+                doc.addField(statusCode, errored ? "STATUS_CODE_ERROR" : "STATUS_CODE_OK");
+                doc.addField(duration, (row + 1) * 1_500_000L);
+                doc.addField(resourceAttrs, attrs("host.name", "host-" + svc, "telemetry.sdk.language", langs[svc]));
+                doc.addField(spanAttrs, attrs("http.method", "GET", "http.status_code", errored ? "500" : "200"));
+
+                // Two events per errored span, one otherwise. Each addField call is one element, which
+                // is how the document parser hands over the elements of a JSON array.
+                if (errored) {
+                    doc.addField(eventsName, "exception");
+                    doc.addField(eventsAttrs, attrs("exception.type", "IOError", "exception.message", "disk full"));
+                    doc.addField(eventsName, "retry");
+                    doc.addField(eventsAttrs, attrs("retry.count", "3"));
+                } else {
+                    doc.addField(eventsName, "cache.hit");
+                    doc.addField(eventsAttrs, attrs("cache.key", "k" + row));
+                }
+
+                // One link on every third span.
+                if (row % 3 == 2) {
+                    doc.addField(linksTraceId, String.format(java.util.Locale.ROOT, "trace-%08d", (row / 3 + 1)));
+                    doc.addField(linksSpanId, "span-linked-" + row);
+                    doc.addField(linksAttrs, attrs("link.kind", "follows_from"));
+                }
+
+                manager.addDocument(doc);
+            }
+
+            var metadata = manager.flush();
+            assertNotNull(metadata);
+            assertEquals(rowCount, metadata.numRows());
+        } finally {
+            manager.close();
+        }
+
+        assertTrue("parquet file should exist at " + out, Files.exists(out));
+        logger.info("WROTE {} ({} bytes)", out, Files.size(out));
+    }
+
+    /**
+     * {@code Events.Timestamp} as {@code date_nanos, multi_value: true} is rejected: only
+     * {@code KeywordParquetField} and {@code FlatObjectParquetField} override
+     * {@link ParquetField#supportsMultiValue()}. This pins the gap that keeps the generated file from
+     * matching the ClickHouse column list exactly.
+     */
+    public void testEventsTimestampMultiValueStillUnsupported() {
+        ParquetField dateNanosField = ArrowFieldRegistry.getParquetField(DateFieldMapper.DATE_NANOS_CONTENT_TYPE);
+        assertFalse(dateNanosField.supportsMultiValue());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> dateNanosField.toArrowField("Events.Timestamp", true)
+        );
+        assertTrue(e.getMessage().contains("Events.Timestamp"));
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
@@ -300,12 +300,15 @@ public class ParquetDataFormatAwareEngineTests extends AbstractDataFormatAwareEn
 
     private Schema buildSchema() {
         List<Field> fields = new ArrayList<>();
+        // Build every column through toArrowField rather than from name + FieldType: a nested column
+        // (flat_object, whose type is a MAP) is not fully described by its FieldType alone, and a MAP
+        // without its `entries` child fails Arrow's vector allocation outright.
         for (MappedFieldType ft : List.of(NAME_FIELD, AGE_FIELD)) {
             ParquetField pf = ArrowFieldRegistry.getParquetField(ft.typeName());
-            fields.add(new Field(ft.name(), pf.getFieldType(), null));
+            fields.add(pf.toArrowField(ft.name(), false));
         }
         for (Map.Entry<String, ParquetField> dataField : new CoreDataFieldPlugin().getParquetFields().entrySet()) {
-            fields.add(new Field(dataField.getKey() + "_field", dataField.getValue().getFieldType(), null));
+            fields.add(dataField.getValue().toArrowField(dataField.getKey() + "_field", false));
         }
         fields.addAll(metadataFields());
         fields.add(new Field(DocumentInput.ROW_ID_FIELD, FieldType.notNullable(new ArrowType.Int(64, true)), null));

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/MultiValueFieldTypeTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/MultiValueFieldTypeTests.java
@@ -1,0 +1,230 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.fields;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.BooleanFieldMapper;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.IpFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.parquet.vsr.ManagedVSR;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Every field type that can be declared {@code multi_value: true} must write a {@code LIST} column, so
+ * that a correlated group is not limited to keyword members.
+ *
+ * <p>Each case asserts three things a type has to get right: {@code supportsMultiValue()} agrees with
+ * whether {@link ParquetField#addToVector} is implemented, the Arrow field is a {@code LIST} of the
+ * element type, and the values written into the child vector read back at the expected positions.
+ * Writing at an explicit index is the part that differs from the scalar path — list elements sit at
+ * positions in the child vector unrelated to the row number.
+ */
+public class MultiValueFieldTypeTests extends OpenSearchTestCase {
+
+    private BufferAllocator allocator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        allocator = new RootAllocator();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        super.tearDown();
+    }
+
+    /** Writes one row holding the given values into a LIST column and hands back the vector. */
+    private ListVector writeRow(String typeName, String name, List<?> values) {
+        ParquetField field = ArrowFieldRegistry.getParquetField(typeName);
+        assertTrue("type [" + typeName + "] should support multi_value", field.supportsMultiValue());
+
+        Field arrowField = field.toArrowField(name, true);
+        assertEquals("multi_value must produce a LIST column", ArrowType.List.INSTANCE, arrowField.getType());
+
+        BufferAllocator child = allocator.newChildAllocator("mv-" + typeName, 0, Long.MAX_VALUE);
+        ManagedVSR vsr = new ManagedVSR("mv-" + typeName, new Schema(List.of(arrowField)), child);
+        ListVector listVector = (ListVector) vsr.getVector(name);
+
+        int start = listVector.startNewValue(0);
+        FieldVector data = listVector.getDataVector();
+        for (int i = 0; i < values.size(); i++) {
+            field.addToVector(data, start + i, values.get(i));
+        }
+        listVector.endValue(0, values.size());
+        vsr.setRowCount(1);
+        return listVector;
+    }
+
+    private static void assertElements(ListVector listVector, List<?> expected) {
+        assertFalse("the row must be a non-null list", listVector.isNull(0));
+        int start = listVector.getOffsetBuffer().getInt(0);
+        int end = listVector.getOffsetBuffer().getInt(ListVector.OFFSET_WIDTH);
+        assertEquals("element count", expected.size(), end - start);
+        FieldVector data = listVector.getDataVector();
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals("element " + i, expected.get(i), data.getObject(start + i));
+        }
+    }
+
+    public void testLongMultiValue() {
+        ListVector v = writeRow(NumberFieldMapper.NumberType.LONG.typeName(), "counts", List.of(1L, 2L, 3L));
+        assertElements(v, List.of(1L, 2L, 3L));
+        v.close();
+    }
+
+    public void testIntegerMultiValue() {
+        ListVector v = writeRow(NumberFieldMapper.NumberType.INTEGER.typeName(), "ints", List.of(7, 8));
+        assertElements(v, List.of(7, 8));
+        v.close();
+    }
+
+    public void testDoubleMultiValue() {
+        ListVector v = writeRow(NumberFieldMapper.NumberType.DOUBLE.typeName(), "ratios", List.of(1.5d, 2.5d));
+        assertElements(v, List.of(1.5d, 2.5d));
+        v.close();
+    }
+
+    public void testShortAndByteMultiValue() {
+        ListVector shorts = writeRow(NumberFieldMapper.NumberType.SHORT.typeName(), "shorts", List.of((short) 1, (short) 2));
+        assertElements(shorts, List.of((short) 1, (short) 2));
+        shorts.close();
+
+        ListVector bytes = writeRow(NumberFieldMapper.NumberType.BYTE.typeName(), "bytes", List.of((byte) 3, (byte) 4));
+        assertElements(bytes, List.of((byte) 3, (byte) 4));
+        bytes.close();
+    }
+
+    /**
+     * The OTel {@code Events.Timestamp Array(DateTime64(9))} case: a LIST of nanosecond timestamps.
+     * Compared through the vector's primitive accessor, since {@code getObject} on a timestamp vector
+     * decodes to a {@link java.time.LocalDateTime}.
+     */
+    public void testDateNanosMultiValue() {
+        long first = 1755684000000000001L;
+        long second = 1755684005000000002L;
+        ListVector v = writeRow(DateFieldMapper.DATE_NANOS_CONTENT_TYPE, "Events.Timestamp", List.of(first, second));
+        TimeStampNanoVector data = (TimeStampNanoVector) v.getDataVector();
+        assertEquals(first, data.get(0));
+        assertEquals(second, data.get(1));
+        assertEquals(
+            new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.NANOSECOND, null),
+            v.getField().getChildren().get(0).getType()
+        );
+        v.close();
+    }
+
+    public void testDateMillisMultiValue() {
+        ListVector v = writeRow(DateFieldMapper.CONTENT_TYPE, "dates", List.of(1755684000000L, 1755684005000L));
+        TimeStampMilliVector data = (TimeStampMilliVector) v.getDataVector();
+        assertEquals(1755684000000L, data.get(0));
+        assertEquals(1755684005000L, data.get(1));
+        v.close();
+    }
+
+    public void testBooleanMultiValue() {
+        ListVector v = writeRow(BooleanFieldMapper.CONTENT_TYPE, "flags", List.of(true, false, true));
+        assertElements(v, List.of(true, false, true));
+        v.close();
+    }
+
+    public void testKeywordAndTextMultiValue() {
+        ListVector kw = writeRow(KeywordFieldMapper.CONTENT_TYPE, "tags", List.of("a", "b"));
+        assertEquals("a", kw.getDataVector().getObject(0).toString());
+        assertEquals("b", kw.getDataVector().getObject(1).toString());
+        kw.close();
+
+        ListVector text = writeRow(TextFieldMapper.CONTENT_TYPE, "bodies", List.of("hello", "world"));
+        assertEquals("hello", text.getDataVector().getObject(0).toString());
+        assertEquals("world", text.getDataVector().getObject(1).toString());
+        text.close();
+    }
+
+    public void testBinaryMultiValue() {
+        byte[] one = "one".getBytes(StandardCharsets.UTF_8);
+        byte[] two = "two".getBytes(StandardCharsets.UTF_8);
+        ListVector v = writeRow(BinaryFieldMapper.CONTENT_TYPE, "blobs", List.of(one, two));
+        assertArrayEquals(one, (byte[]) v.getDataVector().getObject(0));
+        assertArrayEquals(two, (byte[]) v.getDataVector().getObject(1));
+        v.close();
+    }
+
+    /** IP addresses are encoded to their sortable 16-byte form, same as the scalar path. */
+    public void testIpMultiValue() throws Exception {
+        InetAddress first = InetAddress.getByName("10.0.0.1");
+        InetAddress second = InetAddress.getByName("10.0.0.2");
+        ListVector v = writeRow(IpFieldMapper.CONTENT_TYPE, "addrs", List.of(first, second));
+        assertEquals(16, ((byte[]) v.getDataVector().getObject(0)).length);
+        assertFalse(
+            "distinct addresses must encode differently",
+            java.util.Arrays.equals((byte[]) v.getDataVector().getObject(0), (byte[]) v.getDataVector().getObject(1))
+        );
+        v.close();
+    }
+
+    /**
+     * The whole registry is covered: every registered type either supports list storage or is a
+     * deliberate exception. A new type defaulting to unsupported should surface here rather than as a
+     * per-document indexing failure.
+     */
+    public void testEveryRegisteredTypeSupportsMultiValue() {
+        List<String> types = List.of(
+            NumberFieldMapper.NumberType.LONG.typeName(),
+            NumberFieldMapper.NumberType.INTEGER.typeName(),
+            NumberFieldMapper.NumberType.SHORT.typeName(),
+            NumberFieldMapper.NumberType.BYTE.typeName(),
+            NumberFieldMapper.NumberType.FLOAT.typeName(),
+            NumberFieldMapper.NumberType.DOUBLE.typeName(),
+            NumberFieldMapper.NumberType.HALF_FLOAT.typeName(),
+            NumberFieldMapper.NumberType.UNSIGNED_LONG.typeName(),
+            DateFieldMapper.CONTENT_TYPE,
+            DateFieldMapper.DATE_NANOS_CONTENT_TYPE,
+            BooleanFieldMapper.CONTENT_TYPE,
+            IpFieldMapper.CONTENT_TYPE,
+            KeywordFieldMapper.CONTENT_TYPE,
+            TextFieldMapper.CONTENT_TYPE,
+            BinaryFieldMapper.CONTENT_TYPE,
+            "flat_object"
+        );
+        for (String type : types) {
+            ParquetField field = ArrowFieldRegistry.getParquetField(type);
+            assertNotNull("no ParquetField registered for [" + type + "]", field);
+            assertTrue("type [" + type + "] does not support multi_value", field.supportsMultiValue());
+        }
+    }
+
+    /** A MappedFieldType carries the declared arity through to the Arrow field. */
+    public void testArityComesFromTheFieldType() {
+        MappedFieldType scalar = new KeywordFieldMapper.KeywordFieldType("scalar");
+        MappedFieldType list = new KeywordFieldMapper.KeywordFieldType("list");
+        list.setMultiValued(true);
+
+        ParquetField field = ArrowFieldRegistry.getParquetField(KeywordFieldMapper.CONTENT_TYPE);
+        assertEquals(new ArrowType.Utf8(), field.toArrowField(scalar.name(), scalar.isMultiValued()).getType());
+        assertEquals(ArrowType.List.INSTANCE, field.toArrowField(list.name(), list.isMultiValued()).getType());
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetFieldTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetFieldTests.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.fields.core.data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -65,13 +66,13 @@ public class FlatObjectParquetFieldTests extends OpenSearchTestCase {
         assertTrue(value.getFieldType().isNullable());
     }
 
-    public void testMultiValueUnsupported() {
-        // flat_object is single-arity: one MAP cell per document already holds any number of
-        // entries, so wrapping it in a LIST is rejected rather than silently mis-shaping data.
-        FlatObjectParquetField field = new FlatObjectParquetField();
-        assertFalse(field.supportsMultiValue());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> field.toArrowField("attrs", true));
-        assertTrue(e.getMessage().contains("attrs"));
+    /**
+     * Without {@code multi_value} the column stays a single MAP cell per document, which already holds
+     * any number of entries. The LIST wrapper is only added when arity is declared.
+     */
+    public void testSingleArityIsNotWrappedInList() {
+        Field arrowField = new FlatObjectParquetField().toArrowField("attrs", false);
+        assertTrue(arrowField.getType() instanceof ArrowType.Map);
     }
 
     public void testWritesEntriesPreservingOrderAndDuplicates() {
@@ -126,6 +127,128 @@ public class FlatObjectParquetFieldTests extends OpenSearchTestCase {
             result.add(new AbstractMap.SimpleEntry<>(key, value));
         }
         return result;
+    }
+
+    // ---- LIST<MAP>: one map per array element (OTel Events.Attributes) ----
+
+    /**
+     * The list element must carry the {@code entries} struct. Describing a MAP element by its ArrowType
+     * alone yields a childless MAP that allocates as an empty vector, so writes land nowhere and the
+     * column reads back empty — the failure this asserts against.
+     */
+    public void testMultiValueArrowFieldIsListOfMap() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        Field arrowField = field.toArrowField("Events.Attributes", true);
+
+        assertEquals(ArrowType.List.INSTANCE, arrowField.getType());
+        assertEquals(1, arrowField.getChildren().size());
+
+        Field element = arrowField.getChildren().get(0);
+        assertTrue("element must be a MAP", element.getType() instanceof ArrowType.Map);
+        assertTrue("element must be nullable: [{...}, null] is a legal document", element.getFieldType().isNullable());
+
+        assertEquals("element must carry its entries struct", 1, element.getChildren().size());
+        Field entries = element.getChildren().get(0);
+        assertEquals(MapVector.DATA_VECTOR_NAME, entries.getName());
+        assertFalse(entries.getFieldType().isNullable());
+        assertEquals(2, entries.getChildren().size());
+        assertEquals(MapVector.KEY_NAME, entries.getChildren().get(0).getName());
+        assertEquals(MapVector.VALUE_NAME, entries.getChildren().get(1).getName());
+    }
+
+    public void testSupportsMultiValue() {
+        assertTrue(new FlatObjectParquetField().supportsMultiValue());
+    }
+
+    /**
+     * Each array element keeps its own attribute set. Merging them into one map would lose which event
+     * an attribute belonged to, which is the whole reason this column is a LIST.
+     */
+    public void testMultiValueWritesOneMapPerElement() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        ManagedVSR vsr = createListVSR(field);
+        MappedFieldType ft = flatObjectType("Events.Attributes");
+
+        // Row 0: two events, each with its own attributes.
+        field.createField(
+            ft,
+            vsr,
+            List.of(List.of(Map.entry("exception.type", "IOError")), List.of(Map.entry("http.method", "GET"), Map.entry("retry", "1")))
+        );
+        vsr.setRowCount(1);
+        // Row 1: a single event.
+        field.createField(ft, vsr, List.of(List.of(Map.entry("k", "v"))));
+        vsr.setRowCount(2);
+
+        ListVector listVector = (ListVector) vsr.getVector("Events.Attributes");
+        MapVector mapVector = (MapVector) listVector.getDataVector();
+
+        assertEquals(2, elementCount(listVector, 0));
+        int row0 = elementStart(listVector, 0);
+        assertEquals(List.of(Map.entry("exception.type", "IOError")), mapEntries(mapVector, row0));
+        assertEquals(List.of(Map.entry("http.method", "GET"), Map.entry("retry", "1")), mapEntries(mapVector, row0 + 1));
+
+        assertEquals(1, elementCount(listVector, 1));
+        assertEquals(List.of(Map.entry("k", "v")), mapEntries(mapVector, elementStart(listVector, 1)));
+
+        cleanupVSR(vsr);
+    }
+
+    /**
+     * An absent field is a null list and an explicit empty array is a zero-length non-null list, so
+     * {@code "Attributes": []} stays distinguishable from no attributes at all.
+     */
+    public void testMultiValueNullAndEmptyList() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        ManagedVSR vsr = createListVSR(field);
+        MappedFieldType ft = flatObjectType("Events.Attributes");
+
+        field.createField(ft, vsr, null);
+        vsr.setRowCount(1);
+        field.createField(ft, vsr, List.of());
+        vsr.setRowCount(2);
+
+        ListVector listVector = (ListVector) vsr.getVector("Events.Attributes");
+        assertTrue("absent field must be a null list", listVector.isNull(0));
+        assertFalse("an explicit empty array must be non-null", listVector.isNull(1));
+        assertEquals(0, elementCount(listVector, 1));
+
+        cleanupVSR(vsr);
+    }
+
+    /** An empty attribute set on one event must not collapse that element away. */
+    public void testMultiValuePreservesEmptyElement() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        ManagedVSR vsr = createListVSR(field);
+        MappedFieldType ft = flatObjectType("Events.Attributes");
+
+        field.createField(ft, vsr, List.of(List.of(), List.of(Map.entry("a", "1"))));
+        vsr.setRowCount(1);
+
+        ListVector listVector = (ListVector) vsr.getVector("Events.Attributes");
+        MapVector mapVector = (MapVector) listVector.getDataVector();
+        assertEquals("both elements must survive", 2, elementCount(listVector, 0));
+        int start = elementStart(listVector, 0);
+        assertEquals(0, mapEntries(mapVector, start).size());
+        assertEquals(List.of(Map.entry("a", "1")), mapEntries(mapVector, start + 1));
+
+        cleanupVSR(vsr);
+    }
+
+    private static int elementStart(ListVector listVector, int row) {
+        return listVector.getOffsetBuffer().getInt((long) row * ListVector.OFFSET_WIDTH);
+    }
+
+    private static int elementCount(ListVector listVector, int row) {
+        int start = elementStart(listVector, row);
+        int end = listVector.getOffsetBuffer().getInt((long) (row + 1) * ListVector.OFFSET_WIDTH);
+        return end - start;
+    }
+
+    private ManagedVSR createListVSR(FlatObjectParquetField field) {
+        Schema schema = new Schema(List.of(field.toArrowField("Events.Attributes", true)));
+        BufferAllocator child = allocator.newChildAllocator("flat-object-list-test", 0, Long.MAX_VALUE);
+        return new ManagedVSR("flat-object-list-test", schema, child);
     }
 
     private ManagedVSR createVSR(FlatObjectParquetField field) {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetFieldTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/core/data/FlatObjectParquetFieldTests.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.fields.core.data;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.parquet.vsr.ManagedVSR;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FlatObjectParquetFieldTests extends OpenSearchTestCase {
+
+    private BufferAllocator allocator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        allocator = new RootAllocator();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        super.tearDown();
+    }
+
+    public void testArrowFieldIsMapOfUtf8() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        assertTrue(field.getArrowType() instanceof ArrowType.Map);
+        Field arrowField = field.toArrowField("attrs", false);
+        assertEquals(1, arrowField.getChildren().size());
+
+        Field entries = arrowField.getChildren().get(0);
+        assertEquals(MapVector.DATA_VECTOR_NAME, entries.getName());
+        assertFalse("entries struct must be non-nullable per the Arrow MAP spec", entries.getFieldType().isNullable());
+        assertEquals(2, entries.getChildren().size());
+
+        Field key = entries.getChildren().get(0);
+        assertEquals(MapVector.KEY_NAME, key.getName());
+        assertEquals(new ArrowType.Utf8(), key.getType());
+        assertFalse("map keys must be non-nullable per the Arrow MAP spec", key.getFieldType().isNullable());
+
+        Field value = entries.getChildren().get(1);
+        assertEquals(MapVector.VALUE_NAME, value.getName());
+        assertEquals(new ArrowType.Utf8(), value.getType());
+        assertTrue(value.getFieldType().isNullable());
+    }
+
+    public void testMultiValueUnsupported() {
+        // flat_object is single-arity: one MAP cell per document already holds any number of
+        // entries, so wrapping it in a LIST is rejected rather than silently mis-shaping data.
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        assertFalse(field.supportsMultiValue());
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> field.toArrowField("attrs", true));
+        assertTrue(e.getMessage().contains("attrs"));
+    }
+
+    public void testWritesEntriesPreservingOrderAndDuplicates() {
+        FlatObjectParquetField field = new FlatObjectParquetField();
+        MappedFieldType ft = flatObjectType("attrs");
+        ManagedVSR vsr = createVSR(field);
+
+        // Row 0: three entries including a duplicate key ({"a": [1, 2]} shape) in document order.
+        field.createField(ft, vsr, List.of(Map.entry("http.status", "500"), Map.entry("a", "1"), Map.entry("a", "2")));
+        vsr.setRowCount(1);
+        // Row 1: absent field → null cell.
+        field.createField(ft, vsr, null);
+        vsr.setRowCount(2);
+        // Row 2: explicit empty object → zero-entry, non-null map.
+        field.createField(ft, vsr, List.of());
+        vsr.setRowCount(3);
+        // Row 3: a null value inside an entry stays null, key is preserved.
+        field.createField(ft, vsr, List.of(new AbstractMap.SimpleEntry<String, String>("missing", null)));
+        vsr.setRowCount(4);
+
+        MapVector mapVector = (MapVector) vsr.getVector("attrs");
+        assertEquals(
+            List.of(Map.entry("http.status", "500"), Map.entry("a", "1"), Map.entry("a", "2")),
+            mapEntries(mapVector, 0).stream().map(e -> Map.entry(e.getKey(), e.getValue())).toList()
+        );
+        assertTrue("absent field must read back as a null map", mapVector.isNull(1));
+        assertFalse("empty object must read back as a non-null map", mapVector.isNull(2));
+        assertEquals(0, mapEntries(mapVector, 2).size());
+        List<Map.Entry<String, String>> row3 = mapEntries(mapVector, 3);
+        assertEquals(1, row3.size());
+        assertEquals("missing", row3.get(0).getKey());
+        assertNull(row3.get(0).getValue());
+
+        cleanupVSR(vsr);
+    }
+
+    private static MappedFieldType flatObjectType(String name) {
+        return new FlatObjectFieldMapper.FlatObjectFieldType(name, null, true, true);
+    }
+
+    /** Reads back one row of a map vector as (key, value) pairs, preserving order and duplicates. */
+    private static List<Map.Entry<String, String>> mapEntries(MapVector mapVector, int row) {
+        int start = mapVector.getOffsetBuffer().getInt((long) row * 4);
+        int end = mapVector.getOffsetBuffer().getInt((long) (row + 1) * 4);
+        StructVector entries = (StructVector) mapVector.getDataVector();
+        VarCharVector keys = (VarCharVector) entries.getChild(MapVector.KEY_NAME);
+        VarCharVector values = (VarCharVector) entries.getChild(MapVector.VALUE_NAME);
+        List<Map.Entry<String, String>> result = new ArrayList<>(end - start);
+        for (int i = start; i < end; i++) {
+            String key = new String(keys.get(i), StandardCharsets.UTF_8);
+            String value = values.isNull(i) ? null : new String(values.get(i), StandardCharsets.UTF_8);
+            result.add(new AbstractMap.SimpleEntry<>(key, value));
+        }
+        return result;
+    }
+
+    private ManagedVSR createVSR(FlatObjectParquetField field) {
+        Schema schema = new Schema(List.of(field.toArrowField("attrs", false)));
+        BufferAllocator child = allocator.newChildAllocator("flat-object-test", 0, Long.MAX_VALUE);
+        return new ManagedVSR("flat-object-test", schema, child);
+    }
+
+    private void cleanupVSR(ManagedVSR vsr) {
+        vsr.moveToFrozen();
+        vsr.close();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPluginTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/fields/plugins/CoreDataFieldPluginTests.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.fields.plugins;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
 import org.opensearch.index.mapper.IpFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -31,8 +32,9 @@ public class CoreDataFieldPluginTests extends OpenSearchTestCase {
     }
 
     public void testFieldCount() {
-        // 10 numeric + 2 temporal + 1 boolean + 3 text + 1 binary = 17
-        assertEquals(18, fields.size());
+        // 10 numeric + 2 temporal + 1 boolean + 4 text (text, keyword, ip, match_only_text) + 1 binary
+        // + 1 flat_object = 19
+        assertEquals(19, fields.size());
     }
 
     public void testAllNumericTypesPresent() {
@@ -57,6 +59,10 @@ public class CoreDataFieldPluginTests extends OpenSearchTestCase {
     public void testBooleanAndBinaryPresent() {
         assertNotNull(fields.get(BooleanFieldMapper.CONTENT_TYPE));
         assertNotNull(fields.get(BinaryFieldMapper.CONTENT_TYPE));
+    }
+
+    public void testObjectTypesPresent() {
+        assertNotNull(fields.get(FlatObjectFieldMapper.CONTENT_TYPE));
     }
 
     public void testAllValuesNonNull() {

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -28,11 +30,14 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.fields.core.data.text.KeywordParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -570,6 +575,138 @@ public class VSRManagerTests extends ParquetBaseTests {
         } finally {
             manager.close();
         }
+    }
+
+    public void testMultiValueFieldWritesListColumn() throws Exception {
+        String filePath = createTempDir().resolve("multi-value.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            // Mapping update introduces a keyword field declared multi-valued, so it arrives as a
+            // LIST<Utf8> rather than a flat Utf8 column.
+            manager.reconcileSchema(schemaWithMultiValue("tags"));
+
+            KeywordFieldMapper.KeywordFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+            tags.setMultiValued(true);
+            assignTestCapabilities(tags, PARQUET_FORMAT);
+            NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+            assignTestCapabilities(valField, PARQUET_FORMAT);
+
+            // Row 0: three values including a duplicate. Row 1: field absent entirely.
+            // Row 2: a single value. Covers the three cardinalities in one file.
+            ParquetDocumentInput doc0 = new ParquetDocumentInput();
+            populateMetadataFields(doc0);
+            doc0.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc0.addField(valField, 1);
+            doc0.addField(tags, "b");
+            doc0.addField(tags, "a");
+            doc0.addField(tags, "b");
+            manager.addDocument(doc0);
+
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+            doc1.addField(valField, 2);
+            manager.addDocument(doc1);
+
+            ParquetDocumentInput doc2 = new ParquetDocumentInput();
+            populateMetadataFields(doc2);
+            doc2.setRowId(DocumentInput.ROW_ID_FIELD, 2);
+            doc2.addField(valField, 3);
+            doc2.addField(tags, "solo");
+            manager.addDocument(doc2);
+
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertEquals(List.of("b", "a", "b"), listElements(listVector, 0));
+            assertTrue("absent field must read back as a null list", listVector.isNull(1));
+            assertEquals(List.of("solo"), listElements(listVector, 2));
+
+            ParquetFileMetadata metadata = manager.flush();
+            assertNotNull(metadata);
+            assertEquals(3, metadata.numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    public void testMultiValueFieldWritesEmptyListDistinctFromAbsent() throws Exception {
+        String filePath = createTempDir().resolve("multi-value-empty.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            manager.reconcileSchema(schemaWithMultiValue("tags"));
+            NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
+            assignTestCapabilities(valField, PARQUET_FORMAT);
+
+            // An explicit "tags": [] parses to zero addField calls, so the writer never sees the
+            // field and the row is null — same as absent. Documented here so the distinction
+            // between [] and absent is a deliberate, tested choice rather than an accident.
+            ParquetDocumentInput doc = new ParquetDocumentInput();
+            populateMetadataFields(doc);
+            doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc.addField(valField, 1);
+            manager.addDocument(doc);
+
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertTrue(listVector.isNull(0));
+            assertEquals(1, manager.flush().numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    public void testReconcileSchemaPreservesListChildren() throws Exception {
+        String filePath = createTempDir().resolve("reconcile-children.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            assertTrue(manager.reconcileSchema(schemaWithMultiValue("tags")));
+
+            // reconcileSchema used to rebuild each Field from name + FieldType, dropping children
+            // and leaving a ListVector with no element vector to write into.
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
+            assertNotNull(listVector);
+            // A dropped child would leave the data vector as an uninitialized ZeroVector.
+            assertTrue(
+                "list vector must have a typed element vector, got " + listVector.getDataVector().getClass().getSimpleName(),
+                listVector.getDataVector() instanceof VarCharVector
+            );
+
+            // Assert on the VSR *schema* rather than the vector's own field: Arrow Java renames a
+            // list vector's child to "$data$" internally, but the schema — which is what
+            // exportSchema hands to the native writer, and therefore what determines the Parquet
+            // leaf path "tags.list.element" — keeps the declared name.
+            Field tagsField = manager.getActiveManagedVSR()
+                .getSchema()
+                .getFields()
+                .stream()
+                .filter(f -> f.getName().equals("tags"))
+                .findFirst()
+                .orElseThrow();
+            assertEquals(ArrowType.List.INSTANCE, tagsField.getType());
+            assertEquals(1, tagsField.getChildren().size());
+            assertEquals(ParquetField.LIST_ELEMENT_NAME, tagsField.getChildren().get(0).getName());
+            assertEquals(new ArrowType.Utf8(), tagsField.getChildren().get(0).getType());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /** Reads back the elements of one row of a list vector. */
+    private static List<String> listElements(ListVector listVector, int row) {
+        int start = listVector.getOffsetBuffer().getInt((long) row * 4);
+        int end = listVector.getOffsetBuffer().getInt((long) (row + 1) * 4);
+        VarCharVector data = (VarCharVector) listVector.getDataVector();
+        List<String> values = new ArrayList<>(end - start);
+        for (int i = start; i < end; i++) {
+            values.add(new String(data.get(i), StandardCharsets.UTF_8));
+        }
+        return values;
+    }
+
+    /** Test schema plus metadata fields plus a keyword field declared multi-valued. */
+    private Schema schemaWithMultiValue(String name) {
+        List<Field> fields = new ArrayList<>(schema.getFields());
+        fields.addAll(metadataFields());
+        fields.add(new KeywordParquetField().toArrowField(name, true));
+        return new Schema(fields);
     }
 
     /** Returns a copy of the test schema with one extra field appended (alongside metadata fields). */

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -711,6 +711,77 @@ public class VSRManagerTests extends ParquetBaseTests {
         }
     }
 
+    /**
+     * A multi_value flat_object writes {@code LIST<MAP>}, one map per array element — the OTel
+     * {@code Events.Attributes} shape. The flush is the real assertion: a malformed element type (a MAP
+     * described without its {@code entries} struct) survives allocation but fails at export, so only a
+     * completed native write proves the schema is well-formed.
+     */
+    public void testFlatObjectMultiValueWritesListOfMapThroughNativeWriter() throws Exception {
+        String filePath = createTempDir().resolve("flat-object-list-map.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            List<Field> fields = new ArrayList<>(schema.getFields());
+            fields.addAll(metadataFields());
+            fields.add(new FlatObjectParquetField().toArrowField("Events.Attributes", true));
+            manager.reconcileSchema(new Schema(fields));
+
+            FlatObjectFieldMapper.FlatObjectFieldType attrs = new FlatObjectFieldMapper.FlatObjectFieldType(
+                "Events.Attributes",
+                null,
+                true,
+                true
+            );
+            attrs.setMultiValued(true);
+            assignTestCapabilities(attrs, PARQUET_FORMAT);
+            NumberFieldMapper.NumberFieldType valField = createNumberField("val", NumberFieldMapper.NumberType.INTEGER);
+
+            // Row 0: two events, each contributing its own attribute set via a separate addField call,
+            // exactly as the document parser hands over the elements of an array.
+            ParquetDocumentInput doc0 = new ParquetDocumentInput();
+            populateMetadataFields(doc0);
+            doc0.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc0.addField(valField, 1);
+            doc0.addField(attrs, List.of(Map.entry("exception.type", "IOError")));
+            doc0.addField(attrs, List.of(Map.entry("http.method", "GET"), Map.entry("retry", "1")));
+            manager.addDocument(doc0);
+
+            // Row 1: no events at all.
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+            doc1.addField(valField, 2);
+            manager.addDocument(doc1);
+
+            ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("Events.Attributes");
+            assertTrue("the element vector must be a MapVector", listVector.getDataVector() instanceof MapVector);
+            assertFalse(listVector.isNull(0));
+            assertTrue("a document with no events must read back as a null list", listVector.isNull(1));
+
+            MapVector maps = (MapVector) listVector.getDataVector();
+            int start = listVector.getOffsetBuffer().getInt(0);
+            int end = listVector.getOffsetBuffer().getInt(ListVector.OFFSET_WIDTH);
+            assertEquals("two events", 2, end - start);
+            // Element 0 has one attribute, element 1 has two: the counts stay separate per event.
+            assertEquals(
+                1,
+                maps.getOffsetBuffer().getInt((long) (start + 1) * MapVector.OFFSET_WIDTH) - maps.getOffsetBuffer()
+                    .getInt((long) start * MapVector.OFFSET_WIDTH)
+            );
+            assertEquals(
+                2,
+                maps.getOffsetBuffer().getInt((long) (start + 2) * MapVector.OFFSET_WIDTH) - maps.getOffsetBuffer()
+                    .getInt((long) (start + 1) * MapVector.OFFSET_WIDTH)
+            );
+
+            ParquetFileMetadata metadata = manager.flush();
+            assertNotNull(metadata);
+            assertEquals(2, metadata.numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
     public void testReconcileSchemaPreservesListChildren() throws Exception {
         String filePath = createTempDir().resolve("reconcile-children.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -11,6 +11,7 @@ package org.opensearch.parquet.vsr;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -23,6 +24,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.FlatObjectFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetBaseTests;
@@ -31,6 +33,7 @@ import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.fields.ParquetField;
+import org.opensearch.parquet.fields.core.data.FlatObjectParquetField;
 import org.opensearch.parquet.fields.core.data.text.KeywordParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
@@ -40,6 +43,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 public class VSRManagerTests extends ParquetBaseTests {
@@ -648,6 +652,60 @@ public class VSRManagerTests extends ParquetBaseTests {
             ListVector listVector = (ListVector) manager.getActiveManagedVSR().getVector("tags");
             assertTrue(listVector.isNull(0));
             assertEquals(1, manager.flush().numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    public void testFlatObjectFieldWritesMapColumnThroughNativeWriter() throws Exception {
+        String filePath = createTempDir().resolve("flat-object-map.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 100, threadPool, 0L);
+        try {
+            // Mapping update introduces a flat_object field, which arrives as a MAP<Utf8, Utf8>
+            // column rather than a flat column.
+            List<Field> fields = new ArrayList<>(schema.getFields());
+            fields.addAll(metadataFields());
+            fields.add(new FlatObjectParquetField().toArrowField("attrs", false));
+            manager.reconcileSchema(new Schema(fields));
+
+            FlatObjectFieldMapper.FlatObjectFieldType attrs = new FlatObjectFieldMapper.FlatObjectFieldType("attrs", null, true, true);
+            assignTestCapabilities(attrs, PARQUET_FORMAT);
+            NumberFieldMapper.NumberFieldType valField = createNumberField("val", NumberFieldMapper.NumberType.INTEGER);
+
+            // Row 0: two entries plus a duplicate key. Row 1: field absent. Row 2: empty object.
+            ParquetDocumentInput doc0 = new ParquetDocumentInput();
+            populateMetadataFields(doc0);
+            doc0.setRowId(DocumentInput.ROW_ID_FIELD, 0);
+            doc0.addField(valField, 1);
+            doc0.addField(attrs, List.of(Map.entry("http.status", "500"), Map.entry("pod", "web-1"), Map.entry("pod", "web-2")));
+            manager.addDocument(doc0);
+
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+            doc1.addField(valField, 2);
+            manager.addDocument(doc1);
+
+            ParquetDocumentInput doc2 = new ParquetDocumentInput();
+            populateMetadataFields(doc2);
+            doc2.setRowId(DocumentInput.ROW_ID_FIELD, 2);
+            doc2.addField(valField, 3);
+            doc2.addField(attrs, List.of());
+            manager.addDocument(doc2);
+
+            MapVector mapVector = (MapVector) manager.getActiveManagedVSR().getVector("attrs");
+            assertFalse(mapVector.isNull(0));
+            assertTrue("absent field must read back as a null map", mapVector.isNull(1));
+            assertFalse("empty object must read back as a non-null map", mapVector.isNull(2));
+            int row0Start = mapVector.getOffsetBuffer().getInt(0);
+            int row0End = mapVector.getOffsetBuffer().getInt(4);
+            assertEquals(3, row0End - row0Start);
+
+            // The flush is the real assertion: the C Data Interface export and the native arrow-rs
+            // writer must both accept the MAP column.
+            ParquetFileMetadata metadata = manager.flush();
+            assertNotNull(metadata);
+            assertEquals(3, metadata.numRows());
         } finally {
             manager.close();
         }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRPreAllocationTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRPreAllocationTests.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.vsr;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Measures throughput difference between default (grow-on-demand) and
+ * pre-allocated Arrow VectorSchemaRoot for variable-width fields.
+ *
+ * This validates that pre-allocation eliminates reallocDataBuffer calls
+ * during the hot indexing loop, reducing both memcpy and allocator lock pressure.
+ */
+public class VSRPreAllocationTests extends OpenSearchTestCase {
+
+    private static final int BATCH_SIZE = 8192;
+    private static final int NUM_VARCHAR_FIELDS = 10;
+    private static final int AVG_VALUE_BYTES = 20;
+    private static final int WARMUP_ITERATIONS = 5;
+    private static final int MEASURE_ITERATIONS = 20;
+
+    public void testPreAllocationThroughputImprovement() {
+        Schema schema = buildSchema(NUM_VARCHAR_FIELDS);
+        byte[][] values = generateValues(BATCH_SIZE, AVG_VALUE_BYTES);
+
+        try (RootAllocator root = new RootAllocator(Long.MAX_VALUE)) {
+            // Warmup
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                runDefaultAllocation(root, schema, values);
+                runPreAllocated(root, schema, values);
+            }
+
+            // Measure default (grow-on-demand)
+            long defaultTotalNs = 0;
+            for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+                defaultTotalNs += runDefaultAllocation(root, schema, values);
+            }
+
+            // Measure pre-allocated
+            long preAllocTotalNs = 0;
+            for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+                preAllocTotalNs += runPreAllocated(root, schema, values);
+            }
+
+            double defaultAvgMs = (defaultTotalNs / MEASURE_ITERATIONS) / 1_000_000.0;
+            double preAllocAvgMs = (preAllocTotalNs / MEASURE_ITERATIONS) / 1_000_000.0;
+            double speedup = defaultAvgMs / preAllocAvgMs;
+
+            logger.info("=== VSR Pre-Allocation Benchmark ===");
+            logger.info("Schema: {} varchar fields, batch size: {}, avg value: {} bytes", NUM_VARCHAR_FIELDS, BATCH_SIZE, AVG_VALUE_BYTES);
+            logger.info("Default (grow-on-demand): {:.2f} ms per batch", defaultAvgMs);
+            logger.info("Pre-allocated:            {:.2f} ms per batch", preAllocAvgMs);
+            logger.info("Speedup:                  {:.2f}x", speedup);
+            logger.info("====================================");
+
+            // Assert meaningful improvement
+            assertTrue(
+                "Pre-allocation should be faster than grow-on-demand. Default: " + defaultAvgMs + "ms, PreAlloc: " + preAllocAvgMs + "ms",
+                preAllocAvgMs < defaultAvgMs
+            );
+        }
+    }
+
+    /**
+     * Default path: VectorSchemaRoot.create() with no pre-allocation.
+     * Vectors start at minimal capacity and reallocate on each overflow.
+     */
+    private long runDefaultAllocation(BufferAllocator root, Schema schema, byte[][] values) {
+        try (BufferAllocator child = root.newChildAllocator("default-" + System.nanoTime(), 0, Long.MAX_VALUE)) {
+            long start = System.nanoTime();
+
+            VectorSchemaRoot vsr = VectorSchemaRoot.create(schema, child);
+            fillVSR(vsr, values);
+            vsr.close();
+
+            return System.nanoTime() - start;
+        }
+    }
+
+    /**
+     * Pre-allocated path: only offset + validity buffers are pre-sized to final row capacity.
+     * Data buffer stays grow-on-demand (content-dependent, doubling strategy is efficient).
+     * This eliminates row-count-boundary reallocs without over-provisioning data.
+     */
+    private long runPreAllocated(BufferAllocator root, Schema schema, byte[][] values) {
+        try (BufferAllocator child = root.newChildAllocator("prealloc-" + System.nanoTime(), 0, Long.MAX_VALUE)) {
+            long start = System.nanoTime();
+
+            VectorSchemaRoot vsr = VectorSchemaRoot.create(schema, child);
+            for (int i = 0; i < vsr.getFieldVectors().size(); i++) {
+                if (vsr.getFieldVectors().get(i) instanceof BaseVariableWidthVector varVector) {
+                    varVector.setInitialCapacity(BATCH_SIZE);
+                    varVector.allocateNew();
+                }
+            }
+            fillVSR(vsr, values);
+            vsr.close();
+
+            return System.nanoTime() - start;
+        }
+    }
+
+    private void fillVSR(VectorSchemaRoot vsr, byte[][] values) {
+        List<VarCharVector> vectors = new ArrayList<>();
+        for (int i = 0; i < vsr.getFieldVectors().size(); i++) {
+            vectors.add((VarCharVector) vsr.getFieldVectors().get(i));
+        }
+
+        for (int row = 0; row < BATCH_SIZE; row++) {
+            for (VarCharVector vector : vectors) {
+                vector.setSafe(row, values[row]);
+            }
+        }
+        vsr.setRowCount(BATCH_SIZE);
+    }
+
+    private Schema buildSchema(int numFields) {
+        List<Field> fields = new ArrayList<>();
+        for (int i = 0; i < numFields; i++) {
+            fields.add(new Field("field_" + i, FieldType.nullable(ArrowType.Utf8.INSTANCE), null));
+        }
+        return new Schema(fields);
+    }
+
+    private byte[][] generateValues(int count, int avgBytes) {
+        Random rng = new Random(42);
+        byte[][] values = new byte[count][];
+        for (int i = 0; i < count; i++) {
+            int len = Math.max(1, avgBytes + rng.nextInt(avgBytes) - avgBytes / 2);
+            byte[] v = new byte[len];
+            for (int j = 0; j < len; j++) {
+                v[j] = (byte) ('a' + rng.nextInt(26));
+            }
+            values[i] = v;
+        }
+        return values;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -230,4 +230,131 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
             .findFirst()
             .orElseThrow(() -> new AssertionError("no collected field named " + fieldName));
     }
+
+    // ---- correlated-group array-length validation ----
+
+    /**
+     * A multi_value keyword field stamped as a member of {@code group}, standing in for a sub-field of
+     * an object declared {@code nested} with {@code correlated: true} (which applies the stamp at
+     * mapping build time).
+     */
+    private MappedFieldType groupField(String name, String group) {
+        MappedFieldType ft = new KeywordFieldMapper.KeywordFieldType(name);
+        ft.setMultiValued(true);
+        ft.setCorrelationGroup(group);
+        assignTestCapabilities(ft, PARQUET_FORMAT);
+        return ft;
+    }
+
+    /**
+     * Equal array lengths within a group are accepted: each field is a separate LIST column, and index
+     * i of one describing the same element as index i of the others is exactly the invariant being
+     * preserved.
+     */
+    public void testCorrelatedGroupWithEqualLengthsIsAccepted() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType names = groupField("Events.Name", "Events");
+        MappedFieldType kinds = groupField("Events.Kind", "Events");
+        input.addField(names, "a");
+        input.addField(names, "b");
+        input.addField(kinds, "k1");
+        input.addField(kinds, "k2");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        assertFalse(input.getFinalInput().isEmpty());
+    }
+
+    /**
+     * Differing lengths are rejected. Without this the document writes cleanly and reads back
+     * mispaired — Events.Name[1] would be attributed to the element described by Events.Kind[1],
+     * which belongs to a different event. ClickHouse refuses the equivalent insert into a Nested
+     * column for the same reason.
+     */
+    public void testCorrelatedGroupWithUnequalLengthsIsRejected() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType names = groupField("Events.Name", "Events");
+        MappedFieldType kinds = groupField("Events.Kind", "Events");
+        input.addField(names, "a");
+        input.addField(names, "b");
+        input.addField(kinds, "k1");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        MapperParsingException e = expectThrows(MapperParsingException.class, input::getFinalInput);
+        assertTrue("expected the group name in the message: " + e.getMessage(), e.getMessage().contains("Events"));
+        assertTrue("expected both counts in the message: " + e.getMessage(), e.getMessage().contains("2") && e.getMessage().contains("1"));
+        assertTrue(
+            "expected both field names in the message: " + e.getMessage(),
+            e.getMessage().contains("Events.Name") && e.getMessage().contains("Events.Kind")
+        );
+    }
+
+    /**
+     * A sub-field the document never mentions is exempt: with no values at all there is nothing to
+     * mispair, so requiring its presence would reject legitimate documents such as an event batch
+     * carrying no attributes.
+     */
+    public void testCorrelatedGroupIgnoresAbsentSubFields() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType names = groupField("Events.Name", "Events");
+        input.addField(names, "a");
+        input.addField(names, "b");
+        // Events.Kind is simply not in this document.
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        assertFalse(input.getFinalInput().isEmpty());
+    }
+
+    /** Unstamped fields, and single-valued fields, are never compared. */
+    public void testValidationIgnoresUngroupedAndSingleValuedFields() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType names = groupField("Events.Name", "Events");
+        input.addField(names, "a");
+        input.addField(names, "b");
+        // Stamped with the same group but single-valued: it holds one value by definition, so it is
+        // not a mismatched array and must not constrain its multi-valued siblings.
+        MappedFieldType scalar = new KeywordFieldMapper.KeywordFieldType("Events.Scalar");
+        scalar.setCorrelationGroup("Events");
+        assignTestCapabilities(scalar, PARQUET_FORMAT);
+        input.addField(scalar, "s");
+        // A multi_value field in no group at all.
+        MappedFieldType ungrouped = new KeywordFieldMapper.KeywordFieldType("Tags");
+        ungrouped.setMultiValued(true);
+        assignTestCapabilities(ungrouped, PARQUET_FORMAT);
+        input.addField(ungrouped, "t");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        assertFalse(input.getFinalInput().isEmpty());
+    }
+
+    /** Groups are independent: Links having a different length than Events is not a conflict. */
+    public void testGroupsAreValidatedIndependently() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType eventNames = groupField("Events.Name", "Events");
+        input.addField(eventNames, "a");
+        input.addField(eventNames, "b");
+        MappedFieldType linkIds = groupField("Links.TraceId", "Links");
+        input.addField(linkIds, "t1");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        assertFalse(input.getFinalInput().isEmpty());
+    }
+
+    /**
+     * Membership comes from the stamp, not the field name, so a same-prefixed field belonging to no
+     * group is unaffected — there is no path-prefix matching to get wrong.
+     */
+    public void testMembershipIsByStampNotByNamePrefix() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType names = groupField("Events.Name", "Events");
+        input.addField(names, "a");
+        input.addField(names, "b");
+        MappedFieldType lookalike = new KeywordFieldMapper.KeywordFieldType("Events.Unstamped");
+        lookalike.setMultiValued(true);
+        assignTestCapabilities(lookalike, PARQUET_FORMAT);
+        input.addField(lookalike, "x");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        assertFalse(input.getFinalInput().isEmpty());
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -147,6 +147,34 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         assertEquals(0L, input.getFieldCount("tags"));
     }
 
+    public void testMultiValueAccumulationKeyedByNameNotInstanceIdentity() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        // Two DISTINCT field-type instances that share a name, as could arise if the parse path ever
+        // handed back a fresh wrapper per array element. Accumulation keys on the name, so both
+        // elements must land in the SAME list rather than the second creating a new pair (which
+        // would silently degrade multi_value to last-value-wins).
+        MappedFieldType first = new KeywordFieldMapper.KeywordFieldType("tags");
+        first.setMultiValued(true);
+        assignTestCapabilities(first, PARQUET_FORMAT);
+        MappedFieldType second = new KeywordFieldMapper.KeywordFieldType("tags");
+        second.setMultiValued(true);
+        assignTestCapabilities(second, PARQUET_FORMAT);
+        assertNotSame(first, second);
+
+        input.addField(first, "a");
+        input.addField(second, "b");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        assertEquals(
+            "both elements must accumulate into one pair",
+            1,
+            input.getFinalInput().stream().filter(p -> p.getFieldType().name().equals("tags")).count()
+        );
+        FieldValuePair pair = findPair(input, "tags");
+        assertEquals(List.of("a", "b"), pair.getValue());
+    }
+
     public void testUndeclaredFieldStillRejectsMultipleValues() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         populateMetadataFields(input);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -86,4 +86,99 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         input.addField(valField, 10);
         expectThrows(MapperParsingException.class, () -> input.addField(valField, 20));
     }
+
+    public void testDeclaredMultiValueFieldAccumulatesValuesInOrder() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        // The document parser reports one addField call per array element.
+        input.addField(tags, "b");
+        input.addField(tags, "a");
+        input.addField(tags, "b");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        // Document order and duplicates are preserved: the values are the source of truth for
+        // derived _source, so they must not be sorted or deduplicated.
+        assertEquals(List.of("b", "a", "b"), pair.getValue());
+        assertEquals(3, pair.valueCount());
+        assertEquals(3L, input.getFieldCount("tags"));
+    }
+
+    public void testDeclaredMultiValueFieldWithSingleValueIsStillAList() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        input.addField(tags, "solo");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        // A scalar JSON value on a declared list column still writes a one-element list, so the
+        // column type stays consistent across documents.
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of("solo"), pair.getValue());
+    }
+
+    public void testUndeclaredFieldStillRejectsMultipleValues() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType other = new KeywordFieldMapper.KeywordFieldType("other");
+        assignTestCapabilities(other, PARQUET_FORMAT);
+
+        input.addField(other, "one");
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> input.addField(other, "two"));
+        assertTrue(e.getMessage().contains("multi_value"));
+    }
+
+    public void testMultiValueFieldCountIsValueCountNotEntryCount() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+        input.addField(tags, "x");
+        input.addField(tags, "y");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        // Metadata fields must still count as exactly one so getFinalInput's assertions hold.
+        assertEquals(1L, input.getFieldCount(org.opensearch.index.mapper.IdFieldMapper.NAME));
+        assertEquals(2L, input.getFieldCount("tags"));
+        // One collected entry holding two values.
+        assertEquals(5, input.getFinalInput().size());
+    }
+
+    public void testDerivedSourceCompanionFieldFollowsParentCardinality() {
+        // KeywordFieldMapper emits "_ignored_source.<field>" alongside the parent when a normalizer
+        // or ignore_above alters the value, and buildRawKeywordValueFieldType copies the parent's
+        // multi_value flag onto it, so the document input must accumulate its values too —
+        // otherwise it would reject the second value while its own column expects a list.
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType rawValue = new KeywordFieldMapper.KeywordFieldType("_ignored_source.tags");
+        rawValue.setMultiValued(true);
+        assignTestCapabilities(rawValue, PARQUET_FORMAT);
+
+        input.addField(rawValue, "RAW-ONE");
+        input.addField(rawValue, "RAW-TWO");
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "_ignored_source.tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of("RAW-ONE", "RAW-TWO"), pair.getValue());
+    }
+
+    private static FieldValuePair findPair(ParquetDocumentInput input, String fieldName) {
+        return input.getFinalInput()
+            .stream()
+            .filter(p -> p.getFieldType().name().equals(fieldName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no collected field named " + fieldName));
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -126,6 +126,27 @@ public class ParquetDocumentInputTests extends ParquetBaseTests {
         assertEquals(List.of("solo"), pair.getValue());
     }
 
+    public void testDeclaredMultiValueFieldWithEmptyArrayIsPresentEmptyList() {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        populateMetadataFields(input);
+        MappedFieldType tags = new KeywordFieldMapper.KeywordFieldType("tags");
+        tags.setMultiValued(true);
+        assignTestCapabilities(tags, PARQUET_FORMAT);
+
+        // The parser signals an explicit empty array ("tags": []) with an empty List value. It must
+        // seed a present, zero-value list (written as an empty-but-non-null LIST cell) rather than
+        // being dropped, so an empty array stays distinct from an absent field in reconstructed
+        // _source.
+        input.addField(tags, List.of());
+        input.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+
+        FieldValuePair pair = findPair(input, "tags");
+        assertTrue(pair.isMultiValued());
+        assertEquals(List.of(), pair.getValue());
+        assertEquals(0, pair.valueCount());
+        assertEquals(0L, input.getFieldCount("tags"));
+    }
+
     public void testUndeclaredFieldStillRejectsMultipleValues() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         populateMetadataFields(input);

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OtelFlattenedAttributesIndexingIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OtelFlattenedAttributesIndexingIT.java
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end indexing verification for {@code flat_object} attribute maps on a real cluster, using the
+ * OpenTelemetry-logs ("Textbench") mapping shape over the shared 100-document {@code otel_logs} dataset.
+ *
+ * <p>This is the outermost verification layer for the flat_object → Parquet {@code MAP<utf8, utf8>}
+ * column: unlike the unit tests and the {@code internalClusterTest} suite, it runs against a fully
+ * assembled node with the analytics, composite-engine and parquet-data-format plugins installed and
+ * drives everything over the REST API, exactly as a benchmark client would. It therefore covers the
+ * pieces only a real node exercises — plugin wiring and capability assignment across the composite
+ * primary/secondary formats, the bulk path, and flush plus force-merge of MAP columns through the
+ * native writer.
+ *
+ * <p>The documents are the real OTel corpus already used by {@link OtelLogsPplIT}; only the mapping
+ * differs. Where that dataset declares {@code resource}, {@code log} and {@code instrumentationScope}
+ * as explicit object trees, here they are {@code flat_object}, which is how an OTel pipeline models
+ * attribute bags whose keys are not known up front. The corpus is a good stress for that: {@code
+ * resource} alone carries nine sub-trees and the documents span five services, so key sets differ from
+ * document to document — the case a fixed-schema column cannot express.
+ *
+ * <p>Scope: indexing. Values are asserted to be accepted and durable across bulk → flush →
+ * force-merge; projecting them back is the columnar read path's job and is not wired yet (see
+ * {@code FlatObjectMapColumnIT#testAttributesAreNotYetReturnedInSource}).
+ */
+public class OtelFlattenedAttributesIndexingIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "otel_logs_flattened";
+    private static final int EXPECTED_DOCS = 100;
+
+    /**
+     * The Textbench mapping shape: scalars typed as in the OTel spec, and every attribute bag typed
+     * {@code flat_object} so it becomes a single Parquet MAP column. Composite/parquet settings match
+     * what {@link DatasetProvisioner} injects for the other datasets.
+     */
+    private static final String MAPPING = "{"
+        + "\"settings\":{"
+        + "  \"index.pluggable.dataformat.enabled\": true,"
+        + "  \"index.pluggable.dataformat\": \"composite\","
+        + "  \"index.composite.primary_data_format\": \"parquet\","
+        + "  \"index.composite.secondary_data_formats\": [\"lucene\"],"
+        + "  \"number_of_shards\": 1,"
+        + "  \"number_of_replicas\": 0"
+        + "},"
+        + "\"mappings\":{\"properties\":{"
+        + "  \"time\":{\"type\":\"date\"},"
+        + "  \"observedTimestamp\":{\"type\":\"date\"},"
+        + "  \"traceId\":{\"type\":\"keyword\"},"
+        + "  \"spanId\":{\"type\":\"keyword\"},"
+        + "  \"flags\":{\"type\":\"byte\"},"
+        + "  \"severityText\":{\"type\":\"keyword\"},"
+        + "  \"severityNumber\":{\"type\":\"byte\"},"
+        + "  \"serviceName\":{\"type\":\"keyword\"},"
+        + "  \"body\":{\"type\":\"text\"},"
+        + "  \"droppedAttributesCount\":{\"type\":\"long\"},"
+        + "  \"schemaUrl\":{\"type\":\"keyword\"},"
+        // The three attribute bags — the point of this test.
+        + "  \"resource\":{\"type\":\"flat_object\"},"
+        + "  \"log\":{\"type\":\"flat_object\"},"
+        + "  \"instrumentationScope\":{\"type\":\"flat_object\"}"
+        + "}}}";
+
+    /**
+     * Creates the index, or fails the test with the server's explanation if the mapping is rejected.
+     * <p>
+     * The suite preserves indices between test methods ({@code preserveIndicesUponCompletion}), so the
+     * index is dropped first to keep each method independent of execution order.
+     */
+    private void createFlattenedIndex() throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (ResponseException e) {
+            // 404 on the first run: nothing to drop.
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity(MAPPING);
+        try {
+            assertOkAndParse(client().performRequest(create), "create " + INDEX);
+        } catch (ResponseException e) {
+            fail("flat_object mapping must be accepted on a composite parquet index, but got: " + e.getMessage());
+        }
+    }
+
+    /** Bulk-indexes the shared OTel corpus, asserting the server reported no per-item failures. */
+    private void bulkIndexOtelCorpus() throws IOException {
+        String ndjson = DatasetProvisioner.loadResource(OtelLogsTestHelper.DATASET.bulkResourcePath());
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(ndjson);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(bulk), "bulk into " + INDEX);
+        // "errors" is the only signal that individual documents were rejected; a 200 alone would hide
+        // per-item mapper failures, which is exactly how a silently-dropped attribute bag would look.
+        assertEquals("bulk must not report any item failures: " + response.get("items"), Boolean.FALSE, response.get("errors"));
+    }
+
+    private long docCount() throws IOException {
+        Response response = client().performRequest(new Request("GET", "/" + INDEX + "/_stats"));
+        Map<String, Object> stats = assertOkAndParse(response, "stats for " + INDEX);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> indices = (Map<String, Object>) stats.get("indices");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> index = (Map<String, Object>) indices.get(INDEX);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> total = (Map<String, Object>) index.get("total");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> docs = (Map<String, Object>) total.get("docs");
+        return ((Number) docs.get("count")).longValue();
+    }
+
+    private void flush() throws IOException {
+        Request flush = new Request("POST", "/" + INDEX + "/_flush");
+        flush.addParameter("force", "true");
+        client().performRequest(flush);
+    }
+
+    /**
+     * The full lifecycle a benchmark run performs: create with flat_object attribute bags, bulk-index
+     * the corpus, flush, then force-merge to a single segment. Force-merge is the stage that most
+     * specifically exercises this change, because the native merge has to resolve an attribute column
+     * to its two parquet leaves ({@code entries.key} and {@code entries.value}) rather than one.
+     */
+    public void testOtelCorpusIndexesWithFlattenedAttributeBags() throws IOException {
+        createFlattenedIndex();
+
+        // Mapping round-trips: the attribute bags stay flat_object rather than being turned into
+        // dynamic object trees.
+        Map<String, Object> mappingResponse = assertOkAndParse(
+            client().performRequest(new Request("GET", "/" + INDEX + "/_mapping")),
+            "mapping for " + INDEX
+        );
+        String rendered = mappingResponse.toString();
+        for (String bag : List.of("resource", "log", "instrumentationScope")) {
+            assertTrue("mapping must retain attribute bag [" + bag + "]: " + rendered, rendered.contains(bag));
+        }
+        assertTrue("attribute bags must stay flat_object: " + rendered, rendered.contains("flat_object"));
+
+        bulkIndexOtelCorpus();
+        assertEquals("every document must be indexed", EXPECTED_DOCS, docCount());
+
+        flush();
+        assertEquals("document count must survive flush", EXPECTED_DOCS, docCount());
+
+        Request forceMerge = new Request("POST", "/" + INDEX + "/_forcemerge");
+        forceMerge.addParameter("max_num_segments", "1");
+        Map<String, Object> merge = assertOkAndParse(client().performRequest(forceMerge), "force-merge " + INDEX);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> shards = (Map<String, Object>) merge.get("_shards");
+        assertEquals("force-merge must not fail any shard: " + merge, 0, ((Number) shards.get("failed")).intValue());
+
+        flush();
+        assertEquals("document count must survive force-merge", EXPECTED_DOCS, docCount());
+    }
+
+    /**
+     * A benchmark corpus is not uniform, so the shapes a real OTel pipeline emits must all be
+     * admitted into the same MAP column: an empty bag, an omitted bag, an array leaf (duplicate keys),
+     * an explicit null, and a bag whose keys no earlier document used.
+     */
+    public void testHeterogeneousAttributeBagsAreAdmitted() throws IOException {
+        createFlattenedIndex();
+
+        String ndjson = "{\"index\":{}}\n"
+            + "{\"serviceName\":\"cart\",\"log\":{}}\n"
+            + "{\"index\":{}}\n"
+            + "{\"serviceName\":\"cart\"}\n"
+            + "{\"index\":{}}\n"
+            + "{\"serviceName\":\"cart\",\"log\":{\"tag\":[\"a\",\"b\"]}}\n"
+            + "{\"index\":{}}\n"
+            + "{\"serviceName\":\"cart\",\"log\":{\"http\":{\"status\":null}}}\n"
+            + "{\"index\":{}}\n"
+            + "{\"serviceName\":\"cart\",\"log\":{\"brand\":{\"new\":{\"deep\":\"key\"}}}}\n";
+
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(ndjson);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(bulk), "heterogeneous bulk");
+        assertEquals("no shape may be rejected: " + response.get("items"), Boolean.FALSE, response.get("errors"));
+        assertEquals(5, docCount());
+
+        // And they must survive being made durable and re-encoded.
+        flush();
+        Request forceMerge = new Request("POST", "/" + INDEX + "/_forcemerge");
+        forceMerge.addParameter("max_num_segments", "1");
+        Map<String, Object> merge = assertOkAndParse(client().performRequest(forceMerge), "force-merge heterogeneous");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> shards = (Map<String, Object>) merge.get("_shards");
+        assertEquals("force-merge must not fail any shard: " + merge, 0, ((Number) shards.get("failed")).intValue());
+        assertEquals(5, docCount());
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OtelFlattenedAttributesIndexingIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/OtelFlattenedAttributesIndexingIT.java
@@ -171,6 +171,38 @@ public class OtelFlattenedAttributesIndexingIT extends AnalyticsRestTestCase {
     }
 
     /**
+     * Pins where basic search on a flat_object leaf currently stops on a composite index.
+     *
+     * <p>The storage side is in place: the lucene secondary indexes each leaf as a term
+     * ({@code _value} for a bare value, {@code _valueAndPath} for {@code <field>.<path>=<value>}), the
+     * same terms a plain Lucene index holds — {@code FlatObjectEngineParityIT} asserts that directly
+     * against the Lucene {@code FieldInfos}. What is missing is query routing: on a composite index
+     * {@code _search} is handled by the DSL query executor, whose {@code ConversionContext} resolves a
+     * field name against the <em>columnar</em> row type. A dotted sub-path of a flat_object is not a
+     * column of its own — the column is the parent {@code MAP} — so conversion fails before any
+     * backend is chosen, and the Lucene terms are never consulted.
+     *
+     * <p>Fixing it means teaching that layer to route a flat_object predicate to the Lucene backend
+     * (or to rewrite it into a key lookup on the MAP column), the same class of routing gap this suite
+     * already documents for multi-field text in {@code OtelLogsPplIT}'s skip list. Asserted rather
+     * than skipped so the behaviour is visible and this test flips when the routing lands.
+     */
+    public void testBasicSearchOnFlattenedLeafIsNotRoutedYet() throws IOException {
+        createFlattenedIndex();
+        bulkIndexOtelCorpus();
+        flush();
+
+        Request search = new Request("POST", "/" + INDEX + "/_search");
+        search.setJsonEntity("{\"size\":0,\"query\":{\"term\":{\"resource.service.name\":\"cart\"}}}");
+        ResponseException failure = expectThrows(ResponseException.class, () -> client().performRequest(search));
+        String body = org.opensearch.common.io.Streams.readFully(failure.getResponse().getEntity().getContent()).utf8ToString();
+        assertTrue(
+            "expected the columnar schema lookup to be what fails, got: " + body,
+            body.contains("not found in schema") && body.contains("resource.service.name")
+        );
+    }
+
+    /**
      * A benchmark corpus is not uniform, so the shapes a real OTel pipeline emits must all be
      * admitted into the same MAP column: an empty bag, an omitted bag, an array leaf (duplicate keys),
      * an explicit null, and a bag whose keys no earlier document used.

--- a/server/src/main/java/org/opensearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BinaryFieldMapper.java
@@ -94,9 +94,16 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
             this.hasDocValues.setValue(hasDocValues);
         }
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Columnar formats need a field's arity declared up front because the column type is fixed per
+         * file; Lucene is inherently multi-valued and ignores it.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         @Override
         public List<Parameter<?>> getParameters() {
-            return Arrays.asList(meta, stored, hasDocValues);
+            return Arrays.asList(meta, stored, hasDocValues, multiValue);
         }
 
         @Override
@@ -107,6 +114,7 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
                 hasDocValues.getValue(),
                 meta.getValue()
             );
+            bft.setMultiValued(multiValue.getValue());
             return new BinaryFieldMapper(name, bft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
     }

--- a/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
@@ -130,9 +130,16 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
             super(name);
         }
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Columnar formats need a field's arity declared up front because the column type is fixed per
+         * file; Lucene is inherently multi-valued and ignores it.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(meta, boost, docValues, indexed, nullValue, stored);
+            return Arrays.asList(meta, boost, docValues, indexed, nullValue, stored, multiValue);
         }
 
         @Override
@@ -146,6 +153,7 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
                 meta.getValue()
             );
             ft.setBoost(boost.getValue());
+            ft.setMultiValued(multiValue.getValue());
             return new BooleanFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -345,9 +345,29 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
             }
         }
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Columnar formats need a field's arity declared up front because the column type is fixed per
+         * file; Lucene is inherently multi-valued and ignores it.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(index, docValues, store, skiplist, format, printFormat, locale, nullValue, ignoreMalformed, boost, meta);
+            return Arrays.asList(
+                index,
+                docValues,
+                store,
+                skiplist,
+                format,
+                printFormat,
+                locale,
+                nullValue,
+                ignoreMalformed,
+                boost,
+                meta,
+                multiValue
+            );
         }
 
         private Long parseNullValue(DateFieldType fieldType) {
@@ -382,6 +402,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
                 meta.getValue()
             );
             ft.setBoost(boost.getValue());
+            ft.setMultiValued(multiValue.getValue());
             Long nullTimestamp = parseNullValue(ft);
             return new DateFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), nullTimestamp, resolution, this);
         }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -611,7 +611,12 @@ final class DocumentParser {
         }
 
         ObjectMapper.Nested nested = mapper.nested();
-        if (nested.isNested()) {
+        // [correlated: true] keeps the group's fields in the parent document so each accumulates its
+        // values into its own column, paired with its siblings by array position. Building the hidden
+        // per-element documents instead would put every field in a separate document, which is the
+        // representation the declaration exists to opt out of.
+        boolean buildNestedDocuments = nested.isNested() && mapper.correlated() == false;
+        if (buildNestedDocuments) {
             context = nestedContext(context, mapper);
         }
 
@@ -627,7 +632,7 @@ final class DocumentParser {
         innerParseObject(context, mapper, parser, currentFieldName, token);
 
         // restore the enable path flag
-        if (nested.isNested()) {
+        if (buildNestedDocuments) {
             nested(context, nested);
         }
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1559,6 +1559,12 @@ final class DocumentParser {
      *
      * <p>Strictly gated: no-op unless the pluggable data format is enabled and the resolved leaf is
      * a {@code multi_value} {@link FieldMapper}, so stock indexing is unaffected.
+     *
+     * <p>Reached from every scalar-leaf array route — top-level, nested, and disable_objects arrays
+     * all funnel through {@link #parseNonDynamicArray}. The only array route that bypasses it is a
+     * mapper with {@link FieldMapper#parsesArrayValue()} true (geo/completion), which no
+     * {@code multi_value} type currently is; if that ever changes, that route needs equivalent
+     * empty-array handling or {@code []} would collapse to an absent field there.
      */
     private static void registerEmptyMultiValueArray(ParseContext context, ObjectMapper mapper, String lastFieldName, String[] paths) {
         if (context.indexSettings().isPluggableDataFormatEnabled() == false) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -1522,7 +1522,9 @@ final class DocumentParser {
             );
         }
         final String[] paths = resolvePathForParsing(mapper, lastFieldName);
+        boolean sawElement = false;
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            sawElement = true;
             if (token == XContentParser.Token.START_OBJECT) {
                 parseObject(context, mapper, lastFieldName, paths);
             } else if (token == XContentParser.Token.START_ARRAY) {
@@ -1541,6 +1543,30 @@ final class DocumentParser {
                 assert token.isValue();
                 parseValue(context, mapper, lastFieldName, token, paths);
             }
+        }
+        if (sawElement == false) {
+            registerEmptyMultiValueArray(context, mapper, lastFieldName, paths);
+        }
+    }
+
+    /**
+     * Records an empty array ({@code "field": []}) for a pluggable-data-format field mapped with
+     * {@code multi_value: true}. The element loop above never fires for an empty array, so without
+     * this the field would be absent from the document input and its LIST column cell would be
+     * written null — collapsing the distinction between {@code []} and a missing field when
+     * {@code _source} is later reconstructed from the columns. Registering an empty list lets the
+     * writer emit a zero-length, non-null list instead.
+     *
+     * <p>Strictly gated: no-op unless the pluggable data format is enabled and the resolved leaf is
+     * a {@code multi_value} {@link FieldMapper}, so stock indexing is unaffected.
+     */
+    private static void registerEmptyMultiValueArray(ParseContext context, ObjectMapper mapper, String lastFieldName, String[] paths) {
+        if (context.indexSettings().isPluggableDataFormatEnabled() == false) {
+            return;
+        }
+        Mapper leaf = getMapper(context, mapper, lastFieldName, paths);
+        if (leaf instanceof FieldMapper fieldMapper && fieldMapper.fieldType().isMultiValued()) {
+            context.documentInput().addField(fieldMapper.fieldType(), List.of());
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/DynamicKeyFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DynamicKeyFieldMapper.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.index.mapper;
 
-import org.apache.lucene.document.FieldType;
-
 /**
  * A field mapper that supports lookup of dynamic sub-keys. If the field mapper is named 'my_field',
  * then a user is able to search on the field in both of the following ways:
@@ -48,13 +46,20 @@ import org.apache.lucene.document.FieldType;
  * implementing this interface should explicitly disallow multi-fields. The constructor makes
  * sure to passes an empty multi-fields list to help prevent conflicting sub-keys from being
  * registered.
+ * <p>
+ * Extends {@link ParametrizedFieldMapper} so that dynamic-key mappers declare their mapping
+ * parameters the same way every other field type does, getting parsing, serialization,
+ * {@code includeDefaults} handling and update-conflict detection from the framework instead of
+ * hand-rolling them. Subclasses needing a non-default Lucene {@link org.apache.lucene.document.FieldType}
+ * keep their own copy, as {@link KeywordFieldMapper} does — {@link ParametrizedFieldMapper}'s
+ * constructor always passes a fresh one to {@link FieldMapper}.
  *
  * @opensearch.internal
  */
-public abstract class DynamicKeyFieldMapper extends FieldMapper {
+public abstract class DynamicKeyFieldMapper extends ParametrizedFieldMapper {
 
-    public DynamicKeyFieldMapper(String simpleName, FieldType fieldType, MappedFieldType defaultFieldType, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, MultiFields.empty(), copyTo);
+    public DynamicKeyFieldMapper(String simpleName, MappedFieldType defaultFieldType, CopyTo copyTo) {
+        super(simpleName, defaultFieldType, MultiFields.empty(), copyTo);
     }
 
     public abstract MappedFieldType keyedFieldType(String key);

--- a/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
@@ -270,6 +270,16 @@ public abstract class FilterFieldType extends MappedFieldType {
     }
 
     @Override
+    public boolean isMultiValued() {
+        return delegate.isMultiValued();
+    }
+
+    @Override
+    public void setMultiValued(boolean multiValued) {
+        delegate.setMultiValued(multiValued);
+    }
+
+    @Override
     public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
         return delegate.docValueFormat(format, timeZone);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
@@ -280,6 +280,16 @@ public abstract class FilterFieldType extends MappedFieldType {
     }
 
     @Override
+    public String correlationGroup() {
+        return delegate.correlationGroup();
+    }
+
+    @Override
+    public void setCorrelationGroup(String correlationGroup) {
+        delegate.setCorrelationGroup(correlationGroup);
+    }
+
+    @Override
     public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
         return delegate.docValueFormat(format, timeZone);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.FieldExistsQuery;
@@ -31,8 +32,11 @@ import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
@@ -125,7 +129,14 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             );
             FlatObjectFieldType fft = new FlatObjectFieldType(buildFullName(context), null, valueFieldType, valueAndPathFieldType);
 
-            return new FlatObjectFieldMapper(name, Defaults.FIELD_TYPE, fft);
+            // A pluggable data format stores the whole object as one column and reconstructs _source
+            // from it, so derived source is satisfied by the format rather than by the Lucene
+            // field-value generator. Capture the flag so the mapper can accept derived source in that
+            // mode while still rejecting it for a plain Lucene index, where nested source cannot be
+            // rebuilt from the flattened doc-value sub-fields.
+            boolean pluggableDataFormatEnabled = context.indexSettings()
+                .getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
+            return new FlatObjectFieldMapper(name, Defaults.FIELD_TYPE, fft, pluggableDataFormatEnabled);
         }
     }
 
@@ -211,6 +222,18 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        /**
+         * flat_object leaves are keyword-like (term queries over the {@code _value} /
+         * {@code _valueAndPath} sub-fields), so it requests the same search capability keyword does.
+         * Without this override {@link MappedFieldType#requestedCapabilities()} throws for any
+         * flat_object field in a pluggable-data-format index, because the base implementation has no
+         * capability to report for a searchable field.
+         */
+        @Override
+        protected FieldTypeCapabilities.Capability searchCapability() {
+            return FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH;
         }
 
         NamedAnalyzer normalizer() {
@@ -538,12 +561,39 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
     private final KeywordFieldType valueFieldType;
     private final KeywordFieldType valueAndPathFieldType;
+    private final boolean pluggableDataFormatEnabled;
 
-    FlatObjectFieldMapper(String simpleName, FieldType fieldType, FlatObjectFieldType mappedFieldType) {
+    FlatObjectFieldMapper(String simpleName, FieldType fieldType, FlatObjectFieldType mappedFieldType, boolean pluggableDataFormatEnabled) {
         super(simpleName, fieldType, mappedFieldType, CopyTo.empty());
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         valueFieldType = mappedFieldType.valueFieldType;
         valueAndPathFieldType = mappedFieldType.valueAndPathFieldType;
+        this.pluggableDataFormatEnabled = pluggableDataFormatEnabled;
+    }
+
+    /**
+     * flat_object cannot rebuild its nested source from the flattened {@code path=value} doc-value
+     * sub-fields through the generic field-value generator, so derived source is unsupported for a
+     * plain Lucene index. Under a pluggable data format the whole object is stored as one column and
+     * the format reconstructs {@code _source} from it, so derived source is allowed there and the
+     * Lucene {@link #deriveSource} path below is never taken.
+     */
+    @Override
+    public void canDeriveSource() {
+        if (pluggableDataFormatEnabled == false) {
+            throw new UnsupportedOperationException(
+                "Derive source is not supported for field [" + name() + "] with field type [" + fieldType().typeName() + "]"
+            );
+        }
+    }
+
+    @Override
+    public void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) {
+        // A flat_object column is reconstructed by the pluggable data format, not through the Lucene
+        // reader, so this must never be reached. Fail loudly rather than emit an empty/incorrect field.
+        throw new UnsupportedOperationException(
+            "Derive source for flat_object field [" + name() + "] is handled by the data format, not the Lucene reader"
+        );
     }
 
     @Override
@@ -563,17 +613,45 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context) throws IOException {
-        HashSet<String> pathParts = parseObjectPathParts(context);
+        HashSet<String> pathParts = parseObjectPathParts(context, null);
         if (pathParts != null) {
             createPathFields(context, pathParts);
         }
     }
 
     /**
+     * Feeds a pluggable data format one entry per flat_object leaf, as {@code (relative path, value)}
+     * pairs in document order. A columnar format backs the field with a single {@code MAP<key, value>}
+     * column, so the whole attribute set is handed over in one {@code addField} call rather than as N
+     * separate values — that keeps the field single-arity (no {@code multi_value} declaration needed)
+     * while the map itself holds however many entries the document had.
+     * <p>
+     * Keys are relative to this field ({@code http.status}, not {@code LogAttributes.http.status}):
+     * the column name already carries the field prefix that Lucene's {@code _valueAndPath} sub-field
+     * has to spell out. Duplicate keys are preserved rather than collapsed — {@code {"a": [1, 2]}}
+     * yields two {@code a} entries, which a Parquet MAP represents natively as a repeated key/value
+     * group.
+     * <p>
+     * Nothing is added for a null or absent object, so the column stays null and remains
+     * distinguishable from an empty object, which yields a zero-entry map.
+     */
+    @Override
+    protected void parseCreateFieldForPluggableFormat(ParseContext context) throws IOException {
+        List<Map.Entry<String, String>> entries = new ArrayList<>();
+        if (parseObjectPathParts(context, entries) == null) {
+            return;
+        }
+        context.documentInput().addField(fieldType(), entries);
+    }
+
+    /**
      * Parses the flat_object field value and returns the collected path parts,
      * or {@code null} if the field should be skipped (null value or not searchable/stored/docvalues).
+     *
+     * @param entries when non-null, leaf {@code (relative path, value)} pairs are appended here and no
+     *                Lucene fields are created — the pluggable-data-format mode
      */
-    private HashSet<String> parseObjectPathParts(ParseContext context) throws IOException {
+    private HashSet<String> parseObjectPathParts(ParseContext context, List<Map.Entry<String, String>> entries) throws IOException {
         XContentParser ctxParser = context.parser();
         if (fieldType().isSearchable() == false && fieldType().isStored() == false && fieldType().hasDocValues() == false) {
             ctxParser.skipChildren();
@@ -596,7 +674,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         LinkedList<String> path = new LinkedList<>(Collections.singleton(fieldType().name()));
         HashSet<String> pathParts = new HashSet<>();
         while (ctxParser.currentToken() != XContentParser.Token.END_OBJECT) {
-            parseToken(ctxParser, context, path, pathParts);
+            parseToken(ctxParser, context, path, pathParts, entries);
         }
         return pathParts;
     }
@@ -615,13 +693,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
     }
 
-    private void createPathFieldsForPluggableFormat(ParseContext context, HashSet<String> pathParts) {
-        for (String part : pathParts) {
-            final BytesRef value = new BytesRef(name() + DOT_SYMBOL + part);
-            context.documentInput().addField(fieldType(), value);
-        }
-    }
-
     private static String getDVPrefix(String rootFieldName) {
         return rootFieldName + DOT_SYMBOL;
     }
@@ -630,12 +701,18 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         return path + EQUAL_SYMBOL;
     }
 
-    private void parseToken(XContentParser parser, ParseContext context, Deque<String> path, HashSet<String> pathParts) throws IOException {
+    private void parseToken(
+        XContentParser parser,
+        ParseContext context,
+        Deque<String> path,
+        HashSet<String> pathParts,
+        List<Map.Entry<String, String>> entries
+    ) throws IOException {
         if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
             final String currentFieldName = parser.currentName();
             path.addLast(currentFieldName); // Pushing onto the stack *must* be matched by pop
             parser.nextToken(); // advance to the value of fieldName
-            parseToken(parser, context, path, pathParts); // parse the value for fieldName (which will be an array, an object,
+            parseToken(parser, context, path, pathParts, entries); // parse the value for fieldName (which will be an array, an object,
             // or a primitive value)
             path.removeLast(); // Here is where we pop fieldName from the stack (since we're done with the value of fieldName)
             // Note that whichever other branch we just passed through has already ended with nextToken(), so we
@@ -643,13 +720,13 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         } else if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
             parser.nextToken();
             while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
-                parseToken(parser, context, path, pathParts);
+                parseToken(parser, context, path, pathParts, entries);
             }
             parser.nextToken();
         } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
             parser.nextToken();
             while (parser.currentToken() != XContentParser.Token.END_OBJECT) {
-                parseToken(parser, context, path, pathParts);
+                parseToken(parser, context, path, pathParts, entries);
             }
             parser.nextToken();
         } else {
@@ -663,6 +740,14 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                 value = normalizeValue(normalizer, name(), value);
             }
             final String leafPath = Strings.collectionToDelimitedString(path, ".");
+            final String relativePath = leafPath.substring(name().length() + 1);
+            if (entries != null) {
+                // Pluggable-format mode: the leaf becomes one MAP entry. No Lucene fields are built —
+                // the columnar format owns storage for this field.
+                entries.add(Map.entry(relativePath, value));
+                parser.nextToken();
+                return;
+            }
             final String valueAndPath = getPathPrefix(leafPath) + value;
             if (fieldType().isSearchable() || fieldType().isStored()) {
                 context.doc().add(new Field(valueFieldType.name(), new BytesRef(value), fieldType));
@@ -675,7 +760,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                     .add(new SortedSetDocValuesField(valueAndPathFieldType.name(), new BytesRef(getDVPrefix(name()) + valueAndPath)));
             }
 
-            pathParts.addAll(Arrays.asList(leafPath.substring(name().length() + 1).split("\\.")));
+            pathParts.addAll(Arrays.asList(relativePath.split("\\.")));
             parser.nextToken();
         }
     }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -56,7 +56,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.FlatObjectFieldType.getKeywordFieldType;
@@ -87,11 +86,23 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
 
+        /**
+         * Used when the field is mapped {@code index: false}: the object's leaves still get doc
+         * values, but no postings are written. {@link Defaults#FIELD_TYPE} is frozen and shared, so
+         * the not-indexed variant has to be its own instance.
+         */
+        public static final FieldType FIELD_TYPE_NOT_INDEXED = new FieldType();
+
         static {
             FIELD_TYPE.setTokenized(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             FIELD_TYPE.freeze();
+
+            FIELD_TYPE_NOT_INDEXED.setTokenized(false);
+            FIELD_TYPE_NOT_INDEXED.setOmitNorms(true);
+            FIELD_TYPE_NOT_INDEXED.setIndexOptions(IndexOptions.NONE);
+            FIELD_TYPE_NOT_INDEXED.freeze();
         }
     }
 
@@ -106,19 +117,67 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     /**
-     * The builder for the flat_object field mapper using default parameters
+     * The builder for the flat_object field mapper.
+     * <p>
+     * Declares its mapping parameters through {@link ParametrizedFieldMapper}, so parsing,
+     * serialization and update-conflict detection come from the framework rather than being
+     * hand-written — the same path {@code keyword} and every other field type takes. Before this,
+     * flat_object used a {@code TypeParser} that ignored the mapping node entirely, which made
+     * <em>every</em> parameter a mapping error.
+     *
      * @opensearch.internal
      */
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends ParametrizedFieldMapper.Builder {
+
+        /**
+         * Whether the object's leaves are added to the inverted index. Not updateable: flipping it
+         * would leave existing documents' postings inconsistent with the mapping.
+         * <p>
+         * {@code false} keeps doc values and drops postings, so on a plain index the field stays
+         * queryable through the doc-values path. Under a pluggable data format it also drops the
+         * field from the secondary format entirely (no {@code FULL_TEXT_SEARCH} is requested), which
+         * is the point: the columnar primary keeps the values and nothing is indexed twice.
+         */
+        private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).fieldType().isSearchable(), true);
 
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE);
-            builder = this;
+            super(name);
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return Collections.singletonList(indexed);
         }
 
         @Override
         public FlatObjectFieldMapper build(BuilderContext context) {
-            boolean isSearchable = true;
+            // A pluggable data format stores the whole object as one column and reconstructs _source
+            // from it, so derived source is satisfied by the format rather than by the Lucene
+            // field-value generator. Capture the flag so the mapper can accept derived source in that
+            // mode while still rejecting it for a plain Lucene index, where nested source cannot be
+            // rebuilt from the flattened doc-value sub-fields.
+            boolean pluggableDataFormatEnabled = context.indexSettings()
+                .getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
+
+            boolean isSearchable = indexed.getValue();
+            // Deliberately scoped: `index: false` is only accepted where it has a well-defined
+            // meaning today — a columnar primary format that keeps the values and serves them.
+            // On a plain Lucene index it would silently leave the field reachable only through the
+            // doc-values path, a behaviour change for existing mappings with no benefit, so it is
+            // rejected up front rather than supported half-way.
+            if (isSearchable == false && pluggableDataFormatEnabled == false) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + buildFullName(context)
+                        + "] of type ["
+                        + CONTENT_TYPE
+                        + "] does not support [index: false] unless the index uses a pluggable data format "
+                        + "(["
+                        + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
+                        + "] is not enabled)"
+                );
+            }
+
             boolean hasDocValue = true;
             KeywordFieldType valueFieldType = getKeywordFieldType(buildFullName(context), VALUE_SUFFIX, isSearchable, hasDocValue);
             KeywordFieldType valueAndPathFieldType = getKeywordFieldType(
@@ -129,34 +188,20 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             );
             FlatObjectFieldType fft = new FlatObjectFieldType(buildFullName(context), null, valueFieldType, valueAndPathFieldType);
 
-            // A pluggable data format stores the whole object as one column and reconstructs _source
-            // from it, so derived source is satisfied by the format rather than by the Lucene
-            // field-value generator. Capture the flag so the mapper can accept derived source in that
-            // mode while still rejecting it for a plain Lucene index, where nested source cannot be
-            // rebuilt from the flattened doc-value sub-fields.
-            boolean pluggableDataFormatEnabled = context.indexSettings()
-                .getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
-            return new FlatObjectFieldMapper(name, Defaults.FIELD_TYPE, fft, pluggableDataFormatEnabled);
+            return new FlatObjectFieldMapper(
+                name,
+                isSearchable ? Defaults.FIELD_TYPE : Defaults.FIELD_TYPE_NOT_INDEXED,
+                fft,
+                pluggableDataFormatEnabled
+            );
         }
+    }
+
+    private static FlatObjectFieldMapper toType(FieldMapper in) {
+        return (FlatObjectFieldMapper) in;
     }
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
-
-    /**
-     * Creates a new TypeParser for flatObjectFieldMapper that does not use ParameterizedFieldMapper
-     */
-    public static class TypeParser implements Mapper.TypeParser {
-        private final BiFunction<String, ParserContext, Builder> builderFunction;
-
-        public TypeParser(BiFunction<String, ParserContext, Builder> builderFunction) {
-            this.builderFunction = builderFunction;
-        }
-
-        @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            return builderFunction.apply(name, parserContext);
-        }
-    }
 
     /**
      * flat_object fields type contains its own fieldType, one valueFieldType and one valueAndPathFieldType
@@ -563,12 +608,26 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     private final KeywordFieldType valueAndPathFieldType;
     private final boolean pluggableDataFormatEnabled;
 
+    /**
+     * The Lucene field type used when writing this field's terms. Held here, shadowing
+     * {@link FieldMapper#fieldType}, because {@link ParametrizedFieldMapper}'s constructor always
+     * hands {@link FieldMapper} a fresh default {@code FieldType} — the same arrangement
+     * {@link KeywordFieldMapper} uses.
+     */
+    private final FieldType fieldType;
+
     FlatObjectFieldMapper(String simpleName, FieldType fieldType, FlatObjectFieldType mappedFieldType, boolean pluggableDataFormatEnabled) {
-        super(simpleName, fieldType, mappedFieldType, CopyTo.empty());
+        super(simpleName, mappedFieldType, CopyTo.empty());
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
+        this.fieldType = fieldType;
         valueFieldType = mappedFieldType.valueFieldType;
         valueAndPathFieldType = mappedFieldType.valueAndPathFieldType;
         this.pluggableDataFormatEnabled = pluggableDataFormatEnabled;
+    }
+
+    @Override
+    public ParametrizedFieldMapper.Builder getMergeBuilder() {
+        return new Builder(simpleName()).init(this);
     }
 
     /**
@@ -604,10 +663,9 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         return (FlatObjectFieldMapper) super.clone();
     }
 
-    @Override
-    protected void mergeOptions(FieldMapper other, List<String> conflicts) {
-
-    }
+    // No mergeOptions override: ParametrizedFieldMapper makes it final and drives merge from the
+    // declared parameters instead, so `index` now gets a real conflict check on mapping update
+    // (previously this method was empty and every update silently succeeded).
 
     @Override
     public FlatObjectFieldType fieldType() {

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -589,11 +589,14 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
     @Override
     public void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) {
-        // A flat_object column is reconstructed by the pluggable data format, not through the Lucene
-        // reader, so this must never be reached. Fail loudly rather than emit an empty/incorrect field.
-        throw new UnsupportedOperationException(
-            "Derive source for flat_object field [" + name() + "] is handled by the data format, not the Lucene reader"
-        );
+        // Under a pluggable data format the object's leaves live only in that format's column (a
+        // Parquet MAP), never in the Lucene reader this method is handed — LuceneDocumentInput
+        // strips doc values and stored fields for a field the primary format owns. So there is
+        // nothing here to rebuild the object from, and the field is omitted rather than throwing:
+        // this is reachable via TranslogLeafReader when index.derived_source.translog.enabled is
+        // set, where throwing would break realtime GET for the whole document.
+        // Consequence: a flat_object field does not currently round-trip into derived _source. It is
+        // durable in the columnar format; surfacing it back is the format's read path to implement.
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -151,27 +151,30 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
             }
         }
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Columnar formats need a field's arity declared up front because the column type is fixed per
+         * file; Lucene is inherently multi-valued and ignores it.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(indexed, hasDocValues, stored, ignoreMalformed, nullValue, meta);
+            return Arrays.asList(indexed, hasDocValues, stored, ignoreMalformed, nullValue, meta, multiValue);
         }
 
         @Override
         public IpFieldMapper build(BuilderContext context) {
-            return new IpFieldMapper(
-                name,
-                new IpFieldType(
-                    buildFullName(context),
-                    indexed.getValue(),
-                    stored.getValue(),
-                    hasDocValues.getValue(),
-                    parseNullValue(),
-                    meta.getValue()
-                ),
-                multiFieldsBuilder.build(this, context),
-                copyTo.build(),
-                this
+            IpFieldType ft = new IpFieldType(
+                buildFullName(context),
+                indexed.getValue(),
+                stored.getValue(),
+                hasDocValues.getValue(),
+                parseNullValue(),
+                meta.getValue()
             );
+            ft.setMultiValued(multiValue.getValue());
+            return new IpFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -176,6 +176,14 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
         private final Parameter<Float> boost = Parameter.boostParam();
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Lucene is inherently multi-valued, so the flag matters only to consumers projecting a fixed
+         * schema — e.g. a pluggable format whose column type is fixed per file (Parquet stores a
+         * declared field as {@code LIST<element>}). Not updateable: arity is baked into written data.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         private final IndexAnalyzers indexAnalyzers;
         private final boolean canConsumeRawValueForSource;
 
@@ -236,7 +244,8 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
                     normalizer,
                     splitQueriesOnWhitespace,
                     boost,
-                    meta
+                    meta,
+                    multiValue
                 )
             );
             parameters.addAll(pluginMappingParameters());
@@ -359,6 +368,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
             setEagerGlobalOrdinals(builder.eagerGlobalOrdinals.getValue());
             setIndexAnalyzer(normalizer);
             setBoost(builder.boost.getValue());
+            setMultiValued(builder.multiValue.getValue());
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
             this.useSimilarity = builder.useSimilarity.getValue();
@@ -846,6 +856,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
     private final boolean useSimilarity;
     private final String normalizerName;
     private final boolean splitQueriesOnWhitespace;
+    private final boolean multiValued;
     private final KeywordFieldType rawKeywordValueFieldType;
 
     private final IndexAnalyzers indexAnalyzers;
@@ -874,6 +885,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         this.useSimilarity = builder.useSimilarity.getValue();
         this.normalizerName = builder.normalizer.getValue();
         this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace.getValue();
+        this.multiValued = builder.multiValue.getValue();
         this.indexAnalyzers = builder.indexAnalyzers;
         this.canConsumeRawValueForSource = builder.canConsumeRawValueForSource;
         this.mappingPluginParameterValues = builder.pluginMappingParameterValues();
@@ -911,7 +923,18 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
      */
     private KeywordFieldType buildRawKeywordValueFieldType() {
         if (isIneligibleForGeneratingSource() && canConsumeRawValueForSource) {
-            return new KeywordFieldType("_ignored_source." + fieldType().name(), false, true, false, false, fieldType().meta());
+            KeywordFieldType rawValueType = new KeywordFieldType(
+                "_ignored_source." + fieldType().name(),
+                false,
+                true,
+                false,
+                false,
+                fieldType().meta()
+            );
+            // The companion carries the pre-normalization values for derived source, so it must
+            // mirror the parent's cardinality or source reconstruction would lose values.
+            rawValueType.setMultiValued(multiValued);
+            return rawValueType;
         }
         return null;
     }

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -97,6 +97,7 @@ public abstract class MappedFieldType {
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
+    private boolean multiValued;
 
     /**
      * Capability map assigning each registered {@link DataFormat} to the set of capabilities it owns for this field type.
@@ -476,6 +477,30 @@ public abstract class MappedFieldType {
 
     public void setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+    }
+
+    /**
+     * Whether this field is declared to hold multiple values per document in columnar data
+     * formats ({@code multi_value} mapping parameter). Lucene is inherently multi-valued, so
+     * this flag only matters to pluggable formats whose column type is fixed per file (e.g.
+     * Parquet, where a declared field is stored as {@code LIST<element>}).
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public boolean isMultiValued() {
+        return multiValued;
+    }
+
+    /**
+     * Declares this field multi-valued for columnar data formats. Set during mapping build by
+     * mappers exposing the {@code multi_value} parameter.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public void setMultiValued(boolean multiValued) {
+        this.multiValued = multiValued;
     }
 
     @ExperimentalApi

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -98,6 +98,7 @@ public abstract class MappedFieldType {
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
     private boolean multiValued;
+    private String correlationGroup;
 
     /**
      * Capability map assigning each registered {@link DataFormat} to the set of capabilities it owns for this field type.
@@ -501,6 +502,34 @@ public abstract class MappedFieldType {
     @ExperimentalApi
     public void setMultiValued(boolean multiValued) {
         this.multiValued = multiValued;
+    }
+
+    /**
+     * The full path of the enclosing object declared {@code correlated: true}, or {@code null} when
+     * this field belongs to no correlated group.
+     *
+     * <p>Fields sharing a group are parallel arrays whose values are paired by position: index
+     * {@code i} of each describes the same element. Columnar formats store each as an independent
+     * column, so nothing in the storage layer couples them — the group name lets the write path
+     * enforce that the arrays agree in length, without which position {@code i} of one column could
+     * describe a different element than position {@code i} of its sibling.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public String correlationGroup() {
+        return correlationGroup;
+    }
+
+    /**
+     * Assigns this field to a correlated group. Set during mapping build by {@link ObjectMapper}
+     * for the children of an object declared {@code correlated: true}.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public void setCorrelationGroup(String correlationGroup) {
+        this.correlationGroup = correlationGroup;
     }
 
     @ExperimentalApi

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -179,14 +179,22 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
             return this;
         }
 
+        /**
+         * The shared {@code multi_value} arity parameter (see {@link Parameter#multiValueParam()}).
+         * Columnar formats need a field's arity declared up front because the column type is fixed per
+         * file; Lucene is inherently multi-valued and ignores it.
+         */
+        private final Parameter<Boolean> multiValue = Parameter.multiValueParam();
+
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(indexed, hasDocValues, stored, skiplist, ignoreMalformed, coerce, nullValue, meta);
+            return Arrays.asList(indexed, hasDocValues, stored, skiplist, ignoreMalformed, coerce, nullValue, meta, multiValue);
         }
 
         @Override
         public NumberFieldMapper build(BuilderContext context) {
             MappedFieldType ft = new NumberFieldType(buildFullName(context), this);
+            ft.setMultiValued(multiValue.getValue());
             return new NumberFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -46,6 +46,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 
@@ -82,6 +83,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
         public static final Nested NESTED = Nested.NO;
         public static final Dynamic DYNAMIC = null; // not set, inherited from root
         public static final Explicit<Boolean> DISABLE_OBJECTS = new Explicit<>(false, false);
+
+        public static final Explicit<Boolean> CORRELATED = new Explicit<>(false, false);
     }
 
     /**
@@ -205,6 +208,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         protected Explicit<Boolean> disableObjects = Defaults.DISABLE_OBJECTS;
 
+        protected Explicit<Boolean> correlated = Defaults.CORRELATED;
+
         protected final List<Mapper.Builder> mappersBuilders = new ArrayList<>();
 
         public Builder(String name) {
@@ -232,6 +237,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
             return builder;
         }
 
+        public T correlated(boolean correlated) {
+            this.correlated = new Explicit<>(correlated, true);
+            return builder;
+        }
+
         public T add(Mapper.Builder builder) {
             mappersBuilders.add(builder);
             return this.builder;
@@ -252,9 +262,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
             context.path().remove();
 
+            String fullPath = context.path().pathAsText(name);
             ObjectMapper objectMapper = createMapper(
                 name,
-                context.path().pathAsText(name),
+                fullPath,
                 enabled,
                 nested,
                 dynamic,
@@ -262,6 +273,14 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 mappers,
                 context.indexSettings()
             );
+            objectMapper.correlated = correlated;
+
+            if (Boolean.TRUE.equals(correlated.value())) {
+                validateCorrelated(context, mappers);
+                for (Mapper childMapper : mappers.values()) {
+                    stampCorrelationGroup(childMapper, fullPath);
+                }
+            }
 
             // Validate flat field compatibility during build
             if (Boolean.TRUE.equals(disableObjects.value())) {
@@ -280,6 +299,65 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
 
             return objectMapper;
+        }
+
+        /**
+         * Enforces the two preconditions for {@code correlated: true}.
+         *
+         * <p>It requires {@code type: nested}, because {@code correlated} does not declare the
+         * grouping — {@code nested} already does that — it only selects how the group is stored.
+         * Allowing it on a plain object would introduce a second, redundant way to say "these
+         * fields belong together".
+         *
+         * <p>It requires a pluggable data format, because {@code correlated} suppresses the hidden
+         * nested documents that back element-scoped {@code nested} queries. On a plain Lucene index
+         * that would silently downgrade query semantics for no benefit: only columnar formats, which
+         * store each field as an independent column, need the correlation declared at all.
+         */
+        private void validateCorrelated(BuilderContext context, Map<String, Mapper> mappers) {
+            if (nested.isNested() == false) {
+                throw new MapperParsingException(
+                    "Mapping parameter [correlated] requires [type: nested] on object ["
+                        + name
+                        + "]. It selects how a nested group is stored, so there is nothing for it to "
+                        + "apply to on a plain object."
+                );
+            }
+            boolean pluggableDataFormatEnabled = context.indexSettings() != null
+                && context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
+            if (pluggableDataFormatEnabled == false) {
+                throw new MapperParsingException(
+                    "Object ["
+                        + name
+                        + "] does not support [correlated: true] unless the index uses a pluggable data format ["
+                        + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
+                        + ": true]. Without one, nested documents already correlate the fields and "
+                        + "[correlated: true] would only remove element-scoped query support."
+                );
+            }
+            for (Mapper childMapper : mappers.values()) {
+                if (childMapper instanceof ObjectMapper) {
+                    throw new MapperParsingException(
+                        "Object ["
+                            + name
+                            + "] is declared [correlated: true] and cannot contain the sub-object ["
+                            + childMapper.name()
+                            + "]. A correlated group pairs its fields by array position, which is only "
+                            + "defined for leaf fields; a sub-object would nest a second level of arrays "
+                            + "whose correlation is ambiguous."
+                    );
+                }
+            }
+        }
+
+        /**
+         * Records the group on the child's field type so the write path can find it from the field
+         * type alone, without walking the mapper tree.
+         */
+        private static void stampCorrelationGroup(Mapper childMapper, String group) {
+            if (childMapper instanceof FieldMapper fieldMapper && fieldMapper.fieldType() != null) {
+                fieldMapper.fieldType().setCorrelationGroup(group);
+            }
         }
 
         @Deprecated
@@ -383,6 +461,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         e
                     );
                 }
+                return true;
+            } else if (fieldName.equals("correlated")) {
+                builder.correlated(XContentMapValues.nodeBooleanValue(fieldNode, fieldName + ".correlated"));
                 return true;
             } else if (fieldName.equals("derived")) {
                 if (fieldNode instanceof Collection && ((Collection) fieldNode).isEmpty()) {
@@ -698,6 +779,12 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     private Explicit<Boolean> disableObjects;
 
+    /**
+     * Whether this nested group is stored as parallel columns correlated by array position rather
+     * than as hidden nested documents. Assigned by {@link Builder#build} after construction.
+     */
+    private Explicit<Boolean> correlated = Defaults.CORRELATED;
+
     private volatile CopyOnWriteHashMap<String, Mapper> mappers;
 
     ObjectMapper(
@@ -783,6 +870,12 @@ public class ObjectMapper extends Mapper implements Cloneable {
     }
 
     protected void putMapper(Mapper mapper) {
+        // Dynamically added fields land here rather than through Builder#build, so they need the same
+        // stamp — otherwise a sub-field first seen in a document would be silently exempt from the
+        // group's length check, which is exactly the mispairing the declaration exists to prevent.
+        if (correlated()) {
+            Builder.stampCorrelationGroup(mapper, fullPath);
+        }
         mappers = mappers.copyAndPut(mapper.simpleName(), mapper);
     }
 
@@ -809,6 +902,18 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     public Explicit<Boolean> disableObjectsExplicit() {
         return disableObjects;
+    }
+
+    /**
+     * Whether this nested group is stored as parallel, position-correlated columns instead of hidden
+     * nested documents. See the {@code correlated} mapping parameter.
+     */
+    public boolean correlated() {
+        return correlated.value();
+    }
+
+    public Explicit<Boolean> correlatedExplicit() {
+        return correlated;
     }
 
     /**
@@ -878,6 +983,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
             if (mergeWith.disableObjectsExplicit().explicit()) {
                 this.disableObjects = mergeWith.disableObjectsExplicit();
             }
+            if (mergeWith.correlatedExplicit().explicit()) {
+                this.correlated = mergeWith.correlatedExplicit();
+            }
         } else {
             if (isEnabled() != mergeWith.isEnabled()) {
                 throw new MapperException("the [enabled] parameter can't be updated for the object mapping [" + name() + "]");
@@ -885,6 +993,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             // Validate disable_objects immutability (except for MAPPING_RECOVERY)
             if (reason != MergeReason.MAPPING_RECOVERY) {
                 validateDisableObjectsImmutability(mergeWith, reason);
+                validateCorrelatedImmutability(mergeWith);
             }
         }
 
@@ -939,6 +1048,27 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         + "] for object mapping ["
                         + name()
                         + "]. The disable_objects setting is immutable after index creation."
+                );
+            }
+        }
+    }
+
+    /**
+     * Rejects a change to {@code correlated} after creation. It selects the on-disk layout — parallel
+     * columns versus nested documents — so flipping it would leave already-written data in a shape the
+     * new value does not describe.
+     */
+    private void validateCorrelatedImmutability(ObjectMapper mergeWith) {
+        if (this.correlatedExplicit().explicit() && mergeWith.correlatedExplicit().explicit()) {
+            if (this.correlated() != mergeWith.correlated()) {
+                throw new MapperException(
+                    "Cannot update parameter [correlated] from ["
+                        + this.correlated()
+                        + "] to ["
+                        + mergeWith.correlated()
+                        + "] for object mapping ["
+                        + name()
+                        + "]. It determines the storage layout and is immutable after index creation."
                 );
             }
         }
@@ -1016,6 +1146,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
         if (disableObjectsExplicit().explicit()) {
             builder.field("disable_objects", disableObjects.value());
+        }
+        if (correlatedExplicit().explicit()) {
+            builder.field("correlated", correlated.value());
         }
 
         if (custom != null) {

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -202,6 +202,9 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     @PublicApi(since = "1.0.0")
     public static sealed class Parameter<T> implements Supplier<T> permits SideEffectParameter {
 
+        /** Name of the shared {@code multi_value} arity parameter; see {@link #multiValueParam()}. */
+        public static final String MULTI_VALUE_PARAM_NAME = "multi_value";
+
         public final String name;
         private final List<String> deprecatedNames = new ArrayList<>();
         private final Supplier<T> defaultValue;
@@ -407,6 +410,23 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 (n, c, o) -> new Explicit<>(XContentMapValues.nodeBooleanValue(o), true),
                 initializer
             ).setSerializer((b, n, v) -> b.field(n, v.value()), v -> Boolean.toString(v.value()));
+        }
+
+        /**
+         * Defines the shared {@code multi_value} mapping parameter, declaring whether a field holds a
+         * single value or an array. This captures field <em>arity</em> — distinct from the number of
+         * distinct values a field has, and unrelated to the {@code cardinality} aggregation.
+         *
+         * <p>Field types that can hold arrays should register this in {@code getParameters()} and
+         * stamp its value onto the built field type via {@link MappedFieldType#setMultiValued(boolean)}.
+         * Consumers that project a fixed schema (columnar data formats, SQL/PPL, join) read it back via
+         * {@link MappedFieldType#isMultiValued()}. It defaults to {@code false} and is not updateable —
+         * a field's arity is fixed once data is written.
+         *
+         * @return a {@code Parameter<Boolean>} named {@value #MULTI_VALUE_PARAM_NAME}
+         */
+        public static Parameter<Boolean> multiValueParam() {
+            return Parameter.boolParam(MULTI_VALUE_PARAM_NAME, false, m -> m.fieldType().isMultiValued(), false);
         }
 
         /**

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -310,6 +310,20 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         if (!nestedObjectMapper.nested().isNested()) {
             throw new IllegalStateException("[" + NAME + "] nested object under path [" + path + "] is not of nested type");
         }
+        // A correlated group is stored as parallel columns with no per-element document, so the block
+        // join this query relies on has nothing to join against and would silently match nothing.
+        // Fail loudly instead: the weaker semantics are the documented cost of [correlated: true].
+        if (nestedObjectMapper.correlated()) {
+            throw new IllegalStateException(
+                "["
+                    + NAME
+                    + "] cannot be used on the object under path ["
+                    + path
+                    + "] because it is declared [correlated: true], which stores the group as parallel "
+                    + "columns rather than nested documents. Query its fields directly; note that they "
+                    + "match across elements, so a match on two fields need not come from the same element."
+            );
+        }
         final BitSetProducer parentFilter;
         Query innerQuery;
         ObjectMapper objectMapper = context.nestedScope().getObjectMapper();

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
@@ -121,6 +121,16 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
         if (childObjectMapper.nested().isNested() == false) {
             throw new AggregationExecutionException("[nested] nested path [" + path + "] is not nested");
         }
+        // A correlated group is stored as parallel columns with no document per element, so the child
+        // filter this aggregation buckets on matches nothing and every bucket would come back empty.
+        if (childObjectMapper.correlated()) {
+            throw new AggregationExecutionException(
+                "[nested] aggregation is not supported on path ["
+                    + path
+                    + "] because it is declared [correlated: true]: the group is stored as parallel columns "
+                    + "rather than nested documents, so there are no per-element documents to bucket"
+            );
+        }
         try {
             ObjectMapper parentObjectMapper = queryShardContext.nestedScope().nextLevel(childObjectMapper);
             return new NestedAggregatorFactory(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/ReverseNestedAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/ReverseNestedAggregationBuilder.java
@@ -128,6 +128,16 @@ public class ReverseNestedAggregationBuilder extends AbstractAggregationBuilder<
             if (parentObjectMapper.nested().isNested() == false) {
                 throw new AggregationExecutionException("[reverse_nested] nested path [" + path + "] is not nested");
             }
+            // A correlated group has no per-element documents, so there is no parent to reverse to: the
+            // parent filter matches nothing and the aggregation would silently return empty.
+            if (parentObjectMapper.correlated()) {
+                throw new AggregationExecutionException(
+                    "[reverse_nested] aggregation is not supported on path ["
+                        + path
+                        + "] because it is declared [correlated: true]: the group is stored as parallel columns "
+                        + "rather than nested documents, so there is no parent document to step back to"
+                );
+            }
         }
 
         NestedScope nestedScope = queryShardContext.nestedScope();

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -233,6 +233,17 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         if (!nestedObjectMapper.nested().isNested()) {
             throw new QueryShardException(context, "[nested] nested object under path [" + nestedPath + "] is not of nested type");
         }
+        // Nested sorting picks a value from the matching child documents. A correlated group has none,
+        // so the sort would silently fall back to the missing value for every hit.
+        if (nestedObjectMapper.correlated()) {
+            throw new QueryShardException(
+                context,
+                "[nested] sorting is not supported under path ["
+                    + nestedPath
+                    + "] because it is declared [correlated: true]: the group is stored as parallel columns "
+                    + "rather than nested documents, so there are no per-element documents to sort on"
+            );
+        }
         ObjectMapper objectMapper = context.nestedScope().getObjectMapper();
 
         // get our child query, potentially applying a users filter

--- a/server/src/test/java/org/opensearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -152,7 +152,9 @@ public abstract class AbstractFieldDataTestCase extends OpenSearchSingleNodeTest
         } else if (type.equals("geo_point")) {
             fieldType = new GeoPointFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
         } else if (type.equals("flat_object")) {
-            fieldType = new FlatObjectFieldMapper.Builder(fieldName).docValues(docValues).build(context).fieldType();
+            // flat_object always writes doc values for its sub-fields, so it exposes no docValues
+            // setter; the previous .docValues(docValues) call was inherited and had no effect.
+            fieldType = new FlatObjectFieldMapper.Builder(fieldName).build(context).fieldType();
         } else if (type.equals("binary")) {
             fieldType = new BinaryFieldMapper.Builder(fieldName, docValues).build(context).fieldType();
         } else {

--- a/server/src/test/java/org/opensearch/index/mapper/CorrelatedNestedObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/CorrelatedNestedObjectMapperTests.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The {@code correlated} mapping parameter on a {@code nested} object.
+ *
+ * <p>{@code nested} already declares that an object is an array of records whose fields belong
+ * together; {@code correlated: true} keeps that declaration but changes how the group is stored —
+ * parallel columns paired by array position instead of a hidden document per element. It is an
+ * explicit opt-in precisely because it trades away element-scoped {@code nested} queries, so plain
+ * {@code nested} must keep behaving exactly as before.
+ */
+public class CorrelatedNestedObjectMapperTests extends MapperServiceTestCase {
+
+    private Settings pluggableSettings() {
+        return Settings.builder().put(getIndexSettings()).put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true).build();
+    }
+
+    /**
+     * @param correlated {@code null} omits the parameter entirely, otherwise it is written explicitly.
+     *                   The distinction matters: an omitted parameter must not reset an existing value
+     *                   on a mapping update.
+     */
+    private XContentBuilder correlatedEventsMapping(Boolean correlated, String type) throws IOException {
+        return mapping(b -> {
+            b.startObject("Events");
+            b.field("type", type);
+            if (correlated != null) {
+                b.field("correlated", correlated.booleanValue());
+            }
+            b.startObject("properties");
+            b.startObject("Name").field("type", "keyword").field("multi_value", true).endObject();
+            b.startObject("Kind").field("type", "keyword").field("multi_value", true).endObject();
+            b.endObject();
+            b.endObject();
+        });
+    }
+
+    /** The group is accepted and each leaf is stamped with the object's full path. */
+    public void testCorrelatedNestedStampsChildrenWithGroup() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), correlatedEventsMapping(true, "nested"));
+
+        ObjectMapper events = mapperService.getObjectMapper("Events");
+        assertNotNull(events);
+        assertTrue("Events should still be a nested object", events.nested().isNested());
+        assertTrue(events.correlated());
+
+        assertEquals("Events", mapperService.fieldType("Events.Name").correlationGroup());
+        assertEquals("Events", mapperService.fieldType("Events.Kind").correlationGroup());
+    }
+
+    /** Fields outside a correlated group carry no stamp, so the write path leaves them alone. */
+    public void testUncorrelatedFieldsHaveNoGroup() throws IOException {
+        MapperService mapperService = createMapperService(
+            pluggableSettings(),
+            mapping(b -> b.startObject("Tags").field("type", "keyword").field("multi_value", true).endObject())
+        );
+        assertNull(mapperService.fieldType("Tags").correlationGroup());
+    }
+
+    /** Round-trips through mapping serialization, so it survives cluster state and index reopen. */
+    public void testCorrelatedRoundTripsInMapping() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), correlatedEventsMapping(true, "nested"));
+
+        String serialized = mapperService.documentMapper().mappingSource().toString();
+
+        assertTrue("expected [correlated] in the serialized mapping: " + serialized, serialized.contains("\"correlated\":true"));
+        assertTrue("expected the object to stay nested: " + serialized, serialized.contains("\"type\":\"nested\""));
+    }
+
+    /**
+     * A correlated group parses into the parent document. Building the hidden per-element documents
+     * instead would scatter the fields across documents, which is the representation the parameter
+     * exists to opt out of.
+     */
+    public void testCorrelatedNestedDoesNotCreateNestedDocuments() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings(), correlatedEventsMapping(true, "nested"));
+
+        ParsedDocument doc = mapper.parse(source("{\"Events\":{\"Name\":[\"a\",\"b\"],\"Kind\":[\"k1\",\"k2\"]}}"));
+
+        assertEquals("a correlated group must not add per-element documents", 1, doc.docs().size());
+        assertEquals(List.of("a", "b"), indexedValues(doc, "Events.Name"));
+        assertEquals(List.of("k1", "k2"), indexedValues(doc, "Events.Kind"));
+    }
+
+    /** Plain {@code nested} is untouched: it still produces a document per element. */
+    public void testPlainNestedStillCreatesNestedDocuments() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings(), correlatedEventsMapping(false, "nested"));
+
+        ParsedDocument doc = mapper.parse(source("{\"Events\":[{\"Name\":\"a\",\"Kind\":\"k1\"},{\"Name\":\"b\",\"Kind\":\"k2\"}]}"));
+
+        assertTrue("plain nested should still build per-element documents, got " + doc.docs().size(), doc.docs().size() > 1);
+    }
+
+    /**
+     * Rejected on a plain object: {@code nested} is what declares the grouping, so allowing
+     * {@code correlated} without it would be a second, redundant way to say the same thing.
+     */
+    public void testCorrelatedRequiresNestedType() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(pluggableSettings(), correlatedEventsMapping(true, "object"))
+        );
+        assertTrue("unexpected message: " + e.getMessage(), e.getMessage().contains("requires [type: nested]"));
+    }
+
+    /**
+     * Rejected without a pluggable data format. There it would only remove element-scoped query
+     * support, since nested documents already correlate the fields.
+     */
+    public void testCorrelatedRequiresPluggableDataFormat() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(correlatedEventsMapping(true, "nested"))
+        );
+        assertTrue("unexpected message: " + e.getMessage(), e.getMessage().contains("pluggable data format"));
+    }
+
+    /** A sub-object has no single array position, so its correlation would be undefined. */
+    public void testCorrelatedRejectsSubObjects() {
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(pluggableSettings(), mapping(b -> {
+            b.startObject("Events");
+            b.field("type", "nested").field("correlated", true);
+            b.startObject("properties");
+            b.startObject("Name").field("type", "keyword").field("multi_value", true).endObject();
+            b.startObject("Inner").startObject("properties");
+            b.startObject("Deep").field("type", "keyword").endObject();
+            b.endObject().endObject();
+            b.endObject();
+            b.endObject();
+        })));
+        assertTrue("unexpected message: " + e.getMessage(), e.getMessage().contains("cannot contain the sub-object"));
+    }
+
+    /** It selects the on-disk layout, so flipping it would misdescribe already-written data. */
+    public void testCorrelatedIsImmutable() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), correlatedEventsMapping(true, "nested"));
+
+        MapperException e = expectThrows(MapperException.class, () -> merge(mapperService, correlatedEventsMapping(false, "nested")));
+        assertTrue("unexpected message: " + e.getMessage(), e.getMessage().contains("Cannot update parameter [correlated]"));
+    }
+
+    /**
+     * Omitting the parameter on a later mapping update leaves it as it was. Treating an absent
+     * parameter as {@code false} would silently switch the group's storage layout on any unrelated
+     * mapping update, such as adding a field.
+     */
+    public void testOmittingCorrelatedOnUpdatePreservesIt() throws IOException {
+        MapperService mapperService = createMapperService(pluggableSettings(), correlatedEventsMapping(true, "nested"));
+        merge(mapperService, correlatedEventsMapping(null, "nested"));
+
+        assertTrue(mapperService.getObjectMapper("Events").correlated());
+        assertEquals("Events", mapperService.fieldType("Events.Name").correlationGroup());
+    }
+
+    /**
+     * The distinct values a field contributed to the root document, in first-seen order. Keyword
+     * stores each value twice (indexed term plus doc value) and carries it in {@code binaryValue}
+     * rather than {@code stringValue}, so both are accounted for here.
+     */
+    private static List<String> indexedValues(ParsedDocument doc, String field) {
+        Set<String> values = new LinkedHashSet<>();
+        for (IndexableField f : doc.rootDoc().getFields(field)) {
+            if (f.binaryValue() != null) {
+                values.add(f.binaryValue().utf8ToString());
+            } else if (f.stringValue() != null) {
+                values.add(f.stringValue());
+            }
+        }
+        return new ArrayList<>(values);
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
@@ -22,6 +22,8 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryShardContext;
@@ -417,7 +419,93 @@ public class FlatObjectFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
-        // In the future we will want to make sure parameter updates are covered.
+        // `index` is only accepted on a pluggable-data-format index, so the generic checker (which
+        // builds plain indices) cannot exercise it; testIndexParameter* below cover it directly.
+        // Other parameters are still unsupported for flat_object.
+    }
+
+    /**
+     * {@code index: false} is rejected on a plain Lucene index. It is scoped to pluggable data
+     * formats deliberately: there, a columnar primary holds the values, whereas here it would only
+     * leave the field reachable through the doc-values path — a behaviour change for existing
+     * mappings with no upside.
+     */
+    public void testIndexParameterRejectedWithoutPluggableDataFormat() {
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(fieldMapping(b -> b.field("type", CONTENT_TYPE).field("index", false)))
+        );
+        assertTrue(
+            "expected the guard's message, got: " + e.getMessage(),
+            e.getMessage().contains("does not support [index: false] unless the index uses a pluggable data format")
+        );
+    }
+
+    /**
+     * With a pluggable data format configured, {@code index: false} is accepted, reaches the field
+     * type as {@code isSearchable() == false}, and round-trips through serialization. The round trip
+     * matters because flat_object derives its searchability from its {@code _value} sub-field, so the
+     * parameter's read-back has to recover the mapping value from that derived state.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testIndexParameterWithPluggableDataFormat() throws IOException {
+        Settings pluggable = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
+
+        MapperService withIndexFalse = createMapperService(
+            pluggable,
+            fieldMapping(b -> b.field("type", CONTENT_TYPE).field("index", false))
+        );
+        FieldMapper mapper = (FieldMapper) withIndexFalse.documentMapper().mappers().getMapper("field");
+        assertFalse("index:false must reach the field type", mapper.fieldType().isSearchable());
+        assertTrue(
+            "index:false must round-trip through serialization",
+            Strings.toString(MediaTypeRegistry.JSON, mapper).contains("\"index\":false")
+        );
+
+        // The default stays searchable and, being the default, is not serialized.
+        MapperService dflt = createMapperService(pluggable, fieldMapping(this::minimalMapping));
+        FieldMapper defaultMapper = (FieldMapper) dflt.documentMapper().mappers().getMapper("field");
+        assertTrue(defaultMapper.fieldType().isSearchable());
+        assertFalse(Strings.toString(MediaTypeRegistry.JSON, defaultMapper).contains("index"));
+    }
+
+    /**
+     * {@code index} cannot be flipped by a mapping update: existing documents' postings would no
+     * longer match the mapping. Before flat_object became a {@link ParametrizedFieldMapper} its
+     * {@code mergeOptions} was empty, so every update silently succeeded.
+     */
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testIndexParameterIsNotUpdateable() throws IOException {
+        Settings pluggable = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
+        MapperService mapperService = createMapperService(
+            pluggable,
+            fieldMapping(b -> b.field("type", CONTENT_TYPE).field("index", false))
+        );
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> merge(mapperService, fieldMapping(b -> b.field("type", CONTENT_TYPE).field("index", true)))
+        );
+        assertTrue("expected an [index] conflict, got: " + e.getMessage(), e.getMessage().contains("index"));
+    }
+
+    /**
+     * On a plain index the default mapping still writes both the indexed terms and the doc values for
+     * the {@code _value} / {@code _valueAndPath} sub-fields — a guard that the
+     * {@link ParametrizedFieldMapper} refactor did not disturb the write path.
+     */
+    public void testDefaultStillIndexesSubFields() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(b -> b.startObject("field").field("k", "v").endObject()));
+        List<IndexableField> valueFields = List.of(doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+        assertFalse("expected _value fields to be written", valueFields.isEmpty());
+        assertTrue(
+            "expected at least one indexed (non doc-values) _value field",
+            valueFields.stream().anyMatch(f -> f.fieldType().indexOptions() != IndexOptions.NONE)
+        );
+        assertTrue(
+            "expected doc values on _value",
+            valueFields.stream().anyMatch(f -> f.fieldType().docValuesType() != DocValuesType.NONE)
+        );
     }
 
     public void testDefaultsDoNotUseDocumentInput() throws Exception {

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
@@ -17,6 +17,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.TriFunction;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -28,6 +30,7 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.CONTENT_TYPE;
@@ -429,5 +432,56 @@ public class FlatObjectFieldMapperTests extends MapperTestCase {
         ParsedDocument doc = mapper.parse(source(json));
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
+    }
+
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatEmitsOneMapEntryPerLeaf() throws Exception {
+        Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
+
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
+        String json = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("field")
+            .startObject("http")
+            .field("status", 500)
+            .field("method", "GET")
+            .endObject()
+            .array("tags", "a", "b")
+            .endObject()
+            .endObject()
+            .toString();
+        mapper.parse(source(json), docInput);
+
+        // A single addField call for the whole object; the value is the ordered list of leaf entries
+        // (relative path, stringified value), so the column stays a single MAP.
+        List<Map.Entry<MappedFieldType, Object>> captured = docInput.getCapturedFields()
+            .stream()
+            .filter(e -> e.getKey().name().equals("field"))
+            .collect(java.util.stream.Collectors.toList());
+        assertEquals("flat_object must be handed over in one addField call", 1, captured.size());
+
+        @SuppressWarnings("unchecked")
+        List<Map.Entry<String, String>> entries = (List<Map.Entry<String, String>>) captured.get(0).getValue();
+        MatcherAssert.assertThat(
+            entries,
+            containsInAnyOrder(
+                Map.entry("http.status", "500"),
+                Map.entry("http.method", "GET"),
+                Map.entry("tags", "a"),
+                Map.entry("tags", "b")
+            )
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testPluggableDataFormatNullObjectSkipped() throws Exception {
+        Settings pluggableSettings = Settings.builder().put(getIndexSettings()).put("index.pluggable.dataformat.enabled", true).build();
+        DocumentMapper mapper = createDocumentMapper(pluggableSettings, fieldMapping(this::minimalMapping));
+
+        CapturingDocumentInput docInput = new CapturingDocumentInput();
+        mapper.parse(source(b -> b.nullField("field")), docInput);
+
+        assertFalse(docInput.getCapturedFields().stream().anyMatch(e -> e.getKey().name().equals("field")));
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
@@ -55,6 +55,8 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
@@ -197,6 +199,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "foo"));
         checker.registerConflictCheck("similarity", b -> b.field("similarity", "boolean"));
         checker.registerConflictCheck("normalizer", b -> b.field("normalizer", "lowercase"));
+        // Not updateable: the column type is baked into every parquet file the index has written.
+        checker.registerConflictCheck("multi_value", b -> b.field("multi_value", true));
 
         checker.registerUpdateCheck(b -> b.field("eager_global_ordinals", true), m -> assertTrue(m.fieldType().eagerGlobalOrdinals()));
         checker.registerUpdateCheck(b -> b.field("ignore_above", 256), m -> assertEquals(256, ((KeywordFieldMapper) m).ignoreAbove()));
@@ -281,6 +285,20 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
         assertTrue(fields[0].fieldType().stored());
+    }
+
+    public void testMultiValueParameter() throws IOException {
+        // Default is single-valued and, being the default, is not serialized.
+        DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        FieldMapper defaultField = (FieldMapper) defaultMapper.mappers().getMapper("field");
+        assertFalse(defaultField.fieldType().isMultiValued());
+        assertFalse(Strings.toString(MediaTypeRegistry.JSON, defaultField).contains("multi_value"));
+
+        // multi_value: true reaches the field type and round-trips through serialization.
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword").field("multi_value", true)));
+        FieldMapper field = (FieldMapper) mapper.mappers().getMapper("field");
+        assertTrue(field.fieldType().isMultiValued());
+        assertTrue(Strings.toString(MediaTypeRegistry.JSON, field).contains("\"multi_value\":true"));
     }
 
     public void testDisableIndex() throws IOException {


### PR DESCRIPTION
### Description

Adds a `correlated` mapping parameter to `nested` objects, and makes `multi_value` work on `flat_object`, so a group of parallel arrays can be stored as columns whose elements stay aligned by position.

```json
"Events": {
  "type": "nested",
  "correlated": true,
  "properties": {
    "Timestamp":  { "type": "date_nanos",  "multi_value": true },
    "Name":       { "type": "keyword",     "multi_value": true },
    "Attributes": { "type": "flat_object", "multi_value": true }
  }
}
```

A group declared this way is stored as **one `LIST` column per sub-field in the parent document**, rather than as a hidden document per element. Index `i` of each column describes the same element, and a document whose sub-field arrays disagree in length is rejected at parse time.

#### Why the length check is necessary

Each sub-field is an independent `LIST` column with its own offsets, so nothing in the storage layer couples them. A document with 2 names and 1 kind writes cleanly and reads back with `Name[1]` paired against a `Kind` belonging to a different element — accepted at write time, silently wrong at read time. The check is what makes "index `i`" mean the same thing in every column of the group.

Group membership is carried on `MappedFieldType#correlationGroup()`, stamped at mapping build time and in `ObjectMapper#putMapper` (so a dynamically added sub-field is not silently exempt), which lets the write path find the group from the field type alone without walking the mapper tree.

#### `multi_value` on `flat_object`

A `flat_object` declared `multi_value: true` now writes `LIST<MAP>` — one map per array element — instead of being rejected. `[{"exception.type":"IOError"},{"http.method":"GET"}]` reconstructs as two maps rather than one merged map, so which element contributed which attribute survives. Two things were missing:

- The LIST element was built from its `ArrowType` alone, so a MAP element lost its required `entries` struct. A childless MAP allocates as an empty vector, so writes land nowhere rather than failing.
- `FlatObjectParquetField` had no `addToVector`, the base class's contract for list storage. `addToGroup` now delegates to it, so the single-arity MAP and the `LIST<MAP>` share one entry-writing implementation.

Nothing was needed on the read path: `DocumentParser#parseNonDynamicArray` already hands each array element to the mapper separately, and `ArrowValues#toSourceValue` recurses into the list's element vector with the `MapVector` branch checked first, so `_source` reconstructs the elements separately and in order.

This makes the two field types complementary rather than competing: typed columns (`date_nanos`, `keyword`) where the schema is known and individually prunable, an open-ended map for the one member whose keys cannot be declared.

### Queries this does not support

`correlated: true` trades away everything that depends on there being a document per element. Because it keeps the object declared `nested`, every consumer that guards on `ObjectMapper#nested().isNested()` passes the guard and then relies on `nestedTypeFilter()` to select those documents — of which a correlated group has none. Each therefore returned **nothing** rather than failing, which reads as "no matching elements" instead of "this grouping cannot answer that". All four now reject the group with the same explanation:

| Consumer | Site | Was |
|---|---|---|
| `nested` query | `NestedQueryBuilder#doToQuery` | block join with no children to join → matches nothing |
| `nested` aggregation | `NestedAggregationBuilder#doBuild` | child filter matches nothing → empty buckets |
| `reverse_nested` aggregation | `ReverseNestedAggregationBuilder#doBuild` | no parent document to step back to |
| nested-path sorting | `SortBuilder#resolveNested` | no child values → missing value for every hit |

`inner_hits` is reachable only through a `nested` query, so it is covered by the first rejection.

**Cross-element matching remains.** The group's fields are ordinary multi-valued fields to Lucene, so a conjunction across two members can be satisfied by two *different* elements. Given events `{Name: exception, Attributes.exception.type: IOError}` and `{Name: retry}`, the query `Name = retry AND Attributes.exception.type = IOError` matches the document even though no single event satisfies both. Element-scoped querying would require either the per-element documents this parameter forgoes, or a columnar read path able to zip the group's columns element-wise; neither exists here, so the operations above fail loudly instead of approximating.

Positional information is not lost, only unqueryable: because the lengths are guaranteed equal, a client reading `_source` can recover element `i` across every column of the group.

### Scope

Restricted to indices using a pluggable data format — on a plain Lucene index nested documents already correlate the fields, so the parameter would only remove query support. Also rejected on a plain `object` (nothing for it to apply to) and on sub-objects (a second level of arrays has no defined positional correlation). It is immutable after creation, since it selects the on-disk layout, and it round-trips through mapping serialization. Plain `nested` is untouched and still builds a document per element.

### Testing

- `CorrelatedNestedObjectMapperTests` — 10 tests: stamping, serialization round-trip, no per-element documents, plain `nested` unchanged, the three rejections, immutability, and that omitting the parameter on a later update preserves it.
- `ParquetDocumentInputTests` — 19 tests: equal/unequal lengths, absent sub-fields exempt, groups validated independently, membership by stamp rather than name prefix.
- `FlatObjectParquetFieldTests` — `LIST<MAP>` field shape, per-element writes, null vs empty array, empty element preserved.
- `VSRManagerTests` — `LIST<MAP>` flushed through the C Data Interface and the native arrow-rs writer. A malformed element type survives allocation and only fails at export, so a completed native write is the real assertion.
- `ArrowValuesTests` — `_source` reconstructs per element, keeps empty elements, keeps an empty array distinct from an absent field.
- ITs — group accepted/rejected, plain object unaffected, all four unsupported operations rejected, and an end-to-end mapping round-tripping attributes per element.
- Rebased onto `main`; 2338 server mapper/query/agg/sort tests and 1732 sandbox tests across `parquet-data-format`, `analytics-engine`, `analytics-backend-lucene` and `composite-engine` pass.

#### Also fixed here

`ParquetDataFormatAwareEngineTests` was failing 8/8 with `Maps have one List child. Found: none`: the suite built each column as `new Field(name, pf.getFieldType(), null)`, dropping the children a nested column needs, and began iterating a MAP column once `flat_object` joined the field registry. Now routed through `toArrowField` — the same drop-the-children defect this PR fixes for LIST elements, so both paths use the canonical constructor. Strictly it belongs with the `flat_object` MAP work in #22741, which introduced the registry entry; it is fixed here because that is where it surfaced.

The Rust `nested_leaf_paths_match_arrow_rs_writer` test gained a `LIST<MAP>` case but could not be executed locally: the crate does not currently compile because tokio 1.52 removed the unstable `RuntimeMetrics` methods used in `merge/metrics.rs` and `ffm.rs`. ITs compile but have not been run.

#### 3. `multi_value` on the remaining field types

A correlated group could only hold `keyword` and `flat_object` members, because those were the only two `ParquetField` implementations overriding `supportsMultiValue()`. That left the OTel traces schema inexpressible — `Events.Timestamp Array(DateTime64(9))` in particular.

Every remaining type now writes a `LIST` column: all numerics (declared once on `NumericParquetField`), `date`, `date_nanos`, `boolean`, `ip`, `text`/`match_only_text` and `binary`. Each already knew how to encode its value; what was missing was writing at an **explicit index**, since list elements sit at positions in the child vector unrelated to the row number. `addToGroup` now delegates to `addToVector` in each type, so the scalar and list paths share one value-coercion implementation rather than duplicating the cast.

The mapper half is the `multi_value` parameter — previously keyword-only — added to `NumberFieldMapper`, `DateFieldMapper`, `BooleanFieldMapper`, `IpFieldMapper` and `BinaryFieldMapper`, stamped onto the built field type.

The full group is now expressible, confirmed by reading a generated file with DataFusion:

```
Events.Timestamp    List(Timestamp(ns), field: 'element')
Events.Name         List(Utf8, field: 'element')
Events.Attributes   List(Map("entries": ...), field: 'element')
```

#### 4. Evaluation tooling

`OtelTracesParquetGeneratorTests` writes an OTel-traces file through the real write path — same `ParquetField`s, same `VSRManager`, same native arrow-rs writer — and `benchmarks/otel-representation/` carries a cross-engine correctness harness plus a latency comparison against the same data flattened into JSON strings.

Two findings recorded there. Element-scoped and document-scoped evaluation of one predicate return **0 versus 3**, with ClickHouse and DataFusion agreeing on both answers on the same file — so the false positive is a property of document-granularity evaluation, not of either implementation. And on a deliberately ragged file, ClickHouse rejects only when both arrays are projected — **not** under `count(*)`, where the optimizer prunes the arrays and it pads to the longer one, exactly as DataFusion does. Write-time enforcement is therefore the only guarantee that does not depend on the query plan, which is a stronger justification for the parse-time check than the one in commit 1's message.

### Known gaps

Element-scoped querying still requires `LIST`/`MAP` projection in the columnar read path; the four operations listed above reject rather than approximate until that exists. `FlatObjectParquetField` also still declines `BLOOM_FILTER`, although the leaf paths it produces (`Events.Attributes.list.element.entries.key` / `.value`) show it is reachable.

### Related Issues

Follow-up to the composite-engine `flat_object`/MAP work in #22741.

### Check List
- [x] Functionality includes testing.
- [x] Public documented classes and methods have descriptive Javadoc.
- [x] Commits are signed per the DCO using `--signoff`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

