### PR TITLE
Restore size-based flushes for remote translog

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/translog/TranslogSizeFlushDocRepIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/translog/TranslogSizeFlushDocRepIT.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog;
+
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.IndexingMemoryController;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.index.shard.IndexShardTestCase.getTranslog;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Asserts that tracking remote translog bytes since the last commit leaves document replication indices alone. Those
+ * shards keep a local translog and must reach {@code index.translog.flush_threshold_size} exactly as before, whether the
+ * cluster setting is on or off.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class TranslogSizeFlushDocRepIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "docrep-translog-flush-idx";
+    private static final int DOC_SIZE_IN_BYTES = 4 * 1024;
+
+    public void testDocumentReplicationFlushUnchangedWhenTrackingEnabled() throws Exception {
+        assertDocRepSizeBasedFlush(true);
+    }
+
+    public void testDocumentReplicationFlushUnchangedWhenTrackingDisabled() throws Exception {
+        assertDocRepSizeBasedFlush(false);
+    }
+
+    private void assertDocRepSizeBasedFlush(boolean trackBytesSinceLastCommit) throws Exception {
+        Settings nodeSettings = Settings.builder().put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), "1h").build();
+        internalCluster().startClusterManagerOnlyNode(nodeSettings);
+        String dataNode = internalCluster().startDataOnlyNode(nodeSettings);
+
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(
+                            RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(),
+                            trackBytesSinceLastCommit
+                        )
+                )
+                .get()
+        );
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), "32kb")
+                .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "-1")
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "-1")
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
+        // The byte tracking is scoped to remote translog backed shards, so this shard must not even be a candidate.
+        assertFalse(getTranslog(indexShard) instanceof RemoteFsTranslog);
+        long initialPeriodicFlushes = indexShard.flushStats().getPeriodic();
+        long initialCommitCheckpoint = getLastCommittedLocalCheckpoint(indexShard);
+        assertFalse(indexShard.shouldPeriodicallyFlush());
+
+        // Write past the 32kb threshold. Refreshing on every write is what suppresses the flush on a remote translog,
+        // so doing the same here keeps the two setups comparable.
+        String payload = randomAlphaOfLength(DOC_SIZE_IN_BYTES);
+        for (int i = 0; i < 12; i++) {
+            client(dataNode).prepareIndex(INDEX_NAME)
+                .setId(Integer.toString(i))
+                .setSource("payload", payload)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+
+        assertBusy(() -> {
+            assertThat(indexShard.flushStats().getPeriodic(), greaterThan(initialPeriodicFlushes));
+            assertThat(getLastCommittedLocalCheckpoint(indexShard), greaterThan(initialCommitCheckpoint));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private IndexShard getIndexShard(String node, String indexName) {
+        final Index index = resolveIndex(indexName);
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+        IndexService indexService = indicesService.indexService(index);
+        assertNotNull(indexService);
+        return indexService.getShard(0);
+    }
+
+    private long getLastCommittedLocalCheckpoint(IndexShard indexShard) {
+        return Long.parseLong(indexShard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -867,6 +867,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS,
+                RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL,

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -554,9 +554,11 @@ public class DataFormatAwareEngine implements Indexer {
     }
 
     /**
-     * Note that this does not opt into tracking translog bytes since the last commit. That tracking exists to release
-     * soft deleted documents which a lagging safe commit keeps protected, and this engine does not support updates yet,
-     * so it never accumulates them.
+     * Note that this uses the constructor which does not track translog bytes since the last commit, because this
+     * engine's commit path does not release the tracked bytes. That tracking exists to release soft deleted documents
+     * which a lagging safe commit keeps protected, and this engine does not support updates yet, so it never
+     * accumulates them. Opting in would mean wiring {@code startIndexCommit}/{@code finishIndexCommit} around
+     * {@code committer.commit} in {@link #flush(boolean, boolean)} first, including the path where the commit is skipped.
      */
     private TranslogManager createTranslogManager(
         String translogUUID,

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -553,6 +553,11 @@ public class DataFormatAwareEngine implements Indexer {
         };
     }
 
+    /**
+     * Note that this does not opt into tracking translog bytes since the last commit. That tracking exists to release
+     * soft deleted documents which a lagging safe commit keeps protected, and this engine does not support updates yet,
+     * so it never accumulates them.
+     */
     private TranslogManager createTranslogManager(
         String translogUUID,
         TranslogDeletionPolicy deletionPolicy,

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -409,7 +409,8 @@ public class InternalEngine extends Engine {
             this::ensureOpen,
             engineConfig.getTranslogFactory(),
             engineConfig.getStartedPrimarySupplier(),
-            TranslogOperationHelper.create(engineConfig)
+            TranslogOperationHelper.create(engineConfig),
+            true
         );
     }
 
@@ -2222,7 +2223,21 @@ public class InternalEngine extends Engine {
                 refresh("commit", SearcherScope.INTERNAL, true);
             }
 
-            writer.commit();
+            final InternalTranslogManager internalTranslogManager = translogManager instanceof InternalTranslogManager manager
+                ? manager
+                : null;
+            if (internalTranslogManager != null && internalTranslogManager.isTranslogBytesTrackingEnabled()) {
+                internalTranslogManager.startIndexCommit();
+                boolean commitSuccessful = false;
+                try {
+                    writer.commit();
+                    commitSuccessful = true;
+                } finally {
+                    internalTranslogManager.finishIndexCommit(commitSuccessful);
+                }
+            } else {
+                writer.commit();
+            }
         } catch (final Exception ex) {
             try {
                 failEngine("lucene commit failed", ex);

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2191,6 +2191,18 @@ public class InternalEngine extends Engine {
      */
     protected void commitIndexWriter(final DocumentIndexWriter writer, final String translogUUID) throws IOException {
         translogManager.ensureCanFlush();
+        /*
+         * Snapshot the tracked translog bytes before the local checkpoint below is read. This commit only covers
+         * operations up to that checkpoint, so a snapshot taken any later would also claim the bytes of operations that
+         * reached the translog afterwards and are not part of this commit. Those bytes would then be dropped from the
+         * counter for good and every future flush decision would under-count the translog by that much. Snapshotting
+         * first can only leave already committed bytes counted, which merely brings the next periodic flush forward.
+         */
+        final InternalTranslogManager byteTrackingTranslogManager = translogBytesTrackingManager();
+        if (byteTrackingTranslogManager != null) {
+            byteTrackingTranslogManager.startIndexCommit();
+        }
+        boolean commitSuccessful = false;
         try {
             final long localCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
             writer.setLiveCommitData(() -> {
@@ -2223,21 +2235,8 @@ public class InternalEngine extends Engine {
                 refresh("commit", SearcherScope.INTERNAL, true);
             }
 
-            final InternalTranslogManager internalTranslogManager = translogManager instanceof InternalTranslogManager manager
-                ? manager
-                : null;
-            if (internalTranslogManager != null && internalTranslogManager.isTranslogBytesTrackingEnabled()) {
-                internalTranslogManager.startIndexCommit();
-                boolean commitSuccessful = false;
-                try {
-                    writer.commit();
-                    commitSuccessful = true;
-                } finally {
-                    internalTranslogManager.finishIndexCommit(commitSuccessful);
-                }
-            } else {
-                writer.commit();
-            }
+            writer.commit();
+            commitSuccessful = true;
         } catch (final Exception ex) {
             try {
                 failEngine("lucene commit failed", ex);
@@ -2261,7 +2260,22 @@ public class InternalEngine extends Engine {
             } else {
                 throw e;
             }
+        } finally {
+            if (byteTrackingTranslogManager != null) {
+                byteTrackingTranslogManager.finishIndexCommit(commitSuccessful);
+            }
         }
+    }
+
+    /**
+     * Returns the translog manager that tracks translog bytes since the last commit for this shard, or {@code null}
+     * when that tracking is not enabled.
+     */
+    private InternalTranslogManager translogBytesTrackingManager() {
+        if (translogManager instanceof InternalTranslogManager manager && manager.isTranslogBytesTrackingEnabled()) {
+            return manager;
+        }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -47,13 +47,24 @@ public class InternalTranslogManager implements TranslogManager {
     private final Supplier<LocalCheckpointTracker> localCheckpointTrackerSupplier;
     private final Logger logger;
     private final TranslogBytesTracker translogBytesTracker = new TranslogBytesTracker();
-    private final boolean supportsTranslogBytesTracking;
+    /**
+     * Whether this shard qualifies for tracking translog bytes since the last commit at all: the owning engine releases
+     * the tracked bytes on commit, the translog is a {@link RemoteFsTranslog}, and the index is remote translog backed.
+     * Fixed for the life of this manager. The cluster setting is evaluated separately and per call, so use
+     * {@link #isTranslogBytesTrackingEnabled()} rather than reading this directly.
+     */
+    private final boolean bytesTrackingApplicable;
     /**
      * Guarded by the engine's flush lock, which serialises {@link #startIndexCommit()} and
      * {@link #finishIndexCommit(boolean)} and publishes this field between the threads that run successive commits.
      */
     private TranslogBytesTracker.CommitSnapshot commitSnapshot;
 
+    /**
+     * Creates a manager that does not track translog bytes since the last commit. Engines whose commit path does not
+     * release the tracked bytes must use this constructor, otherwise the counter would grow without bound and hold the
+     * shard permanently above its flush threshold.
+     */
     public InternalTranslogManager(
         TranslogConfig translogConfig,
         LongSupplier primaryTermSupplier,
@@ -87,6 +98,15 @@ public class InternalTranslogManager implements TranslogManager {
         );
     }
 
+    /**
+     * Creates a manager, where {@code releasesTrackedBytesOnCommit} is the calling engine's assertion that its commit
+     * path invokes {@link #startIndexCommit()} and {@link #finishIndexCommit(boolean)} around every index commit. Only
+     * an engine that honours that contract may pass {@code true}. Passing {@code true} without it means nothing ever
+     * releases the counted bytes, so the shard reports a due periodic flush on every write for the rest of its life.
+     * <p>
+     * Note that this is only the engine half of the decision. Tracking additionally requires a remote translog, a
+     * remote translog backed index, and the cluster setting to be enabled.
+     */
     public InternalTranslogManager(
         TranslogConfig translogConfig,
         LongSupplier primaryTermSupplier,
@@ -101,7 +121,7 @@ public class InternalTranslogManager implements TranslogManager {
         TranslogFactory translogFactory,
         BooleanSupplier startedPrimarySupplier,
         TranslogOperationHelper translogOperationHelper,
-        boolean supportsTranslogBytesTracking
+        boolean releasesTrackedBytesOnCommit
     ) throws IOException {
         this.shardId = shardId;
         this.readLock = readLock;
@@ -122,7 +142,7 @@ public class InternalTranslogManager implements TranslogManager {
          * for. A node that merely has a translog repository configured also hands a RemoteFsTranslog to the primaries
          * of plain document replication indices, and those must keep using the untouched size computation.
          */
-        this.supportsTranslogBytesTracking = supportsTranslogBytesTracking
+        this.bytesTrackingApplicable = releasesTrackedBytesOnCommit
             && translog instanceof RemoteFsTranslog
             && translogConfig.getIndexSettings().isRemoteTranslogStoreEnabled();
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
@@ -399,10 +419,11 @@ public class InternalTranslogManager implements TranslogManager {
     }
 
     /**
-     * Returns whether byte tracking is supported by the engine and enabled for the remote translog.
+     * Returns whether translog bytes since the last commit are being tracked for this shard right now: the shard
+     * qualifies and the cluster setting is enabled. This is the only predicate callers should consult.
      */
     public boolean isTranslogBytesTrackingEnabled() {
-        return supportsTranslogBytesTracking && ((RemoteFsTranslog) translog).isTranslogBytesTrackingEnabled();
+        return bytesTrackingApplicable && ((RemoteFsTranslog) translog).isBytesTrackingSettingEnabled();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -46,6 +46,9 @@ public class InternalTranslogManager implements TranslogManager {
     private final TranslogEventListener translogEventListener;
     private final Supplier<LocalCheckpointTracker> localCheckpointTrackerSupplier;
     private final Logger logger;
+    private final TranslogBytesTracker translogBytesTracker = new TranslogBytesTracker();
+    private final boolean supportsTranslogBytesTracking;
+    private TranslogBytesTracker.CommitSnapshot commitSnapshot;
 
     public InternalTranslogManager(
         TranslogConfig translogConfig,
@@ -62,6 +65,40 @@ public class InternalTranslogManager implements TranslogManager {
         BooleanSupplier startedPrimarySupplier,
         TranslogOperationHelper translogOperationHelper
     ) throws IOException {
+        this(
+            translogConfig,
+            primaryTermSupplier,
+            globalCheckpointSupplier,
+            translogDeletionPolicy,
+            shardId,
+            readLock,
+            localCheckpointTrackerSupplier,
+            translogUUID,
+            translogEventListener,
+            engineLifeCycleAware,
+            translogFactory,
+            startedPrimarySupplier,
+            translogOperationHelper,
+            false
+        );
+    }
+
+    public InternalTranslogManager(
+        TranslogConfig translogConfig,
+        LongSupplier primaryTermSupplier,
+        LongSupplier globalCheckpointSupplier,
+        TranslogDeletionPolicy translogDeletionPolicy,
+        ShardId shardId,
+        ReleasableLock readLock,
+        Supplier<LocalCheckpointTracker> localCheckpointTrackerSupplier,
+        String translogUUID,
+        TranslogEventListener translogEventListener,
+        LifecycleAware engineLifeCycleAware,
+        TranslogFactory translogFactory,
+        BooleanSupplier startedPrimarySupplier,
+        TranslogOperationHelper translogOperationHelper,
+        boolean supportsTranslogBytesTracking
+    ) throws IOException {
         this.shardId = shardId;
         this.readLock = readLock;
         this.engineLifeCycleAware = engineLifeCycleAware;
@@ -76,6 +113,7 @@ public class InternalTranslogManager implements TranslogManager {
         }, translogUUID, translogFactory, startedPrimarySupplier, translogOperationHelper);
         assert translog.getGeneration() != null;
         this.translog = translog;
+        this.supportsTranslogBytesTracking = supportsTranslogBytesTracking && translog instanceof RemoteFsTranslog;
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
         // don't allow commits until we are done with recovering
         pendingTranslogRecovery.set(true);
@@ -337,7 +375,39 @@ public class InternalTranslogManager implements TranslogManager {
      */
     @Override
     public Translog.Location add(Translog.Operation operation) throws IOException {
-        return translog.add(operation);
+        Translog.Location location = translog.add(operation);
+        if (isTranslogBytesTrackingEnabled()) {
+            translogBytesTracker.addBytes(location.size);
+        }
+        return location;
+    }
+
+    /**
+     * Returns whether byte tracking is supported by the engine and enabled for the remote translog.
+     */
+    public boolean isTranslogBytesTrackingEnabled() {
+        return supportsTranslogBytesTracking && ((RemoteFsTranslog) translog).isTranslogBytesTrackingEnabled();
+    }
+
+    /**
+     * Captures the remote translog bytes that are eligible to be cleared by the next index commit.
+     */
+    public void startIndexCommit() {
+        assert commitSnapshot == null : "an index commit is already in progress";
+        commitSnapshot = translogBytesTracker.startCommit();
+    }
+
+    /**
+     * Completes byte tracking for an index commit.
+     *
+     * @param successful whether the index commit completed successfully
+     */
+    public void finishIndexCommit(boolean successful) {
+        assert commitSnapshot != null : "index commit was not started";
+        if (successful) {
+            translogBytesTracker.completeCommit(commitSnapshot);
+        }
+        commitSnapshot = null;
     }
 
     /**
@@ -450,6 +520,9 @@ public class InternalTranslogManager implements TranslogManager {
          */
         if (translog.shouldFlush()) {
             return true;
+        }
+        if (isTranslogBytesTrackingEnabled()) {
+            return translogBytesTracker.getBytesSinceLastCommit() >= flushThreshold;
         }
         // This is the minimum seqNo that is referred in translog and considered for calculating translog size
         long minTranslogRefSeqNo = translog.getMinUnreferencedSeqNoInSegments(localCheckpointOfLastCommit + 1);

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -48,6 +48,10 @@ public class InternalTranslogManager implements TranslogManager {
     private final Logger logger;
     private final TranslogBytesTracker translogBytesTracker = new TranslogBytesTracker();
     private final boolean supportsTranslogBytesTracking;
+    /**
+     * Guarded by the engine's flush lock, which serialises {@link #startIndexCommit()} and
+     * {@link #finishIndexCommit(boolean)} and publishes this field between the threads that run successive commits.
+     */
     private TranslogBytesTracker.CommitSnapshot commitSnapshot;
 
     public InternalTranslogManager(
@@ -113,7 +117,14 @@ public class InternalTranslogManager implements TranslogManager {
         }, translogUUID, translogFactory, startedPrimarySupplier, translogOperationHelper);
         assert translog.getGeneration() != null;
         this.translog = translog;
-        this.supportsTranslogBytesTracking = supportsTranslogBytesTracking && translog instanceof RemoteFsTranslog;
+        /*
+         * Only indices backed by a remote translog see the moving retention boundary that this tracking compensates
+         * for. A node that merely has a translog repository configured also hands a RemoteFsTranslog to the primaries
+         * of plain document replication indices, and those must keep using the untouched size computation.
+         */
+        this.supportsTranslogBytesTracking = supportsTranslogBytesTracking
+            && translog instanceof RemoteFsTranslog
+            && translogConfig.getIndexSettings().isRemoteTranslogStoreEnabled();
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
         // don't allow commits until we are done with recovering
         pendingTranslogRecovery.set(true);
@@ -375,8 +386,13 @@ public class InternalTranslogManager implements TranslogManager {
      */
     @Override
     public Translog.Location add(Translog.Operation operation) throws IOException {
+        // Read the setting once so that a concurrent update cannot make us add an operation without accounting for it.
+        final boolean trackBytes = isTranslogBytesTrackingEnabled();
+        if (trackBytes) {
+            ensureTranslogBytesTrackerInitialized();
+        }
         Translog.Location location = translog.add(operation);
-        if (isTranslogBytesTrackingEnabled()) {
+        if (trackBytes) {
             translogBytesTracker.addBytes(location.size);
         }
         return location;
@@ -390,10 +406,30 @@ public class InternalTranslogManager implements TranslogManager {
     }
 
     /**
+     * Seeds the tracker with the uncommitted translog bytes this shard already holds. A tracker starts empty, so
+     * without this a shard whose engine was just created (a restart, a relocation or an engine reset) would forget the
+     * uncommitted translog it recovered and postpone the next size based flush by up to a full threshold. The same
+     * seeding lets a cluster that turns the setting on mid flight account for the translog written before that point.
+     * <p>
+     * The baseline matches the {@code uncommitted_size_in_bytes} translog stat. Bytes belonging to generations that
+     * were already trimmed are not part of it because those files no longer exist.
+     */
+    private void ensureTranslogBytesTrackerInitialized() {
+        if (translogBytesTracker.isInitialized()) {
+            return;
+        }
+        final long uncommittedGeneration = translog.getMinGenerationForSeqNo(
+            translog.getDeletionPolicy().getLocalCheckpointOfSafeCommit() + 1
+        ).translogFileGeneration;
+        translogBytesTracker.initialize(translog.sizeInBytesByMinGen(uncommittedGeneration));
+    }
+
+    /**
      * Captures the remote translog bytes that are eligible to be cleared by the next index commit.
      */
     public void startIndexCommit() {
         assert commitSnapshot == null : "an index commit is already in progress";
+        ensureTranslogBytesTrackerInitialized();
         commitSnapshot = translogBytesTracker.startCommit();
     }
 
@@ -522,6 +558,7 @@ public class InternalTranslogManager implements TranslogManager {
             return true;
         }
         if (isTranslogBytesTrackingEnabled()) {
+            ensureTranslogBytesTrackerInitialized();
             return translogBytesTracker.getBytesSinceLastCommit() >= flushThreshold;
         }
         // This is the minimum seqNo that is referred in translog and considered for calculating translog size

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -73,6 +73,7 @@ public class RemoteFsTranslog extends Translog {
     protected final FileTransferTracker fileTransferTracker;
     protected final BooleanSupplier startedPrimarySupplier;
     private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
+    private final RemoteStoreSettings remoteStoreSettings;
     private volatile long maxRemoteTranslogGenerationUploaded;
 
     private volatile long minSeqNoToKeep;
@@ -128,6 +129,7 @@ public class RemoteFsTranslog extends Translog {
         logger = Loggers.getLogger(getClass(), shardId);
         this.startedPrimarySupplier = startedPrimarySupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
+        this.remoteStoreSettings = remoteStoreSettings;
         fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
         isTranslogMetadataEnabled = indexSettings().isTranslogMetadataEnabled();
         this.isServerSideEncryptionEnabled = isServerSideEncryptionEnabled;
@@ -793,6 +795,10 @@ public class RemoteFsTranslog extends Translog {
             return false;
         }
         return readers.size() >= maxRemoteTlogReaders;
+    }
+
+    boolean isTranslogBytesTrackingEnabled() {
+        return remoteStoreSettings.isTranslogBytesTrackingEnabled();
     }
 
     private CryptoMetadata resolveCryptoMetadata() {

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -797,7 +797,12 @@ public class RemoteFsTranslog extends Translog {
         return readers.size() >= maxRemoteTlogReaders;
     }
 
-    boolean isTranslogBytesTrackingEnabled() {
+    /**
+     * Returns whether the cluster setting that enables tracking translog bytes since the last commit is on. This is only
+     * the setting; whether a given shard tracks also depends on the engine and the index, so callers outside this class
+     * should ask {@link InternalTranslogManager#isTranslogBytesTrackingEnabled()}.
+     */
+    boolean isBytesTrackingSettingEnabled() {
         return remoteStoreSettings.isTranslogBytesTrackingEnabled();
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/TranslogBytesTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogBytesTracker.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tracks translog bytes written since the last successful index commit.
+ *
+ * @opensearch.internal
+ */
+final class TranslogBytesTracker {
+
+    private final AtomicLong bytesSinceLastCommit = new AtomicLong();
+
+    void addBytes(long bytes) {
+        if (bytes < 0) {
+            throw new IllegalArgumentException("translog bytes must be non-negative");
+        }
+        bytesSinceLastCommit.updateAndGet(current -> Math.addExact(current, bytes));
+    }
+
+    long getBytesSinceLastCommit() {
+        return bytesSinceLastCommit.get();
+    }
+
+    CommitSnapshot startCommit() {
+        return new CommitSnapshot(bytesSinceLastCommit.get());
+    }
+
+    void completeCommit(CommitSnapshot commitSnapshot) {
+        bytesSinceLastCommit.updateAndGet(current -> {
+            if (commitSnapshot.bytes > current) {
+                throw new IllegalStateException(
+                    "commit snapshot contains [" + commitSnapshot.bytes + "] bytes but only [" + current + "] bytes are tracked"
+                );
+            }
+            return current - commitSnapshot.bytes;
+        });
+    }
+
+    static final class CommitSnapshot {
+        private final long bytes;
+
+        private CommitSnapshot(long bytes) {
+            this.bytes = bytes;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/translog/TranslogBytesTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogBytesTracker.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.translog;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -18,12 +19,40 @@ import java.util.concurrent.atomic.AtomicLong;
 final class TranslogBytesTracker {
 
     private final AtomicLong bytesSinceLastCommit = new AtomicLong();
+    private final AtomicBoolean initialized = new AtomicBoolean();
+
+    /**
+     * Seeds the tracker with the translog bytes that were already written beyond the last commit before this tracker
+     * existed. Only the first call takes effect, so callers can invoke this from every entry point without guarding.
+     *
+     * @param baselineBytes uncommitted translog bytes present at the time tracking starts
+     * @return {@code true} if this call seeded the tracker
+     */
+    boolean initialize(long baselineBytes) {
+        if (baselineBytes < 0) {
+            throw new IllegalArgumentException("translog bytes must be non-negative");
+        }
+        if (initialized.compareAndSet(false, true) == false) {
+            return false;
+        }
+        addBytes(baselineBytes);
+        return true;
+    }
+
+    boolean isInitialized() {
+        return initialized.get();
+    }
 
     void addBytes(long bytes) {
         if (bytes < 0) {
             throw new IllegalArgumentException("translog bytes must be non-negative");
         }
-        bytesSinceLastCommit.updateAndGet(current -> Math.addExact(current, bytes));
+        /*
+         * Saturate rather than overflow. Both operands are non-negative here, so a negative sum can only mean the
+         * counter wrapped. This runs on the indexing path and only feeds a flush decision, so it must never throw and
+         * fail the shard over an accounting detail.
+         */
+        bytesSinceLastCommit.updateAndGet(current -> current + bytes < 0 ? Long.MAX_VALUE : current + bytes);
     }
 
     long getBytesSinceLastCommit() {

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -127,6 +127,17 @@ public class RemoteStoreSettings {
     );
 
     /**
+     * Controls whether remote translog bytes written since the last index commit are used to evaluate
+     * {@code index.translog.flush_threshold_size}.
+     */
+    public static final Setting<Boolean> CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING = Setting.boolSetting(
+        "cluster.remote_store.translog.track_bytes_since_last_commit.enabled",
+        false,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    /**
      * Controls timeout value while uploading segment files to remote segment store
      */
     public static final Setting<TimeValue> CLUSTER_REMOTE_SEGMENT_TRANSFER_TIMEOUT_SETTING = Setting.timeSetting(
@@ -227,6 +238,7 @@ public class RemoteStoreSettings {
     private volatile RemoteStoreEnums.PathType pathType;
     private volatile RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm;
     private volatile int maxRemoteTranslogReaders;
+    private volatile boolean translogBytesTrackingEnabled;
     private volatile boolean isClusterServerSideEncryptionRepoEnabled;
     private volatile boolean isTranslogMetadataEnabled;
     private static volatile boolean isPinnedTimestampsEnabled;
@@ -266,6 +278,12 @@ public class RemoteStoreSettings {
 
         maxRemoteTranslogReaders = CLUSTER_REMOTE_MAX_TRANSLOG_READERS.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_REMOTE_MAX_TRANSLOG_READERS, this::setMaxRemoteTranslogReaders);
+
+        translogBytesTrackingEnabled = CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(
+            CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING,
+            this::setTranslogBytesTrackingEnabled
+        );
 
         clusterRemoteSegmentTransferTimeout = CLUSTER_REMOTE_SEGMENT_TRANSFER_TIMEOUT_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(
@@ -354,6 +372,14 @@ public class RemoteStoreSettings {
 
     private void setMaxRemoteTranslogReaders(int maxRemoteTranslogReaders) {
         this.maxRemoteTranslogReaders = maxRemoteTranslogReaders;
+    }
+
+    public boolean isTranslogBytesTrackingEnabled() {
+        return translogBytesTrackingEnabled;
+    }
+
+    private void setTranslogBytesTrackingEnabled(boolean translogBytesTrackingEnabled) {
+        this.translogBytesTrackingEnabled = translogBytesTrackingEnabled;
     }
 
     public boolean isClusterServerSideEncryptionEnabled() {

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreTranslogBytesFlushTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreTranslogBytesFlushTests.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.translog.RemoteFsTranslog;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.indices.replication.common.ReplicationType;
+
+import java.io.IOException;
+
+/**
+ * Verifies that {@link org.opensearch.index.engine.InternalEngine} drives the translog byte tracking that backs
+ * {@code index.translog.flush_threshold_size} on remote translog backed shards, in particular that a successful index
+ * commit releases the tracked bytes.
+ */
+public class RemoteStoreTranslogBytesFlushTests extends IndexShardTestCase {
+
+    private static final int FLUSH_THRESHOLD_BYTES = 512;
+
+    private boolean trackTranslogBytes = true;
+
+    @Override
+    protected RemoteStoreSettings remoteStoreSettings() {
+        Settings settings = Settings.builder()
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(), trackTranslogBytes)
+            .build();
+        return new RemoteStoreSettings(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+    }
+
+    public void testSuccessfulCommitReleasesTrackedTranslogBytes() throws Exception {
+        trackTranslogBytes = true;
+        IndexShard shard = newStartedShard(true, remoteBackedIndexSettings());
+        try {
+            assertTrue(getTranslog(shard) instanceof RemoteFsTranslog);
+
+            indexUntilFlushThresholdIsCrossed(shard);
+
+            /*
+             * The threshold has been crossed, so a commit has to bring the trigger back down. The translog files still
+             * hold every one of those bytes, so this only passes when the commit released them from the tracker, which
+             * is the wiring under test.
+             */
+            flushShard(shard);
+            assertFalse(shard.shouldPeriodicallyFlush());
+            assertEquals(shard.getProcessedLocalCheckpoint(), lastCommittedLocalCheckpoint(shard));
+
+            // A single small operation must not put the shard back over the threshold.
+            indexDoc(shard, "_doc", "after-flush", "{\"f\":\"v\"}");
+            assertFalse(shard.shouldPeriodicallyFlush());
+
+            // Bytes accumulate again from the commit, so the trigger fires a second time.
+            indexUntilFlushThresholdIsCrossed(shard);
+            flushShard(shard);
+            assertFalse(shard.shouldPeriodicallyFlush());
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * With the setting off the legacy size computation decides when to flush. The commit hooks must stay out of the way
+     * entirely, so a flush still has to produce a commit that carries the shard's processed checkpoint. Note that the
+     * legacy trigger is deliberately not asserted here: it is driven by the remote retention boundary, which only moves
+     * once segments are uploaded, and that is covered end to end by the integration tests.
+     */
+    public void testDisabledTrackingStillCommitsOnFlush() throws Exception {
+        trackTranslogBytes = false;
+        IndexShard shard = newStartedShard(true, remoteBackedIndexSettings());
+        try {
+            assertTrue(getTranslog(shard) instanceof RemoteFsTranslog);
+
+            indexUntilFlushThresholdIsCrossed(shard);
+            flushShard(shard);
+
+            assertEquals(shard.getProcessedLocalCheckpoint(), lastCommittedLocalCheckpoint(shard));
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    private long lastCommittedLocalCheckpoint(IndexShard shard) {
+        return Long.parseLong(shard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+    }
+
+    /**
+     * Indexes until the shard reports that a periodic flush is due. Operations are indexed one at a time because the
+     * shard may flush on its own once the threshold is crossed.
+     */
+    private void indexUntilFlushThresholdIsCrossed(IndexShard shard) throws Exception {
+        String payload = randomAlphaOfLength(FLUSH_THRESHOLD_BYTES);
+        for (int i = 0; i < 100; i++) {
+            if (shard.shouldPeriodicallyFlush()) {
+                return;
+            }
+            indexDoc(shard, "_doc", "id-" + shard.getLocalCheckpoint() + "-" + i, "{\"payload\":\"" + payload + "\"}");
+        }
+        assertTrue("shard did not reach the translog flush threshold", shard.shouldPeriodicallyFlush());
+    }
+
+    private Settings remoteBackedIndexSettings() throws IOException {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, "seg-repo")
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, "txlog-repo")
+            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), FLUSH_THRESHOLD_BYTES + "b")
+            .build();
+    }
+}

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -23,10 +23,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BooleanSupplier;
+import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
@@ -360,6 +365,157 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             deletionPolicy.assertNoOpenTranslogRefs();
         } finally {
             translogManager.close();
+        }
+    }
+
+    public void testRemoteTranslogBytesControlPeriodicFlush() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(new Translog.Location(1, 0, 100));
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            translogManager.add(mock(Translog.Operation.class));
+
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 101));
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 100));
+
+            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(false);
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
+        }
+    }
+
+    public void testRemoteTranslogBytesResetOnlyAfterSuccessfulCommit() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(
+            new Translog.Location(1, 0, 100),
+            new Translog.Location(1, 100, 20),
+            new Translog.Location(1, 120, 30)
+        );
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            Translog.Operation operation = mock(Translog.Operation.class);
+            translogManager.add(operation);
+            translogManager.startIndexCommit();
+            translogManager.add(operation);
+            translogManager.finishIndexCommit(true);
+
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 21));
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 20));
+
+            translogManager.add(operation);
+            translogManager.startIndexCommit();
+            translogManager.finishIndexCommit(false);
+
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 50));
+        }
+    }
+
+    public void testMaxRemoteTranslogReadersRemainsIndependentFlushTrigger() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(false);
+        when(remoteTranslog.shouldFlush()).thenReturn(true);
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog)) {
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, Long.MAX_VALUE));
+        }
+    }
+
+    public void testRemoteTranslogBytesAreNotTrackedWhenDisabled() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(false);
+        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(
+            new Translog.Location(1, 0, 100),
+            new Translog.Location(1, 100, 20)
+        );
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            Translog.Operation operation = mock(Translog.Operation.class);
+            translogManager.add(operation);
+
+            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
+
+            translogManager.add(operation);
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 20));
+        }
+    }
+
+    public void testRemoteTranslogBytesAreNotTrackedForUnsupportedEngine() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(new Translog.Location(1, 0, 100));
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog)) {
+            translogManager.add(mock(Translog.Operation.class));
+
+            assertFalse(translogManager.isTranslogBytesTrackingEnabled());
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
+        }
+    }
+
+    private RemoteFsTranslog mockRemoteTranslog(boolean bytesTrackingEnabled) {
+        RemoteFsTranslog remoteTranslog = mock(RemoteFsTranslog.class);
+        Translog.TranslogGeneration generation = new Translog.TranslogGeneration(translogUUID, 1);
+        when(remoteTranslog.getGeneration()).thenReturn(generation);
+        when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(bytesTrackingEnabled);
+        when(remoteTranslog.getMinUnreferencedSeqNoInSegments(org.mockito.ArgumentMatchers.anyLong())).thenReturn(0L);
+        when(remoteTranslog.getMinGenerationForSeqNo(org.mockito.ArgumentMatchers.anyLong())).thenReturn(generation);
+        when(remoteTranslog.sizeInBytesByMinGen(org.mockito.ArgumentMatchers.anyLong())).thenReturn(0L);
+        return remoteTranslog;
+    }
+
+    private InternalTranslogManager createTranslogManager(Translog translog) throws IOException {
+        return createTranslogManager(translog, false);
+    }
+
+    private InternalTranslogManager createTranslogManager(Translog translog, boolean supportsTranslogBytesTracking) throws IOException {
+        LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
+        return new InternalTranslogManager(
+            new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, "", false),
+            primaryTerm,
+            () -> NO_OPS_PERFORMED,
+            createTranslogDeletionPolicy(INDEX_SETTINGS),
+            shardId,
+            new ReleasableLock(new ReentrantReadWriteLock().readLock()),
+            () -> tracker,
+            translogUUID,
+            TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
+            () -> {},
+            new StubTranslogFactory(translog),
+            () -> true,
+            TranslogOperationHelper.DEFAULT,
+            supportsTranslogBytesTracking
+        );
+    }
+
+    private static class StubTranslogFactory implements TranslogFactory {
+        private final Translog translog;
+
+        StubTranslogFactory(Translog translog) {
+            this.translog = translog;
+        }
+
+        @Override
+        public Translog newTranslog(
+            TranslogConfig config,
+            String translogUUID,
+            TranslogDeletionPolicy deletionPolicy,
+            LongSupplier globalCheckpointSupplier,
+            LongSupplier primaryTermSupplier,
+            LongConsumer persistedSequenceNumberConsumer,
+            BooleanSupplier startedPrimarySupplier
+        ) {
+            return translog;
+        }
+
+        @Override
+        public Translog newTranslog(
+            TranslogConfig config,
+            String translogUUID,
+            TranslogDeletionPolicy deletionPolicy,
+            LongSupplier globalCheckpointSupplier,
+            LongSupplier primaryTermSupplier,
+            LongConsumer persistedSequenceNumberConsumer,
+            BooleanSupplier startedPrimarySupplier,
+            TranslogOperationHelper translogOperationHelper
+        ) {
+            return translog;
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -397,7 +397,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             assertFalse(translogManager.shouldPeriodicallyFlush(0, 101));
             assertTrue(translogManager.shouldPeriodicallyFlush(0, 100));
 
-            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(false);
+            when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(false);
             assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
         }
     }
@@ -445,7 +445,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             Translog.Operation operation = mock(Translog.Operation.class);
             translogManager.add(operation);
 
-            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(true);
             assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
 
             translogManager.add(operation);
@@ -519,7 +519,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             assertFalse(translogManager.shouldPeriodicallyFlush(0, 501));
 
             // Enabling the setting now seeds from the translog, so the threshold is met without any new operation.
-            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(true);
             assertTrue(translogManager.shouldPeriodicallyFlush(0, 500));
         }
     }
@@ -538,12 +538,12 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             translogManager.add(operation);
 
             // Disabled: the legacy computation decides and further operations are not counted.
-            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(false);
+            when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(false);
             translogManager.add(operation);
             assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
 
             // Re-enabled: the 100 bytes counted before the cycle are still there, so the threshold arrives early.
-            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(true);
             assertTrue(translogManager.shouldPeriodicallyFlush(0, 100));
 
             // A single commit brings the count back in line.
@@ -553,11 +553,11 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         }
     }
 
-    private RemoteFsTranslog mockRemoteTranslog(boolean bytesTrackingEnabled) {
+    private RemoteFsTranslog mockRemoteTranslog(boolean bytesTrackingSettingEnabled) {
         RemoteFsTranslog remoteTranslog = mock(RemoteFsTranslog.class);
         Translog.TranslogGeneration generation = new Translog.TranslogGeneration(translogUUID, 1);
         when(remoteTranslog.getGeneration()).thenReturn(generation);
-        when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(bytesTrackingEnabled);
+        when(remoteTranslog.isBytesTrackingSettingEnabled()).thenReturn(bytesTrackingSettingEnabled);
         when(remoteTranslog.getMinUnreferencedSeqNoInSegments(anyLong())).thenReturn(0L);
         when(remoteTranslog.getMinGenerationForSeqNo(anyLong())).thenReturn(generation);
         when(remoteTranslog.sizeInBytesByMinGen(anyLong())).thenReturn(0L);
@@ -569,13 +569,13 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         return createTranslogManager(translog, false);
     }
 
-    private InternalTranslogManager createTranslogManager(Translog translog, boolean supportsTranslogBytesTracking) throws IOException {
-        return createTranslogManager(translog, supportsTranslogBytesTracking, REMOTE_TRANSLOG_INDEX_SETTINGS);
+    private InternalTranslogManager createTranslogManager(Translog translog, boolean releasesTrackedBytesOnCommit) throws IOException {
+        return createTranslogManager(translog, releasesTrackedBytesOnCommit, REMOTE_TRANSLOG_INDEX_SETTINGS);
     }
 
     private InternalTranslogManager createTranslogManager(
         Translog translog,
-        boolean supportsTranslogBytesTracking,
+        boolean releasesTrackedBytesOnCommit,
         IndexSettings indexSettings
     ) throws IOException {
         LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
@@ -593,7 +593,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             new StubTranslogFactory(translog),
             () -> true,
             TranslogOperationHelper.DEFAULT,
-            supportsTranslogBytesTracking
+            releasesTrackedBytesOnCommit
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -8,13 +8,18 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.concurrent.ReleasableLock;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.translog.listener.TranslogEventListener;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.IndexSettingsModule;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -30,10 +35,24 @@ import java.util.function.LongSupplier;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class InternalTranslogManagerTests extends TranslogManagerTestCase {
+
+    private static final IndexSettings REMOTE_TRANSLOG_INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(
+        "index",
+        Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, "seg-repo")
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, "txlog-repo")
+            .build()
+    );
+
+    private static final IndexSettings DOC_REP_INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
 
     public void testRecoveryFromTranslog() throws IOException {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
@@ -370,7 +389,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
     public void testRemoteTranslogBytesControlPeriodicFlush() throws IOException {
         RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
-        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(new Translog.Location(1, 0, 100));
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 0, 100));
 
         try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
             translogManager.add(mock(Translog.Operation.class));
@@ -385,7 +404,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
     public void testRemoteTranslogBytesResetOnlyAfterSuccessfulCommit() throws IOException {
         RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
-        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(
+        when(remoteTranslog.add(any())).thenReturn(
             new Translog.Location(1, 0, 100),
             new Translog.Location(1, 100, 20),
             new Translog.Location(1, 120, 30)
@@ -420,10 +439,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
     public void testRemoteTranslogBytesAreNotTrackedWhenDisabled() throws IOException {
         RemoteFsTranslog remoteTranslog = mockRemoteTranslog(false);
-        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(
-            new Translog.Location(1, 0, 100),
-            new Translog.Location(1, 100, 20)
-        );
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 0, 100), new Translog.Location(1, 100, 20));
 
         try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
             Translog.Operation operation = mock(Translog.Operation.class);
@@ -439,7 +455,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
     public void testRemoteTranslogBytesAreNotTrackedForUnsupportedEngine() throws IOException {
         RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
-        when(remoteTranslog.add(org.mockito.ArgumentMatchers.any())).thenReturn(new Translog.Location(1, 0, 100));
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 0, 100));
 
         try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog)) {
             translogManager.add(mock(Translog.Operation.class));
@@ -449,14 +465,103 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         }
     }
 
+    /**
+     * A node with a translog repository configured hands a {@link RemoteFsTranslog} to the primary of a plain document
+     * replication index too. Those shards must keep the untouched size computation.
+     */
+    public void testRemoteTranslogBytesAreNotTrackedForDocumentReplicationIndex() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 0, 100));
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true, DOC_REP_INDEX_SETTINGS)) {
+            translogManager.add(mock(Translog.Operation.class));
+
+            assertFalse(translogManager.isTranslogBytesTrackingEnabled());
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
+        }
+    }
+
+    public void testTranslogBytesTrackerIsSeededWithUncommittedBytes() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        // The shard recovered 500 uncommitted bytes before this manager, and therefore this tracker, existed.
+        when(remoteTranslog.sizeInBytesByMinGen(anyLong())).thenReturn(500L);
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 501));
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 500));
+        }
+    }
+
+    public void testTranslogBytesTrackerSeedIsReleasedByFirstCommit() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.sizeInBytesByMinGen(anyLong())).thenReturn(500L);
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 500, 20));
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            translogManager.startIndexCommit();
+            translogManager.finishIndexCommit(true);
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 1));
+
+            // The seed is a one time correction, so the next threshold has to be reached by new operations alone even
+            // though the translog files themselves have not shrunk.
+            translogManager.add(mock(Translog.Operation.class));
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 20));
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 21));
+        }
+    }
+
+    public void testTranslogBytesTrackerIsNotSeededWhenTrackingIsDisabled() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(false);
+        when(remoteTranslog.sizeInBytesByMinGen(anyLong())).thenReturn(500L);
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            // While disabled the legacy computation runs, which reports the same 500 bytes but keeps its own guards.
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 501));
+
+            // Enabling the setting now seeds from the translog, so the threshold is met without any new operation.
+            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 500));
+        }
+    }
+
+    /**
+     * Documents an accepted approximation. Commits that run while the setting is off release nothing, so re-enabling it
+     * resumes from a stale count. The error is always toward flushing earlier than needed and the first commit after
+     * re-enabling repairs it.
+     */
+    public void testTrackedBytesRemainStaleAcrossDisableEnableCycle() throws IOException {
+        RemoteFsTranslog remoteTranslog = mockRemoteTranslog(true);
+        when(remoteTranslog.add(any())).thenReturn(new Translog.Location(1, 0, 100), new Translog.Location(1, 100, 30));
+
+        try (InternalTranslogManager translogManager = createTranslogManager(remoteTranslog, true)) {
+            Translog.Operation operation = mock(Translog.Operation.class);
+            translogManager.add(operation);
+
+            // Disabled: the legacy computation decides and further operations are not counted.
+            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(false);
+            translogManager.add(operation);
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 100));
+
+            // Re-enabled: the 100 bytes counted before the cycle are still there, so the threshold arrives early.
+            when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(true);
+            assertTrue(translogManager.shouldPeriodicallyFlush(0, 100));
+
+            // A single commit brings the count back in line.
+            translogManager.startIndexCommit();
+            translogManager.finishIndexCommit(true);
+            assertFalse(translogManager.shouldPeriodicallyFlush(0, 1));
+        }
+    }
+
     private RemoteFsTranslog mockRemoteTranslog(boolean bytesTrackingEnabled) {
         RemoteFsTranslog remoteTranslog = mock(RemoteFsTranslog.class);
         Translog.TranslogGeneration generation = new Translog.TranslogGeneration(translogUUID, 1);
         when(remoteTranslog.getGeneration()).thenReturn(generation);
         when(remoteTranslog.isTranslogBytesTrackingEnabled()).thenReturn(bytesTrackingEnabled);
-        when(remoteTranslog.getMinUnreferencedSeqNoInSegments(org.mockito.ArgumentMatchers.anyLong())).thenReturn(0L);
-        when(remoteTranslog.getMinGenerationForSeqNo(org.mockito.ArgumentMatchers.anyLong())).thenReturn(generation);
-        when(remoteTranslog.sizeInBytesByMinGen(org.mockito.ArgumentMatchers.anyLong())).thenReturn(0L);
+        when(remoteTranslog.getMinUnreferencedSeqNoInSegments(anyLong())).thenReturn(0L);
+        when(remoteTranslog.getMinGenerationForSeqNo(anyLong())).thenReturn(generation);
+        when(remoteTranslog.sizeInBytesByMinGen(anyLong())).thenReturn(0L);
+        when(remoteTranslog.getDeletionPolicy()).thenReturn(createTranslogDeletionPolicy(INDEX_SETTINGS));
         return remoteTranslog;
     }
 
