### PR TITLE
Populate _id in hits from the stored parquet column

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -12,6 +12,7 @@ import org.opensearch.analytics.spi.FieldStorageInfo;
 import org.opensearch.analytics.spi.FieldType;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.index.mapper.IdFieldMapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -75,6 +76,21 @@ public class FieldStorageResolver {
         if (properties != null) {
             populateFromProperties(properties, "", primaryFormat, luceneAvailable);
         }
+        // _id is stored per document in the primary format (like ___row_id) but is not a
+        // mapping property, so register it explicitly for scans that request it.
+        this.fieldStorage.put(
+            IdFieldMapper.NAME,
+            new FieldStorageInfo(
+                IdFieldMapper.NAME,
+                "binary",
+                FieldType.BINARY,
+                List.of(primaryFormat),
+                List.of(),
+                luceneAvailable ? List.of(LUCENE_FORMAT) : List.of(),
+                false,
+                (String) null
+            )
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/IdColumnSchema.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/IdColumnSchema.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.converter;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.index.mapper.IdFieldMapper;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * DSL's view of the engine schema: every table gains the {@code _id} metadata column
+ * (VARBINARY, the stored Uid-encoded bytes), appended after the mapped fields so their
+ * ordinals are unchanged.
+ *
+ * <p>Scans built from this catalog request {@code _id} from the shards the same way QTF
+ * requests {@code ___row_id}: the engine resolves storage for whatever field names the scan's
+ * row type carries. Only DSL's catalog is wrapped — the shared engine schema is untouched, so
+ * PPL's star expansion does not grow an {@code _id} column.
+ */
+final class IdColumnSchema extends AbstractSchema {
+
+    private final SchemaPlus delegate;
+
+    private IdColumnSchema(SchemaPlus delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Wraps the engine-provided schema with the {@code _id}-appending view. */
+    static Schema wrap(SchemaPlus engineSchema) {
+        return new IdColumnSchema(engineSchema);
+    }
+
+    @Override
+    protected Map<String, Table> getTableMap() {
+        // Lazy delegating map: the engine schema resolves index expressions on first lookup.
+        return new AbstractMap<>() {
+            @Override
+            public Table get(Object key) {
+                Table table = delegate.getTable((String) key);
+                return table == null ? null : withIdColumn(table);
+            }
+
+            @Override
+            public boolean containsKey(Object key) {
+                return get(key) != null;
+            }
+
+            @Override
+            public Set<Entry<String, Table>> entrySet() {
+                return Set.of(); // exact-name lookups only, like the underlying lazy schema
+            }
+        };
+    }
+
+    private static Table withIdColumn(Table table) {
+        return new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+                RelDataType original = table.getRowType(typeFactory);
+                if (original.getField(IdFieldMapper.NAME, false, false) != null) {
+                    return original;
+                }
+                RelDataTypeFactory.Builder builder = typeFactory.builder();
+                original.getFieldList().forEach(f -> builder.add(f.getName(), f.getType()));
+                builder.add(
+                    IdFieldMapper.NAME,
+                    typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARBINARY), false)
+                );
+                return builder.build();
+            }
+        };
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ProjectConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ProjectConverter.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
 import java.util.ArrayList;
@@ -25,6 +26,10 @@ import java.util.regex.Pattern;
 /**
  * Converts {@code _source} field selection to a {@link LogicalProject}.
  * Handles exact field names, wildcard patterns, and {@code _source: false}.
+ *
+ * <p>The {@code _id} metadata column is not part of {@code _source} and always survives
+ * source filtering, including {@code _source: false} (which suppresses source but not ids,
+ * matching classic search).
  */
 public class ProjectConverter extends AbstractDslConverter {
 
@@ -41,7 +46,11 @@ public class ProjectConverter extends AbstractDslConverter {
         FetchSourceContext fetchSource = ctx.getSearchSource().fetchSource();
 
         if (!fetchSource.fetchSource()) {
-            return LogicalProject.create(input, List.of(), List.of(), List.of());
+            // _source: false still returns hits with ids; keep only the metadata column if present.
+            List<RexNode> projects = new ArrayList<>();
+            List<String> fieldNames = new ArrayList<>();
+            appendMetadataColumns(input, ctx.getRexBuilder(), projects, fieldNames);
+            return LogicalProject.create(input, List.of(), projects, fieldNames);
         }
 
         String[] includes = fetchSource.includes();
@@ -54,6 +63,19 @@ public class ProjectConverter extends AbstractDslConverter {
         }
 
         return createProjection(input, includes, excludes, ctx.getRexBuilder());
+    }
+
+    /**
+     * Appends metadata columns that survive source filtering (currently only {@code _id}) to the
+     * given projection lists, skipping any already present. The response builder renders these
+     * outside {@code _source}.
+     */
+    private static void appendMetadataColumns(RelNode input, RexBuilder rexBuilder, List<RexNode> projects, List<String> fieldNames) {
+        RelDataTypeField id = input.getRowType().getField(IdFieldMapper.NAME, false, false);
+        if (id != null && !fieldNames.contains(IdFieldMapper.NAME)) {
+            projects.add(rexBuilder.makeInputRef(id.getType(), id.getIndex()));
+            fieldNames.add(IdFieldMapper.NAME);
+        }
     }
 
     private RelNode createProjection(RelNode input, String[] includes, String[] excludes, RexBuilder rexBuilder)
@@ -85,6 +107,9 @@ public class ProjectConverter extends AbstractDslConverter {
                 }
             }
         }
