### PR TITLE
[primary shard balance] relocate blocking replica for primary rebalance

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -175,6 +175,13 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         Property.NodeScope
     );
 
+    public static final Setting<Boolean> RELOCATE_BLOCKING_REPLICA_FOR_PRIMARY_REBALANCE = Setting.boolSetting(
+        "cluster.routing.allocation.rebalance.primary.relocate_blocking_replica.enable",
+        false,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final Setting<Boolean> IGNORE_THROTTLE_FOR_REMOTE_RESTORE = Setting.boolSetting(
         "cluster.routing.allocation.remote_primary.ignore_throttle",
         true,
@@ -238,6 +245,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
     private volatile boolean preferPrimaryShardBalance;
     private volatile boolean preferPrimaryShardRebalance;
+    private volatile boolean relocateBlockingReplicaEnabled;
     private volatile float preferPrimaryShardRebalanceBuffer;
     private volatile float indexBalanceFactor;
     private volatile float shardBalanceFactor;
@@ -266,6 +274,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         setPrimaryConstraintThresholdSetting(PRIMARY_CONSTRAINT_THRESHOLD_SETTING.get(settings));
         setPreferPrimaryShardBalance(PREFER_PRIMARY_SHARD_BALANCE.get(settings));
         setPreferPrimaryShardRebalance(PREFER_PRIMARY_SHARD_REBALANCE.get(settings));
+        setRelocateBlockingReplicaEnabled(RELOCATE_BLOCKING_REPLICA_FOR_PRIMARY_REBALANCE.get(settings));
         setShardMovementStrategy(SHARD_MOVEMENT_STRATEGY_SETTING.get(settings));
         setAllocatorTimeout(ALLOCATOR_TIMEOUT_SETTING.get(settings));
         setFollowUpRerouteTaskPriority(FOLLOW_UP_REROUTE_PRIORITY_SETTING.get(settings));
@@ -276,6 +285,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         clusterSettings.addSettingsUpdateConsumer(SHARD_BALANCE_FACTOR_SETTING, this::updateShardBalanceFactor);
         clusterSettings.addSettingsUpdateConsumer(PRIMARY_SHARD_REBALANCE_BUFFER, this::updatePreferPrimaryShardBalanceBuffer);
         clusterSettings.addSettingsUpdateConsumer(PREFER_PRIMARY_SHARD_REBALANCE, this::setPreferPrimaryShardRebalance);
+        clusterSettings.addSettingsUpdateConsumer(RELOCATE_BLOCKING_REPLICA_FOR_PRIMARY_REBALANCE, this::setRelocateBlockingReplicaEnabled);
         clusterSettings.addSettingsUpdateConsumer(THRESHOLD_SETTING, this::setThreshold);
         clusterSettings.addSettingsUpdateConsumer(PRIMARY_CONSTRAINT_THRESHOLD_SETTING, this::setPrimaryConstraintThresholdSetting);
         clusterSettings.addSettingsUpdateConsumer(IGNORE_THROTTLE_FOR_REMOTE_RESTORE, this::setIgnoreThrottleInRestore);
@@ -368,6 +378,10 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         this.weightFunction.updateRebalanceConstraint(CLUSTER_PRIMARY_SHARD_REBALANCE_CONSTRAINT_ID, preferPrimaryShardRebalance);
     }
 
+    private void setRelocateBlockingReplicaEnabled(boolean relocateBlockingReplicaEnabled) {
+        this.relocateBlockingReplicaEnabled = relocateBlockingReplicaEnabled;
+    }
+
     private void setThreshold(float threshold) {
         this.threshold = threshold;
     }
@@ -409,6 +423,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             threshold,
             preferPrimaryShardBalance,
             preferPrimaryShardRebalance,
+            relocateBlockingReplicaEnabled,
             ignoreThrottleInRestore,
             this::allocatorTimedOut
         );
@@ -435,6 +450,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             threshold,
             preferPrimaryShardBalance,
             preferPrimaryShardRebalance,
