### PR TITLE
Add delete-side repository I/O timeout and reliable release

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotDeleteTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotDeleteTimeoutIT.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.SnapshotDeletionsInProgress;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies the delete-side repository I/O time budget: a hung delete must fail and clear its cluster-state entry
+ * instead of hanging indefinitely.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SnapshotDeleteTimeoutIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING.getKey(), true).build();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(2))
+            .build();
+    }
+
+    public void testDeleteTimesOutWhenRepositoryHangs() throws Exception {
+        disableRepoConsistencyCheck("orphaned worker advances the repo generation after unblock");
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        createIndexWithContent("index-test");
+        final String snapshotName = "snap-1";
+        createFullSnapshot(repoName, snapshotName);
+
+        blockClusterManagerFromDeletingIndexNFile(repoName);
+        final ActionFuture<AcknowledgedResponse> deleteFuture = startDeleteSnapshot(repoName, snapshotName);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        expectThrows(Exception.class, deleteFuture::actionGet);
+        awaitNoMoreRunningOperations();
+
+        unblockNode(repoName, clusterManagerNode);
+    }
+
+    public void testQueuedDeletePromotedAfterTimeout() throws Exception {
+        disableRepoConsistencyCheck("orphaned worker advances the repo generation after unblock");
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        createIndexWithContent("index-1");
+        createIndexWithContent("index-2");
+        final String snap1 = "snap-1";
+        final String snap2 = "snap-2";
+        createFullSnapshot(repoName, snap1);
+        createFullSnapshot(repoName, snap2);
+
+        blockClusterManagerFromDeletingIndexNFile(repoName);
+        final ActionFuture<AcknowledgedResponse> delete1 = startDeleteSnapshot(repoName, snap1);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        final ActionFuture<AcknowledgedResponse> delete2 = startDeleteSnapshot(repoName, snap2);
+        assertBusy(() -> {
+            final SnapshotDeletionsInProgress deletions = clusterService().state()
+                .custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY);
+            assertThat("both deletes should be in progress", deletions.getEntries().size(), equalTo(2));
+        });
+
+        expectThrows(Exception.class, delete1::actionGet);
+        unblockNode(repoName, clusterManagerNode);
+
+        // Either outcome is fine — we're only checking bookkeeping was released, not delete2's result.
+        try {
+            delete2.actionGet(TimeValue.timeValueSeconds(30L));
+        } catch (Exception e) {
+            logger.info("delete2 failed: {}", e.getMessage());
+        }
+        awaitNoMoreRunningOperations();
+
+        final SnapshotDeletionsInProgress finalDeletions = clusterService().state()
+            .custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY);
+        assertFalse("No deletions should remain in progress", finalDeletions.hasDeletionsInProgress());
+    }
+
+    public void testHealthyDeleteUnaffectedByTimeoutWhenEnabled() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(5))
+                        .build()
+                )
+                .get()
+        );
+        createIndexWithContent("index-1");
+        final String snapshotName = "snap-1";
+        createFullSnapshot(repoName, snapshotName);
+
+        assertAcked(startDeleteSnapshot(repoName, snapshotName).actionGet(TimeValue.timeValueSeconds(30L)));
+        awaitNoMoreRunningOperations();
+    }
+}

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -45,6 +45,7 @@ import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotReques
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.ListenerTimeouts;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
@@ -304,6 +305,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     );
 
     private volatile int maxConcurrentOperations;
+    private volatile TimeValue repositoryIoTimeout = SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getDefault(Settings.EMPTY);
 
     public SnapshotsService(
         Settings settings,
@@ -352,6 +354,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             retryBackoff = SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.get(settings);
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRIES_SETTING, i -> maxRetries = i);
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING, t -> retryBackoff = t);
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                repositoryIoTimeout = SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.get(settings);
+                clusterService.getClusterSettings()
+                    .addSettingsUpdateConsumer(SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING, t -> repositoryIoTimeout = t);
+            }
         }
 
         // Task is onboarded for throttling, it will get retried from associated TransportClusterManagerNodeAction.
@@ -2226,6 +2233,20 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         assert removed;
     }
 
