### PR TITLE
Serialize Character values in XContent maps

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilder.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilder.java
@@ -118,6 +118,7 @@ public final class XContentBuilder implements Closeable, Flushable {
         writers.put(short[].class, (b, v) -> b.values((short[]) v));
         writers.put(String.class, (b, v) -> b.value((String) v));
         writers.put(String[].class, (b, v) -> b.values((String[]) v));
+        writers.put(Character.class, (b, v) -> b.value(v.toString()));
         writers.put(Locale.class, (b, v) -> b.value(v.toString()));
         writers.put(Class.class, (b, v) -> b.value(v.toString()));
         writers.put(ZonedDateTime.class, (b, v) -> b.value(v.toString()));

--- a/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
@@ -778,6 +778,7 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
         objects.put("{'obj':50.63}", DistanceUnit.METERS.fromMeters(50.63));
         objects.put("{'obj':'MINUTES'}", TimeUnit.MINUTES);
         objects.put("{'obj':'class org.opensearch.common.xcontent.BaseXContentTestCase'}", BaseXContentTestCase.class);
+        objects.put("{'obj':'a'}", Character.valueOf('a'));
 
         for (Map.Entry<String, ?> o : objects.entrySet()) {
             final String expected = o.getKey();

--- a/server/src/test/java/org/opensearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/builder/XContentBuilderTests.java
@@ -353,6 +353,12 @@ public class XContentBuilderTests extends OpenSearchTestCase {
             }""", string.trim());
     }
 
+    public void testWriteMapWithCharacterValue() throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        builder.map(Collections.singletonMap("char", 'a'));
+        assertThat(builder.toString(), equalTo("{\"char\":\"a\"}"));
+    }
+
     public void testWriteMapWithNullKeys() throws IOException {
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(randomFrom(XContentType.values()));
         try {


### PR DESCRIPTION
### Description
`XContentBuilder` rejected `Character` values with `cannot write xcontent for unknown value of type class java.lang.Character`. Ingest scripts such as `ctx.char = (char)'a'` put a `Character` into the document map, and `IngestService` then failed while serializing that map.

Register `Character` in the `WRITERS` table and write it as a one-character string, matching `Locale` / `Class`.

### Related Issues
Resolves #14382

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

### Test plan
Executed as a non-root user on JDK 21:

- RED: `:server:test --tests org.opensearch.common.xcontent.builder.XContentBuilderTests.testWriteMapWithCharacterValue` failed with `IllegalArgumentException: cannot write xcontent for unknown value of type class java.lang.Character`
- GREEN: the same test plus `JsonXContentTests.testUnknownObject`
- `:server:test --tests org.opensearch.common.xcontent.builder.XContentBuilderTests --tests org.opensearch.common.xcontent.json.JsonXContentTests --tests org.opensearch.common.xcontent.smile.SmileXContentTests.testUnknownObject --tests org.opensearch.common.xcontent.cbor.CborXContentTests.testUnknownObject --tests org.opensearch.common.xcontent.yaml.YamlXContentTests.testUnknownObject`
- `spotlessJavaCheck`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.