### PR TITLE
Add Shreyansh Ray as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -36,6 +36,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sachin Kale       | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
 | Sandesh Kumar     | [sandeshkr419](https://github.com/sandeshkr419)         | Amazon      |
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Shreyansh Ray     | [rayshrey](https://github.com/rayshrey)                 | Amazon      |
 | Shweta Thareja    | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
 | Sorabh Hamirwasia | [sohami](https://github.com/sohami)                     | Amazon      |
 | Varun Bansal      | [linuxpi](https://github.com/linuxpi)                   | Amazon      |


### PR DESCRIPTION
### Description

Note to the maintainers, do not merge this until https://github.com/opensearch-project/.github/issues/631 is marked as complete

Adds Shreyansh Ray ([rayshrey](https://github.com/rayshrey), Amazon) to the current maintainers table in `MAINTAINERS.md`.

Shreyansh has authored [20 issues](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue+author%3Arayshrey) including 4 RFCs and a meta issue, authored [48 PRs](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Aclosed+is%3Apr+author%3Arayshrey) (41 merged to date), and reviewed or commented on [29 PRs](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+commenter%3Arayshrey) and [10 issues](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue+commenter%3Arayshrey) for others. He has been actively contributing to the OpenSearch core repo since September 2023.
Shreyansh has a sustained track record of deep, systems-level contributions to OpenSearch, concentrated in two of the most architecturally significant workstreams in core: Writable Warm and Pluggable Data Formats. His work spans the storage and directory layers (Composite Directory, FileCache, Switchable IndexInput), engine internals (DataFormatAwareEngine, dynamic mappings, indexing memory and merge throttling), and native/Rust integration — areas where correctness bugs are subtle and expensive to find. Contributions range from authoring foundational RFCs, to delivering multi-PR features end to end, to diagnosing and fixing production-critical bugs such as doc corruption from a rolled-back doc in versioned segment replication and a recovery poison pill caused by stale native-side state.

Just as importantly, Shreyansh is a reliable reviewer and collaborator. He has been a primary reviewer across much of the Writable Warm directory, replication, and file cache surface, and across the Pluggable Data Formats merge and memory paths. He consistently engages with external contributors on design questions and root-cause discussions rather than only on his own changes.

Some of his key highlights:

### RFCs and design proposals
1. [Composite Directory for Writable Warm](https://github.com/opensearch-project/OpenSearch/issues/12781)
2. [Parquet Data Format plugin](https://github.com/opensearch-project/OpenSearch/issues/21058)
3. [Dynamic Mapping Support for DataFormatAwareEngine](https://github.com/opensearch-project/OpenSearch/issues/21587)
4. [Switchable IndexInput](https://github.com/opensearch-project/OpenSearch/issues/21101)



PRs — Pluggable Data Formats

1. [Parquet Data Format Plugin](https://github.com/opensearch-project/OpenSearch/pull/20930)
2. [IndexFileDeleter and CatalogSnapshotManager integration](https://github.com/opensearch-project/OpenSearch/pull/21145)
3. [Dynamic mappings for DataFormatAwareEngine](https://github.com/opensearch-project/OpenSearch/pull/21444)
4. [IndexingMemoryController integration](https://github.com/opensearch-project/OpenSearch/pull/21768)
5. Memory pools — [#21885](https://github.com/opensearch-project/OpenSearch/pull/21885), [#22227](https://github.com/opensearch-project/OpenSearch/pull/22227), [#22375](https://github.com/opensearch-project/OpenSearch/pull/22375)

Bug fixes — [#21460](https://github.com/opensearch-project/OpenSearch/pull/21460), [#21940](https://github.com/opensearch-project/OpenSearch/pull/21940)

### Related Issues

N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).