### PR TITLE
[Backport 2.19] Bump 1password/load-secrets-action to v5.0.1 (OpenSearch)

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 21
 
       - name: Load secret
-        uses: 1password/load-secrets-action@14f2fed3712a25f8ad8916ddcca3c4ed737810f6 # v3
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           # Export loaded secrets as environment variables
           export-env: true


### PR DESCRIPTION
Backport of #22778 to `2.19`. The auto-backport failed (cherry-pick conflict), so this was recreated manually to the desired end state.

Relates to https://github.com/opensearch-project/opensearch-build/issues/6440#issuecomment-5349573946

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>