+
+        // _id survives source filtering; the response builder keeps it out of _source.
+        appendMetadataColumns(input, rexBuilder, projects, fieldNames);
 
         return LogicalProject.create(input, List.of(), projects, fieldNames);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -97,7 +97,8 @@ public class SearchSourceConverter {
         // no need to reconstruct typeFactory, CatalogReader, and planning infrastructure here.
         this.typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
 
-        CalciteSchema rootSchema = CalciteSchema.from(schema);
+        // Tables in DSL's catalog carry the _id metadata column; see IdColumnSchema.
+        CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false, "", IdColumnSchema.wrap(schema));
         this.catalogReader = new CalciteCatalogReader(
             rootSchema,
             Collections.singletonList(""),

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/HitsResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/HitsResponseBuilder.java
@@ -15,6 +15,8 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.Uid;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchService;
@@ -36,9 +38,10 @@ import java.util.Map;
  *
  * <p>Legacy-compat choices, constrained by what the analytics engine exposes today:
  * <ul>
- *   <li>{@code _id} is omitted (null): the engine schema exposes only mapped source fields,
- *       no metadata columns. TODO: populate once the engine can project the stored
- *       {@code _id} (and {@code _source}) parquet columns for HITS plans.</li>
+ *   <li>{@code _id} is populated from the row's {@code _id} metadata column (the stored
+ *       Uid-encoded bytes; requested by the plan via {@code IdColumnSchema}). The column is
+ *       lifted out of the row and never appears in {@code _source}. Rows without the column
+ *       render {@code _id} null.</li>
  *   <li>{@code _score}/{@code max_score} are {@link Float#NaN} (rendered {@code null}): the
  *       engine has no relevance scoring, matching legacy's non-scored (field-sorted) responses.</li>
  *   <li>{@code hits.total}: classic {@code track_total_hits} semantics. The COUNT plan's
@@ -81,6 +84,7 @@ public final class HitsResponseBuilder {
 
         int size = resolveSize(request);
         List<String> fieldNames = hitsResult.getFieldNames();
+        int idOrdinal = fieldNames.indexOf(IdFieldMapper.NAME);
         List<Object[]> rows = new ArrayList<>();
         for (Object[] row : hitsResult.getRows()) {
             rows.add(row);
@@ -90,7 +94,7 @@ public final class HitsResponseBuilder {
         int hitCount = Math.min(rows.size(), size);
         SearchHit[] hits = new SearchHit[hitCount];
         for (int i = 0; i < hitCount; i++) {
-            hits[i] = buildHit(i, fieldNames, rows.get(i));
+            hits[i] = buildHit(i, fieldNames, rows.get(i), idOrdinal);
         }
 
         return new SearchHits(hits, resolveTotal(request, countTotals, rows.size()), Float.NaN);
@@ -131,10 +135,25 @@ public final class HitsResponseBuilder {
         return source != null && source.size() != -1 ? source.size() : SearchService.DEFAULT_SIZE;
     }
 
-    private static SearchHit buildHit(int docId, List<String> fieldNames, Object[] row) throws ConversionException {
-        Map<String, Object> source = buildSourceMap(fieldNames, row);
-        // id=null renders the hit without an _id field (see class javadoc).
-        SearchHit hit = new SearchHit(docId, null, null, null);
+    /** Decodes the {@code _id} cell: Uid-encoded bytes from the engine, or a plain string in tests. */
+    private static String decodeId(Object cell) throws ConversionException {
+        if (cell == null) {
+            return null;
+        }
+        if (cell instanceof byte[] bytes) {
+            return Uid.decodeId(bytes);
+        }
+        if (cell instanceof String s) {
+            return s;
+        }
+        throw new ConversionException("Unsupported _id cell type: " + cell.getClass().getName());
+    }
+
+    private static SearchHit buildHit(int docId, List<String> fieldNames, Object[] row, int idOrdinal) throws ConversionException {
+        Map<String, Object> source = buildSourceMap(fieldNames, row, idOrdinal);
+        // Rows without the _id column render the hit without an _id field (id = null).
+        String id = idOrdinal >= 0 ? decodeId(row[idOrdinal]) : null;
+        SearchHit hit = new SearchHit(docId, id, null, null);
         hit.score(Float.NaN);
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.map(source);
@@ -151,7 +170,7 @@ public final class HitsResponseBuilder {
      * rendered {@code _source} matches the legacy document shape. Null cells are omitted —
      * after the columnar round trip an absent field and an explicit null are indistinguishable.
      */
-    static Map<String, Object> buildSourceMap(List<String> fieldNames, Object[] row) throws ConversionException {
+    static Map<String, Object> buildSourceMap(List<String> fieldNames, Object[] row, int idOrdinal) throws ConversionException {
         if (fieldNames.size() != row.length) {
             throw new ConversionException(
                 "HITS row has " + row.length + " cells but the plan row type declares " + fieldNames.size() + " columns"
@@ -159,7 +178,8 @@ public final class HitsResponseBuilder {
         }
         Map<String, Object> source = new LinkedHashMap<>();
         for (int i = 0; i < row.length; i++) {
-            if (row[i] == null) {
+            // _id lives in the hit envelope, never in _source; null cells are omitted.
+            if (i == idOrdinal || row[i] == null) {
                 continue;
             }
             insertNested(source, fieldNames.get(i), row[i]);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
@@ -29,6 +29,7 @@ import org.opensearch.analytics.schema.ScaledFloatType;
 import org.opensearch.analytics.schema.UnsignedLongType;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.DslTypeSystems;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.util.Collections;
@@ -54,13 +55,19 @@ public class TestUtils {
 
     /** Creates a LogicalTableScan backed by the standard test schema. */
     public static LogicalTableScan createTestRelNode() {
-        Infra infra = buildInfra();
+        Infra infra = buildInfra(false);
+        return LogicalTableScan.create(infra.cluster, infra.table, List.of());
+    }
+
+    /** Like {@link #createTestRelNode()}, with the {@code _id} metadata column appended. */
+    public static LogicalTableScan createTestRelNodeWithId() {
+        Infra infra = buildInfra(true);
         return LogicalTableScan.create(infra.cluster, infra.table, List.of());
     }
 
     /** Creates a ConversionContext with the given search source and standard test schema. */
     public static ConversionContext createContext(SearchSourceBuilder searchSource) {
-        Infra infra = buildInfra();
+        Infra infra = buildInfra(false);
         return new ConversionContext(searchSource, infra.cluster, infra.table);
     }
 
@@ -69,7 +76,7 @@ public class TestUtils {
         return createContext(new SearchSourceBuilder());
     }
 
-    private static Infra buildInfra() {
+    private static Infra buildInfra(boolean includeIdColumn) {
         // Mirrors SearchSourceConverter: TIMESTAMP max precision raised to 9 for date_nanos support.
         RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
         HepPlanner planner = new HepPlanner(HepProgram.builder().build());
@@ -80,7 +87,7 @@ public class TestUtils {
             @Override
             public RelDataType getRowType(RelDataTypeFactory tf) {
                 // Nullable fields — matches OpenSearchSchemaBuilder behavior
-                return tf.builder()
+                RelDataTypeFactory.Builder builder = tf.builder()
                     .add("name", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
                     .add("price", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.INTEGER), true))
                     .add("brand", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
@@ -98,8 +105,12 @@ public class TestUtils {
                     .add("unsigned_counter", UnsignedLongType.nullable(tf))
                     .add("tiny_val", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.TINYINT), true))
                     .add("small_val", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.SMALLINT), true))
-                    .add("float_val", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.REAL), true))
-                    .build();
+                    .add("float_val", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.REAL), true));
+                if (includeIdColumn) {
+                    // matches IdColumnSchema: appended last, not null
+                    builder.add(IdFieldMapper.NAME, tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARBINARY), false));
+                }
+                return builder.build();
             }
         });
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
@@ -52,6 +52,37 @@ public class ProjectConverterTests extends OpenSearchTestCase {
         assertEquals(0, result.getRowType().getFieldCount());
     }
 
+    /** _id is metadata, not source: include-mode source filtering keeps it on the row. */
+    public void testIdSurvivesSourceIncludes() throws ConversionException {
+        LogicalTableScan scanWithId = TestUtils.createTestRelNodeWithId();
+        SearchSourceBuilder source = new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[] { "name" }, null));
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scanWithId, ctx);
+
+        assertTrue(result instanceof LogicalProject);
+        assertEquals(List.of("name", "_id"), result.getRowType().getFieldNames());
+    }
+
+    /** _source: false suppresses the source but not the ids: the projection keeps only _id. */
+    public void testFetchSourceFalseKeepsOnlyId() throws ConversionException {
+        LogicalTableScan scanWithId = TestUtils.createTestRelNodeWithId();
+        SearchSourceBuilder source = new SearchSourceBuilder().fetchSource(new FetchSourceContext(false, null, null));
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scanWithId, ctx);
+
+        assertTrue(result instanceof LogicalProject);
+        assertEquals(List.of("_id"), result.getRowType().getFieldNames());
+    }
+
+    /** Without the metadata column on the row, projections are unchanged (no phantom _id). */
+    public void testNoIdColumnMeansNoIdInProjection() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[] { "name" }, null));
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertEquals(List.of("name"), result.getRowType().getFieldNames());
+    }
+
     public void testReturnsUnchangedWhenIncludesEmpty() throws ConversionException {
         SearchSourceBuilder source = new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[] {}, null));
         ConversionContext ctx = TestUtils.createContext(source);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -86,8 +86,9 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         QueryPlans plans = converter.convert(new SearchSourceBuilder(), "test-index");
 
         QueryPlans.QueryPlan plan = plans.get(QueryPlans.Type.HITS).get(0);
