### PR TITLE
Add can_match summary to profile=true for SHARD_FRAGMENT stages

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/CanMatchProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/CanMatchProfile.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.profile;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Per-{@code SHARD_FRAGMENT}-stage summary of the can_match pre-filter phase. Attached to a
+ * {@link StageProfile} only when the phase actually ran for that stage — i.e. the query carried
+ * range filters or a bounded-field sort, and the fan-out cleared the {@code worthPreFiltering}
+ * threshold. Its presence therefore signals "can_match ran here"; its absence means the phase was
+ * skipped (query shape or narrow fan-out) and every resolved shard was dispatched as-is.
+ *
+ * <p>All fields are coordinator-side aggregates. The can_match probe is a plain request/response
+ * transport action (no streaming), and pruning/ordering/top-N decisions are all made on the
+ * coordinator, so no shard-side or native (Rust) metrics are involved.
+ *
+ * @param canMatchMs           wall-clock latency of the parallel can_match probe round-trip, in millis
+ * @param totalShards          shard targets considered before can_match ran
+ * @param shardsPrunedByFilter shards dropped before dispatch because parquet row-group stats proved
+ *                             their range disjoint from the query's {@code WHERE} predicates
+ * @param shardsSkippedByTopN  shards skipped during staggered dispatch because their folded sort-column
+ *                             bounds could not beat the top-N bar (the {@code sort | head N} gate); 0
+ *                             when the query has no gateable sort or the gate never armed
+ * @param topNGateArmed        whether the top-N gate reached its limit K, i.e. dynamic skipping was active
+ * @param shardsDispatched     shards that actually ran a fragment ({@code totalShards - pruned - skipped})
+ */
+public record CanMatchProfile(long canMatchMs, int totalShards, int shardsPrunedByFilter, int shardsSkippedByTopN, boolean topNGateArmed,
+    int shardsDispatched) implements ToXContentObject {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("can_match_ms", canMatchMs);
+        builder.field("total_shards", totalShards);
+        builder.field("shards_pruned_by_filter", shardsPrunedByFilter);
+        builder.field("shards_skipped_by_topn", shardsSkippedByTopN);
+        builder.field("topn_gate_armed", topNGateArmed);
+        builder.field("shards_dispatched", shardsDispatched);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/StageProfile.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/exec/profile/StageProfile.java
@@ -38,10 +38,12 @@ import java.util.List;
  *                             carried by the stage's filter / shard-scan-with-delegation instruction;
  *                             {@code null} when the stage has no delegation-bearing instruction (omitted from JSON).
  * @param tasks                per-partition task profiles registered with the TaskTracker
+ * @param canMatch             can_match pre-filter summary for this stage, or {@code null} when the phase
+ *                             did not run (non-SHARD_FRAGMENT stage, or no filters/bounded sort / narrow fan-out)
  */
 public record StageProfile(int stageId, String executionType, String distribution, String state, long startMs, long endMs, long elapsedMs,
     long rowsProcessed, long tasksCompleted, long tasksFailed, List<String> fragment, String chosenBackend, String treeShape, List<
-        TaskProfile> tasks) implements ToXContentObject {
+        TaskProfile> tasks, CanMatchProfile canMatch) implements ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -64,6 +66,10 @@ public record StageProfile(int stageId, String executionType, String distributio
         }
         builder.field("chosen_backend", chosenBackend != null ? chosenBackend : "unknown");
         if (treeShape != null) builder.field("tree_shape", treeShape);
+        if (canMatch != null) {
+            builder.field("can_match");
+            canMatch.toXContent(builder, params);
+        }
         builder.startArray("tasks");
         for (TaskProfile t : tasks) {
             t.toXContent(builder, params);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/profile/QueryProfileBuilder.java
@@ -14,6 +14,7 @@ import org.opensearch.analytics.exec.QueryContext;
 import org.opensearch.analytics.exec.stage.StageExecution;
 import org.opensearch.analytics.exec.stage.StageMetrics;
 import org.opensearch.analytics.exec.stage.StageTask;
+import org.opensearch.analytics.exec.stage.shard.ShardFragmentStageExecution;
 import org.opensearch.analytics.exec.stage.shard.ShardStageTask;
 import org.opensearch.analytics.planner.dag.ShardExecutionTarget;
 import org.opensearch.analytics.planner.dag.Stage;
@@ -75,6 +76,11 @@ public final class QueryProfileBuilder {
             long tasksCompleted = taskProfiles.stream().filter(t -> "FINISHED".equals(t.state())).count();
             long tasksFailed = taskProfiles.stream().filter(t -> "FAILED".equals(t.state())).count();
 
+            // can_match only runs on shard-fragment stages; null everywhere else (and when the
+            // probe was skipped for this stage). The stage assembles it lazily so top-N skips
+            // that accrued after the probe returned are included.
+            CanMatchProfile canMatch = exec instanceof ShardFragmentStageExecution shardExec ? shardExec.canMatchProfile() : null;
+
             stageProfiles.add(
                 new StageProfile(
                     exec.getStageId(),
@@ -90,7 +96,8 @@ public final class QueryProfileBuilder {
                     fragment,
                     chosenBackend,
                     treeShape,
-                    taskProfiles
+                    taskProfiles,
+                    canMatch
                 )
             );
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
@@ -66,6 +67,16 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
     private final AnalyticsSearchTransportService dispatcher;
     private volatile TopNGate topNGate;
     private volatile Map<ExecutionTarget, ShardSortBounds> sortBounds = Collections.emptyMap();
+
+    // ── can_match profile capture (coordinator-side; null/zero unless the probe ran) ──
+    // Raw pieces set at probe completion; the final CanMatchProfile is assembled lazily at
+    // snapshot time so it reflects top-N skips that accrue AFTER the probe returns.
+    private volatile boolean canMatchRan = false;
+    private volatile long canMatchMs;
+    private volatile int canMatchTotalShards;
+    private volatile int canMatchPrunedByFilter;
+    // Incremented from ShardTaskRunner as the top-N gate skips shards during staggered dispatch.
+    private final AtomicInteger canMatchSkippedByTopN = new AtomicInteger();
 
     public ShardFragmentStageExecution(
         Stage stage,
@@ -218,6 +229,33 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
         return sortBounds;
     }
 
+    /** Records that the top-N gate skipped one shard's dispatch. Called by {@link ShardTaskRunner}. */
+    void recordTopNSkip() {
+        canMatchSkippedByTopN.incrementAndGet();
+    }
+
+    /**
+     * Assembles this stage's can_match profile, or {@code null} if the phase did not run. Read at
+     * profile-snapshot time so top-N skips and gate-armed state reflect the whole dispatch, not
+     * just what was known when the probe returned.
+     */
+    public org.opensearch.analytics.exec.profile.CanMatchProfile canMatchProfile() {
+        if (canMatchRan == false) {
+            return null;
+        }
+        int skipped = canMatchSkippedByTopN.get();
+        boolean armed = topNGate != null && topNGate.isArmed();
+        int dispatched = canMatchTotalShards - canMatchPrunedByFilter - skipped;
+        return new org.opensearch.analytics.exec.profile.CanMatchProfile(
+            canMatchMs,
+            canMatchTotalShards,
+            canMatchPrunedByFilter,
+            skipped,
+            armed,
+            dispatched
+        );
+    }
+
     /**
      * Dispatches can-match with a timeout. Ensures exactly one listener invocation:
      * either the shard-check result on success, or a keep-everything result on timeout/error.
@@ -252,6 +290,13 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
             if (fired.compareAndSet(false, true)) {
                 scheduled.cancel();
                 long elapsed = (System.nanoTime() - startNanos) / 1_000_000;
+                // Retain the coordinator-side can_match aggregates for the profile. The top-N
+                // skip count and gate-armed state are read later, at snapshot time, because they
+                // accrue during the staggered dispatch that follows this callback.
+                this.canMatchRan = true;
+                this.canMatchMs = elapsed;
+                this.canMatchTotalShards = targets.size();
+                this.canMatchPrunedByFilter = targets.size() - checked.targets().size();
                 logger.debug(
                     "can-match complete: {} shards checked, {} pruned, {}ms, sortColumn={}",
                     targets.size(),

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardFragmentStageExecution.java
@@ -23,6 +23,7 @@ import org.opensearch.analytics.exec.canmatch.CanMatchFilterSerializer;
 import org.opensearch.analytics.exec.canmatch.CanMatchPreFilterPhase;
 import org.opensearch.analytics.exec.canmatch.SortSpec;
 import org.opensearch.analytics.exec.canmatch.TopNGate;
+import org.opensearch.analytics.exec.profile.CanMatchProfile;
 import org.opensearch.analytics.exec.stage.AbstractStageExecution;
 import org.opensearch.analytics.exec.stage.DataProducer;
 import org.opensearch.analytics.exec.stage.StageTask;
@@ -239,21 +240,14 @@ public class ShardFragmentStageExecution extends AbstractStageExecution implemen
      * profile-snapshot time so top-N skips and gate-armed state reflect the whole dispatch, not
      * just what was known when the probe returned.
      */
-    public org.opensearch.analytics.exec.profile.CanMatchProfile canMatchProfile() {
+    public CanMatchProfile canMatchProfile() {
         if (canMatchRan == false) {
             return null;
         }
         int skipped = canMatchSkippedByTopN.get();
         boolean armed = topNGate != null && topNGate.isArmed();
         int dispatched = canMatchTotalShards - canMatchPrunedByFilter - skipped;
-        return new org.opensearch.analytics.exec.profile.CanMatchProfile(
-            canMatchMs,
-            canMatchTotalShards,
-            canMatchPrunedByFilter,
-            skipped,
-            armed,
-            dispatched
-        );
+        return new CanMatchProfile(canMatchMs, canMatchTotalShards, canMatchPrunedByFilter, skipped, armed, dispatched);
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardTaskRunner.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/shard/ShardTaskRunner.java
@@ -80,6 +80,7 @@ public final class ShardTaskRunner implements TaskRunner<ShardStageTask> {
         // bottom() is defined here: canEliminate only says yes once K keys are in hand, and the
         // count never shrinks.
         logger.debug("sort-et: skipping shard {} — its whole range is worse than the bar {}", target.shardId(), gate.bottom());
+        stage.recordTopNSkip();
         stage.skipTask(task);
         return false;
     }

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration test for the can_match section of the profile=true response on SHARD_FRAGMENT stages.
+ *
+ * <p>can_match only runs when the query has range filters or a bounded-field sort AND the fan-out
+ * clears the {@code worthPreFiltering} threshold. A {@code sort | head N} drops that threshold to 1,
+ * and we additionally force {@code analytics.query.pre_filter_shard_size=1} so the probe reliably
+ * fires on this small multi-shard index rather than depending on a production-scale fan-out.
+ */
+public class CanMatchProfileIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "canmatch_profile_test";
+    private static final String PRE_FILTER_SETTING = "analytics.query.pre_filter_shard_size";
+    private static boolean provisioned = false;
+
+    private void ensureProvisioned() throws IOException {
+        if (!provisioned) {
+            createIndex();
+            indexData();
+            provisioned = true;
+        }
+    }
+
+    /**
+     * A {@code sort ts | head N} query over a 2-shard index triggers the can_match probe (and the
+     * top-N gate). The SHARD_FRAGMENT stage's profile must carry a can_match block with sensible,
+     * internally-consistent counts.
+     */
+    @SuppressWarnings("unchecked")
+    public void testCanMatchProfileOnSortQuery() throws IOException {
+        ensureProvisioned();
+        applySetting(PRE_FILTER_SETTING, "1");
+        try {
+            Map<String, Object> result = executeWithProfile("source = " + INDEX + " | sort ts | fields host | head 3");
+
+            Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+            assertNotNull("profile present", profile);
+            List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+            assertNotNull("stages present", stages);
+
+            Map<String, Object> canMatch = findCanMatch(stages);
+            assertNotNull("a SHARD_FRAGMENT stage must carry a can_match block. stages: " + stages, canMatch);
+
+            // Latency is always recorded (>= 0). total_shards must be the 2 shards we created.
+            assertNotNull("can_match_ms present", canMatch.get("can_match_ms"));
+            int total = ((Number) canMatch.get("total_shards")).intValue();
+            assertEquals("total_shards should equal the index shard count", 2, total);
+
+            int pruned = ((Number) canMatch.get("shards_pruned_by_filter")).intValue();
+            int skipped = ((Number) canMatch.get("shards_skipped_by_topn")).intValue();
+            int dispatched = ((Number) canMatch.get("shards_dispatched")).intValue();
+            assertNotNull("topn_gate_armed present", canMatch.get("topn_gate_armed"));
+
+            // Internal consistency: dispatched = total - pruned - skipped, and none negative.
+            assertTrue("pruned >= 0", pruned >= 0);
+            assertTrue("skipped >= 0", skipped >= 0);
+            assertEquals("dispatched = total - pruned - skipped. can_match: " + canMatch, total - pruned - skipped, dispatched);
+            assertTrue("counts must not exceed total. can_match: " + canMatch, pruned + skipped <= total);
+        } finally {
+            resetSetting(PRE_FILTER_SETTING);
+        }
+    }
+
+    /**
+     * A query with neither range filters nor a bounded sort must NOT run can_match — so no
+     * SHARD_FRAGMENT stage should carry a can_match block. Guards against always-on overhead.
+     */
+    @SuppressWarnings("unchecked")
+    public void testNoCanMatchWhenNoFilterOrSort() throws IOException {
+        ensureProvisioned();
+        // Deliberately leave pre_filter_shard_size at its default and issue a bare projection.
+        Map<String, Object> result = executeWithProfile("source = " + INDEX + " | fields host");
+
+        Map<String, Object> profile = (Map<String, Object>) result.get("profile");
+        assertNotNull("profile present", profile);
+        List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
+
+        assertNull("no can_match block expected for a filter-less, sort-less query", findCanMatch(stages));
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> findCanMatch(List<Map<String, Object>> stages) {
+        for (Map<String, Object> stage : stages) {
+            if ("SHARD_FRAGMENT".equals(stage.get("execution_type"))) {
+                Object cm = stage.get("can_match");
+                if (cm != null) {
+                    return (Map<String, Object>) cm;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void createIndex() throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {}
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 2,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"ts\":   { \"type\": \"long\" },"
+            + "    \"host\": { \"type\": \"keyword\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request req = new Request("PUT", "/" + INDEX);
+        req.setJsonEntity(body);
+        client().performRequest(req);
+    }
+
+    private void indexData() throws IOException {
+        StringBuilder bulk = new StringBuilder();
+        for (int i = 0; i < 20; i++) {
+            bulk.append("{\"index\":{}}\n");
+            bulk.append("{\"ts\":").append(1_000_000 + i * 1000).append(",\"host\":\"host_").append(i).append("\"}\n");
+        }
+        Request req = new Request("POST", "/" + INDEX + "/_bulk");
+        req.addParameter("refresh", "true");
+        req.setJsonEntity(bulk.toString());
+        Response resp = client().performRequest(req);
+        assertEquals(200, resp.getStatusLine().getStatusCode());
+    }
+
+    private Map<String, Object> executeWithProfile(String ppl) throws IOException {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("{\"query\": \"" + escapeJson(ppl) + "\", \"profile\": true}");
+        Response response = client().performRequest(request);
+        return assertOkAndParse(response, "PROFILE: " + ppl);
+    }
+
+    private void applySetting(String key, String value) throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\": {\"" + key + "\": " + value + "}}");
+        client().performRequest(request);
+    }
+
+    private void resetSetting(String key) throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\": {\"" + key + "\": null}}");
+        client().performRequest(request);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
@@ -65,7 +65,7 @@ public class CanMatchProfileIT extends AnalyticsRestTestCase {
         try {
             // Keep only days 11 and 12 (>= 2026-07-11); days 08-10 prune.
             Map<String, Object> canMatch = canMatchBlockFor(
-                "source = " + indices + " | where `@timestamp` >= '2026-07-11 00:00:00' | fields host"
+                "source = " + indices + " | where `@timestamp` >= TIMESTAMP('2026-07-11 00:00:00') | fields host"
             );
             assertNotNull("can_match block expected for a filtered multi-shard query", canMatch);
             assertEquals("total_shards = one per day", TOTAL_DAYS, intField(canMatch, "total_shards"));
@@ -85,7 +85,7 @@ public class CanMatchProfileIT extends AnalyticsRestTestCase {
         applySetting(PRE_FILTER_SETTING, "1");
         try {
             Map<String, Object> canMatch = canMatchBlockFor(
-                "source = " + indices + " | where `@timestamp` >= '2026-07-01 00:00:00' and `@timestamp` <= '2026-07-31 23:59:59' | fields host"
+                "source = " + indices + " | where `@timestamp` >= TIMESTAMP('2026-07-01 00:00:00') and `@timestamp` <= TIMESTAMP('2026-07-31 23:59:59') | fields host"
             );
             assertNotNull("can_match block expected", canMatch);
             assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));
@@ -104,7 +104,7 @@ public class CanMatchProfileIT extends AnalyticsRestTestCase {
         applySetting(PRE_FILTER_SETTING, "1");
         try {
             Map<String, Object> canMatch = canMatchBlockFor(
-                "source = " + indices + " | where `@timestamp` >= '2026-09-01 00:00:00' | fields host"
+                "source = " + indices + " | where `@timestamp` >= TIMESTAMP('2026-09-01 00:00:00') | fields host"
             );
             assertNotNull("can_match block expected", canMatch);
             assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/CanMatchProfileIT.java
@@ -13,140 +13,258 @@ import org.opensearch.client.Response;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
- * Integration test for the can_match section of the profile=true response on SHARD_FRAGMENT stages.
+ * Integration tests for the {@code can_match} block of the {@code profile=true} response on
+ * SHARD_FRAGMENT stages.
  *
- * <p>can_match only runs when the query has range filters or a bounded-field sort AND the fan-out
- * clears the {@code worthPreFiltering} threshold. A {@code sort | head N} drops that threshold to 1,
- * and we additionally force {@code analytics.query.pre_filter_shard_size=1} so the probe reliably
- * fires on this small multi-shard index rather than depending on a production-scale fan-out.
+ * <p>These are the <b>observability</b> counterpart to the behavioral can-match ITs in the
+ * coordinator module ({@code CanMatchPruningIT}, {@code SortEarlyTerminationIT}). Those assert that
+ * pruning/skipping <i>happened</i> by counting fragment dispatches over the internal transport;
+ * they cannot assert the profile because {@code QueryProfile} is deliberately not serialized over
+ * the wire (see {@code PPLResponse}) — it only exists on the coordinator-local / REST response
+ * path. So the profile can only be validated through the REST endpoint, which is what these tests
+ * do. They reuse the same flagship fixture — one single-shard parquet index per day, addressed as a
+ * PPL comma-list ({@code source = a,b,c}) so the query routes through the distributed analytics
+ * engine where can-match runs (a {@code logs-*} wildcard would bypass it) and day ↔ shard is 1:1,
+ * making prune/skip counts deterministic.
+ *
+ * <p>{@code analytics.query.pre_filter_shard_size=1} forces the probe on for the filter-only cases,
+ * which are below the production fan-out threshold; the sort cases drop the threshold to 1 on their
+ * own.
  */
 public class CanMatchProfileIT extends AnalyticsRestTestCase {
 
-    private static final String INDEX = "canmatch_profile_test";
+    private static final String DAY_INDEX_PREFIX = "canmatch_profile_2026_07_";
+    private static final int FIRST_DAY = 8;
+    private static final int TOTAL_DAYS = 5;              // 2026-07-08 .. 2026-07-12, one shard each
+    private static final int LAST_DAY = FIRST_DAY + TOTAL_DAYS - 1;
+    private static final int DOCS_PER_DAY = 4;
     private static final String PRE_FILTER_SETTING = "analytics.query.pre_filter_shard_size";
+
+    private static String indicesCsv;    // comma-list of the daily indices, provisioned once
     private static boolean provisioned = false;
 
-    private void ensureProvisioned() throws IOException {
+    private String ensureProvisioned() throws IOException {
         if (!provisioned) {
-            createIndex();
-            indexData();
+            indicesCsv = createDailyIndices();
             provisioned = true;
         }
+        return indicesCsv;
     }
 
-    /**
-     * A {@code sort ts | head N} query over a 2-shard index triggers the can_match probe (and the
-     * top-N gate). The SHARD_FRAGMENT stage's profile must carry a can_match block with sensible,
-     * internally-consistent counts.
-     */
+    // ─── Filter-pruning scenarios (mirror CanMatchPruningIT) ────────────────────────
+
+    /** Trailing lower-bound window: older days prune, recent days survive → some pruned, some dispatched. */
     @SuppressWarnings("unchecked")
-    public void testCanMatchProfileOnSortQuery() throws IOException {
-        ensureProvisioned();
+    public void testProfileReportsFilterPruning() throws IOException {
+        String indices = ensureProvisioned();
         applySetting(PRE_FILTER_SETTING, "1");
         try {
-            Map<String, Object> result = executeWithProfile("source = " + INDEX + " | sort ts | fields host | head 3");
-
-            Map<String, Object> profile = (Map<String, Object>) result.get("profile");
-            assertNotNull("profile present", profile);
-            List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
-            assertNotNull("stages present", stages);
-
-            Map<String, Object> canMatch = findCanMatch(stages);
-            assertNotNull("a SHARD_FRAGMENT stage must carry a can_match block. stages: " + stages, canMatch);
-
-            // Latency is always recorded (>= 0). total_shards must be the 2 shards we created.
-            assertNotNull("can_match_ms present", canMatch.get("can_match_ms"));
-            int total = ((Number) canMatch.get("total_shards")).intValue();
-            assertEquals("total_shards should equal the index shard count", 2, total);
-
-            int pruned = ((Number) canMatch.get("shards_pruned_by_filter")).intValue();
-            int skipped = ((Number) canMatch.get("shards_skipped_by_topn")).intValue();
-            int dispatched = ((Number) canMatch.get("shards_dispatched")).intValue();
-            assertNotNull("topn_gate_armed present", canMatch.get("topn_gate_armed"));
-
-            // Internal consistency: dispatched = total - pruned - skipped, and none negative.
-            assertTrue("pruned >= 0", pruned >= 0);
-            assertTrue("skipped >= 0", skipped >= 0);
-            assertEquals("dispatched = total - pruned - skipped. can_match: " + canMatch, total - pruned - skipped, dispatched);
-            assertTrue("counts must not exceed total. can_match: " + canMatch, pruned + skipped <= total);
+            // Keep only days 11 and 12 (>= 2026-07-11); days 08-10 prune.
+            Map<String, Object> canMatch = canMatchBlockFor(
+                "source = " + indices + " | where `@timestamp` >= '2026-07-11 00:00:00' | fields host"
+            );
+            assertNotNull("can_match block expected for a filtered multi-shard query", canMatch);
+            assertEquals("total_shards = one per day", TOTAL_DAYS, intField(canMatch, "total_shards"));
+            assertEquals("days 08-10 prune", 3, intField(canMatch, "shards_pruned_by_filter"));
+            assertEquals("no sort → no top-N skips", 0, intField(canMatch, "shards_skipped_by_topn"));
+            assertEquals("topn_gate_armed false without a sort", Boolean.FALSE, canMatch.get("topn_gate_armed"));
+            assertConsistent(canMatch);
         } finally {
             resetSetting(PRE_FILTER_SETTING);
         }
     }
 
-    /**
-     * A query with neither range filters nor a bounded sort must NOT run can_match — so no
-     * SHARD_FRAGMENT stage should carry a can_match block. Guards against always-on overhead.
-     */
+    /** Window covering every day: nothing disjoint → nothing pruned, all dispatched. */
     @SuppressWarnings("unchecked")
-    public void testNoCanMatchWhenNoFilterOrSort() throws IOException {
-        ensureProvisioned();
-        // Deliberately leave pre_filter_shard_size at its default and issue a bare projection.
-        Map<String, Object> result = executeWithProfile("source = " + INDEX + " | fields host");
+    public void testProfileReportsNoPruneOnCoveringWindow() throws IOException {
+        String indices = ensureProvisioned();
+        applySetting(PRE_FILTER_SETTING, "1");
+        try {
+            Map<String, Object> canMatch = canMatchBlockFor(
+                "source = " + indices + " | where `@timestamp` >= '2026-07-01 00:00:00' and `@timestamp` <= '2026-07-31 23:59:59' | fields host"
+            );
+            assertNotNull("can_match block expected", canMatch);
+            assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));
+            assertEquals("covering window prunes nothing", 0, intField(canMatch, "shards_pruned_by_filter"));
+            assertEquals("all shards dispatched", TOTAL_DAYS, intField(canMatch, "shards_dispatched"));
+            assertConsistent(canMatch);
+        } finally {
+            resetSetting(PRE_FILTER_SETTING);
+        }
+    }
 
+    /** Window disjoint from every day: all prune except the one force-kept for a valid empty result. */
+    @SuppressWarnings("unchecked")
+    public void testProfilePrunesToSingleShard() throws IOException {
+        String indices = ensureProvisioned();
+        applySetting(PRE_FILTER_SETTING, "1");
+        try {
+            Map<String, Object> canMatch = canMatchBlockFor(
+                "source = " + indices + " | where `@timestamp` >= '2026-09-01 00:00:00' | fields host"
+            );
+            assertNotNull("can_match block expected", canMatch);
+            assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));
+            assertEquals("all-but-one pruned (one force-kept)", TOTAL_DAYS - 1, intField(canMatch, "shards_pruned_by_filter"));
+            assertEquals("exactly one shard dispatched", 1, intField(canMatch, "shards_dispatched"));
+            assertConsistent(canMatch);
+        } finally {
+            resetSetting(PRE_FILTER_SETTING);
+        }
+    }
+
+    /** No filter and no sort → the probe is skipped entirely, so no can_match block appears. */
+    @SuppressWarnings("unchecked")
+    public void testProfileNoCanMatchWithoutFilterOrSort() throws IOException {
+        String indices = ensureProvisioned();
+        // Leave pre_filter_shard_size at default; a bare projection has nothing to probe.
+        Map<String, Object> result = executeWithProfile("source = " + indices + " | fields host");
+        List<Map<String, Object>> stages = stagesOf(result);
+        assertNull("no can_match block for a filter-less, sort-less query", findCanMatch(stages));
+    }
+
+    // ─── Sort top-N gate scenarios (mirror SortEarlyTerminationIT) ──────────────────
+
+    /** DESC sort over disjoint daily ranges: the gate arms; any skips are reported consistently. */
+    @SuppressWarnings("unchecked")
+    public void testProfileReportsTopNGateArmed() throws IOException {
+        String indices = ensureProvisioned();
+        // sort drops the threshold to 1 on its own; no setting needed.
+        Map<String, Object> canMatch = canMatchBlockFor(
+            "source = " + indices + " | sort - `@timestamp` | fields host | head " + DOCS_PER_DAY
+        );
+        assertNotNull("can_match block expected for a bounded sort", canMatch);
+        assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));
+        // The gate arming is deterministic (one day's worth of rows fills the top-N heap). Whether
+        // any shard is actually SKIPPED, however, is timing-dependent: elimination only fires on
+        // shards still queued when the gate arms, and the per-node dispatch window (which the
+        // coordinator-level SortEarlyTerminationIT pins to 1 for determinism) can't be controlled
+        // over REST. So assert the deterministic facts — gate armed + consistent counts — and only
+        // that skips never exceed what's eliminable, not that at least one occurred.
+        assertEquals("top-N over one day's worth of rows arms the gate", Boolean.TRUE, canMatch.get("topn_gate_armed"));
+        assertTrue("skipped shards must be within bounds. block: " + canMatch, intField(canMatch, "shards_skipped_by_topn") <= TOTAL_DAYS - 1);
+        assertConsistent(canMatch);
+    }
+
+    /** Sort with a large limit (>= all data): the gate never fills, so nothing is skipped. */
+    @SuppressWarnings("unchecked")
+    public void testProfileTopNNoSkipWhenLimitExceedsData() throws IOException {
+        String indices = ensureProvisioned();
+        int everything = TOTAL_DAYS * DOCS_PER_DAY + 10;   // more than all rows across all days
+        Map<String, Object> canMatch = canMatchBlockFor(
+            "source = " + indices + " | sort - `@timestamp` | fields host | head " + everything
+        );
+        assertNotNull("can_match block expected for a bounded sort", canMatch);
+        assertEquals(TOTAL_DAYS, intField(canMatch, "total_shards"));
+        assertEquals("limit exceeds all data → nothing can be eliminated", 0, intField(canMatch, "shards_skipped_by_topn"));
+        assertEquals("every shard dispatched", TOTAL_DAYS, intField(canMatch, "shards_dispatched"));
+        assertConsistent(canMatch);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────────
+
+    /** Runs a profile=true query and returns the first SHARD_FRAGMENT stage's can_match block (or null). */
+    private Map<String, Object> canMatchBlockFor(String ppl) throws IOException {
+        return findCanMatch(stagesOf(executeWithProfile(ppl)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> stagesOf(Map<String, Object> result) {
         Map<String, Object> profile = (Map<String, Object>) result.get("profile");
         assertNotNull("profile present", profile);
         List<Map<String, Object>> stages = (List<Map<String, Object>>) profile.get("stages");
-
-        assertNull("no can_match block expected for a filter-less, sort-less query", findCanMatch(stages));
+        assertNotNull("stages present", stages);
+        return stages;
     }
-
-    // ─── Helpers ──────────────────────────────────────────────────────────────────
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> findCanMatch(List<Map<String, Object>> stages) {
         for (Map<String, Object> stage : stages) {
-            if ("SHARD_FRAGMENT".equals(stage.get("execution_type"))) {
-                Object cm = stage.get("can_match");
-                if (cm != null) {
-                    return (Map<String, Object>) cm;
-                }
+            if ("SHARD_FRAGMENT".equals(stage.get("execution_type")) && stage.get("can_match") != null) {
+                return (Map<String, Object>) stage.get("can_match");
             }
         }
         return null;
     }
 
-    private void createIndex() throws IOException {
-        try {
-            client().performRequest(new Request("DELETE", "/" + INDEX));
-        } catch (Exception ignored) {}
-
-        String body = "{"
-            + "\"settings\": {"
-            + "  \"number_of_shards\": 2,"
-            + "  \"number_of_replicas\": 0,"
-            + "  \"index.pluggable.dataformat.enabled\": true,"
-            + "  \"index.pluggable.dataformat\": \"composite\","
-            + "  \"index.composite.primary_data_format\": \"parquet\","
-            + "  \"index.composite.secondary_data_formats\": \"lucene\""
-            + "},"
-            + "\"mappings\": {"
-            + "  \"properties\": {"
-            + "    \"ts\":   { \"type\": \"long\" },"
-            + "    \"host\": { \"type\": \"keyword\" }"
-            + "  }"
-            + "}"
-            + "}";
-
-        Request req = new Request("PUT", "/" + INDEX);
-        req.setJsonEntity(body);
-        client().performRequest(req);
+    private int intField(Map<String, Object> block, String key) {
+        Object v = block.get(key);
+        assertNotNull(key + " present in can_match block: " + block, v);
+        return ((Number) v).intValue();
     }
 
-    private void indexData() throws IOException {
-        StringBuilder bulk = new StringBuilder();
-        for (int i = 0; i < 20; i++) {
-            bulk.append("{\"index\":{}}\n");
-            bulk.append("{\"ts\":").append(1_000_000 + i * 1000).append(",\"host\":\"host_").append(i).append("\"}\n");
+    /** dispatched = total - pruned - skipped, no negatives, counts within bounds. */
+    private void assertConsistent(Map<String, Object> canMatch) {
+        assertNotNull("can_match_ms present", canMatch.get("can_match_ms"));
+        int total = intField(canMatch, "total_shards");
+        int pruned = intField(canMatch, "shards_pruned_by_filter");
+        int skipped = intField(canMatch, "shards_skipped_by_topn");
+        int dispatched = intField(canMatch, "shards_dispatched");
+        assertTrue("pruned >= 0", pruned >= 0);
+        assertTrue("skipped >= 0", skipped >= 0);
+        assertTrue("pruned + skipped <= total. block: " + canMatch, pruned + skipped <= total);
+        assertEquals("dispatched = total - pruned - skipped. block: " + canMatch, total - pruned - skipped, dispatched);
+    }
+
+    /**
+     * Creates {@value #TOTAL_DAYS} single-shard daily parquet indices, one day of docs each, and
+     * returns the comma-separated index list for a multi-index PPL {@code source =} clause.
+     */
+    private String createDailyIndices() throws IOException {
+        StringBuilder csv = new StringBuilder();
+        for (int day = FIRST_DAY; day <= LAST_DAY; day++) {
+            String index = String.format(Locale.ROOT, "%s%02d", DAY_INDEX_PREFIX, day);
+            try {
+                client().performRequest(new Request("DELETE", "/" + index));
+            } catch (Exception ignored) {}
+
+            String body = "{"
+                + "\"settings\": {"
+                + "  \"number_of_shards\": 1,"
+                + "  \"number_of_replicas\": 0,"
+                + "  \"index.pluggable.dataformat.enabled\": true,"
+                + "  \"index.pluggable.dataformat\": \"composite\","
+                + "  \"index.composite.primary_data_format\": \"parquet\","
+                + "  \"index.composite.secondary_data_formats\": \"lucene\""
+                + "},"
+                + "\"mappings\": { \"properties\": {"
+                + "  \"@timestamp\": { \"type\": \"date\" },"
+                + "  \"host\": { \"type\": \"keyword\" }"
+                + "} }"
+                + "}";
+            Request create = new Request("PUT", "/" + index);
+            create.setJsonEntity(body);
+            client().performRequest(create);
+
+            StringBuilder bulk = new StringBuilder();
+            for (int i = 0; i < DOCS_PER_DAY; i++) {
+                bulk.append("{\"index\":{}}\n");
+                bulk.append(
+                    String.format(
+                        Locale.ROOT,
+                        "{\"@timestamp\":\"2026-07-%02dT%02d:00:00Z\",\"host\":\"host-%d-%d\"}\n",
+                        day,
+                        i,
+                        day,
+                        i
+                    )
+                );
+            }
+            Request indexBulk = new Request("POST", "/" + index + "/_bulk");
+            indexBulk.addParameter("refresh", "true");
+            indexBulk.setJsonEntity(bulk.toString());
+            Response resp = client().performRequest(indexBulk);
+            assertEquals(200, resp.getStatusLine().getStatusCode());
+
+            if (day > FIRST_DAY) {
+                csv.append(',');
+            }
+            csv.append(index);
         }
-        Request req = new Request("POST", "/" + INDEX + "/_bulk");
-        req.addParameter("refresh", "true");
-        req.setJsonEntity(bulk.toString());
-        Response resp = client().performRequest(req);
-        assertEquals(200, resp.getStatusLine().getStatusCode());
+        return csv.toString();
     }
 
     private Map<String, Object> executeWithProfile(String ppl) throws IOException {


### PR DESCRIPTION
Adding support for `profile=true` for the can_match stage. All metrics are already computed and surfaced on the coordinator.

A `can_match` block is attached to each `SHARD_FRAGMENT` stage in the profile response, present only when the can_match phase actually ran (query had range filters or a bounded-field sort, and the fan-out cleared the pre-filter threshold).

## Fields

| Field | Meaning |
|-------|---------|
| `can_match_ms` | Wall-clock latency of the parallel can_match probe round-trip |
| `total_shards` | Shard targets considered before can_match ran |
| `shards_pruned_by_filter` | Shards dropped pre-dispatch because parquet row-group stats proved their range disjoint from the query filters |
| `shards_skipped_by_topn` | Shards skipped during staggered dispatch because their folded sort bounds could not beat the top-N bar (`sort | head N` gate) |
| `topn_gate_armed` | Whether the top-N gate reached its limit K (dynamic skipping was active) |
| `shards_dispatched` | Shards that actually ran a fragment (`total_shards - pruned - skipped`) |