### PR TITLE
Reject pull-based ingestion indices for data streams and rollover

### DIFF
--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
@@ -8,15 +8,21 @@
 
 package org.opensearch.plugin.ingestion.fs;
 
+import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.rollover.RolloverRequest;
 import org.opensearch.action.admin.indices.stats.IndexStats;
 import org.opensearch.action.admin.indices.stats.ShardStats;
 import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionResponse;
 import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionRequest;
 import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionResponse;
 import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateResponse;
+import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Template;
+import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.indices.pollingingest.PollingIngestStats;
@@ -34,6 +40,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -150,6 +157,70 @@ public class FileBasedIngestionSingleNodeTests extends OpenSearchSingleNodeTestC
 
         // cleanup the test index
         client().admin().indices().delete(new DeleteIndexRequest(index)).actionGet();
+    }
+
+    public void testRolloverIsRejectedForPullBasedIngestion() throws Exception {
+        String mappings = """
+            {
+              "properties": {
+                "name": { "type": "text" },
+                "age": { "type": "integer" },
+                "@timestamp": { "type": "date" }
+              }
+            }
+            """;
+        Settings ingestionSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("ingestion_source.type", "FILE")
+            .put("ingestion_source.pointer.init.reset", "earliest")
+            .put("ingestion_source.param.stream", stream)
+            .put("ingestion_source.param.base_directory", ingestionDir.toString())
+            .put("index.replication.type", "SEGMENT")
+            .build();
+
+        // a data stream would run one poller per backing index and ingest every message once per generation
+        ComposableIndexTemplate dataStreamTemplate = new ComposableIndexTemplate(
+            List.of("ds_test*"),
+            new Template(ingestionSettings, new CompressedXContent(mappings), null),
+            null,
+            null,
+            null,
+            null,
+            new ComposableIndexTemplate.DataStreamTemplate()
+        );
+        PutComposableIndexTemplateAction.Request putTemplate = new PutComposableIndexTemplateAction.Request("ds_test_template");
+        putTemplate.indexTemplate(dataStreamTemplate);
+        assertTrue(client().execute(PutComposableIndexTemplateAction.INSTANCE, putTemplate).get().isAcknowledged());
+
+        IllegalArgumentException dataStreamFailure = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().indices().createDataStream(new CreateDataStreamAction.Request("ds_test")).actionGet()
+        );
+        assertEquals(
+            "cannot create backing index [.ds-ds_test-000001] of data stream [ds_test] with [index.ingestion_source.type] set, "
+                + "pull-based ingestion does not support index rollover",
+            dataStreamFailure.getMessage()
+        );
+
+        // rolling over a write alias would leave the old index polling while the alias points elsewhere
+        String aliasedIndex = "test_index-000001";
+        createIndexWithMappingSource(aliasedIndex, ingestionSettings, mappings);
+        ensureGreen(aliasedIndex);
+        assertTrue(client().admin().indices().prepareAliases().addAlias(aliasedIndex, "test_alias").get().isAcknowledged());
+
+        IllegalArgumentException aliasFailure = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().indices().rolloverIndex(new RolloverRequest("test_alias", null)).actionGet()
+        );
+        assertEquals(
+            "rollover target [test_alias] has write index ["
+                + aliasedIndex
+                + "] with [index.ingestion_source.type] set, pull-based ingestion does not support index rollover",
+            aliasFailure.getMessage()
+        );
+
+        client().admin().indices().delete(new DeleteIndexRequest(aliasedIndex)).actionGet();
     }
 
     public void testFileIngestionOnMissingFiles() throws Exception {

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -416,8 +416,20 @@ public class MetadataRolloverService {
                     + "] was expected"
             );
         }