-        assertEquals(4, plan.relNode().getRowType().getFieldCount());
-        assertEquals(List.of("name", "price", "brand", "rating"), plan.relNode().getRowType().getFieldNames());
+        // mapped fields plus the _id metadata column appended by IdColumnSchema
+        assertEquals(5, plan.relNode().getRowType().getFieldCount());
+        assertEquals(List.of("name", "price", "brand", "rating", "_id"), plan.relNode().getRowType().getFieldNames());
     }
 
     public void testConvertThrowsForMissingIndex() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/CalciteTestInfra.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/CalciteTestInfra.java
@@ -128,6 +128,8 @@ public class CalciteTestInfra {
                 return SqlTypeName.DATE;
             case "TIMESTAMP":
                 return SqlTypeName.TIMESTAMP;
+            case "VARBINARY":
+                return SqlTypeName.VARBINARY;
             case "TIMESTAMP_NANOS":
                 return SqlTypeName.TIMESTAMP;
             default:

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/HitsResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/HitsResponseBuilderTests.java
@@ -15,6 +15,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
+import org.opensearch.index.mapper.Uid;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -47,6 +48,48 @@ public class HitsResponseBuilderTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest("products");
         request.source(new SearchSourceBuilder().size(size));
         return request;
+    }
+
+    /** The _id metadata column is lifted into the hit envelope and never lands in _source. */
+    public void testIdColumnLiftedIntoHits() throws Exception {
+        Map<String, String> mapping = new LinkedHashMap<>(PRODUCTS_MAPPING);
+        mapping.put("_id", "VARBINARY");
+        ExecutionResult result = new ExecutionResult(
+            hitsPlan(mapping),
+            List.of(
+                new Object[] { "laptop", 999, "BrandA", encodedId("doc-1") },
+                new Object[] { "phone", 699, "BrandB", encodedId("doc-2") }
+            )
+        );
+
+        SearchHits hits = HitsResponseBuilder.build(List.of(result), request(10), null);
+
+        assertEquals(2, hits.getHits().length);
+        assertEquals("doc-1", hits.getHits()[0].getId());
+        assertEquals("doc-2", hits.getHits()[1].getId());
+        // _id must not leak into _source
+        assertEquals(Map.of("name", "laptop", "price", 999, "brand", "BrandA"), hits.getHits()[0].getSourceAsMap());
+    }
+
+    /** The engine returns the stored bytes as byte[] (Arrow Binary); mirror that here. */
+    private static byte[] encodedId(String id) {
+        org.apache.lucene.util.BytesRef ref = Uid.encodeId(id);
+        return java.util.Arrays.copyOfRange(ref.bytes, ref.offset, ref.offset + ref.length);
+    }
+
+    /** Test rows may carry the id as a plain string; anything else is a broken contract. */
+    public void testIdCellTypes() throws Exception {
+        Map<String, String> mapping = new LinkedHashMap<>(PRODUCTS_MAPPING);
+        mapping.put("_id", "VARBINARY");
+
+        ExecutionResult stringId = new ExecutionResult(
+            hitsPlan(mapping),
+            List.<Object[]>of(new Object[] { "laptop", 999, "BrandA", "doc-9" })
+        );
+        assertEquals("doc-9", HitsResponseBuilder.build(List.of(stringId), request(10), null).getHits()[0].getId());
+
+        ExecutionResult badId = new ExecutionResult(hitsPlan(mapping), List.<Object[]>of(new Object[] { "laptop", 999, "BrandA", 42 }));
+        expectThrows(ConversionException.class, () -> HitsResponseBuilder.build(List.of(badId), request(10), null));
     }
 
     public void testBuildsHitsFromRows() throws Exception {
@@ -202,7 +245,7 @@ public class HitsResponseBuilderTests extends OpenSearchTestCase {
     public void testDottedColumnConflictingWithScalarThrows() {
         expectThrows(
             ConversionException.class,
-            () -> HitsResponseBuilder.buildSourceMap(List.of("name", "name.first"), new Object[] { "laptop", "x" })
+            () -> HitsResponseBuilder.buildSourceMap(List.of("name", "name.first"), new Object[] { "laptop", "x" }, -1)
         );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_not_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_not_hits.json
@@ -22,10 +22,10 @@
     "  LogicalFilter(condition=[IS NOT TRUE(=($2, CAST('BrandX':VARCHAR):VARCHAR))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price", "brand", "rating"],
+  "mockResultFieldNames": ["name", "price", "brand", "rating", "_id"],
   "mockResultRows": [
-    ["laptop", 999, "BrandA", 4.5],
-    ["tablet", 499, null, 3.0]
+    ["laptop", 999, "BrandA", 4.5, "id-1"],
+    ["tablet", 499, null, 3.0, "id-2"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -43,7 +43,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -51,7 +52,8 @@
             "name": "tablet",
             "price": 499,
             "rating": 3.0
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_should_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_should_hits.json
@@ -26,9 +26,9 @@
     "  LogicalFilter(condition=[=($0, CAST('laptop':VARCHAR):VARCHAR)])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price", "brand", "rating"],
+  "mockResultFieldNames": ["name", "price", "brand", "rating", "_id"],
   "mockResultRows": [
-    ["laptop", 999, "BrandA", 4.5]
+    ["laptop", 999, "BrandA", 4.5, "id-1"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -46,7 +46,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
@@ -17,10 +17,28 @@
     "LogicalSort(fetch=[10])",
     "  LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price", "brand", "rating"],
+  "mockResultFieldNames": [
+    "name",
+    "price",
+    "brand",
+    "rating",
+    "_id"
+  ],
   "mockResultRows": [
-    ["laptop", 999, "BrandA", 4.5],
-    ["phone", 699, "BrandB", 4.2]
+    [
+      "laptop",
+      999,
+      "BrandA",
+      4.5,
+      "id-1"
+    ],
+    [
+      "phone",
+      699,
+      "BrandB",
+      4.2,
+      "id-2"
+    ]
   ],
   "mockCountRow": {
     "_total": 2
@@ -41,7 +59,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -50,7 +69,8 @@
             "price": 699,
             "brand": "BrandB",
             "rating": 4.2
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_case_insensitive_hits.json
@@ -21,10 +21,10 @@
     "  LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'Lap'), MAP('case_insensitive', 'true'))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price"],
+  "mockResultFieldNames": ["name", "price", "_id"],
   "mockResultRows": [
-    ["Laptop", 999],
-    ["LAPTOP_PRO", 1499]
+    ["Laptop", 999, "id-1"],
+    ["LAPTOP_PRO", 1499, "id-2"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -40,14 +40,16 @@
             "name": "Laptop",
             "price": 999
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-1"
         },
         {
           "_source": {
             "name": "LAPTOP_PRO",
             "price": 1499
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/prefix_query_hits.json
@@ -20,10 +20,10 @@
     "  LogicalFilter(condition=[PREFIX_QUERY(MAP('field', $0), MAP('query', 'lap'))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price"],
+  "mockResultFieldNames": ["name", "price", "_id"],
   "mockResultRows": [
-    ["laptop", 999],
-    ["laptop_pro", 1499]
+    ["laptop", 999, "id-1"],
+    ["laptop_pro", 1499, "id-2"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -39,14 +39,16 @@
             "name": "laptop",
             "price": 999
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-1"
         },
         {
           "_source": {
             "name": "laptop_pro",
             "price": 1499
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_boolean.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_boolean.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "is_active"
+    "is_active",
+    "_id"
   ],
   "mockResultRows": [
     [
       "product1",
-      true
+      true,
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "product1",
             "is_active": true
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "created_date"
+    "created_date",
+    "_id"
   ],
   "mockResultRows": [
     [
       "event1",
-      "2024-06-15"
+      "2024-06-15",
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "event1",
             "created_date": "2024-06-15"
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date_nanos.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_date_nanos.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "event_nanos"
+    "event_nanos",
+    "_id"
   ],
   "mockResultRows": [
     [
       "event1",
-      "2024-06-15T10:30:00.000000000Z"
+      "2024-06-15T10:30:00.000000000Z",
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "event1",
             "event_nanos": "2024-06-15T10:30:00.000000000Z"
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_decimal_on_integer_truncate_adjust.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_decimal_on_integer_truncate_adjust.json
@@ -27,20 +27,23 @@
     "name",
     "price",
     "brand",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "laptop",
       999,
       "BrandA",
-      4.5
+      4.5,
+      "id-1"
     ],
     [
       "phone",
       699,
       "BrandB",
-      4.2
+      4.2,
+      "id-2"
     ]
   ],
   "expectedOutputDsl": {
@@ -59,7 +62,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -68,7 +72,8 @@
             "price": 699,
             "brand": "BrandB",
             "rating": 4.2
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_double.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_double.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "item1",
-      4.5
+      4.5,
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "item1",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_keyword_lexicographic.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_keyword_lexicographic.json
@@ -27,14 +27,16 @@
     "name",
     "price",
     "brand",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "laptop",
       999,
       "BrandA",
-      4.5
+      4.5,
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -53,7 +55,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_no_bounds_is_not_null.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_no_bounds_is_not_null.json
@@ -24,20 +24,23 @@
     "name",
     "price",
     "brand",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "laptop",
       999,
       "BrandA",
-      4.5
+      4.5,
+      "id-1"
     ],
     [
       "phone",
       699,
       "BrandB",
-      4.2
+      4.2,
+      "id-2"
     ]
   ],
   "expectedOutputDsl": {
@@ -56,7 +59,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -65,7 +69,8 @@
             "price": 699,
             "brand": "BrandB",
             "rating": 4.2
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_exclusive.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_exclusive.json
@@ -27,20 +27,23 @@
     "name",
     "price",
     "brand",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "laptop",
       999,
       "BrandA",
-      4.5
+      4.5,
+      "id-1"
     ],
     [
       "phone",
       699,
       "BrandB",
-      4.2
+      4.2,
+      "id-2"
     ]
   ],
   "expectedOutputDsl": {
@@ -59,7 +62,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -68,7 +72,8 @@
             "price": 699,
             "brand": "BrandB",
             "rating": 4.2
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_inclusive.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_inclusive.json
@@ -27,20 +27,23 @@
     "name",
     "price",
     "brand",
-    "rating"
+    "rating",
+    "_id"
   ],
   "mockResultRows": [
     [
       "laptop",
       999,
       "BrandA",
-      4.5
+      4.5,
+      "id-1"
     ],
     [
       "phone",
       699,
       "BrandB",
-      4.2
+      4.2,
+      "id-2"
     ]
   ],
   "expectedOutputDsl": {
@@ -59,7 +62,8 @@
             "price": 999,
             "brand": "BrandA",
             "rating": 4.5
-          }
+          },
+          "_id": "id-1"
         },
         {
           "_score": null,
@@ -68,7 +72,8 @@
             "price": 699,
             "brand": "BrandB",
             "rating": 4.2
-          }
+          },
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_scaled_float.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_scaled_float.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "price"
+    "price",
+    "_id"
   ],
   "mockResultRows": [
     [
       "item1",
-      150
+      150,
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "item1",
             "price": 150
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_timestamp.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_timestamp.json
@@ -30,7 +30,8 @@
     "price",
     "brand",
     "rating",
-    "created_at"
+    "created_at",
+    "_id"
   ],
   "mockResultRows": [
     [
@@ -38,7 +39,8 @@
       999,
       "BrandA",
       4.5,
-      "2024-06-15T10:30:00.000Z"
+      "2024-06-15T10:30:00.000Z",
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -58,7 +60,8 @@
             "brand": "BrandA",
             "rating": 4.5,
             "created_at": "2024-06-15T10:30:00.000Z"
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_unsigned_long.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_unsigned_long.json
@@ -23,12 +23,14 @@
   ],
   "mockResultFieldNames": [
     "name",
-    "counter"
+    "counter",
+    "_id"
   ],
   "mockResultRows": [
     [
       "item1",
-      500
+      500,
+      "id-1"
     ]
   ],
   "expectedOutputDsl": {
@@ -45,7 +47,8 @@
           "_source": {
             "name": "item1",
             "counter": 500
-          }
+          },
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_case_insensitive_hits.json
@@ -21,10 +21,10 @@
     "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'LAP*'), MAP('case_insensitive', 'true'))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price"],
+  "mockResultFieldNames": ["name", "price", "_id"],
   "mockResultRows": [
-    ["Laptop", 999],
-    ["LAPTOP_PRO", 1499]
+    ["Laptop", 999, "id-1"],
+    ["LAPTOP_PRO", 1499, "id-2"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -40,14 +40,16 @@
             "name": "Laptop",
             "price": 999
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-1"
         },
         {
           "_source": {
             "name": "LAPTOP_PRO",
             "price": 1499
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-2"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_escaped_hits.json
@@ -20,9 +20,9 @@
     "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'test\\*file\\?name\\\\end'))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price"],
+  "mockResultFieldNames": ["name", "price", "_id"],
   "mockResultRows": [
-    ["test*file?name\\end", 100]
+    ["test*file?name\\end", 100, "id-1"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -38,7 +38,8 @@
             "name": "test*file?name\\end",
             "price": 100
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-1"
         }
       ]
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/wildcard_query_hits.json
@@ -20,10 +20,10 @@
     "  LogicalFilter(condition=[WILDCARD_QUERY_DSL(MAP('field', $0), MAP('query', 'l*pt?p'))])",
     "    LogicalTableScan(table=[[test-index]])"
   ],
-  "mockResultFieldNames": ["name", "price"],
+  "mockResultFieldNames": ["name", "price", "_id"],
   "mockResultRows": [
-    ["laptop", 999],
-    ["leptop", 599]
+    ["laptop", 999, "id-1"],
+    ["leptop", 599, "id-2"]
   ],
   "expectedOutputDsl": {
     "num_reduce_phases": 0,
@@ -39,14 +39,16 @@
             "name": "laptop",
             "price": 999
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-1"
         },
         {
           "_source": {
             "name": "leptop",
             "price": 599
           },
-          "_score": null
+          "_score": null,
+          "_id": "id-2"
         }
       ]
     }


### PR DESCRIPTION
### Description

Stacked on #22722 — **review only the top commit** (`Populate _id in hits from the stored parquet column`); the rest is the parent stack (#22526 + #22722).

Hits on the DSL Calcite path previously rendered `_id` as null: the engine schema exposes only mapped source fields, so plans could not project the stored `_id` column even though the parquet primary stores it for every document.

Per the design discussion with @abandeji, this follows the QTF `___row_id` pattern — the front-end asks for the column planner-side, instead of the shared engine schema growing metadata columns (PPL's `source=idx` star expansion stays unchanged):

- **IdColumnSchema** (dsl, new): DSL's catalog view appends `_id` (VARBINARY, the stored Uid-encoded bytes) to every table, after the mapped fields so their ordinals are unchanged. Scans built from this catalog carry the column and the engine fetches it from the shards.
- **FieldStorageResolver** (engine, +18 lines): registers `_id` as a stored metadata column (columnar in the primary format, like `___row_id`). It is not a mapping property, so scans requesting it previously failed with `Field [_id] not found in field storage`.
- **ProjectConverter**: `_id` is metadata, not source — it survives `_source` filtering, including `_source: false`, which suppresses the source but not the ids, matching classic search.
- **HitsResponseBuilder**: lifts the `_id` cell out of the row into the hit envelope (Uid-decoded); it never appears in `_source`. Rows without the column render `_id` null as before.

### Verification

Unit tests + precommit green on both modules. Live end to end on a composite (parquet + lucene) index:
- ids returned on default, sorted, filtered, `_source`-filtered, and `_source: false` queries
- `size: 0`, aggregations, and `track_total_hits` behavior unchanged
- a returned `_id` fetches the document via `GET /_doc/{id}` — byte-exact decode round trip

Note: composite indexes are append-only (custom document ids are rejected at ingest), so ids are always engine-generated.

### Related
- Stacked on #22722 (hits response), which stacks on #22526
- Design discussion: QTF `___row_id` precedent suggested by @abandeji

### Check List
- [x] Functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`