+            relocateBlockingReplicaEnabled,
             ignoreThrottleInRestore,
             () -> false // as we don't need to check if timed out or not while just understanding ShardAllocationDecision
         );
@@ -795,7 +811,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             float threshold,
             boolean preferPrimaryBalance
         ) {
-            super(logger, allocation, shardMovementStrategy, weight, threshold, preferPrimaryBalance, false, false, () -> false);
+            super(logger, allocation, shardMovementStrategy, weight, threshold, preferPrimaryBalance, false, false, false, () -> false);
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -64,6 +64,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
 
     private final boolean preferPrimaryBalance;
     private final boolean preferPrimaryRebalance;
+    private final boolean relocateBlockingReplicaEnabled;
 
     private final boolean ignoreThrottleInRestore;
     private final BalancedShardsAllocator.WeightFunction weight;
@@ -77,6 +78,10 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private final Supplier<Boolean> timedOutFunc;
     private int totalShardCount = 0;
 
+    // Per-index guard: true once a blocking replica has been relocated during the current index's rebalance pass.
+    // Reset to false at the start of each index in balanceByWeights().
+    private boolean blockingReplicaRelocated = false;
+
     public LocalShardsBalancer(
         Logger logger,
         RoutingAllocation allocation,
@@ -85,6 +90,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         float threshold,
         boolean preferPrimaryBalance,
         boolean preferPrimaryRebalance,
+        boolean relocateBlockingReplicaEnabled,
         boolean ignoreThrottleInRestore,
         Supplier<Boolean> timedOutFunc
     ) {
@@ -102,6 +108,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         inEligibleTargetNode = new HashSet<>();
         this.preferPrimaryBalance = preferPrimaryBalance;
         this.preferPrimaryRebalance = preferPrimaryRebalance;
+        this.relocateBlockingReplicaEnabled = relocateBlockingReplicaEnabled;
         this.shardMovementStrategy = shardMovementStrategy;
         this.ignoreThrottleInRestore = ignoreThrottleInRestore;
         this.timedOutFunc = timedOutFunc;
@@ -350,6 +357,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         final BalancedShardsAllocator.ModelNode[] modelNodes = sorter.modelNodes;
         final float[] weights = sorter.weights;
         for (String index : buildWeightOrderedIndices()) {
+            blockingReplicaRelocated = false;
             // Terminate if the time allocated to the balanced shards allocator has elapsed
             if (timedOutFunc != null && timedOutFunc.get()) {
                 logger.info(
@@ -1081,20 +1089,47 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 }
                 final Decision allocationDecision = deciders.canAllocate(shard, minNode.getRoutingNode(), allocation);
                 if (allocationDecision.type() == Decision.Type.NO) {
+                    if (relocateBlockingReplicaEnabled && shard.primary()) {
+                        tryRelocateBlockingReplica(shard, minNode, maxNode, deciders);
+                    }
                     continue;
                 }
                 // This is a safety net which prevents un-necessary primary shard relocations from maxNode to minNode when
                 // doing such relocation wouldn't help in primary balance. The condition won't be applicable when we enable node level
                 // primary rebalance
-                if (preferPrimaryBalance == true
-                    && preferPrimaryRebalance == false
-                    && shard.primary()
-                    && maxNode.numPrimaryShards(shard.getIndexName()) - minNode.numPrimaryShards(shard.getIndexName()) < 2) {
+                int indexDiff = maxNode.numPrimaryShards(shard.getIndexName()) - minNode.numPrimaryShards(shard.getIndexName());
+                if (preferPrimaryBalance == true && preferPrimaryRebalance == false && shard.primary() && indexDiff < 2) {
+                    logger.trace(
+                        "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], indexDiff [{}]",
+                        shard.shardId(),
+                        maxNode.getNodeId(),
+                        minNode.getNodeId(),
+                        indexDiff
+                    );
                     continue;
                 }
                 // Relax the above condition to per node to allow rebalancing to attain global balance
-                if (preferPrimaryRebalance == true && shard.primary() && maxNode.numPrimaryShards() - minNode.numPrimaryShards() < 2) {
-                    continue;
+                int nodeDiff = maxNode.numPrimaryShards() - minNode.numPrimaryShards();
+                if (preferPrimaryRebalance == true && shard.primary() && nodeDiff < 2) {
+                    boolean tryRebalanceForIndexPrimary = relocateBlockingReplicaEnabled && preferPrimaryBalance && indexDiff >= 2;
+                    if (false == tryRebalanceForIndexPrimary) {
+                        logger.trace(
+                            "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], nodeDiff [{}]",
+                            shard.shardId(),
+                            maxNode.getNodeId(),
+                            minNode.getNodeId(),
+                            nodeDiff
+                        );
+                        continue;
+                    }
+                    logger.trace(
+                        "Attempting primary relocation for per-index rebalance: shard [{}], maxNode [{}], minNode [{}], indexDiff [{}], nodeDiff [{}]",
+                        shard.shardId(),
+                        maxNode.getNodeId(),
+                        minNode.getNodeId(),
+                        indexDiff,
+                        nodeDiff
+                    );
                 }
                 final Decision decision = new Decision.Multi().add(allocationDecision).add(rebalanceDecision);
                 maxNode.removeShard(shard);
@@ -1119,6 +1154,106 @@ public class LocalShardsBalancer extends ShardsBalancer {
         }
         logger.trace("No shards of [{}] can relocate from [{}] to [{}]", idx, maxNode.getNodeId(), minNode.getNodeId());
         return false;
+    }
+
+    private void tryRelocateBlockingReplica(
+        ShardRouting primary,
+        BalancedShardsAllocator.ModelNode minNode,
+        BalancedShardsAllocator.ModelNode maxNode,
+        AllocationDeciders deciders
+    ) {
+        logger.trace(
+            "Attempting blocking replica relocation to make room for primary [{}], maxNode [{}], minNode [{}]",
+            primary,
+            maxNode.getNodeId(),
+            minNode.getNodeId()
+        );
+        if (blockingReplicaRelocated) {
+            logger.trace("Skipping blocking replica relocation for primary [{}]: already relocated in this rebalance", primary);
+            return;
+        }
+
+        final String indexName = primary.getIndexName();
+        final int indexDiff = maxNode.numPrimaryShards(indexName) - minNode.numPrimaryShards(indexName);
+        final int nodeDiff = maxNode.numPrimaryShards() - minNode.numPrimaryShards();
+        if ((preferPrimaryBalance && indexDiff < 2) || (preferPrimaryRebalance && nodeDiff < 2)) {
+            logger.trace(
+                "Skipping blocking replica relocation for primary [{}]: preferPrimaryBalance [{}] indexDiff [{}], preferPrimaryRebalance [{}] nodeDiff [{}]",
+                primary,
+                preferPrimaryBalance,
+                indexDiff,
+                preferPrimaryRebalance,
+                nodeDiff
+            );
+            return;
+        }
+        final ShardRouting blockingReplica = findBlockingReplicaOnNode(primary, minNode);
+        if (blockingReplica == null) {
+            logger.trace("No blocking replica found on minNode [{}] for primary [{}]", minNode.getNodeId(), primary);
+            return;
+        }
+        final BalancedShardsAllocator.ModelNode blockingReplicaTargetNode = findTargetNodeForBlockingReplica(
+            blockingReplica,
+            minNode,
+            maxNode,
+            deciders
+        );
+        if (blockingReplicaTargetNode == null) {
+            logger.trace("Skipping relocation for blocking replica [{}]: no target node available", blockingReplica);
+            return;
+        }
+        Decision.Type decisionType = deciders.canRebalance(blockingReplica, allocation).type();
+        if (decisionType != Decision.Type.YES) {
+            logger.trace(
+                "Skipping relocation for blocking replica [{}]: cannot be rebalanced, decision type [{}]",
+                blockingReplica,
+                decisionType
+            );
+            return;
+        }
+
+        final long replicaSize = allocation.clusterInfo().getShardSize(blockingReplica, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
+
+        logger.debug("Relocate [{}] from [{}] to [{}]", blockingReplica, minNode.getNodeId(), blockingReplicaTargetNode.getNodeId());
+
+        minNode.removeShard(blockingReplica);
+        --totalShardCount;
+        blockingReplicaTargetNode.addShard(
+            routingNodes.relocateShard(blockingReplica, blockingReplicaTargetNode.getNodeId(), replicaSize, allocation.changes()).v1()
+        );
+        ++totalShardCount;
+        blockingReplicaRelocated = true;
+    }
+
+    private ShardRouting findBlockingReplicaOnNode(ShardRouting primary, BalancedShardsAllocator.ModelNode minNode) {
+        for (ShardRouting candidate : routingNodes.assignedShards(primary.shardId())) {
+            if (candidate.primary() == false && candidate.started() && minNode.getNodeId().equals(candidate.currentNodeId())) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private BalancedShardsAllocator.ModelNode findTargetNodeForBlockingReplica(
+        ShardRouting replica,
+        BalancedShardsAllocator.ModelNode minNode,
+        BalancedShardsAllocator.ModelNode maxNode,
+        AllocationDeciders deciders
+    ) {
+        for (BalancedShardsAllocator.ModelNode candidate : sorter.modelNodes) {
+            if (candidate == null) {
+                continue;
+            }
+            final String candidateNode = candidate.getNodeId();
+            if (candidateNode.equals(minNode.getNodeId()) || candidateNode.equals(maxNode.getNodeId())) {
+                continue;
+            }
+            final Decision allocationDecision = deciders.canAllocate(replica, candidate.getRoutingNode(), allocation);
+            if (allocationDecision.type() == Decision.Type.YES) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -1168,6 +1168,15 @@ public class LocalShardsBalancer extends ShardsBalancer {
             maxNode.getNodeId(),
             minNode.getNodeId()
         );
+
+        if (preferPrimaryBalance == false && preferPrimaryRebalance == false) {
+            logger.trace(
+                "Skipping blocking replica relocation for primary [{}]: neither preferPrimaryBalance nor preferPrimaryRebalance is enabled",
+                primary
+            );
+            return;
+        }
+
         if (blockingReplicaRelocated) {
             logger.trace("Skipping blocking replica relocation for primary [{}]: already relocated in this rebalance", primary);
             return;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -1095,42 +1095,11 @@ public class LocalShardsBalancer extends ShardsBalancer {
                     continue;
                 }
                 // This is a safety net which prevents un-necessary primary shard relocations from maxNode to minNode when
-                // doing such relocation wouldn't help in primary balance. The condition won't be applicable when we enable node level
-                // primary rebalance
-                int indexDiff = maxNode.numPrimaryShards(shard.getIndexName()) - minNode.numPrimaryShards(shard.getIndexName());
-                if (preferPrimaryBalance == true && preferPrimaryRebalance == false && shard.primary() && indexDiff < 2) {
-                    logger.trace(
-                        "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], indexDiff [{}]",
-                        shard.shardId(),
-                        maxNode.getNodeId(),
-                        minNode.getNodeId(),
-                        indexDiff
-                    );
+                // doing such relocation wouldn't help in primary balance.
+                if (shouldSkipForPrimaryBalance(shard, maxNode, minNode)) {
                     continue;
                 }
-                // Relax the above condition to per node to allow rebalancing to attain global balance
-                int nodeDiff = maxNode.numPrimaryShards() - minNode.numPrimaryShards();
-                if (preferPrimaryRebalance == true && shard.primary() && nodeDiff < 2) {
-                    boolean tryRebalanceForIndexPrimary = relocateBlockingReplicaEnabled && preferPrimaryBalance && indexDiff >= 2;
-                    if (false == tryRebalanceForIndexPrimary) {
-                        logger.trace(
-                            "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], nodeDiff [{}]",
-                            shard.shardId(),
-                            maxNode.getNodeId(),
-                            minNode.getNodeId(),
-                            nodeDiff
-                        );
-                        continue;
-                    }
-                    logger.trace(
-                        "Attempting primary relocation for per-index rebalance: shard [{}], maxNode [{}], minNode [{}], indexDiff [{}], nodeDiff [{}]",
-                        shard.shardId(),
-                        maxNode.getNodeId(),
-                        minNode.getNodeId(),
-                        indexDiff,
-                        nodeDiff
-                    );
-                }
+
                 final Decision decision = new Decision.Multi().add(allocationDecision).add(rebalanceDecision);
                 maxNode.removeShard(shard);
                 --totalShardCount;
@@ -1153,6 +1122,55 @@ public class LocalShardsBalancer extends ShardsBalancer {
             }
         }
         logger.trace("No shards of [{}] can relocate from [{}] to [{}]", idx, maxNode.getNodeId(), minNode.getNodeId());
+        return false;
+    }
+
+    private boolean shouldSkipForPrimaryBalance(
+        ShardRouting shard,
+        BalancedShardsAllocator.ModelNode maxNode,
+        BalancedShardsAllocator.ModelNode minNode
+    ) {
+        if (shard.primary() == false) {
+            return false;
+        }
+        final int indexDiff = maxNode.numPrimaryShards(shard.getIndexName()) - minNode.numPrimaryShards(shard.getIndexName());
+        final int nodeDiff = maxNode.numPrimaryShards() - minNode.numPrimaryShards();
+
+        // Index-only mode: primary balance requested without node-level rebalance.
+        if (preferPrimaryBalance == true && preferPrimaryRebalance == false && indexDiff < 2) {
+            logger.trace(
+                "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], indexDiff [{}]",
+                shard.shardId(),
+                maxNode.getNodeId(),
+                minNode.getNodeId(),
+                indexDiff
+            );
+            return true;
+        }
+        // Node-level mode (also covers double-flag). When node diff is already balanced, allow
+        // relaxation to per-index rebalance if the blocking-replica feature is enabled and index
+        // diff is still imbalanced.
+        if (preferPrimaryRebalance == true && nodeDiff < 2) {
+            boolean tryRebalanceForIndexPrimary = relocateBlockingReplicaEnabled && preferPrimaryBalance && indexDiff >= 2;
+            if (tryRebalanceForIndexPrimary == false) {
+                logger.trace(
+                    "Skipping shard [{}] relocation: maxNode [{}], minNode [{}], nodeDiff [{}]",
+                    shard.shardId(),
+                    maxNode.getNodeId(),
+                    minNode.getNodeId(),
+                    nodeDiff
+                );
+                return true;
+            }
+            logger.trace(
+                "Attempting primary relocation for per-index rebalance: shard [{}], maxNode [{}], minNode [{}], indexDiff [{}], nodeDiff [{}]",
+                shard.shardId(),
+                maxNode.getNodeId(),
+                minNode.getNodeId(),
+                indexDiff,
+                nodeDiff
+            );
+        }
         return false;
     }
 
@@ -1182,18 +1200,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
             return;
         }
 
-        final String indexName = primary.getIndexName();
-        final int indexDiff = maxNode.numPrimaryShards(indexName) - minNode.numPrimaryShards(indexName);
-        final int nodeDiff = maxNode.numPrimaryShards() - minNode.numPrimaryShards();
-        if ((preferPrimaryBalance && indexDiff < 2) || (preferPrimaryRebalance && nodeDiff < 2)) {
-            logger.trace(
-                "Skipping blocking replica relocation for primary [{}]: preferPrimaryBalance [{}] indexDiff [{}], preferPrimaryRebalance [{}] nodeDiff [{}]",
-                primary,
-                preferPrimaryBalance,
-                indexDiff,
-                preferPrimaryRebalance,
-                nodeDiff
-            );
+        if (shouldSkipForPrimaryBalance(primary, maxNode, minNode)) {
             return;
         }
         final ShardRouting blockingReplica = findBlockingReplicaOnNode(primary, minNode);

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -286,6 +286,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 BalancedShardsAllocator.PRIMARY_SHARD_REBALANCE_BUFFER,
                 BalancedShardsAllocator.PREFER_PRIMARY_SHARD_BALANCE,
                 BalancedShardsAllocator.PREFER_PRIMARY_SHARD_REBALANCE,
+                BalancedShardsAllocator.RELOCATE_BLOCKING_REPLICA_FOR_PRIMARY_REBALANCE,
                 BalancedShardsAllocator.SHARD_MOVE_PRIMARY_FIRST_SETTING,
                 BalancedShardsAllocator.SHARD_MOVEMENT_STRATEGY_SETTING,
                 BalancedShardsAllocator.THRESHOLD_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -57,11 +57,13 @@ import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.opensearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
+import org.opensearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.snapshots.EmptySnapshotsInfoService;
 import org.opensearch.test.gateway.TestGatewayAllocator;
+import org.opensearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -557,6 +559,119 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             balanced = false;
         }
         assertFalse(balanced);
+    }
+
+    /**
+     * Reproduces primary imbalance caused by the interaction between
+     * primary-shard rebalance (both {@code cluster.routing.allocation.balance.prefer_primary}
+     * and {@code cluster.routing.allocation.rebalance.primary.enable} are ON)
+     * and {@link org.opensearch.cluster.routing.allocation.decider.SameShardAllocationDecider}.
+     * Initial state (3 nodes; 2 indices {@code testA} and {@code testB},
+     * each with 3 primaries and 1 replica; 12 shards total):
+     * <pre>
+     *             node_0              node_1                          node_2
+     *             ---------           ------------------------        ---------
+     * testA       PA0 PA1 PA2         RA0 RA1 RA2
+     * testB                           RB0 RB1 RB2                     PB0 PB1 PB2
+     * </pre>
+     *
+     * Primary count is 3 / 0 / 3 across the three nodes. node_1 has zero
+     * primaries but hosts the replica of every shard of BOTH indices, so
+     * any single-step attempt to move a primary onto node_1 is rejected
+     * by SameShardAllocationDecider (the matching replica is still there).
+     * Moving a primary between node_0 and node_2 is also useless because
+     * it just swaps which peer holds 3 primaries. The current weight-based
+     * rebalance logic therefore makes no progress and primaries stay at
+     * 3 / 0 / 3, causing the "2 primaries per node" assertion below to
+     * fail until the balancer is taught to first relocate a blocking
+     * replica off node_1 and then relocate a primary onto the freed slot.
+     */
+    @TestLogging(reason = "Enable trace logs for test", value = "org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator:TRACE")
+    public void testPrimaryRebalance_SameShardConstraint() {
+        AllocationService strategy = createAllocationService(
+            getSettingsBuilderForPrimaryReBalance().put(
+                BalancedShardsAllocator.RELOCATE_BLOCKING_REPLICA_FOR_PRIMARY_REBALANCE.getKey(),
+                true
+            ).put(ShardsLimitAllocationDecider.INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING.getKey(), 2).build(),
+            new TestGatewayAllocator()
+        );
+
+        // 3 nodes, deterministic ids: node_0, node_1, node_2
+        DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
+        List<String> nodesList = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            final DiscoveryNode node = newNode("node_" + i);
+            discoBuilder = discoBuilder.add(node);
+            nodesList.add(node.getId());
+        }
+        discoBuilder.localNodeId(nodesList.get(0));
+        discoBuilder.clusterManagerNodeId(nodesList.get(0));
+
+        Metadata.Builder metadata = Metadata.builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+
+        IndexMetadata indexA = getIndexMetadata("testA", 3, 1);
+        IndexMetadata indexB = getIndexMetadata("testB", 3, 1);
+        IndexRoutingTable.Builder rtA = IndexRoutingTable.builder(indexA.getIndex());
+        IndexRoutingTable.Builder rtB = IndexRoutingTable.builder(indexB.getIndex());
+
+        // testA: primaries on node_0, replicas on node_1
+        IndexShardRoutingTable[] tablesA = new IndexShardRoutingTable[3];
+        for (int shard = 0; shard < 3; shard++) {
+            ShardId sid = new ShardId(indexA.getIndex(), shard);
+            IndexShardRoutingTable.Builder b = new IndexShardRoutingTable.Builder(sid);
+            b.addShard(TestShardRouting.newShardRouting(sid, nodesList.get(0), true, ShardRoutingState.STARTED));
+            b.addShard(TestShardRouting.newShardRouting(sid, nodesList.get(1), false, ShardRoutingState.STARTED));
+            tablesA[shard] = b.build();
+            rtA.addIndexShard(tablesA[shard]);
+        }
+        // testB: primaries on node_2, replicas on node_1
+        IndexShardRoutingTable[] tablesB = new IndexShardRoutingTable[3];
+        for (int shard = 0; shard < 3; shard++) {
+            ShardId sid = new ShardId(indexB.getIndex(), shard);
+            IndexShardRoutingTable.Builder b = new IndexShardRoutingTable.Builder(sid);
+            b.addShard(TestShardRouting.newShardRouting(sid, nodesList.get(2), true, ShardRoutingState.STARTED));
+            b.addShard(TestShardRouting.newShardRouting(sid, nodesList.get(1), false, ShardRoutingState.STARTED));
+            tablesB[shard] = b.build();
+            rtB.addIndexShard(tablesB[shard]);
+        }
+
+        IndexMetadata.Builder indexABuilder = IndexMetadata.builder(indexA);
+        IndexMetadata.Builder indexBBuilder = IndexMetadata.builder(indexB);
+        for (int shard = 0; shard < 3; shard++) {
+            indexABuilder.putInSyncAllocationIds(shard, tablesA[shard].getAllAllocationIds());
+            indexBBuilder.putInSyncAllocationIds(shard, tablesB[shard].getAllAllocationIds());
+        }
+        metadata.put(indexABuilder.build(), false);
+        metadata.put(indexBBuilder.build(), false);
+        routingTable.add(rtA);
+        routingTable.add(rtB);
+
+        ClusterState.Builder stateBuilder = ClusterState.builder(new ClusterName("test"));
+        stateBuilder.nodes(discoBuilder);
+        stateBuilder.metadata(metadata.generateClusterUuidIfNeeded().build());
+        stateBuilder.routingTable(routingTable.build());
+        ClusterState clusterState = stateBuilder.build();
+
+        // Drive multiple reroute rounds so the rebalancer gets its chances.
+        clusterState = strategy.reroute(clusterState, "reroute");
+        clusterState = applyAllocationUntilNoChange(clusterState, strategy);
+        logger.info(ShardAllocations.printShardDistribution(clusterState));
+
+        // Global sanity: no shard lost or duplicated.
+        RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        int totalPrimaries = 0;
+        for (RoutingNode node : routingNodes) {
+            totalPrimaries += (int) node.shardsWithState(STARTED).stream().filter(ShardRouting::primary).count();
+        }
+        assertEquals("total started primaries must stay at 6", 6, totalPrimaries);
+
+        for (String nodeId : nodesList) {
+            long primaryCount = routingNodes.node(nodeId).shardsWithState(STARTED).stream().filter(ShardRouting::primary).count();
+            assertEquals("each node should host exactly 2 primaries after rebalance (node=" + nodeId + ")", 2L, primaryCount);
+        }
+        // Per-index primary balance must also hold.
+        verifyPerIndexPrimaryBalance(clusterState);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancerTests.java
@@ -84,6 +84,7 @@ public class LocalShardsBalancerTests extends OpenSearchAllocationTestCase {
             false,
             false,
             false,
+            false,
             null
         );
 
@@ -131,6 +132,7 @@ public class LocalShardsBalancerTests extends OpenSearchAllocationTestCase {
             false,
             false,
             false,
+            false,
             null
         );
 
@@ -175,6 +177,7 @@ public class LocalShardsBalancerTests extends OpenSearchAllocationTestCase {
             null,
             weightFunction,
             0,
+            false,
             false,
             false,
             false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This PR resolves the issue mentioned in #[[22820](https://github.com/opensearch-project/OpenSearch/issues/22820)] by migrating the blocking replica.

#### Reproduction
I have introduced Test `testPrimaryRebalance_SameShardConstraint`, which can stably reproduce the scenario of primary shard imbalance.
Three data nodes, two indices (testA, testB), each with 3 primaries and 1 replica (12 shards total). Initial layout:
```
              node_0              node_1                          node_2
              ---------           ------------------------        ---------
testA         PA0 PA1 PA2         RA0 RA1 RA2
testB                             RB0 RB1 RB2                     PB0 PB1 PB2
```
- Primary distribution: `node_0=3`, `node_1=0`, `node_2=3` (`avg = 2`).
- `node_1` holds a replica of every primary of both indices.
- Any single-step primary move to `node_1` is rejected by `SameShardAllocationDecider`.
- Since `cluster.routing.allocation.rebalance.primary.enable` is enabled, both `node_0` and `node_2` have `3` primary shards, and migration cannot be performed between them.

The rebalancer therefore makes no progress. Assertions expecting `2` / `2` / `2` primaries per node fail indefinitely.

#### Solution
Key improvements are as follows:
- Add a dynamic configuration (`cluster.routing.allocation.rebalance.primary.relocate_blocking_replica.enable`) to enable the migration of blocking replicas when primary shard balancing is enabled.
- To automate the balancing process, we can add a procedure for actively migrating blocked replicas in [`tryRelocateShard`](https://github.com/opensearch-project/OpenSearch/blob/f81134c7c2f394d69aa502762308054a4e3f1bc3/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java#L1062).
- To avoid excessive replica movement during the same round of [`balanceByWeights`](https://github.com/opensearch-project/OpenSearch/blob/f81134c7c2f394d69aa502762308054a4e3f1bc3/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java#L348) scheduling, we can limit the maximum number of blocking replicas to be migrated to one per round of scheduling for the same index.
- When `relocateBlockingReplicaEnabled` && `preferPrimaryBalance` && [`indexPrimaryShardDiff >= 2`](https://github.com/opensearch-project/OpenSearch/blob/f81134c7c2f394d69aa502762308054a4e3f1bc3/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java#L1092), the [`nodePrimaryShardDiff < 2`](https://github.com/opensearch-project/OpenSearch/blob/f81134c7c2f394d69aa502762308054a4e3f1bc3/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java#L1096) branch no longer skips, because per-index rebalance may still make progress even if the global counters are already balanced.

#### Result
After the optimization is introduced, through the following steps, the shard topology in **Reproduction** will eventually reach a state of primary shard balance.

```
Relocate [[testB][2], node[node_1], [R], s[STARTED], a[id=bsKedNjRS4CiywZ2-W-79A]] from [node_1] to [node_0]

Relocate [[testB][1], node[node_2], [P], s[STARTED], a[id=cA0bueJaRuS9yq7VCXiORQ]] from [node_2] to [node_0]

Relocate [[testA][2], node[node_0], [P], s[STARTED], a[id=Le_kBsaCScSrBkZ-1AvEIg]] from [node_0] to [node_2]

Relocate [[testA][1], node[node_1], [R], s[STARTED], a[id=7QSVf0o4RP6xCcoRbOFTpg]] from [node_1] to [node_2]

Relocate [[testB][2], node[node_2], [P], s[STARTED], a[id=CZ277kfNTGqq61mTwfdU7Q]] from [node_2] to [node_1]

Relocate [[testB][1], node[node_1], [R], s[STARTED], a[id=h7_7kaCSTfi6H9ABgxE6zA]] from [node_1] to [node_2]

Relocate [[testA][1], node[node_0], [P], s[STARTED], a[id=m_z9q24iRROTP55CtZquuA]] from [node_0] to [node_1]

Relocate [[testA][2], node[node_1], [R], s[STARTED], a[id=QNV5Zsp0Rw-X4yqh6s_5bQ]] from [node_1] to [node_0]
```

### Related Issues
Resolves #[[22820](https://github.com/opensearch-project/OpenSearch/issues/22820)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
