### PR TITLE
Add ClickBench streaming aggregation benchmark

### DIFF
--- a/.github/benchmark-configs.json
+++ b/.github/benchmark-configs.json
@@ -293,7 +293,7 @@
       "DATA_INSTANCE_TYPE": "c5.2xlarge",
       "INSTALL_STREAMING_PLUGINS": "true",
       "JVM_SYS_PROPS": "io.netty.allocator.numDirectArenas=16,io.netty.noUnsafe=false,io.netty.tryUnsafe=true,io.netty.tryReflectionSetAccessible=true",
-      "ADDITIONAL_CONFIG": "opensearch.experimental.feature.transport.stream.enabled:true stream.search.enabled:true arrow.flight.publish_host:0.0.0.0 arrow.flight.bind_host:0.0.0.0 search.aggregations.streaming.max_estimated_bucket_count:2000000",
+      "ADDITIONAL_CONFIG": "opensearch.experimental.feature.transport.stream.enabled:true stream.search.enabled:true arrow.flight.publish_host:127.0.0.1 arrow.flight.bind_host:127.0.0.1 search.aggregations.streaming.max_estimated_bucket_count:2000000",
       "TEST_WORKLOAD": "clickbench",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"clickbench_3_shards\",\"use_snapshot\":true,\"snapshot_repo\":\"benchmark-workloads-repo-3x\",\"warmup_iterations\":10,\"test_iterations\":20}",
       "CAPTURE_NODE_STAT": "true",

--- a/.github/benchmark-configs.json
+++ b/.github/benchmark-configs.json
@@ -283,5 +283,27 @@
       "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
     },
     "baseline_cluster_config": "x64-c5.2xlarge-3-shard-0-replica-snapshot-baseline"
+  },
+  "id_17": {
+    "description": "Nested string terms streaming aggregation benchmark",
+    "supported_major_versions": ["3"],
+    "cluster-benchmark-configs": {
+      "SINGLE_NODE_CLUSTER": "true",
+      "MIN_DISTRIBUTION": "true",
+      "DATA_INSTANCE_TYPE": "c5.2xlarge",
+      "INSTALL_STREAMING_PLUGINS": "true",
+      "JVM_SYS_PROPS": "io.netty.allocator.numDirectArenas=16,io.netty.noUnsafe=false,io.netty.tryUnsafe=true,io.netty.tryReflectionSetAccessible=true",
+      "ADDITIONAL_CONFIG": "opensearch.experimental.feature.transport.stream.enabled:true stream.search.enabled:true arrow.flight.publish_host:0.0.0.0 arrow.flight.bind_host:0.0.0.0 search.aggregations.streaming.max_estimated_bucket_count:2000000",
+      "TEST_WORKLOAD": "clickbench",
+      "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"clickbench_3_shards\",\"use_snapshot\":true,\"snapshot_repo\":\"benchmark-workloads-repo-3x\",\"warmup_iterations\":10,\"test_iterations\":20}",
+      "INCLUDE_TASKS": "restore-snapshot,dsl-streaming-nested-string-terms",
+      "CAPTURE_NODE_STAT": "true",
+      "TEST_PROCEDURE": "streaming-agg-clickbench"
+    },
+    "cluster_configuration": {
+      "size": "Single-Node",
+      "data_instance_config": "8vCPU, 32G Mem, 16G Heap"
+    },
+    "baseline_cluster_config": "x64-c5.2xlarge-3-shard-0-replica-snapshot-streaming-aggregation-baseline"
   }
 }

