### PR TITLE
Promote lowest-version replica on document-replication failover

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -42,6 +42,7 @@ import org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
+import org.opensearch.common.annotation.DeprecatedApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.Assertions;
@@ -413,9 +414,16 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      * no active replica is found.
      * <p>
      * Since replicas could possibly be on nodes with an older version of OpenSearch than
-     * the primary is, this will return replicas on the highest version of OpenSearch when document
-     * replication is enabled.
+     * the primary is, this will return replicas on the highest version of OpenSearch.
+     *
+     * @deprecated no longer used for primary promotion. Promoting the highest-version replica
+     * raises the primary's version, after which
+     * {@link org.opensearch.cluster.routing.allocation.decider.NodeVersionAllocationDecider}
+     * refuses to allocate that shard's replicas onto any not-yet-upgraded node. Both replication
+     * types now promote via {@link #activeReplicaWithOldestVersion(ShardId)}.
      */
+    @Deprecated
+    @DeprecatedApi(since = "3.9.0", forRemoval = "4.0.0")
     public ShardRouting activeReplicaWithHighestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null, when disassociating dead nodes
         // that have been removed, the shards are failed, and part of the shard failing
@@ -439,9 +447,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      * no active replica is found.
      * <p>
      * Since replicas could possibly be on nodes with a higher version of OpenSearch than
-     * the primary is, this will return replicas on the oldest version of OpenSearch when segment
-     * replication is enabled to allow for replica to read segments from primary.
-     *
+     * the primary is, this will return replicas on the oldest version of OpenSearch so that
+     * remaining nodes (including not-yet-upgraded ones) are able to read/replicate the
+     * promoted primary's segments and remain eligible allocation targets.
      */
     public ShardRouting activeReplicaWithOldestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null. Therefore, we need to protect against the version being null
@@ -797,11 +805,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             activeReplica = activeReplicaOnRemoteNode(failedShard.shardId());
         }
         if (activeReplica == null) {
-            if (metadata.isSegmentReplicationEnabled(failedShard.getIndexName())) {
-                activeReplica = activeReplicaWithOldestVersion(failedShard.shardId());
-            } else {
-                activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
-            }
+            // Promote the oldest-version in-sync replica for both document and segment replication so the
+            // new primary stays at the minimum version present, keeping it a valid recovery source/target for
+            // any not-yet-upgraded node during a rolling upgrade.
+            activeReplica = activeReplicaWithOldestVersion(failedShard.shardId());
         }
         if (activeReplica == null) {
             moveToUnassigned(failedShard, unassignedInfo);

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -599,7 +599,7 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         clusterState = startShardsAndReroute(allocation, clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0));
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
         assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
 
         // fail the primary shard, check replicas get removed as well...
         ShardRouting primaryShardToFail = clusterState.routingTable().index("test").shard(0).primaryShard();
@@ -658,11 +658,11 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         assertThat(newPrimaryShard, not(equalTo(primaryShardToFail)));
     }
 
-    public void testReplicaOnNewestVersionIsPromoted() {
+    public void testReplicaOnOldestVersionIsPromotedDocRep() {
         testReplicaIsPromoted(false);
     }
 
-    public void testReplicaOnOldestVersionIsPromoted() {
+    public void testReplicaOnOldestVersionIsPromotedSegRep() {
         testReplicaIsPromoted(true);
     }
 
@@ -737,12 +737,7 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(4));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
 
-        ShardRouting startedReplica;
-        if (isSegmentReplicationEnabled) {
-            startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
-        } else {
-            startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
-        }
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
         logger.info("--> all shards allocated, replica that should be promoted: {}", startedReplica);
 
         // fail the primary shard again and make sure the correct replica is promoted
@@ -767,24 +762,13 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            if (isSegmentReplicationEnabled) {
-                assertTrue(
-                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
-                    replicaNodeVersion.onOrBefore(nodeVer)
-                );
-            } else {
-                assertTrue(
-                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
-                    replicaNodeVersion.onOrAfter(nodeVer)
-                );
-            }
+            assertTrue(
+                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                replicaNodeVersion.onOrBefore(nodeVer)
+            );
         }
 