+    // Test-only accessors for the repo loop
+    boolean isRepoLoopHeld(String repository) {
+        return currentlyFinalizing.contains(repository);
+    }
+
+    void seedDeleteInProgressForTest(String repository, String deleteUUID) {
+        tryEnterRepoLoop(repository);
+        repositoryOperations.startDeletion(deleteUUID);
+    }
+
+    boolean isDeletionRunningForTest(String deleteUUID) {
+        return repositoryOperations.isDeletionRunning(deleteUUID);
+    }
+
     private void finalizeSnapshotEntry(SnapshotsInProgress.Entry entry, Metadata metadata, RepositoryData repositoryData) {
         assert currentlyFinalizing.contains(entry.repository());
         try {
@@ -2368,7 +2389,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * TODO: optimize this to execute in a single CS update together with finalizing the latest snapshot
      */
     private void runReadyDeletions(RepositoryData repositoryData, String repository) {
-        clusterService.submitStateUpdateTask("Run ready deletions", new ClusterStateUpdateTask() {
+        final String source = "Run ready deletions";
+        final int attempt = 0;
+        clusterService.submitStateUpdateTask(source, createRunReadyDeletionsTask(source, attempt, repositoryData, repository));
+    }
+
+    ClusterStateUpdateTask createRunReadyDeletionsTask(String source, int attempt, RepositoryData repositoryData, String repository) {
+        return new ClusterStateUpdateTask() {
 
             private SnapshotDeletionsInProgress.Entry deletionToRun;
 
@@ -2389,20 +2416,30 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
 
             @Override
-            public void onFailure(String source, Exception e) {
+            public void onFailure(String src, Exception e) {
                 logger.warn("Failed to run ready delete operations", e);
-                failAllListenersOnMasterFailOver(e);
+                if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                    retryOrFailOnClusterManagerFailOver(
+                        e,
+                        attempt,
+                        source,
+                        () -> createRunReadyDeletionsTask(source, attempt + 1, repositoryData, repository),
+                        () -> failAllListenersOnMasterFailOver(e)
+                    );
+                } else {
+                    failAllListenersOnMasterFailOver(e);
+                }
             }
 
             @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            public void clusterStateProcessed(String src, ClusterState oldState, ClusterState newState) {
                 if (deletionToRun == null) {
                     runNextQueuedOperation(repositoryData, repository, false);
                 } else {
                     deleteSnapshotsFromRepository(deletionToRun, repositoryData, newState.nodes().getMinNodeVersion());
                 }
             }
-        });
+        };
     }
 
     /**
@@ -3202,14 +3239,25 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
 
             } else {
+                ActionListener<RepositoryData> deleteListener = ActionListener.wrap(updatedRepoData -> {
+                    logger.info("snapshots {} deleted", snapshotIds);
+                    removeSnapshotDeletionFromClusterState(deleteEntry, null, updatedRepoData);
+                }, ex -> removeSnapshotDeletionFromClusterState(deleteEntry, ex, repositoryData));
+                // Bound delete-side repository I/O so a hung store fails cleanly instead of stranding the delete
+                if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                    deleteListener = ListenerTimeouts.wrapWithTimeout(
+                        threadPool,
+                        deleteListener,
+                        repositoryIoTimeout,
+                        ThreadPool.Names.GENERIC,
+                        "delete_snapshots[" + deleteEntry.repository() + "]"
+                    );
+                }
                 repository.deleteSnapshots(
                     snapshotIds,
                     repositoryData.getGenId(),
                     minCompatibleVersion(minNodeVersion, repositoryData, snapshotIds),
-                    ActionListener.wrap(updatedRepoData -> {
-                        logger.info("snapshots {} deleted", snapshotIds);
-                        removeSnapshotDeletionFromClusterState(deleteEntry, null, updatedRepoData);
-                    }, ex -> removeSnapshotDeletionFromClusterState(deleteEntry, ex, repositoryData))
+                    deleteListener
                 );
             }
         }
@@ -3229,12 +3277,23 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         @Nullable final Exception failure,
         final RepositoryData repositoryData
     ) {
-        final ClusterStateUpdateTask clusterStateUpdateTask;
+        final String source = "remove snapshot deletion metadata";
+        final int attempt = 0;
+        clusterService.submitStateUpdateTask(
+            source,
+            createRemoveSnapshotDeletionTask(source, attempt, deleteEntry, failure, repositoryData)
+        );
+    }
+
+    ClusterStateUpdateTask createRemoveSnapshotDeletionTask(
+        String source,
+        int attempt,
+        SnapshotDeletionsInProgress.Entry deleteEntry,
+        @Nullable Exception failure,
+        RepositoryData repositoryData
+    ) {
         if (failure == null) {
-            // If we didn't have a failure during the snapshot delete we will remove all snapshot ids that the delete successfully removed
-            // from the repository from enqueued snapshot delete entries during the cluster state update. After the cluster state update we
-            // resolve the delete listeners with the latest repository data from after the delete.
-            clusterStateUpdateTask = new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {
+            return new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData, source, attempt, null) {
                 @Override
                 protected SnapshotDeletionsInProgress filterDeletions(SnapshotDeletionsInProgress deletions) {
                     final SnapshotDeletionsInProgress updatedDeletions = deletionsWithoutSnapshots(
@@ -3257,16 +3316,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
             };
         } else {
-            // The delete failed to execute on the repository. We remove it from the cluster state and then fail all listeners associated
-            // with it.
-            clusterStateUpdateTask = new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {
+            return new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData, source, attempt, failure) {
                 @Override
                 protected void handleListeners(List<ActionListener<Void>> deleteListeners) {
                     failListenersIgnoringException(deleteListeners, failure);
                 }
             };
         }
-        clusterService.submitStateUpdateTask("remove snapshot deletion metadata", clusterStateUpdateTask);
     }
 
     /**
@@ -3396,9 +3452,25 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         private final RepositoryData repositoryData;
 
-        RemoveSnapshotDeletionAndContinueTask(SnapshotDeletionsInProgress.Entry deleteEntry, RepositoryData repositoryData) {
+        private final String taskSource;
+
+        private final int attempt;
+
+        @Nullable
+        private final Exception originalFailure;
+
+        RemoveSnapshotDeletionAndContinueTask(
+            SnapshotDeletionsInProgress.Entry deleteEntry,
+            RepositoryData repositoryData,
+            String taskSource,
+            int attempt,
+            @Nullable Exception originalFailure
+        ) {
             this.deleteEntry = deleteEntry;
             this.repositoryData = repositoryData;
+            this.taskSource = taskSource;
+            this.attempt = attempt;
+            this.originalFailure = originalFailure;
         }
 
         @Override
@@ -3420,8 +3492,21 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         @Override
         public void onFailure(String source, Exception e) {
             logger.warn(() -> new ParameterizedMessage("{} failed to remove snapshot deletion metadata", deleteEntry), e);
-            repositoryOperations.finishDeletion(deleteEntry.uuid());
-            failAllListenersOnMasterFailOver(e);
+            final Runnable fallback = () -> {
+                repositoryOperations.finishDeletion(deleteEntry.uuid());
+                failAllListenersOnMasterFailOver(e);
+            };
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                retryOrFailOnClusterManagerFailOver(
+                    e,
+                    attempt,
+                    taskSource,
+                    () -> createRemoveSnapshotDeletionTask(taskSource, attempt + 1, deleteEntry, originalFailure, repositoryData),
+                    fallback
+                );
+            } else {
+                fallback.run();
+            }
         }
 
         protected SnapshotDeletionsInProgress filterDeletions(SnapshotDeletionsInProgress deletions) {
@@ -4442,6 +4527,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         void finishDeletion(String deleteUUID) {
             runningDeletions.remove(deleteUUID);
+        }
+        
+        boolean isDeletionRunning(String deleteUUID) {
+            return runningDeletions.contains(deleteUUID);
         }
 
         synchronized void addFinalization(SnapshotsInProgress.Entry entry, Metadata metadata) {

--- a/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RetryOrFailOnClusterManagerFailOverTests.java
@@ -12,6 +12,7 @@ import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
 import org.opensearch.cluster.NotClusterManagerException;
+import org.opensearch.cluster.SnapshotDeletionsInProgress;
 import org.opensearch.cluster.SnapshotsInProgress;
 import org.opensearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -34,7 +35,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RetryOrFailOnClusterManagerFailOverTests extends OpenSearchTestCase {
@@ -591,6 +598,95 @@ public class RetryOrFailOnClusterManagerFailOverTests extends OpenSearchTestCase
             null
         );
         task.onFailure("test-source", new NotClusterManagerException("simulated"));
+    }
+
+    // A retained-cluster-manager publish failure schedules a fresh removal task (retry) rather than giving up
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveSnapshotDeletionRetriesOnTransientPublishFailure() {
+        SnapshotDeletionsInProgress.Entry deleteEntry = createMockDeleteEntry();
+        snapshotsService.seedDeleteInProgressForTest(deleteEntry.repository(), deleteEntry.uuid());
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveSnapshotDeletionTask(
+            "test-source",
+            0,
+            deleteEntry,
+            new RuntimeException("repo failure"),
+            null
+        );
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated publish failure"));
+        verify(clusterService, timeout(2000)).submitStateUpdateTask(eq("test-source"), any(ClusterStateUpdateTask.class));
+
+        // A retry must not release bookkeeping yet — the operation is still in flight.
+        assertTrue("repo loop should still be held mid-retry", snapshotsService.isRepoLoopHeld(deleteEntry.repository()));
+        assertTrue("delete should still be tracked as running mid-retry", snapshotsService.isDeletionRunningForTest(deleteEntry.uuid()));
+    }
+
+    // Once retries are exhausted, the fallback must release both the repo loop and the running-deletion tracking
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemoveSnapshotDeletionReleasesBookkeepingWhenRetriesExhausted() {
+        final int exhausted = SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getDefault(Settings.EMPTY);
+        SnapshotDeletionsInProgress.Entry deleteEntry = createMockDeleteEntry();
+        snapshotsService.seedDeleteInProgressForTest(deleteEntry.repository(), deleteEntry.uuid());
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveSnapshotDeletionTask(
+            "test-source",
+            exhausted,
+            deleteEntry,
+            new RuntimeException("repo failure"),
+            null
+        );
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated"));
+
+        verify(clusterService, never()).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
+        assertFalse("repo loop should be released on terminal failure", snapshotsService.isRepoLoopHeld(deleteEntry.repository()));
+        assertFalse("delete should no longer be tracked as running", snapshotsService.isDeletionRunningForTest(deleteEntry.uuid()));
+    }
+
+    // With the feature flag off, the retry machinery is bypassed entirely: today's give-up behavior is preserved
+    public void testRemoveSnapshotDeletionDoesNotRetryWhenFeatureDisabled() {
+        SnapshotDeletionsInProgress.Entry deleteEntry = createMockDeleteEntry();
+        snapshotsService.seedDeleteInProgressForTest(deleteEntry.repository(), deleteEntry.uuid());
+
+        ClusterStateUpdateTask task = snapshotsService.createRemoveSnapshotDeletionTask(
+            "test-source",
+            0,
+            deleteEntry,
+            new RuntimeException("repo failure"),
+            null
+        );
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated"));
+        verify(clusterService, never()).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
+        assertFalse(
+            "bookkeeping should release immediately when the feature is off",
+            snapshotsService.isRepoLoopHeld(deleteEntry.repository())
+        );
+    }
+
+    // The ready-deletions promoter also retries a retained-cluster-manager publish failure instead of giving up
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRunReadyDeletionsRetriesOnTransientPublishFailure() {
+        ClusterStateUpdateTask task = snapshotsService.createRunReadyDeletionsTask("test-source", 0, null, "test-repo");
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated publish failure"));
+        verify(clusterService, timeout(2000)).submitStateUpdateTask(eq("test-source"), any(ClusterStateUpdateTask.class));
+    }
+
+    // ...and falls back once retries are exhausted, scheduling nothing further.
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRunReadyDeletionsFallsBackWhenRetriesExhausted() {
+        final int exhausted = SnapshotsService.SNAPSHOT_CLEANUP_RETRIES_SETTING.getDefault(Settings.EMPTY);
+        ClusterStateUpdateTask task = snapshotsService.createRunReadyDeletionsTask("test-source", exhausted, null, "test-repo");
+        task.onFailure("test-source", new FailedToCommitClusterStateException("simulated"));
+        verify(clusterService, never()).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
+    }
+
+    private SnapshotDeletionsInProgress.Entry createMockDeleteEntry() {
+        return new SnapshotDeletionsInProgress.Entry(
+            Collections.singletonList(new SnapshotId("snap-1", UUIDs.randomBase64UUID())),
+            "test-repo",
+            System.currentTimeMillis(),
+            0L,
+            SnapshotDeletionsInProgress.State.STARTED
+        );
     }
 
 }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -168,7 +168,9 @@ import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.PrioritizedOpenSearchThreadPoolExecutor;
@@ -313,6 +315,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
      */
     @Nullable
     private MockEventuallyConsistentRepository.Context blobStoreContext;
+
+    private volatile boolean blockRepositoryDeletes = false;
 
     @Before
     public void createServices() {
@@ -1654,6 +1658,56 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
         }, TimeUnit.MINUTES.toMillis(1L));
     }
 