--- a/.github/benchmark-configs.json
+++ b/.github/benchmark-configs.json
@@ -285,7 +285,7 @@
     "baseline_cluster_config": "x64-c5.2xlarge-3-shard-0-replica-snapshot-baseline"
   },
   "id_17": {
-    "description": "Nested string terms streaming aggregation benchmark",
+    "description": "ClickBench streaming aggregation benchmark",
     "supported_major_versions": ["3"],
     "cluster-benchmark-configs": {
       "SINGLE_NODE_CLUSTER": "true",
@@ -296,7 +296,6 @@
       "ADDITIONAL_CONFIG": "opensearch.experimental.feature.transport.stream.enabled:true stream.search.enabled:true arrow.flight.publish_host:0.0.0.0 arrow.flight.bind_host:0.0.0.0 search.aggregations.streaming.max_estimated_bucket_count:2000000",
       "TEST_WORKLOAD": "clickbench",
       "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-3x\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"10.5.0\",\"snapshot_name\":\"clickbench_3_shards\",\"use_snapshot\":true,\"snapshot_repo\":\"benchmark-workloads-repo-3x\",\"warmup_iterations\":10,\"test_iterations\":20}",
-      "INCLUDE_TASKS": "restore-snapshot,dsl-streaming-nested-string-terms",
       "CAPTURE_NODE_STAT": "true",
       "TEST_PROCEDURE": "streaming-agg-clickbench"
     },

--- a/.github/workflows/benchmark-pull-request.yml
+++ b/.github/workflows/benchmark-pull-request.yml
@@ -147,7 +147,21 @@ jobs:
           distribution: 'temurin'
       - name: Build and Assemble OpenSearch from PR
         run: |
-          ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false
+          tasks=(':distribution:archives:linux-tar:assemble')
+          if [[ "$INSTALL_STREAMING_PLUGINS" == "true" ]]; then
+            tasks+=(':plugins:arrow-base:bundlePlugin' ':plugins:arrow-flight-rpc:bundlePlugin')
+          fi
+          ./gradlew "${tasks[@]}" -Dbuild.snapshot=false
+
+          if [[ "$INSTALL_STREAMING_PLUGINS" == "true" ]]; then
+            archive="distribution/archives/linux-tar/build/distributions/opensearch-min-$OPENSEARCH_VERSION-linux-x64.tar.gz"
+            distribution_dir=$(mktemp -d)
+            tar -xzf "$archive" -C "$distribution_dir"
+            opensearch="$distribution_dir/opensearch-$OPENSEARCH_VERSION"
+            "$opensearch/bin/opensearch-plugin" install --batch "file://$GITHUB_WORKSPACE/plugins/arrow-base/build/distributions/arrow-base-$OPENSEARCH_VERSION.zip"
+            "$opensearch/bin/opensearch-plugin" install --batch "file://$GITHUB_WORKSPACE/plugins/arrow-flight-rpc/build/distributions/arrow-flight-rpc-$OPENSEARCH_VERSION.zip"
+            tar -czf "$archive" -C "$distribution_dir" "opensearch-$OPENSEARCH_VERSION"
+          fi
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:

--- a/PERFORMANCE_BENCHMARKS.md
+++ b/PERFORMANCE_BENCHMARKS.md
@@ -79,6 +79,7 @@ The benchmark-config.json file accepts the following schema.
       "DATA_INSTANCE_TYPE": "EC2 instance type for data node, empty defaults to r5.xlarge.",
       "DATA_NODE_STORAGE": "Data node ebs block storage size, empty value defaults to 100Gb",
       "JVM_SYS_PROPS": "A comma-separated list of key=value pairs that will be added to jvm.options as JVM system properties",
+      "INSTALL_STREAMING_PLUGINS": "Bundle arrow-base and arrow-flight-rpc into the pull request distribution, accepted values are \"true\" or \"false\"",
       "ADDITIONAL_CONFIG": "Additional space delimited opensearch.yml config parameters. e.g., `search.concurrent_segment_search.enabled:true`",
       "TEST_WORKLOAD": "The workload name from OpenSearch Benchmark Workloads. https://github.com/opensearch-project/opensearch-benchmark-workloads. Default is nyc_taxis",
       "WORKLOAD_PARAMS": "With this parameter you can inject variables into workloads, e.g.{\"number_of_replicas\":\"0\",\"number_of_shards\":\"3\"}. See https://opensearch.org/docs/latest/benchmark/reference/commands/command-flags/#workload-params",


### PR DESCRIPTION
### Description
Adds GitHub pull-request benchmark configuration `id_17` for the full `streaming-agg-clickbench` procedure. The procedure includes the nested string terms operation introduced by opensearch-project/opensearch-benchmark-workloads#815.

The configuration:
- restores the three-shard ClickBench snapshot;
- runs all streaming-eligible ClickBench aggregation operations;
- enables stream search and raises the estimated bucket limit to cover the nested aggregation;
- conditionally bundles `arrow-base` and `arrow-flight-rpc` into the pull-request distribution.

This PR depends on opensearch-project/opensearch-benchmark-workloads#815 being merged and backported to branch `3`.

### Related Issues
Related workload PR: opensearch-project/opensearch-benchmark-workloads#815

### Testing
- `./gradlew precommit`
- Built the Linux distribution and both Arrow plugin bundles.
- Installed both plugins into the minimal distribution and verified their descriptors in the repacked archive.
- Started the packaged single-node distribution with Flight bound to loopback and ran a streaming aggregation search.
- Validated the benchmark configuration JSON, workflow YAML, and embedded Bash syntax.
- Rendered the full workload schedule with `opensearch-benchmark info`.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