-        if (indexAbstraction.getWriteIndex() == null) {
+        final IndexMetadata writeIndex = indexAbstraction.getWriteIndex();
+        if (writeIndex == null) {
             throw new IllegalArgumentException("rollover target [" + indexAbstraction.getName() + "] does not point to a write index");
+        }
+        if (writeIndex.useIngestionSource()) {
+            throw new IllegalArgumentException(
+                "rollover target ["
+                    + indexAbstraction.getName()
+                    + "] has write index ["
+                    + writeIndex.getIndex().getName()
+                    + "] with ["
+                    + IndexMetadata.SETTING_INGESTION_SOURCE_TYPE
+                    + "] set, pull-based ingestion does not support index rollover"
+            );
         }
         if (indexAbstraction.getType() == DATA_STREAM) {
             if (Strings.isNullOrEmpty(newIndexName) == false) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -663,8 +663,28 @@ public class MetadataCreateIndexService {
         // Set up everything, now locally create the index to see that things are ok, and apply
         IndexMetadata tempMetadata = tmpImdBuilder.build();
         validateActiveShardCount(request.waitForActiveShards(), tempMetadata);
+        validateDataStreamIngestionSource(request, tempMetadata);
 
         return tempMetadata;
+    }
+
+    /**
+     * Pull-based ingestion binds a poller to a single concrete index, so every backing index of a data stream would
+     * poll the source independently and index the same messages once per generation. Rollover is documented as
+     * unsupported for pull-based ingestion, so reject the backing index instead of silently duplicating data.
+     */
+    private static void validateDataStreamIngestionSource(CreateIndexClusterStateUpdateRequest request, IndexMetadata indexMetadata) {
+        if (request.dataStreamName() != null && indexMetadata.useIngestionSource()) {
+            throw new IllegalArgumentException(
+                "cannot create backing index ["
+                    + request.index()
+                    + "] of data stream ["
+                    + request.dataStreamName()
+                    + "] with ["
+                    + IndexMetadata.SETTING_INGESTION_SOURCE_TYPE
+                    + "] set, pull-based ingestion does not support index rollover"
+            );
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -398,6 +398,65 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         MetadataRolloverService.validate(metadata, aliasWithWriteIndex, randomAlphaOfLength(5), req);
     }
 
+    public void testPullBasedIngestionValidation() {
+        final Settings ingestionSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_INGESTION_SOURCE_TYPE, "kafka")
+            .build();
+
+        final String aliasName = randomAlphaOfLength(5);
+        final String indexName = randomAlphaOfLength(6);
+        Metadata aliasMetadata = Metadata.builder()
+            .put(IndexMetadata.builder(indexName).settings(ingestionSettings).putAlias(AliasMetadata.builder(aliasName)))
+            .build();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> MetadataRolloverService.validate(aliasMetadata, aliasName, null, new CreateIndexRequest())
+        );
+        assertThat(
+            exception.getMessage(),
+            equalTo(
+                "rollover target ["
+                    + aliasName
+                    + "] has write index ["
+                    + indexName
+                    + "] with [index.ingestion_source.type] set, pull-based ingestion does not support index rollover"
+            )
+        );
+
+        // a data stream created before this validation existed must not be rolled over either
+        final String dataStreamName = randomAlphaOfLength(7);
+        final String backingIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
+        IndexMetadata backingIndex = IndexMetadata.builder(backingIndexName).settings(ingestionSettings).build();
+        Metadata dataStreamMetadata = Metadata.builder()
+            .put(backingIndex, false)
+            .put(
+                new DataStream(
+                    dataStreamName,
+                    DataStreamTestHelper.createTimestampField("@timestamp"),
+                    Collections.singletonList(backingIndex.getIndex())
+                )
+            )
+            .build();
+        exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> MetadataRolloverService.validate(dataStreamMetadata, dataStreamName, null, new CreateIndexRequest())
+        );
+        assertThat(
+            exception.getMessage(),
+            equalTo(
+                "rollover target ["
+                    + dataStreamName
+                    + "] has write index ["
+                    + backingIndexName
+                    + "] with [index.ingestion_source.type] set, pull-based ingestion does not support index rollover"
+            )
+        );
+    }
+
     public void testDataStreamValidation() throws IOException {
         Metadata.Builder md = Metadata.builder();
         DataStream randomDataStream = DataStreamTests.randomInstance();

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1999,6 +1999,63 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(expectedValue, customData.get(expectedKey));
     }
 
+    public void testDataStreamBackingIndexRejectsIngestionSource() {
+        withTemporaryClusterService(((clusterService, threadPool) -> {
+            MetadataCreateIndexService checkerService = new MetadataCreateIndexService(
+                Settings.EMPTY,
+                clusterService,
+                indicesServices,
+                null,
+                null,
+                createTestShardLimitService(randomIntBetween(1, 1000), false, clusterService),
+                null,
+                null,
+                threadPool,
+                null,
+                new SystemIndices(Collections.emptyMap()),
+                false,
+                new AwarenessReplicaBalance(Settings.EMPTY, clusterService.getClusterSettings()),
+                DefaultRemoteStoreSettings.INSTANCE,
+                repositoriesServiceSupplier
+            );
+            Settings indexSettings = Settings.builder()
+                .put("index.version.created", Version.CURRENT)
+                .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
+                .put(IndexMetadata.SETTING_INGESTION_SOURCE_TYPE, "kafka")
+                .build();
+            String backingIndexName = DataStream.getDefaultBackingIndexName("logs", 1);
+            CreateIndexClusterStateUpdateRequest request = new CreateIndexClusterStateUpdateRequest(
+                "create index",
+                backingIndexName,
+                backingIndexName
+            ).dataStreamName("logs");
+
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> checkerService.buildAndValidateTemporaryIndexMetadata(indexSettings, request, 1, clusterService.state())
+            );
+            assertEquals(
+                "cannot create backing index ["
+                    + backingIndexName
+                    + "] of data stream [logs] with [index.ingestion_source.type] set, "
+                    + "pull-based ingestion does not support index rollover",
+                exception.getMessage()
+            );
+
+            // the same settings are still accepted for a standalone index
+            CreateIndexClusterStateUpdateRequest standaloneRequest = new CreateIndexClusterStateUpdateRequest(
+                "create index",
+                "test",
+                "test"
+            );
+            assertNotNull(
+                checkerService.buildAndValidateTemporaryIndexMetadata(indexSettings, standaloneRequest, 1, clusterService.state())
+            );
+        }));
+    }
+
     public void testNumberOfRoutingShardsShowsInIndexSettings() {
         withTemporaryClusterService(((clusterService, threadPool) -> {
             MetadataCreateIndexService checkerService = new MetadataCreateIndexService(


### PR DESCRIPTION
### Description
Pull-based ingestion binds one poller to one concrete index, and index rollover is documented as unsupported for it. Nothing enforced that. A template combining `data_stream: {}` with `index.ingestion_source.*` was accepted, so every backing index started its own poller and re-read the source from `pointer.init.reset` — each generation re-indexed the same messages. Rolling over a write alias whose write index uses an ingestion source was accepted too, leaving the old index polling while the alias moved on.

`MetadataCreateIndexService` now rejects an ingestion source on a data-stream backing index, checked against the resolved settings so template-supplied values are covered, and `MetadataRolloverService.validate` refuses rollover when the write index uses one. Standalone indices with `ingestion_source` are unaffected.

Verified with the `ingestion-fs` source: before the change, creating such a data stream and rolling it over succeeded and 2 source messages became 4 documents; after, the create is rejected. All three new tests fail without the main-code change and pass with it.

### Related Issues
Resolves #22202

### Check List
- [x] Functionality includes testing.