+    // A delete whose repository I/O hangs must still terminate via the I/O timeout
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testDeleteTimesOutWhenRepositoryHangs() {
+        blobStoreContext = null; // use the plain FsRepository, which hangs deleteSnapshots when blockRepositoryDeletes is set
+        setupTestCluster(1, 1);
+
+        final String repoName = "repo";
+        final String snapshotName = "snapshot";
+        final String index = "test";
+        final int shards = randomIntBetween(1, 5);
+
+        final TestClusterNodes.TestClusterNode clusterManagerNode = testClusterNodes.currentClusterManager(
+            testClusterNodes.nodes.values().iterator().next().clusterService.state()
+        );
+
+        final StepListener<CreateSnapshotResponse> createSnapshotListener = new StepListener<>();
+        continueOrDie(
+            createRepoAndIndex(repoName, index, shards),
+            createIndexResponse -> client().admin()
+                .cluster()
+                .prepareCreateSnapshot(repoName, snapshotName)
+                .setWaitForCompletion(true)
+                .execute(createSnapshotListener)
+        );
+
+        final StepListener<AcknowledgedResponse> deleteListener = new StepListener<>();
+        continueOrDie(createSnapshotListener, createSnapshotResponse -> {
+            blockRepositoryDeletes = true;
+            client().admin().cluster().prepareDeleteSnapshot(repoName, snapshotName).execute(deleteListener);
+        });
+
+        deterministicTaskQueue.runAllRunnableTasks();
+
+        assertTrue(
+            "a delete should be in progress while the repository hangs",
+            clusterManagerNode.clusterService.state()
+                .custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY)
+                .hasDeletionsInProgress()
+        );
+
+        runUntil(
+            () -> clusterManagerNode.clusterService.state()
+                .custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY)
+                .hasDeletionsInProgress() == false,
+            TimeValue.timeValueHours(1).millis()
+        );
+
+        blockRepositoryDeletes = false;
+    }
+
     private void runUntil(Supplier<Boolean> fulfilled, long timeout) {
         final long start = deterministicTaskQueue.getCurrentTimeMillis();
         while (timeout > deterministicTaskQueue.getCurrentTimeMillis() - start) {
@@ -2568,6 +2622,19 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         @Override
                         protected void assertSnapshotOrGenericThread() {
                             // eliminate thread name check as we create repo in the test thread
+                        }
+
+                        @Override
+                        public void deleteSnapshots(
+                            Collection<SnapshotId> snapshotIds,
+                            long repositoryStateId,
+                            Version repositoryMetaVersion,
+                            ActionListener<RepositoryData> listener
+                        ) {
+                            if (blockRepositoryDeletes) {
+                                return; // never complete, simulating a hung store
+                            }
+                            super.deleteSnapshots(snapshotIds, repositoryStateId, repositoryMetaVersion, listener);
                         }
                     };
                 } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

  ### Description
