### PR TITLE
Skip stream connections to nodes without a stream address to avoid transient log noise

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransport.java
@@ -345,6 +345,11 @@ class FlightTransport extends TcpTransport {
     @Override
     protected TcpChannel initiateChannel(DiscoveryNode node) throws IOException {
         TransportAddress publishAddress = node.getStreamAddress();
+        // A node that predates the stream transport, or has it disabled, publishes no stream address.
+        // Fail cleanly instead of NPEing on the address below.
+        if (publishAddress == null) {
+            throw new ConnectTransportException(node, "node does not publish a stream (Flight) address");
+        }
         String address = publishAddress.getAddress();
         int flightPort = publishAddress.address().getPort();
         Location location = sslContextProvider != null

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportMixedVersionTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportMixedVersionTests.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.Version;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.transport.ConnectTransportException;
+
+import java.net.InetAddress;
+
+/**
+ * A node that predates the stream transport (or has it disabled) publishes no stream address. In a mixed-version
+ * cluster the stream connection driver must not attempt a Flight connection to such a node. These tests pin both
+ * guards: the {@link org.opensearch.transport.StreamTransportService} skip and the {@link FlightTransport} backstop.
+ */
+public class FlightTransportMixedVersionTests extends FlightTransportTestBase {
+
+    private DiscoveryNode nodeWithoutStreamAddress() {
+        TransportAddress transportAddress = new TransportAddress(InetAddress.getLoopbackAddress(), 9);
+        // The (id, address, version) constructor leaves streamAddress null - the mixed-version case.
+        return new DiscoveryNode("old-node-id", transportAddress, Version.CURRENT);
+    }
+
+    public void testConnectToNodeSkipsNodeWithoutStreamAddress() {
+        DiscoveryNode oldNode = nodeWithoutStreamAddress();
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        streamTransportService.connectToNode(oldNode, future);
+        assertNull("connect to a node without a stream address must be skipped, not attempted", future.actionGet());
+        assertFalse(streamTransportService.nodeConnected(oldNode));
+    }
+
+    public void testInitiateChannelThrowsConnectTransportExceptionInsteadOfNpe() {
+        DiscoveryNode oldNode = nodeWithoutStreamAddress();
+        ConnectTransportException e = expectThrows(ConnectTransportException.class, () -> flightTransport.initiateChannel(oldNode));
+        assertTrue(e.getMessage().contains("stream"));
+    }
+}

--- a/server/src/main/java/org/opensearch/transport/StreamTransportService.java
+++ b/server/src/main/java/org/opensearch/transport/StreamTransportService.java
@@ -109,7 +109,14 @@ public class StreamTransportService extends TransportService {
             listener.onResponse(null);
             return;
         }
-        // TODO: add logic for validation
+        // A node without a stream address (predates the stream transport, or has it disabled) cannot serve
+        // a Flight connection. Skip it rather than attempting a connect that would fail; this avoids the
+        // retry/log-noise seen against older nodes during a mixed-version rolling upgrade.
+        if (node.getStreamAddress() == null) {
+            logger.debug("skipping stream connection to [{}]: node publishes no stream address", node);
+            listener.onResponse(null);
+            return;
+        }
         final ActionListener<Void> wrappedListener = ActionListener.wrap(response -> { listener.onResponse(response); }, exception -> {
             logger.warn("Failed to connect to streaming node [{}]: {}", node, exception.getMessage());
             listener.onFailure(new ConnectTransportException(node, "Failed to connect for streaming", exception));


### PR DESCRIPTION
### Description

In a mixed-version cluster, a node that predates the stream transport — or has it disabled — publishes no stream address (`DiscoveryNode.getStreamAddress() == null`, version-gated at `V_3_2_0`). With the experimental stream transport enabled, the stream connection driver still attempted a Flight connection to such a node and hit an NPE:

```
[WARN][o.o.t.StreamTransportService] Failed to connect to streaming node ...
  Failed to open Flight connection ...
  NullPointerException: Cannot invoke ... getAddress() because "publishAddress" is null
```

This produced repeated connect failures and log noise during a rolling upgrade.

Two guards:
- `StreamTransportService.connectToNode` now skips a node with no stream address (implements the existing `// TODO`).
- `FlightTransport.initiateChannel` throws `ConnectTransportException` instead of NPEing, as a backstop for the `openConnection` path.

Gating on a null stream address (rather than a version check) also covers a current-version node that has the feature disabled.

### Related Issues

N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable.
- [x] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