@@ -465,12 +570,20 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
     }
 
     private InternalTranslogManager createTranslogManager(Translog translog, boolean supportsTranslogBytesTracking) throws IOException {
+        return createTranslogManager(translog, supportsTranslogBytesTracking, REMOTE_TRANSLOG_INDEX_SETTINGS);
+    }
+
+    private InternalTranslogManager createTranslogManager(
+        Translog translog,
+        boolean supportsTranslogBytesTracking,
+        IndexSettings indexSettings
+    ) throws IOException {
         LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
         return new InternalTranslogManager(
-            new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, "", false),
+            new TranslogConfig(shardId, primaryTranslogDir, indexSettings, BigArrays.NON_RECYCLING_INSTANCE, "", false),
             primaryTerm,
             () -> NO_OPS_PERFORMED,
-            createTranslogDeletionPolicy(INDEX_SETTINGS),
+            createTranslogDeletionPolicy(indexSettings),
             shardId,
             new ReleasableLock(new ReentrantReadWriteLock().readLock()),
             () -> tracker,

--- a/server/src/test/java/org/opensearch/index/translog/TranslogBytesTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogBytesTrackerTests.java
@@ -30,14 +30,71 @@ public class TranslogBytesTrackerTests extends OpenSearchTestCase {
         assertEquals(0, tracker.getBytesSinceLastCommit());
     }
 
-    public void testFailedCommitDoesNotResetTrackedBytes() {
+    public void testDiscardedCommitSnapshotRetainsTrackedBytes() {
         TranslogBytesTracker tracker = new TranslogBytesTracker();
         tracker.addBytes(10);
 
+        // A snapshot that is never completed, which is what a failed index commit leaves behind, must not release
+        // anything. The bytes have to stay eligible for the commit that follows.
         tracker.startCommit();
         tracker.addBytes(20);
-
         assertEquals(30, tracker.getBytesSinceLastCommit());
+
+        tracker.completeCommit(tracker.startCommit());
+        assertEquals(0, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testInitializeSeedsBaselineOnce() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        assertFalse(tracker.isInitialized());
+
+        assertTrue(tracker.initialize(100));
+        assertTrue(tracker.isInitialized());
+        assertEquals(100, tracker.getBytesSinceLastCommit());
+
+        // A second seeding attempt is a no-op so that every entry point can call it unguarded.
+        assertFalse(tracker.initialize(500));
+        assertEquals(100, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testInitializeRemainsMarkedAfterCommit() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        assertTrue(tracker.initialize(100));
+        tracker.completeCommit(tracker.startCommit());
+
+        assertEquals(0, tracker.getBytesSinceLastCommit());
+        assertTrue(tracker.isInitialized());
+        assertFalse(tracker.initialize(100));
+        assertEquals(0, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testInitializeRejectsNegativeBaseline() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> tracker.initialize(-1));
+        assertEquals("translog bytes must be non-negative", exception.getMessage());
+        assertFalse(tracker.isInitialized());
+    }
+
+    public void testAddBytesSaturatesInsteadOfOverflowing() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        tracker.addBytes(Long.MAX_VALUE - 1);
+
+        tracker.addBytes(10);
+
+        assertEquals(Long.MAX_VALUE, tracker.getBytesSinceLastCommit());
+        tracker.completeCommit(tracker.startCommit());
+        assertEquals(0, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testCompleteCommitRejectsSnapshotLargerThanTrackedBytes() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        tracker.addBytes(100);
+        TranslogBytesTracker.CommitSnapshot commitSnapshot = tracker.startCommit();
+        tracker.completeCommit(commitSnapshot);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> tracker.completeCommit(commitSnapshot));
+        assertEquals("commit snapshot contains [100] bytes but only [0] bytes are tracked", exception.getMessage());
     }
 
     public void testSuccessfulCommitRetainsConcurrentWrites() throws Exception {

--- a/server/src/test/java/org/opensearch/index/translog/TranslogBytesTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogBytesTrackerTests.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TranslogBytesTrackerTests extends OpenSearchTestCase {
+
+    public void testTracksBytesSinceLastCommit() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+
+        tracker.addBytes(10);
+        tracker.addBytes(20);
+
+        assertEquals(30, tracker.getBytesSinceLastCommit());
+        TranslogBytesTracker.CommitSnapshot commitSnapshot = tracker.startCommit();
+        tracker.completeCommit(commitSnapshot);
+        assertEquals(0, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testFailedCommitDoesNotResetTrackedBytes() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        tracker.addBytes(10);
+
+        tracker.startCommit();
+        tracker.addBytes(20);
+
+        assertEquals(30, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testSuccessfulCommitRetainsConcurrentWrites() throws Exception {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+        tracker.addBytes(100);
+        TranslogBytesTracker.CommitSnapshot commitSnapshot = tracker.startCommit();
+
+        int threadCount = randomIntBetween(2, 5);
+        int writesPerThread = randomIntBetween(100, 500);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Thread> threads = new ArrayList<>(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new Thread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    for (int write = 0; write < writesPerThread; write++) {
+                        tracker.addBytes(1);
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                } finally {
+                    done.countDown();
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+
+        assertTrue(ready.await(30, TimeUnit.SECONDS));
+        start.countDown();
+        tracker.completeCommit(commitSnapshot);
+        assertTrue(done.await(30, TimeUnit.SECONDS));
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        if (failure.get() != null) {
+            throw new AssertionError(failure.get());
+        }
+        assertEquals((long) threadCount * writesPerThread, tracker.getBytesSinceLastCommit());
+    }
+
+    public void testRejectsNegativeBytes() {
+        TranslogBytesTracker tracker = new TranslogBytesTracker();
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> tracker.addBytes(-1));
+        assertEquals("translog bytes must be non-negative", exception.getMessage());
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/RemoteStoreSettingsDynamicUpdateTests.java
+++ b/server/src/test/java/org/opensearch/indices/RemoteStoreSettingsDynamicUpdateTests.java
@@ -128,6 +128,22 @@ public class RemoteStoreSettingsDynamicUpdateTests extends OpenSearchTestCase {
         assertEquals(-1, remoteStoreSettings.getMaxRemoteTranslogReaders());
     }
 
+    public void testTranslogBytesTracking() {
+        assertFalse(remoteStoreSettings.isTranslogBytesTrackingEnabled());
+
+        clusterSettings.applySettings(
+            Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(), true).build()
+        );
+        assertTrue(remoteStoreSettings.isTranslogBytesTrackingEnabled());
+
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(), false)
+                .build()
+        );
+        assertFalse(remoteStoreSettings.isTranslogBytesTrackingEnabled());
+    }
+
     public void testUploadedSegmentsCleanupThreshold() {
         // Test default value
         assertEquals(1000, remoteStoreSettings.getUploadedSegmentsCleanupThreshold());

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -131,6 +131,7 @@ import org.opensearch.index.translog.TranslogFactory;
 import org.opensearch.index.translog.TranslogManager;
 import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.indices.recovery.AsyncRecoveryTarget;
 import org.opensearch.indices.recovery.DefaultRecoverySettings;
@@ -313,6 +314,14 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         PlainActionFuture<Releasable> fut = new PlainActionFuture<>();
         indexShard.acquirePrimaryOperationPermit(fut, ThreadPool.Names.WRITE, "");
         return fut.get();
+    }
+
+    /**
+     * The cluster level remote store settings handed to the remote backed components of shards created by this test.
+     * Override to exercise a non default {@code cluster.remote_store.*} setting.
+     */
+    protected RemoteStoreSettings remoteStoreSettings() {
+        return DefaultRemoteStoreSettings.INSTANCE;
     }
 
     /**
@@ -759,7 +768,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                         threadPool,
                         settings.getRemoteStoreTranslogRepository(),
                         new RemoteTranslogTransferTracker(shardRouting.shardId(), 20),
-                        DefaultRemoteStoreSettings.INSTANCE,
+                        remoteStoreSettings(),
                         RemoteStoreUtils.isServerSideEncryptionEnabledIndex(settings.getIndexMetadata())
                     );
                 }
@@ -795,7 +804,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 remoteStoreStatsTrackerFactory,
                 "dummy-node",
                 recoverySettings,
-                DefaultRemoteStoreSettings.INSTANCE,
+                remoteStoreSettings(),
                 false,
                 discoveryNodes,
                 mockReplicationStatsProvider,

--- a/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
@@ -1096,6 +1096,102 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
         }
     }
 
+    /**
+     * Verifies that byte tracking accounts for the uncommitted translog a shard already holds when tracking begins.
+     * <ol>
+     *     <li>Builds up uncommitted translog with byte tracking disabled, which the legacy retention boundary never
+     *     flushes.</li>
+     *     <li>Records the uncommitted translog size and enables byte tracking.</li>
+     *     <li>Lowers the flush threshold to that size, so only a tracker seeded from the existing translog can reach
+     *     it. A tracker starting from zero would need a whole threshold of new writes first.</li>
+     *     <li>Asserts a periodic flush becomes due without any further indexing, and that one small write is enough to
+     *     carry it out and advance the commit.</li>
+     * </ol>
+     */
+    public void testRemoteTranslogSizeFlushSeedsExistingUncommittedBytes() throws Exception {
+        Settings nodeSettings = Settings.builder().put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), "1h").build();
+        internalCluster().startClusterManagerOnlyNode(nodeSettings);
+        String dataNode = internalCluster().startDataOnlyNode(nodeSettings);
+
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS.getKey(), -1)
+                        .put(CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.getKey(), "0ms")
+                        .put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(), false)
+                )
+                .get()
+        );
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(remoteStoreIndexSettings(0, 10000L, -1))
+                .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), "32kb")
+                .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "-1")
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
+        RemoteFsTranslog remoteTranslog = (RemoteFsTranslog) getTranslog(indexShard);
+        long initialPeriodicFlushes = indexShard.flushStats().getPeriodic();
+        long initialCommitCheckpoint = getLastCommittedLocalCheckpoint(indexShard);
+
+        String payload = randomAlphaOfLength(4 * 1024);
+        for (int i = 0; i < 10; i++) {
+            IndexResponse response = client(dataNode).prepareIndex(INDEX_NAME)
+                .setId(Integer.toString(i))
+                .setSource("payload", payload)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+            assertBusy(
+                () -> assertThat(remoteTranslog.getMinUnreferencedSeqNoInSegments(0), greaterThanOrEqualTo(response.getSeqNo())),
+                30,
+                TimeUnit.SECONDS
+            );
+        }
+        assertEquals(initialCommitCheckpoint, getLastCommittedLocalCheckpoint(indexShard));
+
+        long uncommittedSizeInBytes = indexShard.translogStats().getUncommittedSizeInBytes();
+        assertThat(uncommittedSizeInBytes, greaterThan(0L));
+
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(), true)
+                )
+                .get()
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .updateSettings(
+                    new UpdateSettingsRequest(INDEX_NAME).settings(
+                        Settings.builder()
+                            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), uncommittedSizeInBytes + "b")
+                    )
+                )
+                .get()
+        );
+
+        // Nothing has been written since the threshold was lowered, so this can only be true if the tracker picked up
+        // the translog that already existed.
+        assertTrue(indexShard.shouldPeriodicallyFlush());
+        assertEquals(initialPeriodicFlushes, indexShard.flushStats().getPeriodic());
+
+        client(dataNode).prepareIndex(INDEX_NAME).setId("trigger").setSource("payload", "v").get();
+        assertBusy(() -> {
+            assertThat(indexShard.flushStats().getPeriodic(), greaterThan(initialPeriodicFlushes));
+            assertThat(getLastCommittedLocalCheckpoint(indexShard), greaterThan(initialCommitCheckpoint));
+        }, 30, TimeUnit.SECONDS);
+    }
+
     private long getLastCommittedLocalCheckpoint(IndexShard indexShard) {
         return Long.parseLong(indexShard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
     }

--- a/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
@@ -18,6 +18,7 @@ import org.opensearch.action.admin.indices.recovery.RecoveryResponse;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
@@ -28,10 +29,13 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.BufferedAsyncIOProcessor;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardClosedException;
+import org.opensearch.index.translog.RemoteFsTranslog;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.Translog.Durability;
+import org.opensearch.indices.IndexingMemoryController;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
@@ -75,6 +79,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
@@ -993,6 +998,106 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
             long totalFiles = files.filter(f -> f.getFileName().toString().endsWith(Translog.TRANSLOG_FILE_SUFFIX)).count();
             assertEquals(totalFiles, 501L);
         }