Part of the snapshot-resilience initiative to make stuck snapshot operations recoverable. This PR bounds **delete-side** repository I/O with a time budget and guarantees the in-memory delete bookkeeping is always released, so a hung or failed snapshot delete fails cleanly instead of stranding an "in-progress" marker forever.

1. **Time budget on the delete repository call.** The listener passed to `repository.deleteSnapshots(...)` is wrapped with `ListenerTimeouts.wrapWithTimeout(..., ThreadPool.Names.GENERIC, ...)` using the `snapshot.repository.io_timeout` setting (default 30m). A hung delete now fails with a timeout that routes into the ordinary delete-failure cleanup — the marker is removed. The timeout callback fires on `GENERIC`, never the snapshot pool.

2. **Guaranteed, exactly-once bookkeeping release.** `finishDeletion(uuid)` and the repo-loop release now run on success, failure, **and** timeout — exactly once. On the retry path (below), `finishDeletion` fires only on the *final* failure, not per retried attempt, so the running-deletion record isn't cleared mid-retry.
  
3. **Reliable cleanup retries.** The delete-cleanup `onFailure` paths (`RemoveSnapshotDeletionAndContinueTask.onFailure`,`runReadyDeletions.onFailure`) are converted to route through the `retryOrFailOnClusterManagerFailOver` foundation helper: a marker-removal publish that fails while this node is still cluster-manager is retried with backoff instead of giving up.

All new behavior is gated behind the `SNAPSHOT_RESILIENCE` feature flag (`opensearch.experimental.feature.snapshot_resilience.enabled`, default off). With the flag off, every path is byte-for-byte the existing behavior.

  ### Related Issues
  <!-- Replace with the issue this resolves, or remove if none -->
  Resolves #[issue number]

  ### Check List
  - [x] Functionality includes testing.
  - [ ] API changes companion pull request created, if applicable.
  - [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
