### PR TITLE
[BUG] Add timeout to on-demand block fetch and read timeout to async S3 client (#22763)

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
@@ -370,6 +370,7 @@ class S3AsyncService implements Closeable {
         // TODO: add max retry and UseThrottleRetry. Replace values with settings and put these in default settings
         clientBuilder.connectionTimeout(Duration.ofMillis(clientSettings.connectionTimeoutMillis));
         clientBuilder.connectionAcquisitionTimeout(Duration.ofMillis(clientSettings.connectionAcquisitionTimeoutMillis));
+        clientBuilder.readTimeout(Duration.ofMillis(clientSettings.readTimeoutMillis));
         clientBuilder.maxPendingConnectionAcquires(10_000);
         clientBuilder.maxConcurrency(clientSettings.maxConnections);
         clientBuilder.eventLoopGroup(SdkEventLoopGroup.create(asyncTransferEventLoopGroup.getEventLoopGroup()));
@@ -394,6 +395,7 @@ class S3AsyncService implements Closeable {
         }
 
         crtClientBuilder.connectionTimeout(Duration.ofMillis(clientSettings.connectionTimeoutMillis));
+        crtClientBuilder.readTimeout(Duration.ofMillis(clientSettings.readTimeoutMillis));
         crtClientBuilder.maxConcurrency(clientSettings.maxConnections);
         return crtClientBuilder.build();
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -52,6 +54,12 @@ public class TransferManager {
     private final StreamReader streamReader;
     private final FileCache fileCache;
     private final ThreadPool threadPool;
+
+    /**
+     * Default timeout for block fetch operations (5 minutes).
+     * Used when no explicit timeout is provided.
+     */
+    static final long DEFAULT_BLOCK_FETCH_TIMEOUT_MILLIS = 300_000L;
 
     public TransferManager(final StreamReader streamReader, final FileCache fileCache, ThreadPool threadPool) {
         this.streamReader = streamReader;
@@ -197,11 +205,17 @@ public class TransferManager {
         private final CompletableFuture<IndexInput> result = new CompletableFuture<>();
         private final AtomicBoolean isStarted = new AtomicBoolean(false);
         private final AtomicBoolean isClosed = new AtomicBoolean(false);
+        private final long timeoutMillis;
 
         private DelayedCreationCachedIndexInput(FileCache fileCache, StreamReader streamReader, BlobFetchRequest request) {
+            this(fileCache, streamReader, request, DEFAULT_BLOCK_FETCH_TIMEOUT_MILLIS);
+        }
+
+        private DelayedCreationCachedIndexInput(FileCache fileCache, StreamReader streamReader, BlobFetchRequest request, long timeoutMillis) {
             this.fileCache = fileCache;
             this.streamReader = streamReader;
             this.request = request;
+            this.timeoutMillis = timeoutMillis;
         }
 
         @Override
@@ -219,14 +233,24 @@ public class TransferManager {
                 }
             }
             try {
-                return result.join();
-            } catch (CompletionException e) {
-                if (e.getCause() instanceof UncheckedIOException) {
-                    throw ((UncheckedIOException) e.getCause()).getCause();
-                } else if (e.getCause() instanceof RuntimeException) {
-                    throw (RuntimeException) e.getCause();
+                return result.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                throw new IOException(
+                    "Timed out after " + timeoutMillis + "ms waiting for block fetch: " + request.getFilePath()
+                );
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException(
+                    "Interrupted while waiting for block fetch: " + request.getFilePath()
+                );
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof UncheckedIOException) {
+                    throw ((UncheckedIOException) cause).getCause();
+                } else if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
                 }
-                throw e;
+                throw new IOException(e);
             }
         }
 


### PR DESCRIPTION
## Description

Fixes #22763 — on-demand block fetch can hang indefinitely, blocking searches and recovery on remote-store-backed / searchable-snapshot nodes.

### Three fixes in this PR:

1. **TransferManager — bounded timeout on block fetch (`getIndexInput()`)**
   Replace `CompletableFuture.join()` (no timeout) with `CompletableFuture.get(timeoutMillis, TimeUnit.MILLISECONDS)`. If the underlying `createIndexInput` call stalls (stuck S3 read, thread pool exhaustion), the wait now fails fast after 5 minutes with a clear `IOException` instead of parking threads forever.

2. **S3AsyncService — read timeout on async Netty HTTP client**
   The synchronous S3 client already sets `socketTimeout` (= read timeout), but the async Netty NIO client was missing `readTimeout`. Without this, a stalled S3 body read on the async path could hang unboundedly. Added `clientBuilder.readTimeout(Duration.ofMillis(clientSettings.readTimeoutMillis))` to the Netty builder.

3. **S3AsyncService — read timeout on async CRT HTTP client**
   Added `readTimeout` to the CRT client builder as well, for consistency and safety.

### Testing
- Existing tests pass (TransferManagerTestCase, S3AsyncServiceTests)
- The timeout flows through the existing `S3ClientSettings.readTimeoutMillis` setting, which is already configured by `s3.client.default.read_timeout` (default 50s)

### Backport
This is a candidate for backport to 2.x (remote-store + warm tier is widely used in production on the 2.x line).

Signed-off-by: waterWang <waterwang@proton.me>