+    }
+
+    /**
+     * Verifies that disabling byte tracking preserves the legacy remote-translog flush behavior.
+     * <ol>
+     *     <li>Disables reader-count and background flush triggers so only the size threshold can initiate a periodic flush.</li>
+     *     <li>Creates a remote-backed index with byte tracking disabled and a small translog flush threshold.</li>
+     *     <li>Indexes and refreshes documents until the remote retention boundary advances beyond its initial value.</li>
+     *     <li>Asserts that the moving legacy boundary prevents a periodic flush and leaves the commit checkpoint unchanged.</li>
+     * </ol>
+     */
+    public void testRemoteTranslogSizeFlushUsesLegacyRetentionBoundaryWhenDisabled() throws Exception {
+        assertRemoteTranslogSizeBasedFlush(false);
+    }
+
+    /**
+     * Verifies that enabled byte tracking restores size-based remote-translog flushes across refreshes.
+     * <ol>
+     *     <li>Disables reader-count and background flush triggers so only the size threshold can initiate a periodic flush.</li>
+     *     <li>Creates a remote-backed index with byte tracking enabled and a small translog flush threshold.</li>
+     *     <li>Indexes and refreshes documents while the remote retention boundary advances and tracked bytes accumulate.</li>
+     *     <li>Asserts that a periodic flush commits the accumulated operations after the threshold is crossed.</li>
+     *     <li>Asserts that the successful commit resets the size trigger.</li>
+     * </ol>
+     */
+    public void testRemoteTranslogSizeFlushTracksBytesAcrossRefreshes() throws Exception {
+        assertRemoteTranslogSizeBasedFlush(true);
+    }
+
+    private void assertRemoteTranslogSizeBasedFlush(boolean trackBytesSinceLastCommit) throws Exception {
+        Settings nodeSettings = Settings.builder().put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), "1h").build();
+        internalCluster().startClusterManagerOnlyNode(nodeSettings);
+        String dataNode = internalCluster().startDataOnlyNode(nodeSettings);
+
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS.getKey(), -1)
+                        .put(CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.getKey(), "0ms")
+                        .put(
+                            RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_TRACK_BYTES_SINCE_LAST_COMMIT_SETTING.getKey(),
+                            trackBytesSinceLastCommit
+                        )
+                )
+                .get()
+        );
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(remoteStoreIndexSettings(0, 10000L, -1))
+                .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), "32kb")
+                .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "-1")
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
+        RemoteFsTranslog remoteTranslog = (RemoteFsTranslog) getTranslog(indexShard);
+        long initialRemoteRetentionBoundary = remoteTranslog.getMinUnreferencedSeqNoInSegments(0);
+        long initialPeriodicFlushes = indexShard.flushStats().getPeriodic();
+        long initialCommitCheckpoint = getLastCommittedLocalCheckpoint(indexShard);
+        assertFalse(indexShard.shouldPeriodicallyFlush());
+
+        String payload = randomAlphaOfLength(4 * 1024);
+        for (int i = 0; i < 10; i++) {
+            IndexResponse response = client(dataNode).prepareIndex(INDEX_NAME)
+                .setId(Integer.toString(i))
+                .setSource("payload", payload)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+            assertBusy(
+                () -> assertThat(remoteTranslog.getMinUnreferencedSeqNoInSegments(0), greaterThanOrEqualTo(response.getSeqNo())),
+                30,
+                TimeUnit.SECONDS
+            );
+            if (trackBytesSinceLastCommit == false) {
+                assertFalse(indexShard.shouldPeriodicallyFlush());
+            }
+        }
+        assertThat(remoteTranslog.getMinUnreferencedSeqNoInSegments(0), greaterThan(initialRemoteRetentionBoundary));
+
+        if (trackBytesSinceLastCommit) {
+            assertBusy(() -> {
+                assertThat(indexShard.flushStats().getPeriodic(), greaterThan(initialPeriodicFlushes));
+                assertThat(getLastCommittedLocalCheckpoint(indexShard), greaterThan(initialCommitCheckpoint));
+                assertFalse(indexShard.shouldPeriodicallyFlush());
+            }, 30, TimeUnit.SECONDS);
+        } else {
+            assertEquals(initialPeriodicFlushes, indexShard.flushStats().getPeriodic());
+            assertEquals(initialCommitCheckpoint, getLastCommittedLocalCheckpoint(indexShard));
+            assertFalse(indexShard.shouldPeriodicallyFlush());
+        }
+    }
+
+    private long getLastCommittedLocalCheckpoint(IndexShard indexShard) {
+        return Long.parseLong(indexShard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
     }
 
     public void testAsyncTranslogDurabilityRestrictionsThroughIdxTemplates() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

For remote-store indices, `index.translog.flush_threshold_size` can stop triggering Lucene commits entirely. Every successful remote segment upload advances `minSeqNoToKeep` to the last refreshed checkpoint, and because `shouldPeriodicallyFlush` sizes the translog from that moving boundary rather than from the last commit, older generations stop counting toward the threshold. Under a steady refresh cycle the threshold is effectively never reached, the safe commit lags arbitrarily far behind the current sequence number, and soft-deleted documents stay protected from merge reclamation — so `docs.deleted` accumulates unboundedly between commits.

#### How the accounting drifted from the commit

This is not an oversight — it is the compound effect of two deliberate changes, and this PR partially re-decides the second one. Calling that out up front.

**1. #7383 removed the safe-commit floor from remote translog retention** (`613f4aa0469`, May 2023), for #7381 *"[Remote Translog] High failover durations"*:

```java
// before
minGenerationForSeqNo(Math.min(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, minSeqNoToKeep), current, readers)
// after
minGenerationForSeqNo(minSeqNoToKeep, current, readers)
```

> "the min generation translog retain should just use the seq no upload there instead of using local checkpoint of safe commit, which gets updated only on flush"

The goal was failover latency: trimming gated on the rare flush meant a newly promoted primary had to download a large translog. The reasoning holds — once segments are durably uploaded, the translog generations they cover are not needed for recovery. Nothing in this PR changes that retention behaviour.

**2. #10761 aligned the flush check with that new retention boundary** (`a1fde65fe2a`, Oct 2023), for #10727 *"[BUG] [Remote Store] Timeout on shard relocation"*. It introduced `getMinUnreferencedSeqNoInSegments` (`RemoteFsTranslog` returns `minSeqNoToKeep`) and repointed `shouldPeriodicallyFlush` at it, to fix:

> "the bug where actual translog retention was higher than the translog flush threshold size"

When uploads lag the commit, the `Math.min` in `getMinReferencedGen` pins generations *below* the commit generation; the flush check was counting only from the commit generation and so under-reported real on-disk translog, which is how a 25 GB shard relocation could time out in the prepare-translog phase.

**The consequence.** Together these reinterpreted `index.translog.flush_threshold_size` from *"bytes written since the last commit"* to *"currently retained translog bytes."* In document replication the two are the same number because retention is commit-anchored; #7383 broke that identity for remote store and #10761 followed retention. That serves one job of the size-based flush and drops the other:

| Job | Served by measuring |
|---|---|
| Bound translog disk and recovery cost | retained bytes (#10761) |
| Bound safe-commit lag so soft deletes become reclaimable | bytes since commit (this PR) |

**Why this does not regress #10761.** Tracked bytes are always greater than or equal to retained bytes, so the trigger fires at least as often as it does today — and #10761's symptom was the check under-reporting and therefore *not* firing. Under upload lag a flush still cannot release upload-pinned generations, but that was equally true before, since flushing does not move `minSeqNoToKeep`. Disk retention is therefore unchanged or better, never worse. Separately, #14027 has since given translog *file count* its own trigger (`cluster.remote_store.translog.max_readers`), so the size threshold no longer has to carry the disk-bounding job alone.

#### This change

This PR adds commit-relative byte accounting for remote-translog-backed shards, gated behind a new cluster setting.

**`cluster.remote_store.translog.track_bytes_since_last_commit.enabled`** — dynamic, node scope, **defaults to `false`**.

When enabled, `InternalTranslogManager` counts the bytes of every successful translog append and releases them only when a Lucene commit succeeds. `shouldPeriodicallyFlush` then compares that counter against the threshold instead of measuring files from the retention boundary.

Mapping to the fix contract in the issue:

| Requirement | How |
|---|---|
| Include every successful translog append since the last commit | `InternalTranslogManager#add` accumulates `Translog.Location#size` |
| Survive remote generation trimming | The counter is independent of the translog files, so trimming cannot reduce it |
| Reset only after a successful Lucene commit | `commitIndexWriter` calls `finishIndexCommit(commitSuccessful)`; a failed commit releases nothing |
| Preserve writes concurrent with that commit | A commit releases only a snapshot taken before the commit, so concurrent appends stay counted. The snapshot is taken *before* the local checkpoint the commit records, since the commit only covers operations up to that checkpoint |
| Leave remote retention and `cluster.remote_store.translog.max_readers` unchanged | The reader-count trigger (`translog.shouldFlush()`) is still evaluated first and independently; nothing in the retention or trimming path is touched |

The tracker is also seeded from the uncommitted translog a shard already holds, so a newly created engine — or a cluster that turns the setting on mid-flight — accounts for translog written before tracking began instead of waiting a full threshold.

#### Isolation

- Disabled by default. With the setting off, no bytes are counted, the counter is never read, and the commit hooks are not invoked — the pre-existing size computation runs unchanged.
- Scoped to shards whose index is actually remote-translog backed. A node with a translog repository configured also hands a `RemoteFsTranslog` to the primaries of plain document replication indices; those keep the untouched computation.
- Document replication is unaffected: non-remote primaries get a `LocalTranslog`, replicas always get an `InternalTranslogFactory`, and `NRTReplicationEngine`/`DataFormatAwareNRTReplicationEngine` return `false` from `shouldPeriodicallyFlush` regardless.
- `DataFormatAwareEngine` deliberately does not opt in — it does not support updates yet, so it never accumulates protected soft deletes.

#### Why not reuse `translog.uncommitted_size_in_bytes`?

It reports the wrong number on exactly these shards. `Translog#stats` computes the uncommitted generation from the safe commit but then sums only *surviving* files, and `RemoteFsTranslog#getMinReferencedGen` replaces the base class's safe-commit retention floor with `minSeqNoToKeep`, so generations are deleted locally long before a commit covers them. Measured on a remote-store index after 10 × ~4 KB documents with **zero commits**: `uncommitted_operations` reports **1** and `uncommitted_size_in_bytes` reports **4,267** — the surviving tail. The same measurement on a document replication index is exact (3 of 3 operations, 12,544 bytes). Exposing the tracked value as a stat is left to a follow-up.

#### Testing

24 new unit tests and 5 new integration tests.

- `TranslogBytesTrackerTests` — accumulation, snapshot/release semantics, discarded snapshots (failed commits), one-shot seeding, saturation, concurrent writes during a commit.
- `InternalTranslogManagerTests` — the threshold decision, release only on successful commit, the remote-translog and remote-index gates, `max_readers` remaining an independent trigger, seeding, and the accepted disable→enable staleness.
- `RemoteStoreTranslogBytesFlushTests` — a real remote-translog-backed shard, asserting a commit releases the tracked bytes while the translog files still hold them.
- `RemoteStoreCoreTestCase` — an A/B pair proving the legacy retention boundary suppresses the flush when disabled and that tracking restores it when enabled, plus a seeding test. All three disable the idle, interval and reader-count triggers so the size threshold is the only one in play.
- `TranslogSizeFlushDocRepIT` — document replication flushes identically with the setting on and off.

All pass; the ITs were run over 15 seeds each. `./gradlew :server:precommit :test:framework:precommit` passes. The seeding IT was verified to fail when seeding is disabled.

### Related Issues
Resolves #22802

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.