-        if (isSegmentReplicationEnabled) {
-            startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
-        } else {
-            startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
-        }
+        startedReplica = clusterState.getRoutingNodes().activeReplicaWithOldestVersion(shardId);
         logger.info("--> failing primary shard a second time, should select: {}", startedReplica);
 
         // fail the primary shard again, and ensure the same thing happens
@@ -810,17 +794,10 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            if (isSegmentReplicationEnabled) {
-                assertTrue(
-                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
-                    replicaNodeVersion.onOrBefore(nodeVer)
-                );
-            } else {
-                assertTrue(
-                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
-                    replicaNodeVersion.onOrAfter(nodeVer)
-                );
-            }
+            assertTrue(
+                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                replicaNodeVersion.onOrBefore(nodeVer)
+            );
         }
     }
 


### PR DESCRIPTION
### Description

During a rolling upgrade with document replication, primary failover promotes the **highest**-version in-sync replica. This raises the primary's version, after which [`NodeVersionAllocationDecider`][decider] -- which requires `replica.version >= primary.version` -- refuses to allocate that shard's replicas onto any not-yet-upgraded node. The shard stays under-replicated until the whole cluster has been upgraded, which in turn can stall an upgrade that waits for a green cluster before proceeding.

[`RoutingNodes#unassignPrimaryAndPromoteActiveReplicaIfExists`][routingnodes]
currently branches on replication type:

```java
if (metadata.isSegmentReplicationEnabled(failedShard.getIndexName())) {
    activeReplica = activeReplicaWithOldestVersion(failedShard.shardId());
} else {
    activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
}
```

Promote-highest directly contradicts the invariant the decider is trying to maintain. Segment replication already promotes the oldest version (`activeReplicaWithOldestVersion`, added in #9536). This change makes document replication do the same, so the primary stays at the minimum version present and `node_version` remains satisfiable for every node during the upgrade.

The promote-highest rule dates to elastic/elasticsearch#25277 (2017) and existed only because sequence numbers were then new and older nodes could not interpret them. That hazard does not exist in any currently supported version skew, so both replication types can share the same rule.

Note this promotion runs inside `failShard` and is therefore *not* gated by `EnableAllocationDecider` -- setting `cluster.routing.allocation.enable: primaries` during an upgrade does not prevent it.

### Relationship to #22668 (reverted)

This is a **reduced-scope** version of #22668, which was reverted in #22726.

#22668 contained two changes: this failover fix, and a relaxation of `NodeVersionAllocationDecider` to compare Lucene versions instead of OpenSearch version ids. The decider change is what broke: it keyed only on Lucene major.minor, so once `Version.CURRENT` advanced to 3.9.0 (#22666) -- which shares Lucene 10.5.0 with 3.8.x -- it began permitting allocations the tests correctly expected to be blocked. Eight tests failed across `NodeVersionAllocationDeciderTests` and `IndexShardConstraintDeciderOverlapTests`.

**The decider change is deliberately excluded here.** This PR:

- touches no allocation decider,
- changes no version-comparison logic,
- affects none of the eight tests that failed in #22668.

The decider relaxation needs a narrower rule and an explicit discussion about the recovery-version invariant asserted by `assertRecoveryNodeVersions`; that will be raised separately on #22520 rather than bundled with this fix.

### Changes

**`RoutingNodes`** -- promote the lowest-version in-sync replica for both replication types.

`activeReplicaWithHighestVersion` is no longer used for promotion. Since `RoutingNodes` is annotated `@PublicApi(since = "1.0.0")`, removing the method would be a binary-incompatible change and fail `:server:japicmp`, so it is retained and marked `@Deprecated` /`@DeprecatedApi(since = "3.9.0", forRemoval = "4.0.0")` instead.

**`FailedShardsRoutingTests`** -- both replication types now expect oldest-version promotion.

### Testing

Run locally against `main` with JDK 21:

- `FailedShardsRoutingTests` -- 11 tests, 0 failures
- `NodeVersionAllocationDeciderTests` -- 7 tests, 0 failures (unchanged from `main`)
- `IndexShardConstraintDeciderOverlapTests` -- 4 tests, 0 failures
- `:server:spotlessJavaCheck` -- passes

The latter two classes are the ones that failed in #22668 and are included here to
show they are unaffected.

### Related Issues

Related to #22520

### Check List

- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here][dco].

[routingnodes]: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
[decider]: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
[dco]: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
