### PR TITLE
fix(mapper): Skip forced store for text multi-fields under derived source

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -1587,6 +1587,109 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
     }
 
+    /**
+     * BWC for the derived-source multi-field store fix: under index.derived_source.enabled, text
+     * multi-fields (sub-fields) are no longer force-stored, while the parent text field still is.
+     * The forced store is a Lucene FieldType bit recomputed on every mapping parse (incl.
+     * MAPPING_RECOVERY on restart), so this verifies both _source reconstruction (GET) and search
+     * (query) keep working for documents indexed BEFORE and AFTER the upgrade.
+     *
+     * NOTE: derived_source (index.derived_source.enabled) is available from 3.3.0 onwards (#18565).
+     */
+    public void testDerivedSourceMultiFieldStore() throws Exception {
+        assumeTrue(
+            "derived_source (index.derived_source.enabled) is available from 3.3.0 onwards",
+            getOldClusterVersion().onOrAfter(Version.fromString("3.3.0"))
+        );
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder mappingsAndSettings = jsonBuilder();
+            mappingsAndSettings.startObject();
+            {
+                mappingsAndSettings.startObject("settings");
+                mappingsAndSettings.field("number_of_shards", 1);
+                mappingsAndSettings.field("number_of_replicas", 0);
+                mappingsAndSettings.field("index.derived_source.enabled", true);
+                mappingsAndSettings.endObject();
+            }
+            {
+                mappingsAndSettings.startObject("mappings");
+                mappingsAndSettings.startObject("properties");
+                {
+                    mappingsAndSettings.startObject("title");
+                    mappingsAndSettings.field("type", "text");
+                    mappingsAndSettings.startObject("fields");
+                    {
+                        mappingsAndSettings.startObject("sub");
+                        mappingsAndSettings.field("type", "text");
+                        mappingsAndSettings.endObject();
+                    }
+                    mappingsAndSettings.endObject();
+                    mappingsAndSettings.endObject();
+                }
+                mappingsAndSettings.endObject();
+                mappingsAndSettings.endObject();
+            }
+            mappingsAndSettings.endObject();
+
+            Request createIndex = new Request("PUT", "/" + index);
+            createIndex.setJsonEntity(mappingsAndSettings.toString());
+            client().performRequest(createIndex);
+
+            // 3 OLD docs (multi-field force-stored by old code)
+            for (int i = 0; i < 3; i++) {
+                Request doc = new Request("PUT", "/" + index + "/_doc/" + i);
+                doc.setJsonEntity("{\"title\":\"quick brown fox " + i + "\"}");
+                client().performRequest(doc);
+            }
+            client().performRequest(new Request("POST", "/" + index + "/_refresh"));
+
+            // OLD cluster: GET _source + query both work on old docs
+            assertDerivedSourceTitle(0, "quick brown fox 0");
+            assertDerivedSourceTitle(2, "quick brown fox 2");
+            assertMatchCount("title.sub", "fox", 3);   // query on the multi-field
+            assertMatchCount("title", "quick", 3);      // query on the parent
+        } else {
+            // --- OLD docs after full restart + mapping re-parse by new code ---
+            // GET _source still reconstructs for old docs
+            assertDerivedSourceTitle(0, "quick brown fox 0");
+            assertDerivedSourceTitle(2, "quick brown fox 2");
+            // query still matches old docs (sub-field still indexed; parent still stored)
+            assertMatchCount("title.sub", "fox", 3);
+            assertMatchCount("title", "quick", 3);
+
+            // --- NEW docs written on the upgraded cluster into the SAME old index ---
+            for (int i = 10; i < 13; i++) {
+                Request doc = new Request("PUT", "/" + index + "/_doc/" + i);
+                doc.setJsonEntity("{\"title\":\"lazy dog " + i + "\"}");
+                client().performRequest(doc);
+            }
+            client().performRequest(new Request("POST", "/" + index + "/_refresh"));
+
+            // GET _source works for new docs (parent field still force-stored -> derivation OK)
+            assertDerivedSourceTitle(11, "lazy dog 11");
+            assertDerivedSourceTitle(12, "lazy dog 12");
+            // query works for new docs on both the multi-field and the parent
+            assertMatchCount("title.sub", "dog", 3);
+            assertMatchCount("title", "lazy", 3);
+
+            // old docs remain queryable alongside the new ones
+            assertMatchCount("title.sub", "fox", 3);
+        }
+    }
+
+    private void assertDerivedSourceTitle(int id, String expectedTitle) throws IOException {
+        Map<String, Object> doc = entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_doc/" + id)));
+        assertThat(XContentMapValues.extractValue("_source.title", doc), equalTo(expectedTitle));
+    }
+
+    private void assertMatchCount(String field, String term, int expectedHits) throws IOException {
+        Request search = new Request("GET", "/" + index + "/_search");
+        search.setJsonEntity("{\"track_total_hits\":true,\"query\":{\"match\":{\"" + field + "\":\"" + term + "\"}}}");
+        Map<String, Object> resp = entityAsMap(client().performRequest(search));
+        assertNoFailures(resp);
+        assertThat("hits for " + field + ":" + term, extractTotalHits(resp), equalTo(expectedHits));
+    }
+
     public static void assertNumHits(String index, int numHits, int totalShards) throws IOException {
         Map<String, Object> resp = entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search")));
         assertNoFailures(resp);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/DerivedSourceUpgradeIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/DerivedSourceUpgradeIT.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.upgrades;
+
+import org.opensearch.Version;
+import org.opensearch.client.Request;
+import org.opensearch.common.xcontent.support.XContentMapValues;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Rolling-upgrade BWC for the derived-source multi-field store fix (TextFieldMapper: under
+ * index.derived_source.enabled, text multi-fields/sub-fields are no longer force-stored, while the
+ * parent text field still is). The forced store is a Lucene FieldType bit recomputed per node on
+ * every mapping parse, so during the MIXED phase some shard copies (written by old nodes) store the
+ * sub-field and others (new nodes) do not. This verifies _source reconstruction (GET) and search
+ * (query) stay correct for documents indexed in every phase: OLD, MIXED and UPGRADED.
+ *
+ * NOTE: derived_source (index.derived_source.enabled) is available from 3.3.0 onwards (#18565).
+ */
+public class DerivedSourceUpgradeIT extends AbstractRollingTestCase {
+
+    private static final String INDEX = "derived_src_mf_rolling";
+
+    public void testDerivedSourceMultiFieldStoreRolling() throws Exception {
+        assumeTrue(
+            "derived_source (index.derived_source.enabled) is available from 3.3.0 onwards",
+            UPGRADE_FROM_VERSION.onOrAfter(Version.fromString("3.3.0"))
+        );
+        switch (CLUSTER_TYPE) {
+            case OLD:
+                createDerivedSourceIndex();
+                indexTitles(0, "quick brown fox");   // ids 0,1,2
+                refreshIndex();
+                // GET _source + query on old docs (old cluster)
+                assertSourceTitle(0, "quick brown fox 0");
+                assertMatchCount("title.sub", "fox", 3);
+                assertMatchCount("title", "quick", 3);
+                break;
+            case MIXED:
+                ensureHealth();
+                // index mixed-phase docs once (MIXED runs once per node upgraded)
+                if (firstMixedRound) {
+                    indexTitles(100, "lazy dog");    // ids 100,101,102
+                    refreshIndex();
+                }
+                // old docs survive; mixed docs (served across old+new nodes) are correct
+                assertSourceTitle(0, "quick brown fox 0");
+                assertMatchCount("title.sub", "fox", 3);
+                assertSourceTitle(100, "lazy dog 100");
+                assertMatchCount("title.sub", "dog", 3);
+                break;
+            case UPGRADED:
+                ensureHealth();
+                indexTitles(200, "sleepy cat");      // ids 200,201,202
+                refreshIndex();
+                // all three generations: GET _source + query
+                assertSourceTitle(0, "quick brown fox 0");
+                assertSourceTitle(100, "lazy dog 100");
+                assertSourceTitle(200, "sleepy cat 200");
+                assertMatchCount("title.sub", "fox", 3);
+                assertMatchCount("title.sub", "dog", 3);
+                assertMatchCount("title.sub", "cat", 3);
+                assertMatchCount("title", "sleepy", 3);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        }
+    }
+
+    private void createDerivedSourceIndex() throws IOException {
+        Request req = new Request("PUT", "/" + INDEX);
+        req.setJsonEntity(
+            "{"
+                + "\"settings\":{\"number_of_shards\":2,\"number_of_replicas\":1,\"index.derived_source.enabled\":true},"
+                + "\"mappings\":{\"properties\":{\"title\":{\"type\":\"text\",\"fields\":{\"sub\":{\"type\":\"text\"}}}}}"
+                + "}"
+        );
+        client().performRequest(req);
+    }
+
+    private void indexTitles(int startId, String phrase) throws IOException {
+        for (int i = 0; i < 3; i++) {
+            int id = startId + i;
+            Request doc = new Request("PUT", "/" + INDEX + "/_doc/" + id);
+            doc.setJsonEntity("{\"title\":\"" + phrase + " " + id + "\"}");
+            client().performRequest(doc);
+        }
+    }
+
+    private void refreshIndex() throws IOException {
+        client().performRequest(new Request("POST", "/" + INDEX + "/_refresh"));
+    }
+
+    private void ensureHealth() throws IOException {
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "yellow");
+        health.addParameter("timeout", "90s");
+        client().performRequest(health);
+    }
+
+    private void assertSourceTitle(int id, String expectedTitle) throws IOException {
+        Map<String, Object> doc = entityAsMap(client().performRequest(new Request("GET", "/" + INDEX + "/_doc/" + id)));
+        assertThat(XContentMapValues.extractValue("_source.title", doc), equalTo(expectedTitle));
+    }
+
+    private void assertMatchCount(String field, String term, int expectedHits) throws IOException {
+        Request search = new Request("GET", "/" + INDEX + "/_search");
+        search.setJsonEntity("{\"track_total_hits\":true,\"query\":{\"match\":{\"" + field + "\":\"" + term + "\"}}}");
+        Map<String, Object> resp = entityAsMap(client().performRequest(search));
+        int hits = ((Number) XContentMapValues.extractValue("hits.total.value", resp)).intValue();
+        assertThat("hits for " + field + ":" + term, hits, equalTo(expectedHits));
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -802,6 +802,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     return empty();
                 } else {
                     context.path().add(mainFieldBuilder.name());
+                    context.setMultiField(true);
                     Map mapperBuilders = this.mapperBuilders;
                     for (final Map.Entry<String, Mapper.Builder> cursor : this.mapperBuilders.entrySet()) {
                         String key = cursor.getKey();
@@ -810,6 +811,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                         assert mapper instanceof FieldMapper;
                         mapperBuilders.put(key, mapper);
                     }
+                    context.setMultiField(false);
                     context.path().remove();
                     final Map<String, FieldMapper> mappers = (Map<String, FieldMapper>) mapperBuilders;
                     return new MultiFields(mappers);

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -96,6 +96,16 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             return this.indexSettings;
         }
 
+        private boolean multiField = false;
+
+        public boolean isMultiField() {
+            return multiField;
+        }
+
+        public void setMultiField(boolean multiField) {
+            this.multiField = multiField;
+        }
+
         public void assignCapabilities(MappedFieldType fieldType) {
             if (capabilityAssigner != null) {
                 capabilityAssigner.accept(fieldType);

--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -473,8 +473,9 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         public TextFieldMapper build(BuilderContext context) {
             FieldType fieldType = TextParams.buildFieldType(index, store, indexOptions, norms, termVectors);
             TextFieldType tft = buildFieldType(fieldType, context);
-            if (context.indexSettings().getAsBoolean(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), false)
-                || context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)) {
+            if ((context.indexSettings().getAsBoolean(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), false)
+                || context.indexSettings().getAsBoolean(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false))
+                && !context.isMultiField()) {
                 fieldType.setStored(true);
             }
             return new TextFieldMapper(

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -1096,7 +1096,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertThrows(UnsupportedOperationException.class, mapper::canDeriveSource);
     }
 
-    public void testDefaultStoredFieldForDerivedSource() throws IOException {
+    private MapperService createDerivedSourceMapperService() throws IOException {
         IndexMetadata build = IndexMetadata.builder("test_index")
             .settings(
                 Settings.builder()
@@ -1116,7 +1116,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         ScriptService scriptService = new ScriptService(getIndexSettings(), scriptModule.engines, scriptModule.contexts);
         SimilarityService similarityService = new SimilarityService(indexSettings, scriptService, emptyMap());
-        MapperService mapperService = new MapperService(
+        return new MapperService(
             indexSettings,
             createIndexAnalyzers(indexSettings),
             xContentRegistry(),
@@ -1128,10 +1128,39 @@ public class TextFieldMapperTests extends MapperTestCase {
             () -> true,
             scriptService
         );
+    }
 
+    public void testDefaultStoredFieldForDerivedSource() throws IOException {
+        MapperService mapperService = createDerivedSourceMapperService();
         merge(mapperService, fieldMapping(b -> b.field("type", "text").field("store", false)));
         TextFieldMapper textFieldMapper = (TextFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertTrue(textFieldMapper.fieldType.stored());
+    }
+
+    public void testMultiFieldTextNotStoredForDerivedSource() throws IOException {
+        MapperService mapperService = createDerivedSourceMapperService();
+        merge(mapperService, mapping(b -> {
+            // top-level text field: still force-stored (it is walked by _source reconstruction)
+            b.startObject("desc").field("type", "text").field("store", false).endObject();
+            // keyword field with a text multi-field: the multi-field must NOT be force-stored,
+            // as multi-fields are never used for derived-source reconstruction
+            b.startObject("app_name");
+            {
+                b.field("type", "keyword");
+                b.startObject("fields");
+                {
+                    b.startObject("analyzed").field("type", "text").field("store", false).endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        TextFieldMapper topLevel = (TextFieldMapper) mapperService.documentMapper().mappers().getMapper("desc");
+        assertTrue("top-level text field should be force-stored under derived_source", topLevel.fieldType.stored());
+
+        TextFieldMapper multiField = (TextFieldMapper) mapperService.documentMapper().mappers().getMapper("app_name.analyzed");
+        assertFalse("text multi-field should NOT be force-stored under derived_source", multiField.fieldType.stored());
     }
 
     public void testDerivedValueFetching_StoredField() throws IOException {


### PR DESCRIPTION
### Description

When `index.derived_source.enabled` is `true`, `TextFieldMapper.Builder.build()` forces `stored=true` on **all** text fields, including multi-fields (sub-fields).

Multi-field values are never used for `_source` reconstruction — derivation reads the **parent** field's stored value / doc_values, and multi-fields are by design never part of `_source`. Forcing store on them writes a redundant copy of the parent value per sub-field per document, defeating the storage savings derived source is meant to provide. Example (reported shape): a `text` sub-field under a `keyword` parent gets `store: true` even though the keyword parent's doc_values fully cover derivation.

**Fix:** `Mapper.BuilderContext` now tracks whether a multi-field is being built (`isMultiField()`/`setMultiField()`, toggled by `FieldMapper.MultiFields.Builder.build()`), and `TextFieldMapper.Builder.build()` skips the forced store for multi-fields. Top-level text fields are still force-stored, so `_source` derivation is unchanged.

**Why this is safe / BWC notes:**

- The forced store is a Lucene `FieldType` bit recomputed on every mapping parse (including `MAPPING_RECOVERY`); it is not persisted in the mapping JSON. Existing indices simply stop storing the redundant value for newly indexed docs.
- Old documents keep their stored sub-field values (harmless leftover) and remain fully searchable; new documents are searchable too since the sub-field is still indexed.
- Only observable change: `stored_fields: ["field.sub"]` returns nothing for new docs — consistent with non-derived-source indices, where sub-fields are not stored by default.
- An explicit `store: true` set by the user on a multi-field is still honored.

**Testing:**

- Unit tests (`TextFieldMapperTests`): multi-field not force-stored (text and keyword parents), parent still force-stored, explicit `store: true` on a multi-field preserved.
- Full-cluster-restart BWC (`FullClusterRestartIT#testDerivedSourceMultiFieldStore`): index created on 3.3.0 with derived source + text multi-field; `GET _source` and `match` queries verified for docs indexed before and after upgrade. Passing.
- Rolling upgrade (`DerivedSourceUpgradeIT#testDerivedSourceMultiFieldStoreRolling`): `_source` reconstruction and queries verified across OLD/MIXED/UPGRADED phases, covering shard copies written by both old (stored) and new (unstored) nodes in the same index. Passing.

### Related Issues

Resolves #22536

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. — N/A, no API changes.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. — N/A, no user-facing API/setting change; storage behavior fix only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
