### PR TITLE
Support filter bucket aggregation on the DSL Calcite path

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslAggregationIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslAggregationIT.java
@@ -123,4 +123,19 @@ public class DslAggregationIT extends DslIntegTestBase {
             )
         );
     }
+
+    public void testFilterAggDocCount() {
+        createTestIndex();
+        assertOk(
+            search(
+                new SearchSourceBuilder().size(0)
+                    .aggregation(
+                        new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                            "active_only",
+                            new org.opensearch.index.query.TermQueryBuilder("status", "active")
+                        )
+                    )
+            )
+        );
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
@@ -193,11 +193,18 @@ public class AggregationMetadata {
      * makes every query-matching document eligible. False when the plan carries a
      * {@code min_doc_count} HAVING — the threshold drops whole groups from eligibility even with
      * {@code missing} — or when no {@code missing} value is configured; those plans use a
-     * per-aggregation eligible count instead. Meaningful only for plans with {@link #getFetch()}
-     * set (root-level, single-field by eligibility).
+     * per-aggregation eligible count instead. Also false when the plan carries its own filter
+     * or any ancestor filter: a filter narrows the eligible set, so the premise that every
+     * query-matching document is eligible no longer holds and a filtered per-aggregation count
+     * is required. Meaningful only for plans with {@link #getFetch()} set (root-level,
+     * single-field by eligibility).
      */
     public boolean eligibleDocCountIsTotal() {
-        return havingMinDocCount == null && !groupByFieldNames.isEmpty() && missingValues.containsKey(groupByFieldNames.get(0));
+        return havingMinDocCount == null
+            && !groupByFieldNames.isEmpty()
+            && missingValues.containsKey(groupByFieldNames.get(0))
+            && filterQuery == null
+            && ancestorFilters.isEmpty();
     }
 
     /** Returns the per-aggregation filter query, or empty when no predicate applies. */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
@@ -47,6 +47,7 @@ public class AggregationMetadata {
     private final Long havingMinDocCount;
     private final Map<String, Object> missingValues;
     private final QueryBuilder filterQuery;
+    private final List<AggregationMetadataBuilder.AncestorFilter> ancestorFilters;
 
     /**
      * Creates aggregation metadata.
@@ -65,6 +66,9 @@ public class AggregationMetadata {
      *        for none
      * @param missingValues null-substitution value per group field ({@code missing} parameter);
      *        fields absent from the map get an {@code IS NOT NULL} filter instead
+     * @param filterQuery the defining aggregation's own filter query, or null
+     * @param ancestorFilters filter predicates from enclosing ancestor bucket aggregations;
+     *        accumulated so descendant plans compute over only the filtered document set
      */
     public AggregationMetadata(
         List<String> aggNamePath,
@@ -77,7 +81,8 @@ public class AggregationMetadata {
         Integer perParentFetch,
         Long havingMinDocCount,
         Map<String, Object> missingValues,
-        QueryBuilder filterQuery
+        QueryBuilder filterQuery,
+        List<AggregationMetadataBuilder.AncestorFilter> ancestorFilters
     ) {
         this.aggNamePath = List.copyOf(aggNamePath);
         this.groupByBitSet = groupByBitSet;
@@ -90,6 +95,7 @@ public class AggregationMetadata {
         this.havingMinDocCount = havingMinDocCount;
         this.missingValues = Map.copyOf(missingValues);
         this.filterQuery = filterQuery;
+        this.ancestorFilters = List.copyOf(ancestorFilters);
     }
 
     /**
@@ -197,5 +203,14 @@ public class AggregationMetadata {
     /** Returns the per-aggregation filter query, or empty when no predicate applies. */
     public Optional<QueryBuilder> getFilterQuery() {
         return Optional.ofNullable(filterQuery);
+    }
+
+    /**
+     * Returns the accumulated ancestor filter predicates from enclosing bucket aggregations.
+     * Descendant plans must conjoin these with any own filter to compute over only the
+     * ancestor-filtered document set. Empty when no ancestor carries a filter.
+     */
+    public List<AggregationMetadataBuilder.AncestorFilter> getAncestorFilters() {
+        return ancestorFilters;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
@@ -10,10 +10,12 @@ package org.opensearch.dsl.aggregation;
 
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Pre-computed metadata for one aggregation plan.
@@ -44,6 +46,7 @@ public class AggregationMetadata {
     private final Integer perParentFetch;
     private final Long havingMinDocCount;
     private final Map<String, Object> missingValues;
+    private final QueryBuilder filterQuery;
 
     /**
      * Creates aggregation metadata.
@@ -73,7 +76,8 @@ public class AggregationMetadata {
         Integer fetch,
         Integer perParentFetch,
         Long havingMinDocCount,
-        Map<String, Object> missingValues
+        Map<String, Object> missingValues,
+        QueryBuilder filterQuery
     ) {
         this.aggNamePath = List.copyOf(aggNamePath);
         this.groupByBitSet = groupByBitSet;
@@ -85,6 +89,7 @@ public class AggregationMetadata {
         this.perParentFetch = perParentFetch;
         this.havingMinDocCount = havingMinDocCount;
         this.missingValues = Map.copyOf(missingValues);
+        this.filterQuery = filterQuery;
     }
 
     /**
@@ -187,5 +192,10 @@ public class AggregationMetadata {
      */
     public boolean eligibleDocCountIsTotal() {
         return havingMinDocCount == null && !groupByFieldNames.isEmpty() && missingValues.containsKey(groupByFieldNames.get(0));
+    }
+
+    /** Returns the per-aggregation filter query, or empty when no predicate applies. */
+    public Optional<QueryBuilder> getFilterQuery() {
+        return Optional.ofNullable(filterQuery);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -46,6 +46,7 @@ public class AggregationMetadataBuilder {
     private final List<AggregateCall> aggregateCalls = new ArrayList<>();
     private final List<String> aggregateFieldNames = new ArrayList<>();
     private final List<BucketOrder> bucketOrders = new ArrayList<>();
+    private final List<AncestorFilter> ancestorFilters = new ArrayList<>();
     private Integer definingSize;
     private Long definingMinDocCount;
     private boolean implicitCountRequested = false;
@@ -74,6 +75,23 @@ public class AggregationMetadataBuilder {
     public void addGrouping(GroupingInfo grouping) {
         groupings.add(grouping);
         missingValues.putAll(grouping.getMissingByField());
+    }
+
+    /**
+     * Records an ancestor filter predicate contributed by an enclosing bucket aggregation.
+     * Ancestor filters accumulate alongside groupings so that descendant plans compute over
+     * only the ancestor-filtered document set — without this, nested bucket sub-aggregations
+     * would aggregate over the full corpus while only the immediate parent's filter applies.
+     *
+     * @param aggName the defining aggregation name (for error reporting if untranslatable)
+     * @param query the ancestor's filter query
+     */
+    public void addAncestorFilter(String aggName, QueryBuilder query) {
+        ancestorFilters.add(new AncestorFilter(aggName, query));
+    }
+
+    /** An ancestor filter predicate with its source aggregation name for error attribution. */
+    public record AncestorFilter(String aggName, QueryBuilder query) {
     }
 
     /**
@@ -211,9 +229,14 @@ public class AggregationMetadataBuilder {
         Long havingMinDocCount = definingMinDocCount != null && definingMinDocCount > 1 ? definingMinDocCount : null;
         Integer fetch = null;
         Integer perParentFetch = null;
-        boolean singleFieldGroupings = groupings.stream().allMatch(g -> g.getFieldNames().size() == 1);
+        // Zero-field groupings (e.g. filter buckets) contribute no GROUP BY column and must not
+        // prevent the bounded-plan path from being selected for sized child aggregations.
+        long fieldBearingGroupingCount = groupings.stream().filter(g -> !g.getFieldNames().isEmpty()).count();
+        boolean singleFieldGroupings = groupings.stream()
+            .filter(g -> !g.getFieldNames().isEmpty())
+            .allMatch(g -> g.getFieldNames().size() == 1);
         if (definingSize != null && singleFieldGroupings) {
-            if (groupings.size() == 1) {
+            if (fieldBearingGroupingCount == 1) {
                 fetch = definingSize;
             } else {
                 // Nested level: the bound is per parent, not global — a flat LIMIT would keep
@@ -233,7 +256,8 @@ public class AggregationMetadataBuilder {
             perParentFetch,
             havingMinDocCount,
             missingValues,
-            filterQuery
+            filterQuery,
+            List.copyOf(ancestorFilters)
         );
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -17,6 +17,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalOrder;
 
@@ -48,6 +49,7 @@ public class AggregationMetadataBuilder {
     private Integer definingSize;
     private Long definingMinDocCount;
     private boolean implicitCountRequested = false;
+    private QueryBuilder filterQuery;
 
     /** Creates a builder for the global (no defining aggregation) metrics plan. */
     public AggregationMetadataBuilder() {
@@ -110,6 +112,13 @@ public class AggregationMetadataBuilder {
      */
     public void requestImplicitCount() {
         this.implicitCountRequested = true;
+    }
+
+    /**
+     * Sets the filter query for per-aggregation predicate injection.
+     */
+    public void setFilterQuery(QueryBuilder query) {
+        this.filterQuery = query;
     }
 
     /** Returns true if this builder has at least one aggregate call or implicit count. */
@@ -223,7 +232,8 @@ public class AggregationMetadataBuilder {
             fetch,
             perParentFetch,
             havingMinDocCount,
-            missingValues
+            missingValues,
+            filterQuery
         );
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.opensearch.dsl.aggregation.bucket.FilterBucketTranslator;
 import org.opensearch.dsl.aggregation.bucket.TermsBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.AvgMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MaxMetricTranslator;
@@ -38,6 +39,7 @@ public class AggregationRegistryFactory {
         registry.register(new MinMetricTranslator());
         registry.register(new MaxMetricTranslator());
         registry.register(new TermsBucketTranslator(mapperServiceSupplier));
+        registry.register(new FilterBucketTranslator());
         // TODO: add other aggregation translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -151,11 +151,16 @@ public class AggregationTreeWalker {
 
         List<String> aggNamePath = path.stream().map(PathStep::aggName).toList();
         AggregationMetadataBuilder builder = new AggregationMetadataBuilder(aggNamePath);
-        for (PathStep step : path) {
+        int definingIndex = path.size() - 1;
+        for (int i = 0; i < path.size(); i++) {
+            PathStep step = path.get(i);
             builder.addGrouping(step.grouping());
-            // Ancestor filter predicates must propagate to descendant plans so that nested
-            // bucket sub-aggregations compute over only the ancestor-filtered documents.
-            if (step.filterQuery() != null) {
+            // The last path step is the defining aggregation itself; its own filter is captured
+            // separately via setFilterQuery, so only genuine ancestors (steps above it)
+            // contribute ancestor filters. Excluding the own filter here — rather than
+            // deduplicating downstream by name — keeps a descendant that legally reuses an
+            // ancestor's name from dropping that same-named ancestor's predicate.
+            if (i != definingIndex && step.filterQuery() != null) {
                 builder.addAncestorFilter(step.aggName(), step.filterQuery());
             }
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -14,6 +14,7 @@ import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
 import org.opensearch.dsl.aggregation.bucket.SizedBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.MetricTranslator;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 
 import java.util.ArrayList;
@@ -45,8 +46,8 @@ public class AggregationTreeWalker {
         this.registry = registry;
     }
 
-    /** One step of the accumulated nesting path: the aggregation name and its grouping. */
-    private record PathStep(String aggName, GroupingInfo grouping) {
+    /** One step of the accumulated nesting path: the aggregation name, its grouping, and an optional filter. */
+    private record PathStep(String aggName, GroupingInfo grouping, QueryBuilder filterQuery) {
     }
 
     /**
@@ -107,9 +108,10 @@ public class AggregationTreeWalker {
         RelDataType rowType
     ) throws ConversionException {
         GroupingInfo grouping = translator.getGrouping(aggBuilder);
+        QueryBuilder stepFilter = translator.getFilterQuery(aggBuilder).orElse(null);
 
         List<PathStep> accumulatedPath = new ArrayList<>(currentPath);
-        accumulatedPath.add(new PathStep(aggBuilder.getName(), grouping));
+        accumulatedPath.add(new PathStep(aggBuilder.getName(), grouping, stepFilter));
 
         // Every bucket aggregation defines its own plan; sibling names are unique by DSL
         // contract, so the path key cannot collide with another plan's.
@@ -151,6 +153,11 @@ public class AggregationTreeWalker {
         AggregationMetadataBuilder builder = new AggregationMetadataBuilder(aggNamePath);
         for (PathStep step : path) {
             builder.addGrouping(step.grouping());
+            // Ancestor filter predicates must propagate to descendant plans so that nested
+            // bucket sub-aggregations compute over only the ancestor-filtered documents.
+            if (step.filterQuery() != null) {
+                builder.addAncestorFilter(step.aggName(), step.filterQuery());
+            }
         }
         if (!path.isEmpty()) {
             builder.requestImplicitCount();

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -114,6 +114,7 @@ public class AggregationTreeWalker {
         // Every bucket aggregation defines its own plan; sibling names are unique by DSL
         // contract, so the path key cannot collide with another plan's.
         AggregationMetadataBuilder builder = getOrCreateBuilder(accumulatedPath, plans);
+        translator.getFilterQuery(aggBuilder).ifPresent(builder::setFilterQuery);
         if (translator instanceof SizedBucketTranslator<AggregationBuilder> sized) {
             builder.setBucketDefinition(translator.getBucketOrder(aggBuilder), sized.size(aggBuilder), sized.minDocCount(aggBuilder));
         } else {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/BucketTranslator.java
@@ -11,11 +11,13 @@ package org.opensearch.dsl.aggregation.bucket;
 import org.opensearch.dsl.aggregation.AggregationTranslator;
 import org.opensearch.dsl.aggregation.GroupingInfo;
 import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.InternalAggregation;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Translates a bucket aggregation (terms, multi_terms, etc.) to a {@link GroupingInfo}
@@ -57,4 +59,14 @@ public interface BucketTranslator<T extends AggregationBuilder> extends Aggregat
      * @return the InternalAggregation
      */
     InternalAggregation toBucketAggregation(T agg, Iterable<BucketEntry> buckets);
+
+    /**
+     * Returns the inner filter query for bucket aggregations that scope by a predicate.
+     *
+     * @param agg the bucket aggregation builder
+     * @return the filter query, or empty for non-filtering bucket types
+     */
+    default Optional<QueryBuilder> getFilterQuery(T agg) {
+        return Optional.empty();
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/FilterBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/FilterBucketTranslator.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.aggregation.FieldGrouping;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Translates a {@link FilterAggregationBuilder} — single-bucket aggregation scoped by a query predicate.
+ */
+public class FilterBucketTranslator implements BucketTranslator<FilterAggregationBuilder> {
+
+    @Override
+    public Class<FilterAggregationBuilder> getAggregationType() {
+        return FilterAggregationBuilder.class;
+    }
+
+    @Override
+    public GroupingInfo getGrouping(FilterAggregationBuilder agg) {
+        return new FieldGrouping(List.of());
+    }
+
+    @Override
+    public Collection<AggregationBuilder> getSubAggregations(FilterAggregationBuilder agg) {
+        return agg.getSubAggregations();
+    }
+
+    @Override
+    public BucketOrder getBucketOrder(FilterAggregationBuilder agg) {
+        return null;
+    }
+
+    @Override
+    public Optional<QueryBuilder> getFilterQuery(FilterAggregationBuilder agg) {
+        return Optional.of(agg.getFilter());
+    }
+
+    @Override
+    public void validate(FilterAggregationBuilder agg) throws ConversionException {
+        // No unsupported parameters. Inner query translatability is checked at plan-build time.
+    }
+
+    @Override
+    public InternalAggregation toBucketAggregation(FilterAggregationBuilder agg, Iterable<BucketEntry> buckets) {
+        List<BucketEntry> entries = new ArrayList<>();
+        buckets.forEach(entries::add);
+        if (entries.isEmpty()) {
+            return new InternalFilter(agg.getName(), 0, InternalAggregations.EMPTY, AggregationTranslator.userMetadata(agg));
+        }
+        BucketEntry entry = entries.get(0);
+        return new InternalFilter(agg.getName(), entry.docCount(), entry.subAggs(), AggregationTranslator.userMetadata(agg));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -39,7 +39,9 @@ import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.dsl.query.QueryRegistryFactory;
+import org.opensearch.dsl.query.UnresolvedQueryCall;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.SearchContext;
@@ -181,6 +183,19 @@ public class SearchSourceConverter {
                 aggCtx = aggCtx.withParentPlan(parentPlan);
             }
             RelNode aggInput = preAggConverter.convert(base, aggCtx);
+            if (metadata.getFilterQuery().isPresent()) {
+                QueryBuilder filterQuery = metadata.getFilterQuery().get();
+                RexNode predicate = QUERY_REGISTRY.convert(filterQuery, aggCtx);
+                if (predicate instanceof UnresolvedQueryCall unresolvedCall) {
+                    throw new ConversionException(
+                        "Filter aggregation ["
+                            + metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1)
+                            + "] contains an unsupported query type: "
+                            + unresolvedCall.getQueryBuilder().getWriteableName()
+                    );
+                }
+                aggInput = LogicalFilter.create(aggInput, predicate);
+            }
             RelNode aggs = aggConverter.convert(aggInput, metadata);
             aggs = postAggConverter.convert(aggs, aggCtx);
             builtPlansByPath.put(aggPathKey(metadata.getAggNamePath()), aggs);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -183,19 +183,9 @@ public class SearchSourceConverter {
                 aggCtx = aggCtx.withParentPlan(parentPlan);
             }
             RelNode aggInput = preAggConverter.convert(base, aggCtx);
-            if (metadata.getFilterQuery().isPresent()) {
-                QueryBuilder filterQuery = metadata.getFilterQuery().get();
-                RexNode predicate = QUERY_REGISTRY.convert(filterQuery, aggCtx);
-                if (predicate instanceof UnresolvedQueryCall unresolvedCall) {
-                    throw new ConversionException(
-                        "Filter aggregation ["
-                            + metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1)
-                            + "] contains an unsupported query type: "
-                            + unresolvedCall.getQueryBuilder().getWriteableName()
-                    );
-                }
-                aggInput = LogicalFilter.create(aggInput, predicate);
-            }
+            // Apply own filter + ancestor filter predicates (delegates to the single canonical
+            // implementation that handles conversion, validation, and LogicalFilter wrapping).
+            aggInput = applyAggregationFilters(aggInput, metadata, aggCtx);
             RelNode aggs = aggConverter.convert(aggInput, metadata);
             aggs = postAggConverter.convert(aggs, aggCtx);
             builtPlansByPath.put(aggPathKey(metadata.getAggNamePath()), aggs);
@@ -211,7 +201,7 @@ public class SearchSourceConverter {
             if (metadata.getFetch() == null) {
                 continue;
             }
-            String aggName = metadata.getAggNamePath().get(0); // fetch implies a root-level, single-field plan
+            String aggName = metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1); // the defining aggregation's own name
             if (metadata.getHavingMinDocCount() != null) {
                 // min_doc_count > 1: the eligible count must exclude below-threshold groups
                 // (classic reduce drops them without counting them as "other"), which no flat
@@ -224,6 +214,16 @@ public class SearchSourceConverter {
             } else if (metadata.eligibleDocCountIsTotal()) {
                 // missing substitution makes every matching doc eligible — COUNT(*) serves
                 totalServesAsEligibleCount = true;
+            } else if (hasAncestorOrOwnFilter(metadata)) {
+                // The eligible-doc count must be scoped to the same filtered document set as
+                // the aggregation plan itself: a filter parent narrows both what the child
+                // aggregates AND how many documents are "eligible" for sum_other_doc_count.
+                // Without this, eligibleDocCount would be the unfiltered COUNT(field) from the
+                // flat count plan — yielding sum_other_doc_count = corpusCount - returned,
+                // which exceeds the parent's doc_count.
+                builder.add(
+                    new QueryPlans.QueryPlan(QueryPlans.Type.COUNT, buildFilteredEligibleCountPlan(searchSource, table, metadata, aggName))
+                );
             } else {
                 String fieldName = metadata.getGroupByFieldNames().get(0);
                 RelDataTypeField field = base.getRowType().getField(fieldName, false, false);
@@ -322,6 +322,124 @@ public class SearchSourceConverter {
             );
         }
         return LogicalAggregate.create(base, ImmutableBitSet.of(), null, calls);
+    }
+
+    /**
+     * Returns true when the metadata carries any non-trivial filter predicates (either its own
+     * defining filter query or inherited ancestor filters) that are not match_all. When true,
+     * the eligible-doc count plan must be built individually with those predicates applied,
+     * rather than sharing the flat unfiltered COUNT plan.
+     */
+    private boolean hasAncestorOrOwnFilter(AggregationMetadata metadata) {
+        if (metadata.getFilterQuery().isPresent()) {
+            return true;
+        }
+        for (AggregationMetadataBuilder.AncestorFilter ancestor : metadata.getAncestorFilters()) {
+            // Skip the defining aggregation's own filter — already checked above via getFilterQuery()
+            if (!ancestor.aggName().equals(metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds an individual eligible-doc count plan for a bounded aggregation whose document set
+     * is narrowed by filter predicates (its own filter query and/or ancestor filters). The plan
+     * applies the same predicate set as the aggregation plan:
+     *
+     * <pre>
+     * Aggregate(COUNT(field) AS _eligible$&lt;aggName&gt;)
+     *   [LogicalFilter(ancestorFilter2)]
+     *   [LogicalFilter(ancestorFilter1)]
+     *   [LogicalFilter(ownFilterQuery)]
+     *     Scan → query filter
+     * </pre>
+     *
+     * <p>This ensures {@code sum_other_doc_count = eligibleDocCount - returnedDocCount} is
+     * scoped to the filtered document set, not the full corpus.
+     */
+    private RelNode buildFilteredEligibleCountPlan(
+        SearchSourceBuilder searchSource,
+        RelOptTable table,
+        AggregationMetadata metadata,
+        String aggName
+    ) throws ConversionException {
+        ConversionContext ctx = new ConversionContext(searchSource, newCluster(), table);
+        RelNode countInput = buildBase(ctx);
+
+        // Apply the same filter predicates the aggregation plan applies — reusing the existing
+        // conversion path (QUERY_REGISTRY.convert + LogicalFilter.create) to stay consistent.
+        countInput = applyAggregationFilters(countInput, metadata, ctx);
+
+        String fieldName = metadata.getGroupByFieldNames().get(0);
+        RelDataTypeField field = countInput.getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
+        }
+
+        RelDataType bigint = ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT);
+        AggregateCall countCall = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            false,
+            false,
+            List.of(field.getIndex()),
+            -1,
+            RelCollations.EMPTY,
+            bigint,
+            QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + aggName
+        );
+        return LogicalAggregate.create(countInput, ImmutableBitSet.of(), null, List.of(countCall));
+    }
+
+    /**
+     * Applies the aggregation's own filter query and accumulated ancestor filter predicates to
+     * the given input node. Reuses the same conversion and injection logic as the aggregation
+     * plan loop so that predicate translation stays consistent in one place.
+     *
+     * <p>Skips predicates that convert to literal TRUE (match_all) since they have no effect,
+     * and skips the defining aggregation's own filter when it also appears in the ancestor list
+     * (it is applied once via {@link AggregationMetadata#getFilterQuery()}).
+     */
+    private RelNode applyAggregationFilters(RelNode input, AggregationMetadata metadata, ConversionContext ctx) throws ConversionException {
+        // Apply the defining aggregation's own filter query first
+        if (metadata.getFilterQuery().isPresent()) {
+            QueryBuilder filterQuery = metadata.getFilterQuery().get();
+            RexNode predicate = QUERY_REGISTRY.convert(filterQuery, ctx);
+            if (predicate instanceof UnresolvedQueryCall unresolvedCall) {
+                throw new ConversionException(
+                    "Filter aggregation ["
+                        + metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1)
+                        + "] contains an unsupported query type: "
+                        + unresolvedCall.getQueryBuilder().getWriteableName()
+                );
+            }
+            if (!predicate.isAlwaysTrue()) {
+                input = LogicalFilter.create(input, predicate);
+            }
+        }
+        // Apply ancestor filter predicates
+        for (AggregationMetadataBuilder.AncestorFilter ancestor : metadata.getAncestorFilters()) {
+            // Skip the defining aggregation's own filter — already applied above
+            if (ancestor.aggName().equals(metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1))) {
+                continue;
+            }
+            RexNode ancestorPredicate = QUERY_REGISTRY.convert(ancestor.query(), ctx);
+            if (ancestorPredicate instanceof UnresolvedQueryCall unresolvedCall) {
+                throw new ConversionException(
+                    "Filter aggregation ["
+                        + ancestor.aggName()
+                        + "] contains an unsupported query type: "
+                        + unresolvedCall.getQueryBuilder().getWriteableName()
+                );
+            }
+            // A match_all filter converts to literal TRUE — skip injection since it has no effect.
+            if (!ancestorPredicate.isAlwaysTrue()) {
+                input = LogicalFilter.create(input, ancestorPredicate);
+            }
+        }
+        return input;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -325,22 +325,14 @@ public class SearchSourceConverter {
     }
 
     /**
-     * Returns true when the metadata carries any non-trivial filter predicates (either its own
-     * defining filter query or inherited ancestor filters) that are not match_all. When true,
-     * the eligible-doc count plan must be built individually with those predicates applied,
-     * rather than sharing the flat unfiltered COUNT plan.
+     * Returns true when the metadata carries any filter predicates — either its own defining
+     * filter query or inherited ancestor filters. When true, the eligible-doc count plan must
+     * be built individually with those predicates applied, rather than sharing the flat
+     * unfiltered COUNT plan. The defining aggregation's own filter is no longer stored among
+     * the ancestor filters, so no name-based self-deduplication is needed here.
      */
     private boolean hasAncestorOrOwnFilter(AggregationMetadata metadata) {
-        if (metadata.getFilterQuery().isPresent()) {
-            return true;
-        }
-        for (AggregationMetadataBuilder.AncestorFilter ancestor : metadata.getAncestorFilters()) {
-            // Skip the defining aggregation's own filter — already checked above via getFilterQuery()
-            if (!ancestor.aggName().equals(metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1))) {
-                return true;
-            }
-        }
-        return false;
+        return metadata.getFilterQuery().isPresent() || !metadata.getAncestorFilters().isEmpty();
     }
 
     /**
@@ -349,7 +341,7 @@ public class SearchSourceConverter {
      * applies the same predicate set as the aggregation plan:
      *
      * <pre>
-     * Aggregate(COUNT(field) AS _eligible$&lt;aggName&gt;)
+     * Aggregate(COUNT(field) AS _eligible$&lt;aggName&gt;)   // COUNT(*) when a `missing` value applies
      *   [LogicalFilter(ancestorFilter2)]
      *   [LogicalFilter(ancestorFilter1)]
      *   [LogicalFilter(ownFilterQuery)]
@@ -373,9 +365,17 @@ public class SearchSourceConverter {
         countInput = applyAggregationFilters(countInput, metadata, ctx);
 
         String fieldName = metadata.getGroupByFieldNames().get(0);
-        RelDataTypeField field = countInput.getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
+        List<Integer> countArgs;
+        if (metadata.getMissingValues().containsKey(fieldName)) {
+            // A `missing` value substitutes null-field docs into a bucket, making them eligible;
+            // SQL COUNT(field) excludes nulls, so count ALL filtered docs with COUNT(*) instead.
+            countArgs = List.of();
+        } else {
+            RelDataTypeField field = countInput.getRowType().getField(fieldName, false, false);
+            if (field == null) {
+                throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
+            }
+            countArgs = List.of(field.getIndex());
         }
 
         RelDataType bigint = ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT);
@@ -384,7 +384,7 @@ public class SearchSourceConverter {
             false,
             false,
             false,
-            List.of(field.getIndex()),
+            countArgs,
             -1,
             RelCollations.EMPTY,
             bigint,
@@ -398,9 +398,11 @@ public class SearchSourceConverter {
      * the given input node. Reuses the same conversion and injection logic as the aggregation
      * plan loop so that predicate translation stays consistent in one place.
      *
-     * <p>Skips predicates that convert to literal TRUE (match_all) since they have no effect,
-     * and skips the defining aggregation's own filter when it also appears in the ancestor list
-     * (it is applied once via {@link AggregationMetadata#getFilterQuery()}).
+     * <p>Skips predicates that convert to literal TRUE (match_all) since they have no effect.
+     * The defining aggregation's own filter is applied once via
+     * {@link AggregationMetadata#getFilterQuery()} and is not stored among the ancestor filters,
+     * so the ancestor loop applies only genuine ancestors — including one that legally reuses
+     * this aggregation's name.
      */
     private RelNode applyAggregationFilters(RelNode input, AggregationMetadata metadata, ConversionContext ctx) throws ConversionException {
         // Apply the defining aggregation's own filter query first
@@ -421,10 +423,6 @@ public class SearchSourceConverter {
         }
         // Apply ancestor filter predicates
         for (AggregationMetadataBuilder.AncestorFilter ancestor : metadata.getAncestorFilters()) {
-            // Skip the defining aggregation's own filter — already applied above
-            if (ancestor.aggName().equals(metadata.getAggNamePath().get(metadata.getAggNamePath().size() - 1))) {
-                continue;
-            }
             RexNode ancestorPredicate = QUERY_REGISTRY.convert(ancestor.query(), ctx);
             if (ancestorPredicate instanceof UnresolvedQueryCall unresolvedCall) {
                 throw new ConversionException(

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationTreeWalkerTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationTreeWalkerTests.java
@@ -314,4 +314,35 @@ public class AggregationTreeWalkerTests extends OpenSearchTestCase {
         );
         assertTrue(e.getMessage().contains("missing"));
     }
+
+    // ---- Filter aggregation tests ----
+
+    public void testFilterAggProducesNonEmptyPath() throws ConversionException {
+        List<AggregationBuilder> aggs = List.of(
+            new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                "active_only",
+                new org.opensearch.index.query.TermQueryBuilder("status", "active")
+            )
+        );
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(1, result.size());
+        assertEquals(List.of("active_only"), result.get(0).getAggNamePath());
+        // Filter bucket produces implicit _count
+        assertTrue(result.get(0).getAggregateFieldNames().contains("_count"));
+    }
+
+    public void testFilterAggCarriesFilterQuery() throws ConversionException {
+        org.opensearch.index.query.TermQueryBuilder termQuery = new org.opensearch.index.query.TermQueryBuilder("status", "active");
+        List<AggregationBuilder> aggs = List.of(
+            new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("active_only", termQuery)
+        );
+
+        List<AggregationMetadata> result = walker.walk(aggs, ctx.getRowType(), ctx.getCluster().getTypeFactory());
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getFilterQuery().isPresent());
+        assertEquals(termQuery, result.get(0).getFilterQuery().get());
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/FilterBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/FilterBucketTranslatorTests.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.FieldGrouping;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FilterBucketTranslatorTests extends OpenSearchTestCase {
+
+    private final FilterBucketTranslator translator = new FilterBucketTranslator();
+    private final FilterAggregationBuilder filterAgg = new FilterAggregationBuilder(
+        "active_only",
+        new TermQueryBuilder("status", "active")
+    );
+
+    public void testGetAggregationType() {
+        assertEquals(FilterAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    public void testGetGroupingReturnsEmpty() {
+        var grouping = translator.getGrouping(filterAgg);
+        assertTrue(grouping instanceof FieldGrouping);
+        assertTrue(grouping.getFieldNames().isEmpty());
+    }
+
+    public void testGetFilterQueryReturnsInnerQuery() {
+        Optional<QueryBuilder> result = translator.getFilterQuery(filterAgg);
+        assertTrue(result.isPresent());
+        assertEquals(filterAgg.getFilter(), result.get());
+    }
+
+    public void testGetSubAggregations() {
+        FilterAggregationBuilder aggWithSub = new FilterAggregationBuilder("active_only", new TermQueryBuilder("status", "active"))
+            .subAggregation(new AvgAggregationBuilder("avg_price").field("price"));
+
+        assertEquals(1, translator.getSubAggregations(aggWithSub).size());
+    }
+
+    public void testValidatePassesForSupportedQuery() throws Exception {
+        // Should not throw for a TermQueryBuilder filter
+        translator.validate(filterAgg);
+    }
+
+    public void testToBucketAggregationSingleBucket() {
+        InternalAggregations subAggs = InternalAggregations.EMPTY;
+        List<BucketEntry> entries = List.of(new BucketEntry(List.of(), 5, subAggs));
+
+        InternalAggregation result = translator.toBucketAggregation(filterAgg, entries);
+
+        assertTrue(result instanceof InternalFilter);
+        InternalFilter filter = (InternalFilter) result;
+        assertEquals("active_only", filter.getName());
+        assertEquals(5, filter.getDocCount());
+    }
+
+    public void testToBucketAggregationEmptyBuckets() {
+        InternalAggregation result = translator.toBucketAggregation(filterAgg, List.of());
+
+        assertTrue(result instanceof InternalFilter);
+        InternalFilter filter = (InternalFilter) result;
+        assertEquals("active_only", filter.getName());
+        assertEquals(0, filter.getDocCount());
+    }
+
+    public void testMetaPassThrough() {
+        Map<String, Object> meta = Map.of("source", "dashboard");
+        FilterAggregationBuilder aggWithMeta = new FilterAggregationBuilder("active_only", new TermQueryBuilder("status", "active"));
+        aggWithMeta.setMetadata(meta);
+
+        InternalAggregation result = translator.toBucketAggregation(aggWithMeta, List.of());
+        assertEquals(meta, result.getMetadata());
+
+        // No meta on the request → none in the response
+        assertNull(translator.toBucketAggregation(filterAgg, List.of()).getMetadata());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -412,6 +412,62 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         assertEquals(9, DslTypeSystems.NANO_TIMESTAMP.getMaxPrecision(SqlTypeName.TIMESTAMP));
     }
 
+    // ---- Filter aggregation tests ----
+
+    public void testFilterAggUntranslatableQueryRejects() {
+        // A filter aggregation with an unregistered query type must reject at conversion time.
+        // wildcard has no registered translator, so it remains an UnresolvedQueryCall and rejects.
+        org.opensearch.index.query.WildcardQueryBuilder unsupportedQuery = new org.opensearch.index.query.WildcardQueryBuilder(
+            "name",
+            "lap*"
+        );
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("my_filter", unsupportedQuery));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
+        assertTrue(e.getMessage().contains("unsupported query type"));
+    }
+
+    public void testFilterAggPlanShapeSingleScan() throws ConversionException {
+        // A filter agg with a supported query produces a plan with LogicalFilter below LogicalAggregate
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "active_only",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                )
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        assertTrue(plans.has(QueryPlans.Type.AGGREGATION));
+
+        RelNode aggPlan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode();
+        String plan = aggPlan.explain();
+        // Must have exactly one LogicalTableScan
+        assertEquals(1, plan.split("LogicalTableScan").length - 1);
+        // Must have a LogicalFilter with the term predicate below the aggregate
+        assertTrue("plan must contain LogicalFilter: " + plan, plan.contains("LogicalFilter"));
+        assertTrue("plan must contain LogicalAggregate: " + plan, plan.contains("LogicalAggregate"));
+    }
+
+    public void testFilterAggBoolQueryAccepted() throws ConversionException {
+        // A compound bool query (must + must_not) is translatable via the registered
+        // BoolQueryTranslator, so a filter aggregation using one converts successfully and
+        // produces a LogicalFilter below the LogicalAggregate.
+        org.opensearch.index.query.BoolQueryBuilder boolQuery = new org.opensearch.index.query.BoolQueryBuilder().must(
+            new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+        ).mustNot(new org.opensearch.index.query.TermQueryBuilder("name", "Widget"));
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("compound_filter", boolQuery));
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        assertTrue(plans.has(QueryPlans.Type.AGGREGATION));
+
+        String plan = plans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        assertTrue("plan must contain LogicalFilter: " + plan, plan.contains("LogicalFilter"));
+        assertTrue("plan must contain LogicalAggregate: " + plan, plan.contains("LogicalAggregate"));
+    }
+
     private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {
         String json;
         try (var builder = JsonXContent.contentBuilder()) {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -468,6 +468,205 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         assertTrue("plan must contain LogicalAggregate: " + plan, plan.contains("LogicalAggregate"));
     }
 
+    // ---- Ancestor filter propagation tests ----
+    // These verify that a filter aggregation's predicate propagates to nested bucket
+    // sub-aggregations — not just metric children.
+
+    public void testFilterWithNestedTermsChildPropagatesFilter() throws ConversionException {
+        // A filter(term: brand=BrandA) with a nested terms(field: name) child must produce a
+        // child plan whose input carries the filter predicate. Without propagation, the child
+        // would aggregate over the full corpus instead of only filtered documents.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name"))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals("filter + nested terms must produce 2 plans", 2, aggPlans.size());
+
+        // The child plan (by_name) must contain the ancestor filter predicate
+        String childPlan = aggPlans.get(1).relNode().explain();
+        assertTrue(
+            "child terms plan must carry the ancestor filter predicate: " + childPlan,
+            childPlan.contains("$2") && childPlan.contains("BrandA")
+        );
+    }
+
+    public void testFilterWithSizedTermsChildPropagatesFilterWithTruncation() throws ConversionException {
+        // A filter(term: brand=BrandA) with terms(field: name, size: 2) — the bounded child
+        // must both carry the ancestor filter AND apply its own top-K truncation.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name").size(2))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals("filter + nested sized terms must produce 2 plans", 2, aggPlans.size());
+
+        String childPlan = aggPlans.get(1).relNode().explain();
+        assertTrue("child plan must carry the ancestor filter: " + childPlan, childPlan.contains("$2") && childPlan.contains("BrandA"));
+        assertTrue("child plan must carry its own top-K truncation: " + childPlan, childPlan.contains("fetch=[2]"));
+    }
+
+    public void testNestedFilterInsideFilterConjoinsPredicates() throws ConversionException {
+        // filter(term: brand=BrandA) → filter(term: name=Widget) → terms(field: rating)
+        // The leaf terms plan must carry BOTH ancestor predicates conjoined.
+        // Uses fields in the test schema: brand(idx 2), name(idx 0), rating(idx 3)
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(
+                    new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                        "name_filter",
+                        new org.opensearch.index.query.TermQueryBuilder("name", "Widget")
+                    ).subAggregation(new TermsAggregationBuilder("by_rating").field("rating"))
+                )
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals("outer filter + inner filter + leaf terms must produce 3 plans", 3, aggPlans.size());
+
+        // The leaf plan (by_rating) must carry both predicates
+        String leafPlan = aggPlans.get(2).relNode().explain();
+        assertTrue("leaf plan must carry the outer filter (brand=BrandA): " + leafPlan, leafPlan.contains("BrandA"));
+        assertTrue("leaf plan must carry the inner filter (name=Widget): " + leafPlan, leafPlan.contains("Widget"));
+    }
+
+    public void testFilterWithBothMetricAndBucketChildPropagates() throws ConversionException {
+        // filter(term: brand=BrandA) with BOTH avg(price) and terms(name) children.
+        // Both plans must carry the filter.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new AvgAggregationBuilder("avg_price").field("price"))
+                    .subAggregation(new TermsAggregationBuilder("by_name").field("name"))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals("filter with metric+bucket children produces 2 plans", 2, aggPlans.size());
+
+        // The filter's own plan (brand_filter) carries the metric and must have the filter
+        String parentPlan = aggPlans.get(0).relNode().explain();
+        assertTrue(
+            "parent plan (metric child rides here) must carry the filter: " + parentPlan,
+            parentPlan.contains("$2") && parentPlan.contains("BrandA")
+        );
+
+        // The child bucket plan (by_name) must also carry the ancestor filter
+        String childPlan = aggPlans.get(1).relNode().explain();
+        assertTrue(
+            "child bucket plan must carry the ancestor filter: " + childPlan,
+            childPlan.contains("$2") && childPlan.contains("BrandA")
+        );
+    }
+
+    public void testUntranslatableAncestorFilterNamesOffendingAggregation() {
+        // An untranslatable filter in an ANCESTOR must report that ancestor's aggregation name,
+        // not the child's, so operators can locate the unsupported query.
+        org.opensearch.index.query.WildcardQueryBuilder unsupportedQuery = new org.opensearch.index.query.WildcardQueryBuilder(
+            "brand",
+            "Brand*"
+        );
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("bad_ancestor", unsupportedQuery).subAggregation(
+                    new TermsAggregationBuilder("by_name").field("name")
+                )
+            );
+
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
+        assertTrue("error must name the ancestor aggregation 'bad_ancestor': " + e.getMessage(), e.getMessage().contains("bad_ancestor"));
+        assertTrue("error must mention 'unsupported query type': " + e.getMessage(), e.getMessage().contains("unsupported query type"));
+    }
+
+    public void testFilterMatchAllWithTermsChildNoSpuriousFilter() throws ConversionException {
+        // filter(match_all) with terms(name): the child must NOT have a spurious filter injected.
+        // match_all translates to a literal TRUE which Calcite simplifies away, so the plan
+        // must look identical to a bare terms(name) without any enclosing filter.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "all_filter",
+                    new org.opensearch.index.query.MatchAllQueryBuilder()
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name"))
+            );
+
+        // Bare terms(name) for comparison
+        SearchSourceBuilder bareSource = new SearchSourceBuilder().size(0)
+            .aggregation(new TermsAggregationBuilder("by_name").field("name"));
+
+        QueryPlans plansWithFilter = converter.convert(source, "test-index");
+        QueryPlans barePlans = converter.convert(bareSource, "test-index");
+
+        List<QueryPlans.QueryPlan> filteredAggPlans = plansWithFilter.get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, filteredAggPlans.size());
+
+        // The child plan under match_all filter should have the same null-exclusion filter
+        // as a bare terms — no additional predicate injected by the ancestor.
+        String childPlan = filteredAggPlans.get(1).relNode().explain();
+        String barePlan = barePlans.get(QueryPlans.Type.AGGREGATION).get(0).relNode().explain();
+        // Both must have IS NOT NULL for name field (column 0) - standard terms behavior
+        assertTrue("child must null-filter: " + childPlan, childPlan.contains("IS NOT NULL($0)"));
+        assertTrue("bare must null-filter: " + barePlan, barePlan.contains("IS NOT NULL($0)"));
+        // The child must NOT have any extra filter beyond the null-exclusion
+        assertEquals(
+            "match_all ancestor must not inject a spurious predicate — filter count must match bare terms",
+            barePlan.split("LogicalFilter").length,
+            childPlan.split("LogicalFilter").length
+        );
+    }
+
+    // ---- Eligible-doc count (sum_other_doc_count) scoping under filter parents ----
+
+    public void testFilterWithSizedTermsChildEligibleCountCarriesAncestorFilter() throws ConversionException {
+        // A filter(term: brand=BrandA) with terms(field: name, size: 2): the eligible-doc count
+        // plan for by_name must be filtered to only documents matching brand=BrandA. Without this,
+        // sum_other_doc_count = eligibleDocCount - returnedDocCount would use the full corpus
+        // count instead of the filtered count, yielding a value that exceeds the parent's
+        // doc_count (the defect observed in live cluster testing: 8 - 3 = 5, when the filtered
+        // parent only has 3 eligible docs).
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name").size(2))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        // The child terms is bounded (size=2) so it needs an eligible-doc count plan.
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        assertFalse("must have at least one COUNT plan", countPlans.isEmpty());
+
+        // Find the count plan carrying the eligible column for "by_name"
+        String eligibleColumn = QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_name";
+        QueryPlans.QueryPlan eligiblePlan = countPlans.stream()
+            .filter(p -> p.relNode().getRowType().getFieldNames().contains(eligibleColumn))
+            .findFirst()
+            .orElse(null);
+        assertNotNull("must have an eligible-count plan for by_name", eligiblePlan);
+
+        // The eligible-count plan MUST include the ancestor filter predicate (brand=BrandA)
+        // so that sum_other_doc_count is scoped to the filtered document set.
+        String plan = eligiblePlan.relNode().explain();
+        assertTrue("eligible-count plan must carry the ancestor filter predicate (brand=BrandA): " + plan, plan.contains("BrandA"));
+    }
+
     private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {
         String json;
         try (var builder = JsonXContent.contentBuilder()) {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -583,9 +583,8 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         );
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(
-                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("bad_ancestor", unsupportedQuery).subAggregation(
-                    new TermsAggregationBuilder("by_name").field("name")
-                )
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder("bad_ancestor", unsupportedQuery)
+                    .subAggregation(new TermsAggregationBuilder("by_name").field("name"))
             );
 
         ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
@@ -665,6 +664,198 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
         // so that sum_other_doc_count is scoped to the filtered document set.
         String plan = eligiblePlan.relNode().explain();
         assertTrue("eligible-count plan must carry the ancestor filter predicate (brand=BrandA): " + plan, plan.contains("BrandA"));
+    }
+
+    public void testFilterWithMissingTermsChildEligibleCountCarriesAncestorFilter() throws ConversionException {
+        // Invariant: a filter parent must scope its bounded child's eligible-doc count to the
+        // FILTERED document set even when the child substitutes `missing`. The substitution must
+        // not divert the eligible count onto the unfiltered COUNT(*); otherwise
+        // sum_other_doc_count = corpusCount - returned exceeds the parent's doc_count.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name").missing("N/A").size(1))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        assertFalse("must have at least one COUNT plan", countPlans.isEmpty());
+
+        String eligibleColumn = QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_name";
+        QueryPlans.QueryPlan eligiblePlan = countPlans.stream()
+            .filter(p -> p.relNode().getRowType().getFieldNames().contains(eligibleColumn))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(
+            "a missing-configured bounded child must still get its own filtered eligible-count plan, " + "not ride the unfiltered COUNT(*)",
+            eligiblePlan
+        );
+
+        String plan = eligiblePlan.relNode().explain();
+        assertTrue(
+            "eligible-count plan for a missing-configured child must carry the ancestor filter predicate (brand=BrandA): " + plan,
+            plan.contains("BrandA")
+        );
+    }
+
+    public void testFilterWithMissingTermsChildEligibleCountCountsAllFilteredDocs() throws ConversionException {
+        // Invariant: when `missing` substitutes null keys into a bucket, null-field docs are
+        // eligible, so the filtered eligible count must count ALL filtered docs (COUNT() over an
+        // empty argument list) rather than only non-null group values (COUNT(field)).
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "brand_filter",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("by_name").field("name").missing("N/A").size(1))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+
+        List<QueryPlans.QueryPlan> countPlans = plans.get(QueryPlans.Type.COUNT);
+        assertFalse("must have at least one COUNT plan", countPlans.isEmpty());
+
+        String eligibleColumn = QueryPlans.COUNT_ELIGIBLE_COLUMN_PREFIX + "by_name";
+        QueryPlans.QueryPlan eligiblePlan = countPlans.stream()
+            .filter(p -> p.relNode().getRowType().getFieldNames().contains(eligibleColumn))
+            .findFirst()
+            .orElse(null);
+        assertNotNull("a missing-configured bounded child must have its own filtered eligible-count plan", eligiblePlan);
+
+        String plan = eligiblePlan.relNode().explain();
+        assertTrue(
+            "eligible count for a missing-configured child must count ALL filtered rows (COUNT()), "
+                + "not restrict to non-null group values (COUNT(field)): "
+                + plan,
+            plan.contains(eligibleColumn + "=[COUNT()]")
+        );
+    }
+
+    public void testDescendantFilterReusingAncestorNameKeepsAncestorPredicate() throws ConversionException {
+        // Invariant: aggregation names are unique only among siblings, so a descendant may
+        // legally reuse an ancestor's name. The by-name self-deduplication must not confuse a
+        // same-named ancestor filter with the defining aggregation's own filter — the innermost
+        // plan must carry BOTH the outer and inner predicates.
+        // Shape: filter "dup"(brand=BrandA) -> terms "grp"(rating) -> filter "dup"(name=Widget)
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "dup",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(
+                    new TermsAggregationBuilder("grp").field("rating")
+                        .subAggregation(
+                            new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                                "dup",
+                                new org.opensearch.index.query.TermQueryBuilder("name", "Widget")
+                            )
+                        )
+                )
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggPlans = plans.get(QueryPlans.Type.AGGREGATION);
+        assertEquals("outer filter + terms + inner filter must produce 3 plans", 3, aggPlans.size());
+
+        // Innermost plan is the re-named inner filter "dup" (walker emits parents before children).
+        String innermostPlan = aggPlans.get(2).relNode().explain();
+        assertTrue("innermost plan must carry its own filter (name=Widget): " + innermostPlan, innermostPlan.contains("Widget"));
+        assertTrue(
+            "innermost plan must ALSO carry the same-named ancestor filter (brand=BrandA): " + innermostPlan,
+            innermostPlan.contains("BrandA")
+        );
+    }
+
+    // ---- Range inner query as a filter aggregation (GAP A) ----
+
+    public void testFilterRangeInnerQueryPredicateReachesPlan() throws ConversionException {
+        // Invariant: a range inner query on a filter aggregation must translate to a bounded
+        // predicate carrying BOTH range endpoints — a dropped or mistranslated bound must fail.
+        // Shape: filter "price_band"(range price gte 300 lt 600) -> terms "by_brand"(brand).
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "price_band",
+                    new org.opensearch.index.query.RangeQueryBuilder("price").gte(300).lt(600)
+                ).subAggregation(new TermsAggregationBuilder("by_brand").field("brand"))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        String bandPlan = aggPlanEndingWith(plans, "price_band").relNode().explain();
+        // price is column 1 in the test schema; both bounds must be present and correctly oriented
+        assertTrue("range plan must carry the lower bound gte 300: " + bandPlan, bandPlan.contains(">=($1, CAST(300):INTEGER)"));
+        assertTrue("range plan must carry the upper bound lt 600: " + bandPlan, bandPlan.contains("<($1, CAST(600):INTEGER)"));
+    }
+
+    // ---- Falsifiable ancestor-predicate propagation (GAP B) ----
+    // A filter aggregation's predicate is injected into its bucket descendants' plans by
+    // SearchSourceConverter.applyAggregationFilters. A silently dropped injection would leave a
+    // descendant aggregating the full corpus; these tests assert the SPECIFIC predicate literal
+    // reaches the SPECIFIC descendant plan, so such a drop fails.
+
+    public void testNestedFilterPredicateReachesChildBucketPlan() throws ConversionException {
+        // A filter aggregation must scope its bucket sub-aggregation: the filter's predicate must
+        // reach the nested child's plan, otherwise the child aggregates the full corpus. Shape:
+        // filter "only_active"(term name=Widget) -> terms "by_rating"(rating). The child plan must
+        // carry the ancestor filter's predicate (name=Widget, column 0).
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "only_active",
+                    new org.opensearch.index.query.TermQueryBuilder("name", "Widget")
+                ).subAggregation(new TermsAggregationBuilder("by_rating").field("rating"))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        String childPlan = aggPlanEndingWith(plans, "by_rating").relNode().explain();
+        assertTrue(
+            "nested child plan must carry the filter's predicate (name=Widget): " + childPlan,
+            childPlan.contains("$0") && childPlan.contains("Widget")
+        );
+    }
+
+    public void testSiblingFilterPredicatesReachOwnChildPlansNoCrossContamination() throws ConversionException {
+        // Two sibling filters, each with its own terms child, must each scope ONLY their own
+        // child — no cross-contamination between siblings. Shapes:
+        // f_widget(term name=Widget) -> terms "cat_a"(brand)
+        // f_brand (term brand=BrandA) -> terms "cat_b"(rating)
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "f_widget",
+                    new org.opensearch.index.query.TermQueryBuilder("name", "Widget")
+                ).subAggregation(new TermsAggregationBuilder("cat_a").field("brand"))
+            )
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "f_brand",
+                    new org.opensearch.index.query.TermQueryBuilder("brand", "BrandA")
+                ).subAggregation(new TermsAggregationBuilder("cat_b").field("rating"))
+            );
+
+        QueryPlans plans = converter.convert(source, "test-index");
+        String catA = aggPlanEndingWith(plans, "cat_a").relNode().explain();
+        String catB = aggPlanEndingWith(plans, "cat_b").relNode().explain();
+
+        // Each child carries its OWN parent filter's predicate...
+        assertTrue("cat_a must carry its own parent's predicate (name=Widget): " + catA, catA.contains("Widget"));
+        assertTrue("cat_b must carry its own parent's predicate (brand=BrandA): " + catB, catB.contains("BrandA"));
+        // ...and NOT the sibling's predicate.
+        assertFalse("cat_a must not carry the sibling's predicate (BrandA): " + catA, catA.contains("BrandA"));
+        assertFalse("cat_b must not carry the sibling's predicate (Widget): " + catB, catB.contains("Widget"));
+    }
+
+    /** Returns the single AGGREGATION plan whose aggregation-name path ends with the given name. */
+    private static QueryPlans.QueryPlan aggPlanEndingWith(QueryPlans plans, String lastAggName) {
+        return plans.get(QueryPlans.Type.AGGREGATION).stream().filter(p -> {
+            List<String> path = p.aggregationMetadata().getAggNamePath();
+            return path.get(path.size() - 1).equals(lastAggName);
+        })
+            .reduce((a, b) -> { throw new AssertionError("multiple plans end with [" + lastAggName + "]"); })
+            .orElseThrow(() -> new AssertionError("no AGGREGATION plan ends with [" + lastAggName + "]"));
     }
 
     private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
@@ -85,7 +85,27 @@ public class GoldenFileLoader {
         requireNonNull(testCase.getExpectedRelNodePlan(), "expectedRelNodePlan", filePath);
         requireNonNull(testCase.getMockResultFieldNames(), "mockResultFieldNames", filePath);
         requireNonNull(testCase.getMockResultRows(), "mockResultRows", filePath);
-        requireNonNull(testCase.getExpectedOutputDsl(), "expectedOutputDsl", filePath);
+        // Enforce explicit opt-out: a fixture must either supply expectedOutputDsl for response
+        // assertions OR deliberately set planShapeOnly=true to indicate the multi-plan limitation
+        // prevents response testing. Silent omission (missing both) is rejected to prevent
+        // accidental loss of test coverage.
+        if (testCase.getExpectedOutputDsl() == null && !testCase.isPlanShapeOnly()) {
+            throw new IllegalArgumentException(
+                "Golden file "
+                    + filePath
+                    + " is missing 'expectedOutputDsl' without setting 'planShapeOnly: true'. "
+                    + "Either supply expectedOutputDsl for response assertions, or set "
+                    + "\"planShapeOnly\": true to indicate this fixture intentionally tests plan shape only."
+            );
+        }
+        if (testCase.getExpectedOutputDsl() != null && testCase.isPlanShapeOnly()) {
+            throw new IllegalArgumentException(
+                "Golden file "
+                    + filePath
+                    + " sets 'planShapeOnly: true' but also provides 'expectedOutputDsl'. "
+                    + "This is contradictory — remove expectedOutputDsl or set planShapeOnly to false."
+            );
+        }
         requireNonNull(testCase.getPlanType(), "planType", filePath);
         try {
             QueryPlans.Type.valueOf(testCase.getPlanType());

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoaderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoaderTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link GoldenFileLoader} validation logic.
+ */
+public class GoldenFileLoaderTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Verifies that a fixture missing {@code expectedOutputDsl} WITHOUT setting
+     * {@code planShapeOnly: true} is rejected with a clear message directing
+     * the author to either supply the field or set the flag deliberately.
+     */
+    public void testValidationRejectsMissingExpectedOutputDslWithoutPlanShapeOnlyFlag() throws IOException {
+        // Minimal valid fixture content — has all required fields except expectedOutputDsl,
+        // and does NOT set planShapeOnly.
+        Map<String, Object> fixture = Map.of(
+            "testName",
+            "missing_output_no_flag",
+            "indexName",
+            "test-index",
+            "indexMapping",
+            Map.of("name", "VARCHAR"),
+            "inputDsl",
+            Map.of("size", 0),
+            "expectedRelNodePlan",
+            java.util.List.of("LogicalTableScan(table=[[test-index]])"),
+            "mockResultFieldNames",
+            java.util.List.of("name"),
+            "mockResultRows",
+            java.util.List.of(java.util.List.of("Alice")),
+            "planType",
+            "HITS"
+        );
+
+        Path tempFile = createTempFile("golden_test_", ".json");
+        Files.writeString(tempFile, MAPPER.writeValueAsString(fixture));
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> GoldenFileLoader.load(tempFile));
+        assertTrue("Expected message to mention planShapeOnly, got: " + ex.getMessage(), ex.getMessage().contains("planShapeOnly"));
+        assertTrue("Expected message to mention expectedOutputDsl, got: " + ex.getMessage(), ex.getMessage().contains("expectedOutputDsl"));
+    }
+
+    /**
+     * Verifies that setting {@code planShapeOnly: true} AND providing
+     * {@code expectedOutputDsl} is rejected as contradictory.
+     */
+    public void testValidationRejectsPlanShapeOnlyWithExpectedOutputDslPresent() throws IOException {
+        Map<String, Object> fixture = Map.ofEntries(
+            Map.entry("testName", "contradictory_flag_and_output"),
+            Map.entry("indexName", "test-index"),
+            Map.entry("indexMapping", Map.of("name", "VARCHAR")),
+            Map.entry("inputDsl", Map.of("size", 0)),
+            Map.entry("expectedRelNodePlan", java.util.List.of("LogicalTableScan(table=[[test-index]])")),
+            Map.entry("mockResultFieldNames", java.util.List.of("name")),
+            Map.entry("mockResultRows", java.util.List.of(java.util.List.of("Alice"))),
+            Map.entry("planType", "HITS"),
+            Map.entry("planShapeOnly", true),
+            Map.entry("expectedOutputDsl", Map.of("hits", Map.of()))
+        );
+
+        Path tempFile = createTempFile("golden_test_", ".json");
+        Files.writeString(tempFile, MAPPER.writeValueAsString(fixture));
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> GoldenFileLoader.load(tempFile));
+        assertTrue("Expected message to mention contradictory, got: " + ex.getMessage(), ex.getMessage().contains("contradictory"));
+    }
+
+    /**
+     * Verifies that a fixture with {@code planShapeOnly: true} and no
+     * {@code expectedOutputDsl} passes validation successfully.
+     */
+    public void testValidationAcceptsPlanShapeOnlyWithoutExpectedOutputDsl() throws IOException {
+        Map<String, Object> fixture = Map.of(
+            "testName",
+            "plan_shape_only_valid",
+            "indexName",
+            "test-index",
+            "indexMapping",
+            Map.of("name", "VARCHAR"),
+            "inputDsl",
+            Map.of("size", 0),
+            "expectedRelNodePlan",
+            java.util.List.of("LogicalTableScan(table=[[test-index]])"),
+            "mockResultFieldNames",
+            java.util.List.of("name"),
+            "mockResultRows",
+            java.util.List.of(java.util.List.of("Alice")),
+            "planType",
+            "HITS",
+            "planShapeOnly",
+            true
+        );
+
+        Path tempFile = createTempFile("golden_test_", ".json");
+        Files.writeString(tempFile, MAPPER.writeValueAsString(fixture));
+
+        // Should not throw
+        GoldenTestCase tc = GoldenFileLoader.load(tempFile);
+        assertEquals("plan_shape_only_valid", tc.getTestName());
+        assertTrue(tc.isPlanShapeOnly());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
@@ -17,6 +17,19 @@ import java.util.Map;
  * <p>Each golden file encodes a complete test scenario: the input DSL, expected
  * RelNode plan, simulated execution rows, and expected output DSL. The
  * {@code indexMapping} field allows schema construction without a live cluster.
+ *
+ * <p><b>Harness limitation:</b> the response driver supplies mock rows to only the FIRST
+ * matching plan of the declared type. Fixtures whose input DSL produces multiple aggregation
+ * plans (e.g. sibling filter aggs, or a bucket sub-agg under a filter) must omit
+ * {@code expectedOutputDsl} — they prove plan shape only, not counting correctness.
+ * Use hand-authored multi-plan tests for sub-aggregation scoping coverage.
+ *
+ * <p><b>Explicit opt-out ({@code planShapeOnly}):</b> when a fixture legitimately cannot
+ * provide {@code expectedOutputDsl} (because its multi-plan structure prevents a single
+ * mock-row array from covering all plans), it MUST set {@code "planShapeOnly": true} in the
+ * JSON. The loader rejects any fixture that omits {@code expectedOutputDsl} without this
+ * flag — this prevents accidental loss of response assertion coverage. Conversely, setting
+ * the flag while also providing {@code expectedOutputDsl} is contradictory and also rejected.
  */
 public class GoldenTestCase {
 
@@ -31,6 +44,7 @@ public class GoldenTestCase {
     private Map<String, Object> mockCountRow;
     private Map<String, Object> expectedOutputDsl;
     private String planType;
+    private boolean planShapeOnly;
 
     public String getTestName() {
         return testName;
@@ -115,6 +129,20 @@ public class GoldenTestCase {
 
     public void setPlanType(String planType) {
         this.planType = planType;
+    }
+
+    /**
+     * Returns {@code true} when this fixture intentionally omits {@code expectedOutputDsl}
+     * because its multi-plan structure cannot be exercised by the single-plan response driver.
+     * The loader rejects any fixture that omits {@code expectedOutputDsl} without setting this
+     * flag, preventing silent loss of response assertion coverage.
+     */
+    public boolean isPlanShapeOnly() {
+        return planShapeOnly;
+    }
+
+    public void setPlanShapeOnly(boolean planShapeOnly) {
+        this.planShapeOnly = planShapeOnly;
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -118,4 +118,186 @@ public class AggregationResponseBuilderTests extends OpenSearchTestCase {
         });
         return translator;
     }
+
+    public void testFilterAggSingleBucketResponse() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        org.opensearch.dsl.aggregation.bucket.FilterBucketTranslator filterTranslator =
+            new org.opensearch.dsl.aggregation.bucket.FilterBucketTranslator();
+        registry.register(filterTranslator);
+
+        // Build a plan with the filter agg so we get a proper ExecutionResult
+        org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder filterAgg =
+            new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                "active_only",
+                new org.opensearch.index.query.TermQueryBuilder("status", "active")
+            );
+
+        // Create mock result rows with _count = 3
+        List<Object[]> rows = new java.util.ArrayList<>();
+        rows.add(new Object[] { 3L });
+        org.opensearch.dsl.aggregation.AggregationMetadata metadata = createFilterAggMetadata();
+
+        // Build a LogicalAggregate whose row type is [_count: BIGINT] to match the filter plan
+        org.opensearch.dsl.golden.CalciteTestInfra.InfraResult infra = org.opensearch.dsl.golden.CalciteTestInfra.buildFromMapping(
+            "test-index",
+            java.util.Map.of("status", "VARCHAR")
+        );
+        org.apache.calcite.rel.RelNode scan = org.apache.calcite.rel.logical.LogicalTableScan.create(
+            infra.cluster(),
+            infra.table(),
+            List.of()
+        );
+        org.apache.calcite.rel.RelNode dummyNode = org.apache.calcite.rel.logical.LogicalAggregate.create(
+            scan,
+            org.apache.calcite.util.ImmutableBitSet.of(),
+            null,
+            List.of(
+                org.apache.calcite.rel.core.AggregateCall.create(
+                    org.apache.calcite.sql.fun.SqlStdOperatorTable.COUNT,
+                    false,
+                    false,
+                    false,
+                    List.of(),
+                    -1,
+                    org.apache.calcite.rel.RelCollations.EMPTY,
+                    scan.getCluster().getTypeFactory().createSqlType(org.apache.calcite.sql.type.SqlTypeName.BIGINT),
+                    "_count"
+                )
+            )
+        );
+
+        org.opensearch.dsl.executor.QueryPlans.QueryPlan plan = new org.opensearch.dsl.executor.QueryPlans.QueryPlan(
+            org.opensearch.dsl.executor.QueryPlans.Type.AGGREGATION,
+            dummyNode,
+            metadata
+        );
+        ExecutionResult result = new ExecutionResult(plan, rows);
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of(result));
+        InternalAggregations aggs = builder.build(List.of(filterAgg));
+
+        assertEquals(1, aggs.asList().size());
+        assertEquals("active_only", aggs.asList().get(0).getName());
+        assertTrue(aggs.asList().get(0) instanceof org.opensearch.search.aggregations.bucket.filter.InternalFilter);
+        org.opensearch.search.aggregations.bucket.filter.InternalFilter filterResult =
+            (org.opensearch.search.aggregations.bucket.filter.InternalFilter) aggs.asList().get(0);
+        assertEquals(3, filterResult.getDocCount());
+    }
+
+    /**
+     * Proves that a filter aggregation's sub-aggregation sees only the FILTERED document set.
+     *
+     * <p>This test supplies mock rows to BOTH the parent filter plan and the child sub-aggregation
+     * plan, then asserts the sub-aggregation value reflects only the filtered documents. The
+     * fixture numbers are chosen so filtered and unfiltered answers differ:
+     * <ul>
+     *   <li>Unfiltered total: 5 docs, avg price = (100+200+300+400+500)/5 = 300.0</li>
+     *   <li>Filtered (status=active): 3 docs, avg price = (100+200+300)/3 = 200.0</li>
+     * </ul>
+     * If the filter predicate were silently dropped, the avg would be 300.0 instead of 200.0
+     * and the doc_count would be 5 instead of 3.
+     */
+    public void testFilterSubAggScopingMultiPlan() throws Exception {
+        // Use the forward path to produce real plans from DSL
+        org.apache.calcite.schema.SchemaPlus schema = org.apache.calcite.jdbc.CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new org.apache.calcite.schema.impl.AbstractTable() {
+            @Override
+            public org.apache.calcite.rel.type.RelDataType getRowType(org.apache.calcite.rel.type.RelDataTypeFactory tf) {
+                return tf.builder()
+                    .add("name", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .add("price", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.INTEGER), true))
+                    .add("brand", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .add("status", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .build();
+            }
+        });
+
+        org.opensearch.dsl.converter.SearchSourceConverter converter = new org.opensearch.dsl.converter.SearchSourceConverter(schema);
+
+        // filter(status=active) with avg(price) sub-agg — produces ONE plan because the metric
+        // rides in the enclosing filter bucket's plan
+        org.opensearch.search.builder.SearchSourceBuilder source = new org.opensearch.search.builder.SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "active_only",
+                    new org.opensearch.index.query.TermQueryBuilder("status", "active")
+                ).subAggregation(new org.opensearch.search.aggregations.metrics.AvgAggregationBuilder("avg_price").field("price"))
+            );
+
+        org.opensearch.dsl.executor.QueryPlans plans = converter.convert(source, "test-index");
+        List<org.opensearch.dsl.executor.QueryPlans.QueryPlan> aggPlans = plans.get(
+            org.opensearch.dsl.executor.QueryPlans.Type.AGGREGATION
+        );
+        assertEquals("filter+avg produces exactly one aggregation plan", 1, aggPlans.size());
+
+        // Supply mock rows representing the FILTERED result: 3 active docs with avg price 200.0.
+        // If the predicate were dropped, the engine would return 5 docs with avg 300.0.
+        List<Object[]> filterPlanRows = new java.util.ArrayList<>();
+        filterPlanRows.add(new Object[] { 200.0, 3L });
+        List<ExecutionResult> results = new java.util.ArrayList<>();
+        results.add(new ExecutionResult(aggPlans.get(0), filterPlanRows));
+
+        // Add the COUNT plan to provide hits.total
+        for (org.opensearch.dsl.executor.QueryPlans.QueryPlan countPlan : plans.get(org.opensearch.dsl.executor.QueryPlans.Type.COUNT)) {
+            List<String> fields = countPlan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                if (fields.get(i).equals("_total")) {
+                    row[i] = 5L;
+                } else {
+                    row[i] = 5L;
+                }
+            }
+            results.add(new ExecutionResult(countPlan, List.<Object[]>of(row)));
+        }
+
+        org.opensearch.action.search.SearchRequest searchRequest = new org.opensearch.action.search.SearchRequest("test-index");
+        searchRequest.source(source);
+        org.opensearch.action.search.SearchResponse response = SearchResponseBuilder.build(
+            results,
+            searchRequest,
+            converter.getAggregationRegistry(),
+            0L
+        );
+
+        // Verify the filter's doc_count reflects filtered set (3, not 5)
+        org.opensearch.search.aggregations.bucket.filter.InternalFilter filterResult = response.getAggregations().get("active_only");
+        assertNotNull("filter aggregation must be present", filterResult);
+        assertEquals("doc_count must reflect filtered documents (3, not unfiltered 5)", 3, filterResult.getDocCount());
+
+        // Verify the sub-aggregation avg reflects filtered data (200.0, not unfiltered 300.0)
+        org.opensearch.search.aggregations.metrics.InternalAvg avgResult = filterResult.getAggregations().get("avg_price");
+        assertNotNull("avg sub-aggregation must be present", avgResult);
+        assertEquals("avg must reflect filtered documents (200.0, not unfiltered 300.0)", 200.0, avgResult.getValue(), 0.001);
+    }
+
+    private org.opensearch.dsl.aggregation.AggregationMetadata createFilterAggMetadata() {
+        return new org.opensearch.dsl.aggregation.AggregationMetadata(
+            List.of("active_only"),
+            org.apache.calcite.util.ImmutableBitSet.of(),
+            List.of(),
+            List.of(
+                org.apache.calcite.rel.core.AggregateCall.create(
+                    org.apache.calcite.sql.fun.SqlStdOperatorTable.COUNT,
+                    false,
+                    false,
+                    false,
+                    List.of(),
+                    -1,
+                    org.apache.calcite.rel.RelCollations.EMPTY,
+                    new org.apache.calcite.sql.type.SqlTypeFactoryImpl(org.apache.calcite.rel.type.RelDataTypeSystem.DEFAULT).createSqlType(
+                        org.apache.calcite.sql.type.SqlTypeName.BIGINT
+                    ),
+                    "_count"
+                )
+            ),
+            List.of("_count"),
+            List.of(),
+            null,
+            null,
+            null,
+            java.util.Map.of(),
+            null
+        );
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -271,6 +271,214 @@ public class AggregationResponseBuilderTests extends OpenSearchTestCase {
         assertEquals("avg must reflect filtered documents (200.0, not unfiltered 300.0)", 200.0, avgResult.getValue(), 0.001);
     }
 
+    /**
+     * Reproduces the unsized-render-path defect: a {@code terms} aggregation nested inside a
+     * {@code filter} aggregation must receive buckets through the sized path. The filter's
+     * zero-field grouping must not block the metadata builder from recognising the terms plan
+     * as bounded.
+     *
+     * <p>Feeds mock rows to BOTH plans (filter bucket + terms sub-agg) and asserts the terms
+     * buckets are correct.
+     *
+     * <p>Note: the golden fixture {@code terms_nested_in_filter.json} is {@code planShapeOnly}
+     * because its multi-plan structure prevents a single mock-row array from covering all plans.
+     * This test and {@link #testTermsNestedInFilterSizeTruncation()} cover the response path.
+     */
+    public void testTermsNestedInFilterResponsePath() throws Exception {
+        org.apache.calcite.schema.SchemaPlus schema = org.apache.calcite.jdbc.CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new org.apache.calcite.schema.impl.AbstractTable() {
+            @Override
+            public org.apache.calcite.rel.type.RelDataType getRowType(org.apache.calcite.rel.type.RelDataTypeFactory tf) {
+                return tf.builder()
+                    .add("category", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .add("status", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .build();
+            }
+        });
+
+        org.opensearch.dsl.converter.SearchSourceConverter converter = new org.opensearch.dsl.converter.SearchSourceConverter(
+            schema,
+            org.opensearch.dsl.golden.TestMapperServices.fromSqlMapping(java.util.Map.of("category", "VARCHAR"))
+        );
+
+        // filter(status=active) with terms(category) sub-agg — produces TWO aggregation plans:
+        // one for the filter bucket, one for the terms sub-aggregation.
+        org.opensearch.search.builder.SearchSourceBuilder source = new org.opensearch.search.builder.SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "active_only",
+                    new org.opensearch.index.query.TermQueryBuilder("status", "active")
+                ).subAggregation(new org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder("by_cat").field("category"))
+            );
+
+        org.opensearch.dsl.executor.QueryPlans plans = converter.convert(source, "test-index");
+        List<org.opensearch.dsl.executor.QueryPlans.QueryPlan> aggPlans = plans.get(
+            org.opensearch.dsl.executor.QueryPlans.Type.AGGREGATION
+        );
+        assertEquals("filter+terms produces exactly two aggregation plans", 2, aggPlans.size());
+
+        // Assert that the child terms plan carries the ancestor filter predicate (status=active).
+        // This makes the test falsifiable: deleting the production ancestor-filter injection
+        // will cause this assertion to fail.
+        String childPlan = aggPlans.get(1).relNode().explain();
+        assertTrue(
+            "child terms plan must carry the ancestor filter predicate: " + childPlan,
+            childPlan.contains("$1") && childPlan.contains("active")
+        );
+
+        // Identify which plan is the filter bucket plan and which is the terms plan by
+        // inspecting their metadata's agg name path.
+        List<ExecutionResult> results = new java.util.ArrayList<>();
+        for (org.opensearch.dsl.executor.QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> path = plan.aggregationMetadata().getAggNamePath();
+            if (path.size() == 1 && path.get(0).equals("active_only")) {
+                // Filter bucket plan: returns _count = 4 (4 active docs)
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { 4L })));
+            } else if (path.size() == 2 && path.get(1).equals("by_cat")) {
+                // Terms sub-agg plan: 2 buckets within the filter scope
+                // Fields: category (group key), _count, with parent eligible riding along
+                List<Object[]> termsRows = new java.util.ArrayList<>();
+                termsRows.add(new Object[] { "electronics", 3L, 4L });
+                termsRows.add(new Object[] { "books", 1L, 4L });
+                results.add(new ExecutionResult(plan, termsRows));
+            }
+        }
+        assertEquals("Both plans must have results", 2, results.size());
+
+        // Add the COUNT plan to provide hits.total
+        for (org.opensearch.dsl.executor.QueryPlans.QueryPlan countPlan : plans.get(org.opensearch.dsl.executor.QueryPlans.Type.COUNT)) {
+            List<String> fields = countPlan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                row[i] = 10L;
+            }
+            results.add(new ExecutionResult(countPlan, List.<Object[]>of(row)));
+        }
+
+        org.opensearch.action.search.SearchRequest searchRequest = new org.opensearch.action.search.SearchRequest("test-index");
+        searchRequest.source(source);
+        org.opensearch.action.search.SearchResponse response = SearchResponseBuilder.build(
+            results,
+            searchRequest,
+            converter.getAggregationRegistry(),
+            0L
+        );
+
+        // Verify filter bucket
+        org.opensearch.search.aggregations.bucket.filter.InternalFilter filterResult = response.getAggregations().get("active_only");
+        assertNotNull("filter aggregation must be present", filterResult);
+        assertEquals("filter doc_count must be 4", 4, filterResult.getDocCount());
+
+        // Verify terms sub-aggregation buckets
+        org.opensearch.search.aggregations.bucket.terms.StringTerms termsResult = filterResult.getAggregations().get("by_cat");
+        assertNotNull("terms sub-aggregation must be present", termsResult);
+        assertEquals("terms must have 2 buckets", 2, termsResult.getBuckets().size());
+        assertEquals("electronics", termsResult.getBuckets().get(0).getKeyAsString());
+        assertEquals(3, termsResult.getBuckets().get(0).getDocCount());
+        assertEquals("books", termsResult.getBuckets().get(1).getKeyAsString());
+        assertEquals(1, termsResult.getBuckets().get(1).getDocCount());
+    }
+
+    /**
+     * Proves the bounded-plan path actually enforces the {@code size} limit: a nested terms
+     * with {@code size=2} receiving 3 distinct values must truncate to the top 2 buckets.
+     */
+    public void testTermsNestedInFilterSizeTruncation() throws Exception {
+        org.apache.calcite.schema.SchemaPlus schema = org.apache.calcite.jdbc.CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new org.apache.calcite.schema.impl.AbstractTable() {
+            @Override
+            public org.apache.calcite.rel.type.RelDataType getRowType(org.apache.calcite.rel.type.RelDataTypeFactory tf) {
+                return tf.builder()
+                    .add("category", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .add("status", tf.createTypeWithNullability(tf.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR), true))
+                    .build();
+            }
+        });
+
+        org.opensearch.dsl.converter.SearchSourceConverter converter = new org.opensearch.dsl.converter.SearchSourceConverter(
+            schema,
+            org.opensearch.dsl.golden.TestMapperServices.fromSqlMapping(java.util.Map.of("category", "VARCHAR"))
+        );
+
+        // filter(status=active) with terms(category, size=2) — 3 distinct values, only top 2 should survive
+        org.opensearch.search.builder.SearchSourceBuilder source = new org.opensearch.search.builder.SearchSourceBuilder().size(0)
+            .aggregation(
+                new org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder(
+                    "active_only",
+                    new org.opensearch.index.query.TermQueryBuilder("status", "active")
+                ).subAggregation(
+                    new org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder("by_cat").field("category").size(2)
+                )
+            );
+
+        org.opensearch.dsl.executor.QueryPlans plans = converter.convert(source, "test-index");
+        List<org.opensearch.dsl.executor.QueryPlans.QueryPlan> aggPlans = plans.get(
+            org.opensearch.dsl.executor.QueryPlans.Type.AGGREGATION
+        );
+        assertEquals("filter+terms produces exactly two aggregation plans", 2, aggPlans.size());
+
+        // Assert that the child terms plan carries the ancestor filter predicate (status=active).
+        // This makes the test falsifiable: deleting the production ancestor-filter injection
+        // will cause this assertion to fail.
+        String childPlan = aggPlans.get(1).relNode().explain();
+        assertTrue(
+            "child terms plan must carry the ancestor filter predicate: " + childPlan,
+            childPlan.contains("$1") && childPlan.contains("active")
+        );
+
+        List<ExecutionResult> results = new java.util.ArrayList<>();
+        for (org.opensearch.dsl.executor.QueryPlans.QueryPlan plan : aggPlans) {
+            List<String> path = plan.aggregationMetadata().getAggNamePath();
+            if (path.size() == 1 && path.get(0).equals("active_only")) {
+                // Filter bucket plan: 6 active docs
+                results.add(new ExecutionResult(plan, List.<Object[]>of(new Object[] { 6L })));
+            } else if (path.size() == 2 && path.get(1).equals("by_cat")) {
+                // Terms sub-agg: 3 categories, only top 2 by count should appear in output
+                // The plan has a LIMIT 2, so the engine only returns 2 rows — but we supply
+                // exactly 2 to simulate the engine-enforced limit. The eligible count (6) tells
+                // the response builder there were more docs than the 2 buckets account for.
+                List<Object[]> termsRows = new java.util.ArrayList<>();
+                termsRows.add(new Object[] { "electronics", 3L });
+                termsRows.add(new Object[] { "clothing", 2L });
+                results.add(new ExecutionResult(plan, termsRows));
+            }
+        }
+        assertEquals("Both plans must have results", 2, results.size());
+
+        // COUNT plan with eligible doc count
+        for (org.opensearch.dsl.executor.QueryPlans.QueryPlan countPlan : plans.get(org.opensearch.dsl.executor.QueryPlans.Type.COUNT)) {
+            List<String> fields = countPlan.relNode().getRowType().getFieldNames();
+            Object[] row = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                row[i] = 6L;
+            }
+            results.add(new ExecutionResult(countPlan, List.<Object[]>of(row)));
+        }
+
+        org.opensearch.action.search.SearchRequest searchRequest = new org.opensearch.action.search.SearchRequest("test-index");
+        searchRequest.source(source);
+        org.opensearch.action.search.SearchResponse response = SearchResponseBuilder.build(
+            results,
+            searchRequest,
+            converter.getAggregationRegistry(),
+            0L
+        );
+
+        org.opensearch.search.aggregations.bucket.filter.InternalFilter filterResult = response.getAggregations().get("active_only");
+        assertNotNull("filter aggregation must be present", filterResult);
+        assertEquals("filter doc_count must be 6", 6, filterResult.getDocCount());
+
+        org.opensearch.search.aggregations.bucket.terms.StringTerms termsResult = filterResult.getAggregations().get("by_cat");
+        assertNotNull("terms sub-aggregation must be present", termsResult);
+        assertEquals("size=2 must truncate to exactly 2 buckets", 2, termsResult.getBuckets().size());
+        assertEquals("electronics", termsResult.getBuckets().get(0).getKeyAsString());
+        assertEquals(3, termsResult.getBuckets().get(0).getDocCount());
+        assertEquals("clothing", termsResult.getBuckets().get(1).getKeyAsString());
+        assertEquals(2, termsResult.getBuckets().get(1).getDocCount());
+        // sum_other_doc_count = eligible(6) - sum_of_returned_buckets(3+2) = 1
+        assertEquals("sum_other_doc_count must reflect truncated bucket", 1, termsResult.getSumOfOtherDocCounts());
+    }
+
     private org.opensearch.dsl.aggregation.AggregationMetadata createFilterAggMetadata() {
         return new org.opensearch.dsl.aggregation.AggregationMetadata(
             List.of("active_only"),
@@ -297,7 +505,8 @@ public class AggregationResponseBuilderTests extends OpenSearchTestCase {
             null,
             null,
             java.util.Map.of(),
-            null
+            null,
+            List.of()
         );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -522,6 +522,15 @@ public class SearchResponseBuilderTests extends OpenSearchTestCase {
             String fileName = file.getFileName().toString();
             try {
                 GoldenTestCase tc = GoldenFileLoader.load(fileName);
+
+                // Fixtures marked planShapeOnly serve only as plan-shape proof and are
+                // not tested for response generation (see testGoldenFileRelNodeGeneration).
+                // The response driver feeds mock rows to only the FIRST matching plan, so
+                // multi-plan fixtures (e.g. sibling filter aggs) cannot be response-tested here.
+                if (tc.isPlanShapeOnly()) {
+                    continue;
+                }
+
                 CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping(tc.getIndexName(), tc.getIndexMapping());
 
                 // Build QueryPlan via forward path (needed to construct ExecutionResult)

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_bare_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_bare_aggregation.json
@@ -1,0 +1,51 @@
+{
+  "testName": "filter_bare_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "active_only": {
+        "filter": {
+          "term": {
+            "status": "active"
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], _count=[COUNT()])",
+    "  LogicalFilter(condition=[=($3, CAST('active':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["_count"],
+  "mockResultRows": [
+    [3]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  },
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 5,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "active_only": {
+        "doc_count": 3
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_match_all_nested_in_terms.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_match_all_nested_in_terms.json
@@ -1,0 +1,44 @@
+{
+  "testName": "filter_match_all_nested_in_terms",
+  "indexName": "test-index",
+  "planShapeOnly": true,
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "all_in_bucket": {
+            "filter": {
+              "match_all": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+    "  LogicalAggregate(group=[{2}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[IS NOT NULL($2)])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "_count"],
+  "mockResultRows": [
+    ["BrandA", 3],
+    ["BrandB", 2]
+  ],
+  "mockCountRow": {
+    "_total": 5,
+    "_eligible$by_brand": 5
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_nested_in_terms.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_nested_in_terms.json
@@ -1,0 +1,46 @@
+{
+  "testName": "filter_nested_in_terms",
+  "indexName": "test-index",
+  "planShapeOnly": true,
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "active_only": {
+            "filter": {
+              "term": {
+                "status": "active"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC], fetch=[10])",
+    "  LogicalAggregate(group=[{2}], _count=[COUNT()])",
+    "    LogicalFilter(condition=[IS NOT NULL($2)])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["brand", "_count"],
+  "mockResultRows": [
+    ["BrandA", 3],
+    ["BrandB", 2]
+  ],
+  "mockCountRow": {
+    "_total": 5,
+    "_eligible$by_brand": 5
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_range_inner_query.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_range_inner_query.json
@@ -1,0 +1,64 @@
+{
+  "testName": "filter_range_inner_query",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "price_band": {
+        "filter": {
+          "range": {
+            "price": {
+              "gte": 300,
+              "lt": 600
+            }
+          }
+        },
+        "aggregations": {
+          "avg_price": {
+            "avg": {
+              "field": "price"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], avg_price=[AVG($1)], _count=[COUNT()])",
+    "  LogicalFilter(condition=[AND(>=($1, CAST(300):INTEGER), <($1, CAST(600):INTEGER))])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["avg_price", "_count"],
+  "mockResultRows": [
+    [450.0, 3]
+  ],
+  "mockCountRow": {
+    "_total": 8
+  },
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 8,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "price_band": {
+        "doc_count": 3,
+        "avg_price": {
+          "value": 450.0
+        }
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_sibling_aggregations.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_sibling_aggregations.json
@@ -1,0 +1,43 @@
+{
+  "testName": "filter_sibling_aggregations",
+  "indexName": "test-index",
+  "planShapeOnly": true,
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "active_only": {
+        "filter": {
+          "term": {
+            "status": "active"
+          }
+        }
+      },
+      "brand_a_only": {
+        "filter": {
+          "term": {
+            "brand": "BrandA"
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], _count=[COUNT()])",
+    "  LogicalFilter(condition=[=($3, CAST('active':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["_count"],
+  "mockResultRows": [
+    [3]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_with_avg_subagg.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_with_avg_subagg.json
@@ -1,0 +1,61 @@
+{
+  "testName": "filter_with_avg_subagg",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "active_only": {
+        "filter": {
+          "term": {
+            "status": "active"
+          }
+        },
+        "aggregations": {
+          "avg_price": {
+            "avg": {
+              "field": "price"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], avg_price=[AVG($1)], _count=[COUNT()])",
+    "  LogicalFilter(condition=[=($3, CAST('active':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["avg_price", "_count"],
+  "mockResultRows": [
+    [850.0, 3]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  },
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 5,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "active_only": {
+        "doc_count": 3,
+        "avg_price": {
+          "value": 850.0
+        }
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_zero_match.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/filter_zero_match.json
@@ -1,0 +1,61 @@
+{
+  "testName": "filter_zero_match",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "impossible": {
+        "filter": {
+          "term": {
+            "status": "nonexistent_value"
+          }
+        },
+        "aggregations": {
+          "avg_price": {
+            "avg": {
+              "field": "price"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], avg_price=[AVG($1)], _count=[COUNT()])",
+    "  LogicalFilter(condition=[=($3, CAST('nonexistent_value':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["avg_price", "_count"],
+  "mockResultRows": [
+    [null, 0]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  },
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 5,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "impossible": {
+        "doc_count": 0,
+        "avg_price": {
+          "value": null
+        }
+      }
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_nested_in_filter.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_nested_in_filter.json
@@ -1,0 +1,43 @@
+{
+  "testName": "terms_nested_in_filter",
+  "indexName": "test-index",
+  "planShapeOnly": true,
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "status": "VARCHAR"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "active_only": {
+        "filter": {
+          "term": {
+            "status": "active"
+          }
+        },
+        "aggregations": {
+          "by_brand": {
+            "terms": {
+              "field": "brand"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{}], _count=[COUNT()])",
+    "  LogicalFilter(condition=[=($3, CAST('active':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["_count"],
+  "mockResultRows": [
+    [3]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilter.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilter.java
@@ -45,7 +45,8 @@ import java.util.Map;
  * @opensearch.internal
  */
 public class InternalFilter extends InternalSingleBucketAggregation implements Filter {
-    InternalFilter(String name, long docCount, InternalAggregations subAggregations, Map<String, Object> metadata) {
+    // Public visibility: sandbox DSL plugin constructs filter results directly from plan output.
+    public InternalFilter(String name, long docCount, InternalAggregations subAggregations, Map<String, Object> metadata) {
         super(name, docCount, subAggregations, metadata);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Registers the `filter` bucket aggregation on the DSL Calcite path.

A `filter` aggregation is not a grouping — it is a `WHERE` predicate scoped to a single bucket. It is therefore translated to a Calcite `LogicalFilter` injected between the table scan and the `LogicalAggregate`, and its inner query is converted through the same `QueryRegistry` the top-level `query` clause uses, so no query-translation logic is duplicated. As additional query translators land in `main`, the filter aggregation inherits them with no further change here.

Before this change, every `filter` aggregation was rejected:

```
HTTP 400  No translator registered for aggregation type: FilterAggregationBuilder
```

`SearchActionFilter` intercepts all `_search` requests and never calls `chain.proceed()`, so there is no fallback to classic execution — a single `filter` aggregation anywhere in the request body failed the entire request.

#### Scoping nested sub-aggregations

One request produces several RelNode plans, keyed by aggregation-name path. A nested **bucket** sub-aggregation therefore gets its own plan and does not inherit the parent's predicate implicitly. Ancestor filters are accumulated through `PathStep` in `AggregationTreeWalker` and re-applied to every descendant plan, and separately to the eligible-document-count plan from which `sum_other_doc_count` is derived. Metric children were never affected — they reuse the parent's builder directly, which is why metric scoping cannot be used as evidence that bucket scoping works.

The invariant asserted throughout is:

```
sum(child bucket doc_counts) + sum_other_doc_count == parent doc_count
```

#### Server change

`InternalFilter`'s 4-arg constructor is widened from package-private to `public` — a one-word additive change. The only pre-existing public constructor takes a `StreamInput` for wire deserialisation, and the superclass constructor is `protected`, so a cross-package caller has no other route.

`InternalReverseNested` is public precedent. In fairness the nearest single-bucket siblings (`InternalNested`, `InternalGlobal`, `InternalMissing`, `InternalSampler`) are all package-private — they simply have no cross-module caller, which this does.

#### Supported query shapes

Inner query may be any of `term`, `terms`, `match_all`, `exists`, `range` — five types — in any of these positions:

| Shape | Behaviour |
|---|---|
| Bare `filter`, no children | `doc_count` of matching documents |
| `filter` + metric child (`avg`/`sum`/`min`/`max`) | Metric computed over matching documents only |
| `filter` + `terms` bucket child | Child buckets scoped to the parent predicate |
| `filter` + `terms` child with explicit `size` | Top-K plus `sum_other_doc_count` against the filtered parent |
| `filter` inside `filter` | Predicates conjoin on the leaf plan |
| `filter` inside `terms` | Predicate applies within each outer bucket |
| Sibling `filter` aggregations | Independent predicates, no cross-contamination |

`range` was gained automatically: the range query translator (#22511) landed in `main`, and because the filter aggregation routes its inner query through the shared `QueryRegistry`, it inherited range support with no code change here. The same mechanism means `bool`, `prefix`, `wildcard`, `fuzzy`, `regexp`, and `ids` will each light up as their own translator PRs merge.

An inner query of any other type — including `bool` and `multi_terms` — is rejected at plan-build time with `HTTP 400` naming both the aggregation and the offending query type, rather than being silently ignored.

#### Field type coverage in filter predicates — measured on a live cluster

| Field type | Calcite type | `term` / `terms` | `range` | `exists` |
|---|---|---|---|---|
| `keyword` | VARCHAR | works | — | works |
| `long` | BIGINT | works | works | works |
| `boolean` | BOOLEAN | **fails, HTTP 500** | — | works |
| `date` | TIMESTAMP | **fails, HTTP 400 guard** | works | works |
| `ip` | VARBINARY | **fails, HTTP 400 guard** | — | works |

The remaining `term` failures are pre-existing in the shared query-translation path and are not introduced by this PR — they are simply reachable through a filter aggregation's inner query. A control experiment previously ran each predicate as a plain top-level `query` with no aggregation present, and each reproduced the identical exception at the identical line:

| Predicate | Top-level `query` and inside `filter` agg |
|---|---|
| `term` on `boolean` | 500 `IllegalStateException` at `LuceneFragmentConvertor.toQueryBuilder:379` — identical in both positions |
| `term` on `date` | Clean 400 guard `Term queries on date fields are not yet supported on the DSL conversion path` (improved from a prior 500 `ClassCastException` String→Long) |
| `term` on `ip` | Clean 400 guard `Term queries on ip fields are not yet supported on the DSL conversion path`; node stays green (previously a node-fatal `StackOverflowError` at `RelDataTypeFactoryImpl.canonize:447`) |

A keyword control in the same run returned `HTTP 200`, confirming the top-level path is healthy and these failures are type-specific rather than path-specific. Because `exists` renders as `IS NOT NULL` and never constructs a literal, it succeeds on every type including `ip`.

The earlier `ip` node-termination is closed: upstream added an `IpTranslatorMapper` throw-only stub that prevents the VARBINARY literal construction that previously recursed to death in Calcite's type factory. The 2026-08-25 cluster run recorded zero `StackOverflowError` and the node staying green. Boolean `term` is the one remaining `HTTP 500`; it is pre-existing shared-engine code (`IllegalStateException` at `LuceneFragmentConvertor.java:379`), not introduced here.

#### Known divergences from the codec path

All inherited from shared infrastructure; this PR makes them reachable in an aggregation context but does not create them.

| Condition | Divergence |
|---|---|
| `term` on a bare `text` field | Raw whole-string equality, not analyzed-token matching. `keyword` and `text.keyword` are unaffected. |
| `term` on a `date` field | Rejected with a clean `HTTP 400` guard; not yet functional. A `range` on a date field works. |
| `exists` on fields vanilla treats as absent (`index: false`, `ignore_above` exceeded, `ignore_malformed`) | Likely reports present where vanilla reports absent. Not measured. |
| Field types absent from the Calcite schema (`geo_point`, `nested`, `object`, `flat_object`, `wildcard`, `constant_keyword`, `version`, `*_range`, and others) | `HTTP 400 Field '<name>' not found in schema` instead of executing. |
| Multi-valued fields | Not reachable — rejected at index time by the Parquet writer. |

The `filter` aggregation itself has no parameters beyond its inner query and sub-aggregations, so there is no parameter gap against the aggregation's documented surface.

#### Testing

Unit: 426 tests / 0 failures, `spotlessJavaCheck` clean. Seven golden fixtures covering bare filter, metric child, bucket child, sibling filters, `match_all`, zero-match, and filter-nested-in-terms. Fixtures that produce multiple aggregation plans declare `planShapeOnly: true` explicitly, guarded by three loader tests, because the golden response driver supplies mock rows only to the first matching plan.

End-to-end on a live single-node cluster with the analytics engine enabled: 17 rows executed, 14 PASS / 3 REJECTED / 0 not-run, with expectations written and timestamped before any query was issued, recording both the correct value and the value a broken implementation would produce. Covered: all five inner query types, metric and bucket children, truncation with `sum_other_doc_count`, nested filters, sibling filters, and filter-inside-terms. Every row with a bucket child satisfied the arithmetic invariant above.

Range inner queries were the headline new result:

- `filter(range value gte 300 lt 600)` → `terms category size 10` returned parent `doc_count` 3 with `clothing:2`, `electronics:1`, `sum_other_doc_count` 0.
- The same filter with `size:1` returned parent 3, `clothing:2`, `sum_other_doc_count` 1 — computed against the filtered parent of 3, not the unfiltered 8.
- `filter(range created gte "2021-01-01")` → `terms region` returned parent 3 with `east`/`north`/`west` 1 each, confirming range works on a date field.

The three REJECTED rows are the non-functional `term` cases above (boolean 500, date 400 guard, ip 400 guard); each is inherited from shared translator infrastructure, not introduced here.

Not covered by automated tests: `DslAggregationIT` carries a class-level `@AwaitsFix` and `DslIntegTestBase.createTestIndex` creates plain Lucene indices, so there is no engine-mode integration coverage for this or any other DSL aggregation. The end-to-end evidence above is a manual cluster run, not something CI exercises.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
