### PR TITLE
[Sandbox] Log individual test names in analytics QA integ tests

### DIFF
--- a/sandbox/qa/analytics-engine-coordinator/build.gradle
+++ b/sandbox/qa/analytics-engine-coordinator/build.gradle
@@ -146,6 +146,13 @@ configurations.all {
 // Arrow/Flight requires these JVM flags. DataFusion backend requires the native lib
 // path so JNI can locate libopensearch_native.dylib built by dataformat-native.
 internalClusterTest {
+  // Name each test in the console as it runs so CI failures identify the specific test
+  // rather than only showing "Task ... internalClusterTest FAILED".
+  testLogging {
+    events "started", "passed", "skipped", "failed"
+    exceptionFormat = 'full'
+    displayGranularity = 2
+  }
   jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
   jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
   jvmArgs '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -142,7 +142,15 @@ integTest {
     // Source resources dir, so -Dplan.generate writes goldens to the source tree (not build/).
     systemProperty 'plan.resourcesDir', file('src/test/resources').absolutePath
     testLogging {
+        // Print each test as it starts/finishes so failures name the specific test in the
+        // console log (CI otherwise only shows "Task ... integTest FAILED" with no test name).
+        // The OpenSearchTestBasePlugin's ErrorReportingTestListener additionally prints a
+        // "Tests with failures:" summary at the end of the run.
+        events "started", "passed", "skipped", "failed"
         exceptionFormat = 'full'
+        showStandardStreams = false
+        // Show the full test path (class + method) rather than just the method name.
+        displayGranularity = 2
     }
     exclude '**/CoordinatorReduceMemtableIT.class'
     exclude '**/StreamingCoordinatorReduceIT.class'


### PR DESCRIPTION
When an analytics QA integration test fails in CI, the console log currently only shows a generic `Task :sandbox:qa:...:integTest FAILED` line with no indication of which test failed — you have to dig into the uploaded HTML report to find out, and cluster-level failures (like a node network disconnect) show nothing at all. This adds `testLogging` events to the `analytics-engine-rest` integTest and `analytics-engine-coordinator` internalClusterTest tasks so each test is named in the console as it starts and finishes, and failing tests print their full class and method name with the stack trace inline. This is a build-config-only change with no impact on test behavior.