### PR TITLE
Drop resize source settings when restoring a snapshot into a new index

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -46,6 +46,7 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.NamedDiff;
 import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -983,6 +984,61 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .get();
         assertEquals(restoreResponse.getRestoreInfo().totalShards(), restoreResponse.getRestoreInfo().successfulShards());
         ensureYellow();
+    }
+
+    /**
+     * Tests that a snapshot of a shrunken index, restored into a new index, does not inherit the resize source of the
+     * shrink. The restored index gets a new UUID, so the recorded source can never be resolved again, and leaving it in
+     * place makes cluster recovery treat the index as a resize target that no node is allowed to hold.
+     */
+    public void testRestoreOfShrunkIndexDropsResizeSourceSettings() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        final String repo = "test-repo";
+        final String snapshot = "test-snap";
+        final String sourceIdx = "test-idx";
+        final String shrunkIdx = "test-idx-shrunk";
+        final String restoredIdx = "test-idx-restored";
+
+        createRepository(repo, "fs");
+
+        assertAcked(prepareCreate(sourceIdx, 0, indexSettingsNoReplicas(between(2, 4))));
+        ensureGreen();
+        indexRandomDocs(sourceIdx, randomIntBetween(10, 100));
+
+        logger.info("--> shrink the index");
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(sourceIdx)
+                .setSettings(Settings.builder().put("index.blocks.write", true))
+                .get()
+        );
+        assertAcked(client().admin().indices().prepareResizeIndex(sourceIdx, shrunkIdx).get());
+        assertNotNull(
+            "the shrink target is expected to record its resize source",
+            clusterAdmin().prepareState().get().getState().metadata().index(shrunkIdx).getResizeSourceIndex()
+        );
+
+        logger.info("--> snapshot the shrunk index and delete the shrink source");
+        createSnapshot(repo, snapshot, Collections.singletonList(shrunkIdx));
+        assertAcked(client().admin().indices().prepareDelete(sourceIdx).get());
+
+        logger.info("--> restore the shrunk index under a new name");
+        RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(repo, snapshot)
+            .setWaitForCompletion(true)
+            .setIndices(shrunkIdx)
+            .setRenamePattern(shrunkIdx)
+            .setRenameReplacement(restoredIdx)
+            .get();
+        assertEquals(restoreResponse.getRestoreInfo().totalShards(), restoreResponse.getRestoreInfo().successfulShards());
+        ensureYellow(restoredIdx);
+
+        final IndexMetadata restored = clusterAdmin().prepareState().get().getState().metadata().index(restoredIdx);
+        assertNull("the restored index must not inherit a resize source", restored.getResizeSourceIndex());
+        assertFalse(IndexMetadata.INDEX_RESIZE_SOURCE_NAME.exists(restored.getSettings()));
+        assertFalse(IndexMetadata.INDEX_RESIZE_SOURCE_UUID.exists(restored.getSettings()));
     }
 
     public void testSnapshotWithDateMath() {

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -557,11 +557,16 @@ public class RestoreService implements ClusterStateApplier {
                                     IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata)
                                         .state(IndexMetadata.State.OPEN)
                                         .index(renamedIndexName);
-                                    indexMdBuilder.settings(
-                                        Settings.builder()
-                                            .put(snapshotIndexMetadata.getSettings())
-                                            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-                                    );
+                                    final Settings.Builder restoredIndexSettings = Settings.builder()
+                                        .put(snapshotIndexMetadata.getSettings())
+                                        .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
+                                    // The restored index is a new index with a new UUID, so a resize source inherited from
+                                    // the snapshot can never be resolved again (Metadata#index matches on name and UUID).
+                                    // Left in place it makes IndexRoutingTable treat the index as a resize target on cluster
+                                    // recovery, and ResizeAllocationDecider then rejects every node.
+                                    restoredIndexSettings.remove(IndexMetadata.INDEX_RESIZE_SOURCE_NAME_KEY);
+                                    restoredIndexSettings.remove(IndexMetadata.INDEX_RESIZE_SOURCE_UUID_KEY);
+                                    indexMdBuilder.settings(restoredIndexSettings);
                                     createIndexService.addRemoteStoreCustomMetadata(indexMdBuilder, false, currentState);
                                     shardLimitValidator.validateShardLimit(
                                         renamedIndexName,


### PR DESCRIPTION
### Description
Restoring a snapshot of a shrunk index into a new index copies `index.resize.source.name`/`uuid` over while stamping a fresh `index.uuid`, so the restored index claims a resize source that `Metadata#index` (name + UUID) can never resolve. When that shard's in-sync allocation IDs are empty at cluster recovery, `IndexRoutingTable.Builder#initializeEmpty` gives the primary a `LOCAL_SHARDS` recovery source and `ResizeAllocationDecider` rejects every node with `resize source index [...] doesn't exists`. It is unrecoverable in place: `canForceAllocatePrimary` delegates to `canAllocate`, and the settings are private and final.

This drops both settings when a restore creates a new index; every consumer of `getResizeSourceIndex` is gated on `LOCAL_SHARDS`, which a restored index can never legitimately have.

Verified on main (42a1e959d4c): the new test fails without the fix and passes with it; precommit plus the snapshot/restore and resize suites pass.

### Related Issues
Resolves #22492

### Check List
- [x] Functionality includes testing.
