### PR TITLE
Add RankDocsQuery and RankDocsSortField for internal retriever ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@ As of the 3.6 release [the CHANGELOG is no longer used][1] to generate release n
 
 [1]: https://github.com/opensearch-project/OpenSearch/issues/21071
 [2]: https://github.com/opensearch-project/OpenSearch/pulls?q=sort%3Amerged-desc+is%3Apr+-label%3Askip-changelog+is%3Amerged+base%3Amain+
+
+## [Unreleased]
+### Added
+- Add RankDocsQuery and RankDocsSortField for internal retriever ranking ([#22842](https://github.com/opensearch-project/OpenSearch/pull/22842))

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -1122,6 +1122,18 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(DisMaxQueryBuilder.NAME, DisMaxQueryBuilder::new, DisMaxQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(IdsQueryBuilder.NAME, IdsQueryBuilder::new, IdsQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchAllQueryBuilder.NAME, MatchAllQueryBuilder::new, MatchAllQueryBuilder::fromXContent));
+        // RankDocsQueryBuilder is built in-process by the retriever framework on the coordinator and set on
+        // the SearchSourceBuilder directly. It is registered (NamedWriteable + NamedXContent) so it serializes
+        // to data nodes and can be inspected via the profile API. It is purely internal: authoring it directly
+        // in a _search body is impossible because RankDocsQueryBuilder.fromXContent always rejects. The internal
+        // retriever path reconstructs it on data nodes over the binary stream, never via fromXContent.
+        registerQuery(
+            new QuerySpec<>(
+                org.opensearch.search.retriever.RankDocsQueryBuilder.NAME,
+                org.opensearch.search.retriever.RankDocsQueryBuilder::new,
+                org.opensearch.search.retriever.RankDocsQueryBuilder::fromXContent
+            )
+        );
         registerQuery(new QuerySpec<>(QueryStringQueryBuilder.NAME, QueryStringQueryBuilder::new, QueryStringQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(BoostingQueryBuilder.NAME, BoostingQueryBuilder::new, BoostingQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(BoolQueryBuilder.NAME, BoolQueryBuilder::new, BoolQueryBuilder::fromXContent));
@@ -1213,6 +1225,16 @@ public class SearchModule {
         registerSort(new SortSpec<>(ScoreSortBuilder.NAME, ScoreSortBuilder::new, ScoreSortBuilder::fromXContent));
         registerFromPlugin(plugins, SearchPlugin::getSorts, this::registerSort);
         registerSort(new SortSpec<>(ShardDocSortBuilder.NAME, ShardDocSortBuilder::new, ShardDocSortBuilder::fromXContent));
+        // Internal to the retriever framework: registered so it serializes to data nodes and builds the
+        // per-shard RankDocsSortField. It is purely internal — authoring it in a _search body is impossible
+        // because RankDocsSortBuilder.fromXContent always rejects.
+        registerSort(
+            new SortSpec<>(
+                org.opensearch.search.retriever.RankDocsSortBuilder.NAME,
+                org.opensearch.search.retriever.RankDocsSortBuilder::new,
+                org.opensearch.search.retriever.RankDocsSortBuilder::fromXContent
+            )
+        );
     }
 
     private void registerIntervalsSourceProviders() {

--- a/server/src/main/java/org/opensearch/search/retriever/RankDoc.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDoc.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A single entry in a resolved retriever ranking: the document identified by its
+ * {@code (index, shardId, _id)} coordinate, together with the pre-computed relevance
+ * {@code score} and the retriever-assigned {@code position} (rank).
+ * <p>
+ * The coordinator produces a list of these after resolving the retriever tree (fusion, reranking,
+ * pinning, etc.) and ships it to every shard as part of the internal {@link RankDocsQuery}. {@code _id}
+ * is unique only within an index and a document routes to exactly one shard, so the
+ * {@code (index, shardId)} pair disambiguates a cross-index {@code _id} collision on the broadcast query.
+ *
+ * @opensearch.internal
+ */
+public final class RankDoc implements Writeable, ToXContentObject {
+
+    static final String INDEX_FIELD = "index";
+    static final String SHARD_FIELD = "shard";
+    static final String ID_FIELD = "id";
+    static final String SCORE_FIELD = "score";
+    static final String POSITION_FIELD = "position";
+
+    private final String index;
+    private final int shardId;
+    private final String id;
+    private final float score;
+    private final int position;
+
+    /**
+     * @param index    the concrete index name the document belongs to
+     * @param shardId  the shard the document routes to within {@code index}
+     * @param id       the document {@code _id} (original string form, not the encoded {@link org.opensearch.index.mapper.Uid} bytes)
+     * @param score    the pre-computed retriever score for the document
+     * @param position the retriever-assigned rank (0-based); lower means higher in the ranking
+     */
+    public RankDoc(String index, int shardId, String id, float score, int position) {
+        this.index = Objects.requireNonNull(index, "index");
+        this.shardId = shardId;
+        this.id = Objects.requireNonNull(id, "id");
+        this.score = score;
+        this.position = position;
+    }
+
+    /** Reads a {@code RankDoc} from the wire. Field order must match {@link #writeTo}. */
+    public RankDoc(StreamInput in) throws IOException {
+        this.index = in.readString();
+        this.shardId = in.readVInt();
+        this.id = in.readString();
+        this.score = in.readFloat();
+        this.position = in.readVInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(index);
+        out.writeVInt(shardId);
+        out.writeString(id);
+        out.writeFloat(score);
+        out.writeVInt(position);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(INDEX_FIELD, index);
+        builder.field(SHARD_FIELD, shardId);
+        builder.field(ID_FIELD, id);
+        builder.field(SCORE_FIELD, score);
+        builder.field(POSITION_FIELD, position);
+        builder.endObject();
+        return builder;
+    }
+
+    /** The concrete index name the document belongs to. */
+    public String index() {
+        return index;
+    }
+
+    /** The shard the document routes to within its index. */
+    public int shardId() {
+        return shardId;
+    }
+
+    /** The document {@code _id} in its original string form. */
+    public String id() {
+        return id;
+    }
+
+    /** The pre-computed retriever score for the document. */
+    public float score() {
+        return score;
+    }
+
+    /** The retriever-assigned rank (0-based); lower means higher in the ranking. */
+    public int position() {
+        return position;
+    }
+
+    /** Whether this doc belongs to the given {@code (index, shardId)} shard. */
+    public boolean belongsTo(String indexName, int shard) {
+        return this.shardId == shard && this.index.equals(indexName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RankDoc other = (RankDoc) o;
+        return shardId == other.shardId
+            && position == other.position
+            && Float.compare(other.score, score) == 0
+            && index.equals(other.index)
+            && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, shardId, id, score, position);
+    }
+
+    @Override
+    public String toString() {
+        return "RankDoc{index='" + index + "', shardId=" + shardId + ", id='" + id + "', score=" + score + ", position=" + position + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/RankDocsQuery.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDocsQuery.java
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Internal-only query that replays a pre-computed retriever ranking onto an ordinary search.
+ * <p>
+ * The coordinator resolves the retriever tree to a list of {@link RankDoc}s — each a
+ * {@code (index, shardId, _id, score, position)}. The whole window is broadcast to every shard as the
+ * {@link RankDocsQueryBuilder}; {@link RankDocsQueryBuilder#doToQuery} then scopes it to this shard's
+ * {@code (index, shardId)} <em>before</em> building this query, so the query holds only its own shard's
+ * docs. It seeks each {@code _id} in the {@code _id} terms dictionary and hands back the document's
+ * <em>pre-computed</em> score. Ordering by {@code position} (when order is decoupled from score) is
+ * handled separately by {@link RankDocsSortField}; this query only carries {@code _id}s and scores.
+ * <p>
+ * This query has no scoring logic of its own — it replays a ranking the coordinator already computed —
+ * so it does <b>not</b> support {@code explain}: {@code Weight.explain} throws
+ * {@link UnsupportedOperationException}. The user-facing {@code _explanation} is the coordinator-built
+ * retriever tree, and the retriever framework never runs the final {@code RankDocsQuery} search with
+ * explain enabled.
+ *
+ * @opensearch.internal
+ */
+public final class RankDocsQuery extends Query {
+
+    private final List<RankDoc> rankDocs;
+    private final String indexName;
+    private final int shardId;
+
+    /**
+     * @param rankDocs  this shard's slice of the resolved window ({@code (index, shardId)}-scoped by
+     *                  {@link RankDocsQueryBuilder#doToQuery}); MUST already be immutable
+     * @param indexName the concrete index this shard belongs to
+     * @param shardId   this shard's id within {@code indexName}
+     */
+    public RankDocsQuery(List<RankDoc> rankDocs, String indexName, int shardId) {
+        // The list is already an immutable, shard-scoped copy from the builder; store the reference directly.
+        this.rankDocs = Objects.requireNonNull(rankDocs, "rankDocs");
+        this.indexName = Objects.requireNonNull(indexName, "indexName");
+        this.shardId = shardId;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new Weight(this) {
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                // RankDocsQuery only replays a ranking the retriever already computed on the coordinator;
+                // it has no scoring logic of its own to explain, and the retriever framework never issues
+                // the final RankDocsQuery search with explain enabled (the user-facing _explanation is the
+                // coordinator-built retriever tree, which overwrites any per-query explanation). There is
+                // no valid case in which this is called, so fail loudly rather than emit a misleading one.
+                throw new UnsupportedOperationException(
+                    "RankDocsQuery does not support explain; the retriever framework builds the explanation "
+                        + "on the coordinator and never runs the final RankDocsQuery search with explain enabled"
+                );
+            }
+
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                final RankDocsResolver.Resolved resolved = RankDocsResolver.resolve(context, rankDocs);
+                if (resolved.size() == 0) {
+                    return null;
+                }
+                final float[] scores = new float[resolved.size()];
+                for (int i = 0; i < resolved.size(); i++) {
+                    scores[i] = resolved.docs[i].score() * boost;
+                }
+                final Scorer scorer = new RankDocsScorer(resolved.docIds, scores);
+                return new DefaultScorerSupplier(scorer);
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                // Matches/scores depend on a per-request window shipped from the coordinator, not on stable
+                // segment content, so this query must never be cached in the query cache.
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        visitor.visitLeaf(this);
+    }
+
+    @Override
+    public String toString(String field) {
+        return "RankDocsQuery(index=" + indexName + ", shardId=" + shardId + ", docs=" + rankDocs.size() + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        RankDocsQuery other = (RankDocsQuery) o;
+        return shardId == other.shardId && indexName.equals(other.indexName) && rankDocs.equals(other.rankDocs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), rankDocs, indexName, shardId);
+    }
+
+    /**
+     * A {@link Scorer} that walks a sorted array of Lucene doc ids and returns each one's pre-computed score.
+     * {@code docIds} MUST be sorted ascending; {@code scores[i]} is the score for {@code docIds[i]}.
+     */
+    static final class RankDocsScorer extends Scorer {
+        private final int[] docIds;
+        private final float[] scores;
+        private final ArrayDocIdSetIterator iterator;
+
+        RankDocsScorer(int[] docIds, float[] scores) {
+            this.docIds = docIds;
+            this.scores = scores;
+            this.iterator = new ArrayDocIdSetIterator(docIds);
+        }
+
+        @Override
+        public int docID() {
+            return iterator.docID();
+        }
+
+        @Override
+        public float score() {
+            final int idx = iterator.currentIndex();
+            if (idx < 0 || idx >= scores.length) {
+                return 0f;
+            }
+            return scores[idx];
+        }
+
+        @Override
+        public float getMaxScore(int upTo) {
+            float max = 0f;
+            for (int i = 0; i < docIds.length && docIds[i] <= upTo; i++) {
+                max = Math.max(max, scores[i]);
+            }
+            return max;
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return iterator;
+        }
+    }
+
+    /** A forward-only {@link DocIdSetIterator} over a sorted, de-duplicated array of doc ids. */
+    static final class ArrayDocIdSetIterator extends DocIdSetIterator {
+        private final int[] docIds;
+        private int index = -1;
+        private int doc = -1;
+
+        ArrayDocIdSetIterator(int[] docIds) {
+            this.docIds = docIds;
+        }
+
+        int currentIndex() {
+            return index;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) {
+            int lo = Math.max(index, 0);
+            while (lo < docIds.length && docIds[lo] < target) {
+                lo++;
+            }
+            if (lo >= docIds.length) {
+                index = docIds.length;
+                doc = NO_MORE_DOCS;
+            } else {
+                index = lo;
+                doc = docIds[lo];
+            }
+            return doc;
+        }
+
+        @Override
+        public long cost() {
+            return docIds.length;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/RankDocsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDocsQueryBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Internal query builder that carries a resolved retriever window onto a real {@code _search} and, on
+ * each shard, turns it into a {@link RankDocsQuery} scoped to that shard's {@code (index, shardId)}.
+ * <p>
+ * This is intentionally minimal: it exists so a resolved ranking can ride the ordinary search path
+ * (and be inspected with the profile API). The retriever framework always builds it in-process, so it
+ * is registered as a named query and always serializes to data nodes. It is purely internal — it cannot
+ * be authored directly in a {@code _search} body: {@link #fromXContent} always rejects, and the query is
+ * only ever reconstructed on data nodes over the binary {@link StreamInput} path.
+ * <p>
+ * JSON shape (rendered by {@link #doXContent} for the profile API / debugging only):
+ * <pre>
+ * { "rank_docs": {
+ *     "docs": [ { "index": "products", "shard": 0, "id": "a", "score": 0.9, "position": 0 }, ... ]
+ * } }
+ * </pre>
+ *
+ * @opensearch.internal
+ */
+public final class RankDocsQueryBuilder extends AbstractQueryBuilder<RankDocsQueryBuilder> {
+
+    public static final String NAME = "rank_docs";
+
+    private final List<RankDoc> rankDocs;
+
+    public RankDocsQueryBuilder(List<RankDoc> rankDocs) {
+        // The retriever executor sets an immutable resolved window; nothing mutates it after, so no copy.
+        this.rankDocs = Objects.requireNonNull(rankDocs, "rankDocs");
+    }
+
+    public RankDocsQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.rankDocs = in.readList(RankDoc::new);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeCollection(rankDocs);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.startArray("docs");
+        for (RankDoc rd : rankDocs) {
+            rd.toXContent(builder, params);
+        }
+        builder.endArray();
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    /**
+     * Always rejects: {@code rank_docs} is internal to the retriever framework and cannot be authored in a
+     * {@code _search} body. The query is only ever built in-process on the coordinator and transported to
+     * data nodes over the binary {@link StreamInput}/{@link StreamOutput} path (see {@link #RankDocsQueryBuilder(StreamInput)}),
+     * never parsed from XContent. This method exists solely to satisfy the {@code QuerySpec} registration
+     * contract, which requires a parser.
+     */
+    public static RankDocsQueryBuilder fromXContent(XContentParser parser) {
+        throw new ParsingException(
+            parser.getTokenLocation(),
+            "[" + NAME + "] query is internal to the retriever framework and cannot be used directly in a search request"
+        );
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) {
+        final String indexName = context.index().getName();
+        final int shardId = context.getShardId();
+        // Filter the window down to this shard's (index, shardId) HERE, before building the query,
+        // so RankDocsQuery only holds — and only tries to resolve — the docs that can exist on this shard.
+        return new RankDocsQuery(filterToShard(rankDocs, indexName, shardId), indexName, shardId);
+    }
+
+    /**
+     * The subset of {@code window} whose docs belong to {@code (indexName, shardId)}, in order. Returns a
+     * freshly-built list (no defensive copy needed — it is not retained here). Package-visible for testing
+     * the per-shard scoping independently of a {@link QueryShardContext}.
+     */
+    static List<RankDoc> filterToShard(List<RankDoc> window, String indexName, int shardId) {
+        final List<RankDoc> mine = new ArrayList<>();
+        for (RankDoc rd : window) {
+            if (rd.belongsTo(indexName, shardId)) {
+                mine.add(rd);
+            }
+        }
+        return mine;
+    }
+
+    @Override
+    protected boolean doEquals(RankDocsQueryBuilder other) {
+        return rankDocs.equals(other.rankDocs);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(rankDocs);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/RankDocsResolver.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDocsResolver.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.Uid;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Resolves a window of {@link RankDoc}s to their Lucene doc ids within a single segment by seeking each
+ * {@code _id} in the segment's {@code _id} terms dictionary ({@code TermsEnum.seekExact}). This is the one
+ * place the {@code _id -> luceneDocId} translation lives, shared by {@link RankDocsQuery}'s scorer (to
+ * attach the pre-computed score) and {@link RankDocsSortField}'s comparator (to attach the position), so the
+ * seek is implemented exactly once.
+ * <p>
+ * {@code _id} is the only identity that is stable across the fresh readers of the final search (a Lucene
+ * doc id from an earlier round is meaningless against a different reader), so a per-{@code _id} seek is
+ * the correct re-identification mechanism when the retriever tree is not pinned to a point-in-time reader.
+ * <p>
+ * The result is a compact, ascending-by-docId mapping of the docs that actually resolved in this segment.
+ * Docs whose {@code _id} does not resolve (deleted / moved / not on this segment) are omitted, mirroring
+ * how a plain {@code _search} drops a doc deleted between its query and fetch phases.
+ * <p>
+ * Not thread safe; construct and use one per segment on the thread handling that segment.
+ *
+ * @opensearch.internal
+ */
+final class RankDocsResolver {
+
+    private RankDocsResolver() {}
+
+    /** A resolved {@code (luceneDocId -> RankDoc)} pair for one segment, sorted ascending by docId. */
+    static final class Resolved {
+        final int[] docIds;
+        final RankDoc[] docs;
+
+        Resolved(int[] docIds, RankDoc[] docs) {
+            this.docIds = docIds;
+            this.docs = docs;
+        }
+
+        int size() {
+            return docIds.length;
+        }
+    }
+
+    /**
+     * Resolve {@code window} against {@code ctx}'s segment by seeking each {@code _id}.
+     * Only the entries of {@code window} that belong to this segment's reader are resolved; the caller is
+     * expected to have already filtered {@code window} to the shard, but any {@code _id} that does not seek
+     * is simply skipped.
+     *
+     * @return docs that resolved in this segment, sorted ascending by Lucene doc id (never null; may be empty)
+     */
+    static Resolved resolve(LeafReaderContext ctx, List<RankDoc> window) throws IOException {
+        if (window.isEmpty()) {
+            return new Resolved(new int[0], new RankDoc[0]);
+        }
+        final Terms terms = ctx.reader().terms(IdFieldMapper.NAME);
+        if (terms == null) {
+            // Segment carries no _id terms (e.g. an all-no-op segment); nothing resolves here.
+            return new Resolved(new int[0], new RankDoc[0]);
+        }
+        final TermsEnum termsEnum = terms.iterator();
+        final Bits liveDocs = ctx.reader().getLiveDocs();
+
+        final List<int[]> docIdIndex = new ArrayList<>(window.size()); // [docId, windowOrdinal]
+        PostingsEnum postings = null;
+        for (int i = 0; i < window.size(); i++) {
+            if (termsEnum.seekExact(Uid.encodeId(window.get(i).id())) == false) {
+                continue;
+            }
+            postings = termsEnum.postings(postings, PostingsEnum.NONE);
+            final int docId = firstLiveDoc(postings, liveDocs);
+            if (docId != DocIdSetIterator.NO_MORE_DOCS) {
+                docIdIndex.add(new int[] { docId, i });
+            }
+        }
+
+        // DocIdSetIterator requires strictly ascending doc ids: ArrayDocIdSetIterator.advance walks the
+        // array forward only, so the scorer would drop or misorder hits if these weren't sorted. The _id
+        // seek yields them in window (ranking) order, which is unrelated to Lucene doc-id order.
+        docIdIndex.sort(Comparator.comparingInt(a -> a[0]));
+        final int[] docIds = new int[docIdIndex.size()];
+        final RankDoc[] docs = new RankDoc[docIdIndex.size()];
+        for (int i = 0; i < docIdIndex.size(); i++) {
+            docIds[i] = docIdIndex.get(i)[0];
+            docs[i] = window.get(docIdIndex.get(i)[1]);
+        }
+        return new Resolved(docIds, docs);
+    }
+
+    /** The _id field is a primary key: return the single live doc for the current term, or NO_MORE_DOCS. */
+    private static int firstLiveDoc(PostingsEnum postings, Bits liveDocs) throws IOException {
+        for (int d = postings.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = postings.nextDoc()) {
+            if (liveDocs == null || liveDocs.get(d)) {
+                return d;
+            }
+        }
+        return DocIdSetIterator.NO_MORE_DOCS;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/RankDocsSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDocsSortBuilder.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.sort.BucketedSort;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortFieldAndFormat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Coordinator-side, serializable companion to {@link RankDocsSortField} — the sort analogue of
+ * {@link RankDocsQueryBuilder}. The retriever framework injects this on the final search's {@code sort}
+ * when the resolved root's order is decoupled from {@code _score} (e.g. {@code pinned}) and the user gave
+ * no top-level sort. It carries the whole resolved window and is broadcast to every shard; {@link #build}
+ * then runs <em>on each shard</em> — where {@link QueryShardContext#getShardId()} is available — scopes
+ * the window to that shard's {@code (index, shardId)}, and produces the shard-local {@link RankDocsSortField}.
+ * <p>
+ * This split is why the shard id is knowable at all: the coordinator cannot know a specific shard, so it
+ * only builds this spec; the {@code shardId} is resolved per shard in {@link #build}, exactly as
+ * {@link RankDocsQueryBuilder#doToQuery} does for the query.
+ * <p>
+ * Like {@link RankDocsQueryBuilder}, this is purely internal to the retriever framework: it is registered
+ * so it serializes to data nodes, but it cannot be authored directly in a {@code _search} body —
+ * {@link #fromXContent} always rejects, and it is only ever reconstructed on data nodes over the binary
+ * {@link StreamInput} path.
+ *
+ * @opensearch.internal
+ */
+public final class RankDocsSortBuilder extends SortBuilder<RankDocsSortBuilder> {
+
+    public static final String NAME = "rank_docs_sort";
+
+    private final List<RankDoc> rankDocs;
+
+    public RankDocsSortBuilder(List<RankDoc> rankDocs) {
+        // The retriever executor sets an immutable resolved window; nothing mutates it after, so no copy.
+        this.rankDocs = Objects.requireNonNull(rankDocs, "rankDocs");
+    }
+
+    public RankDocsSortBuilder(StreamInput in) throws IOException {
+        this.rankDocs = in.readList(RankDoc::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeCollection(rankDocs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startArray(NAME);
+        for (RankDoc rd : rankDocs) {
+            rd.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Always rejects: {@code rank_docs_sort} is internal to the retriever framework and cannot be authored
+     * in a {@code _search} body. It is only ever built in-process on the coordinator and transported to data
+     * nodes over the binary {@link StreamInput}/{@link StreamOutput} path (see {@link #RankDocsSortBuilder(StreamInput)}),
+     * never parsed from XContent. This method exists solely to satisfy the {@code SortSpec} registration
+     * contract, which requires a parser.
+     */
+    public static RankDocsSortBuilder fromXContent(XContentParser parser, String fieldName) {
+        throw new ParsingException(
+            parser.getTokenLocation(),
+            "[" + NAME + "] sort is internal to the retriever framework and cannot be used directly in a search request"
+        );
+    }
+
+    @Override
+    protected SortFieldAndFormat build(QueryShardContext context) {
+        final String indexName = context.index().getName();
+        final int shardId = context.getShardId();
+        // Scope the broadcast window to this shard HERE (shard id is only available on the shard), so the
+        // RankDocsSortField only carries — and only resolves — the docs that can exist on this shard.
+        return new SortFieldAndFormat(
+            new RankDocsSortField(RankDocsQueryBuilder.filterToShard(rankDocs, indexName, shardId), indexName, shardId),
+            DocValueFormat.RAW
+        );
+    }
+
+    @Override
+    public BucketedSort buildBucketedSort(QueryShardContext context, int bucketSize, BucketedSort.ExtraData extra) {
+        throw new UnsupportedOperationException("bucketed sort not supported for " + NAME);
+    }
+
+    @Override
+    public RankDocsSortBuilder rewrite(QueryRewriteContext ctx) {
+        return this;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return rankDocs.equals(((RankDocsSortBuilder) o).rankDocs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rankDocs);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/RankDocsSortField.java
+++ b/server/src/main/java/org/opensearch/search/retriever/RankDocsSortField.java
@@ -1,0 +1,193 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.SortField;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A synthetic, query-scoped {@link SortField} that orders documents by their retriever-assigned
+ * {@code position} whenever the retriever's desired order is decoupled from {@code _score} — i.e. the
+ * final ranking cannot be reproduced by sorting on score. Pinning a document to a fixed rank is one such
+ * case; others include reranked results whose new order no longer tracks the original scores, or any
+ * retriever that assigns an explicit position independent of the score it reports.
+ * <p>
+ * The value being sorted on — {@code position} — does not exist in the index; it is a per-request number
+ * the coordinator computed. The only identity stable across the fresh readers of the final
+ * search is {@code _id}, so the comparator resolves the window's {@code _id}s to <em>this segment's</em>
+ * Lucene doc ids <b>once</b> in {@link FieldComparator#getLeafComparator(LeafReaderContext)} — building a
+ * {@code docId -> position} lookup via {@link RankDocsResolver} — after which every comparison is an
+ * O(1) array lookup. This is deliberately independent of {@link RankDocsQuery}'s own {@code _id} seek:
+ * the two share no shard-side channel and have no ordering dependency, so the sort is correct regardless
+ * of how Lucene schedules the query scorer.
+ * <p>
+ * Documents that are not part of the window sort <em>after</em> all positioned docs (sentinel position
+ * {@link #UNPINNED_POSITION}).
+ *
+ * @opensearch.internal
+ */
+public final class RankDocsSortField extends SortField {
+
+    /** Field name is synthetic; there is no such field in the index. */
+    public static final String NAME = "_rank_docs";
+
+    /** Position assigned to any doc not present in the retriever window (sorts last). */
+    static final int UNPINNED_POSITION = Integer.MAX_VALUE;
+
+    private final List<RankDoc> rankDocs;
+    private final String indexName;
+    private final int shardId;
+
+    public RankDocsSortField(List<RankDoc> rankDocs, String indexName, int shardId) {
+        super(NAME, SortField.Type.CUSTOM);
+        // Already scoped to this shard and made immutable by RankDocsSortBuilder#build; store the reference.
+        this.rankDocs = Objects.requireNonNull(rankDocs, "rankDocs");
+        this.indexName = Objects.requireNonNull(indexName, "indexName");
+        this.shardId = shardId;
+    }
+
+    @Override
+    public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
+        return new FieldComparator<Integer>() {
+            private final int[] values = new int[numHits];
+            private int bottom;
+            private int topValue;
+
+            @Override
+            public int compare(int slot1, int slot2) {
+                return Integer.compare(values[slot1], values[slot2]);
+            }
+
+            @Override
+            public void setTopValue(Integer value) {
+                this.topValue = value;
+            }
+
+            @Override
+            public Integer value(int slot) {
+                return values[slot];
+            }
+
+            @Override
+            public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
+                // Resolve the window to this segment's doc ids ONCE, then serve O(1) lookups from an
+                // O(window)-sized map (NOT an O(maxDoc) dense array): the window (10s-100s) is tiny next
+                // to maxDoc (millions), so a dense array would cost O(maxDoc) alloc+fill on every query.
+                final RankDocsResolver.Resolved resolved = RankDocsResolver.resolve(context, rankDocs);
+                final DocIdToPosition positions = new DocIdToPosition(resolved.size());
+                for (int i = 0; i < resolved.size(); i++) {
+                    positions.put(resolved.docIds[i], resolved.docs[i].position());
+                }
+
+                return new LeafFieldComparator() {
+                    @Override
+                    public void setScorer(Scorable scorer) {}
+
+                    @Override
+                    public void setBottom(int slot) {
+                        bottom = values[slot];
+                    }
+
+                    @Override
+                    public int compareBottom(int doc) {
+                        return Integer.compare(bottom, positions.getOrDefault(doc));
+                    }
+
+                    @Override
+                    public void copy(int slot, int doc) {
+                        values[slot] = positions.getOrDefault(doc);
+                    }
+
+                    @Override
+                    public int compareTop(int doc) {
+                        return Integer.compare(topValue, positions.getOrDefault(doc));
+                    }
+                };
+            }
+        };
+    }
+
+    // SortField.equals for a CUSTOM field ignores our window, so two RankDocsSortFields with different
+    // windows would compare equal — override so distinct rankings are never treated as the same sort.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RankDocsSortField other = (RankDocsSortField) o;
+        return shardId == other.shardId && indexName.equals(other.indexName) && rankDocs.equals(other.rankDocs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rankDocs, indexName, shardId);
+    }
+
+    /**
+     * A minimal primitive {@code int -> int} open-addressing hash map sized to the window, returning
+     * {@link #UNPINNED_POSITION} for absent keys. Avoids the boxing of {@code HashMap<Integer,Integer>}
+     * and the O(maxDoc) footprint of a dense array — footprint and build cost are O(window).
+     */
+    static final class DocIdToPosition {
+        private final int[] keys;
+        private final int[] vals;
+        private final int mask;
+        private static final int EMPTY = -1;
+
+        DocIdToPosition(int expected) {
+            // Next power of two >= expected / 0.6 (load factor ~0.6), min 16.
+            int cap = 16;
+            final int target = Math.max(1, (int) (expected / 0.6f) + 1);
+            while (cap < target) {
+                cap <<= 1;
+            }
+            this.keys = new int[cap];
+            this.vals = new int[cap];
+            this.mask = cap - 1;
+            java.util.Arrays.fill(keys, EMPTY); // O(window), not O(maxDoc)
+        }
+
+        void put(int key, int value) {
+            int i = hash(key) & mask;
+            while (keys[i] != EMPTY && keys[i] != key) {
+                i = (i + 1) & mask;
+            }
+            keys[i] = key;
+            vals[i] = value;
+        }
+
+        int getOrDefault(int key) {
+            int i = hash(key) & mask;
+            while (keys[i] != EMPTY) {
+                if (keys[i] == key) {
+                    return vals[i];
+                }
+                i = (i + 1) & mask;
+            }
+            return UNPINNED_POSITION;
+        }
+
+        private static int hash(int key) {
+            // Fibonacci-style mixing to spread sequential doc ids.
+            int h = key * 0x9E3779B1;
+            return h ^ (h >>> 16);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/retriever/package-info.java
+++ b/server/src/main/java/org/opensearch/search/retriever/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Internal support classes for the retriever framework that replay a coordinator-computed ranking
+ * onto the final search, including the query and sort used to carry and apply that ranking on each shard.
+ */
+package org.opensearch.search.retriever;

--- a/server/src/test/java/org/opensearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchModuleTests.java
@@ -621,7 +621,8 @@ public class SearchModuleTests extends OpenSearchTestCase {
         "wildcard",
         "wrapper",
         "distance_feature",
-        "template" };
+        "template",
+        "rank_docs" };
 
     // add here deprecated queries to make sure we log a deprecation warnings when they are used
     private static final String[] DEPRECATED_QUERIES = new String[] { "common", "field_masking_span" };

--- a/server/src/test/java/org/opensearch/search/retriever/RankDocsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/retriever/RankDocsQueryBuilderTests.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link RankDocsQueryBuilder}. The {@code rank_docs} query is purely internal to the
+ * retriever framework: it is built in-process on the coordinator and transported to data nodes over the
+ * binary stream, and can never be authored in a {@code _search} body. These tests pin that contract:
+ * {@link RankDocsQueryBuilder#fromXContent} always rejects, while binary serialization and programmatic
+ * construction (the paths the framework actually uses) work.
+ */
+public class RankDocsQueryBuilderTests extends OpenSearchTestCase {
+
+    private static final String RANK_DOCS_JSON =
+        "{\"docs\":[{\"index\":\"products\",\"shard\":0,\"id\":\"a\",\"score\":0.9,\"position\":0}]}";
+
+    /** A parser positioned at the start of the rank_docs body (mirrors how the query registry invokes fromXContent). */
+    private XContentParser parser(String json) throws Exception {
+        XContentParser parser = createParser(JsonXContent.jsonXContent, json);
+        // Advance to the first token (START_OBJECT) so fromXContent begins where the registry would hand off.
+        parser.nextToken();
+        return parser;
+    }
+
+    public void testFromXContentAlwaysRejects() throws Exception {
+        // rank_docs is internal-only: authoring it in a _search body must always fail, with a message naming the query.
+        ParsingException e = expectThrows(ParsingException.class, () -> RankDocsQueryBuilder.fromXContent(parser(RANK_DOCS_JSON)));
+        assertTrue(
+            "message should name the query and explain it is internal, got: " + e.getMessage(),
+            e.getMessage().contains(RankDocsQueryBuilder.NAME) && e.getMessage().contains("internal")
+        );
+    }
+
+    public void testFromXContentRejectsEvenWellFormedBody() throws Exception {
+        // A structurally valid body (docs + boost + _name) is still rejected — there is no flag or path that admits it.
+        String json = "{\"docs\":[{\"index\":\"products\",\"shard\":0,\"id\":\"a\",\"score\":0.9,\"position\":0}],"
+            + "\"boost\":2.5,\"_name\":\"my_query\"}";
+        expectThrows(ParsingException.class, () -> RankDocsQueryBuilder.fromXContent(parser(json)));
+    }
+
+    public void testProgrammaticConstruction() {
+        // The internal retriever path builds the query directly; this must work unconditionally.
+        RankDocsQueryBuilder builder = new RankDocsQueryBuilder(List.of(new RankDoc("products", 0, "a", 0.9f, 0)));
+        assertEquals(RankDocsQueryBuilder.NAME, builder.getWriteableName());
+    }
+
+    public void testRankDocStreamRoundTrip() throws Exception {
+        RankDoc original = new RankDoc("products", 3, "abc", 0.42f, 7);
+        RankDoc copy;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                copy = new RankDoc(in);
+            }
+        }
+        assertEquals(original, copy);
+    }
+
+    public void testBuilderStreamRoundTrip() throws Exception {
+        // This is the path the coordinator -> data-node hop actually uses (readNamedWriteable -> StreamInput ctor).
+        RankDocsQueryBuilder original = new RankDocsQueryBuilder(
+            List.of(new RankDoc("products", 0, "a", 0.9f, 0), new RankDoc("reviews", 2, "b", 0.1f, 5))
+        );
+        RankDocsQueryBuilder copy;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                copy = new RankDocsQueryBuilder(in);
+            }
+        }
+        assertEquals(original, copy);
+    }
+
+    public void testRankDocRendersToXContent() throws Exception {
+        // toXContent is retained for the profile API / debugging; verify it emits all five fields.
+        RankDoc doc = new RankDoc("products", 3, "abc", 0.42f, 7);
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            doc.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            String json = builder.toString();
+            assertTrue(json, json.contains("\"index\":\"products\""));
+            assertTrue(json, json.contains("\"shard\":3"));
+            assertTrue(json, json.contains("\"id\":\"abc\""));
+            assertTrue(json, json.contains("\"score\":0.42"));
+            assertTrue(json, json.contains("\"position\":7"));
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/retriever/RankDocsQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/retriever/RankDocsQueryTests.java
@@ -1,0 +1,250 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.Uid;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Unit tests for {@link RankDocsQuery} and {@link RankDocsSortField}: score fidelity, per-shard
+ * filtering, cross-index {@code _id} disambiguation, missing-doc omission, and position sort.
+ */
+public class RankDocsQueryTests extends OpenSearchTestCase {
+
+    private static final String INDEX = "products";
+    private static final int SHARD = 0;
+
+    /** Index {@code ids} as documents whose only field is the encoded {@code _id}, one doc per id. */
+    private static void indexIds(RandomIndexWriter w, List<String> ids) throws IOException {
+        for (String id : ids) {
+            Document doc = new Document();
+            doc.add(new Field(IdFieldMapper.NAME, Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE));
+            w.addDocument(doc);
+        }
+    }
+
+    private static RankDoc doc(String id, float score, int position) {
+        return new RankDoc(INDEX, SHARD, id, score, position);
+    }
+
+    public void testScoreFidelity() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b", "c", "d", "e"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            List<RankDoc> window = List.of(doc("a", 0.95f, 0), doc("c", 0.82f, 1), doc("e", 0.40f, 2));
+            RankDocsQuery q = new RankDocsQuery(window, INDEX, SHARD);
+
+            TopDocs td = searcher.search(q, 10);
+            assertEquals(3, td.totalHits.value());
+
+            for (ScoreDoc sd : td.scoreDocs) {
+                boolean matched = false;
+                for (RankDoc rd : window) {
+                    if (Float.compare(rd.score(), sd.score) == 0) {
+                        matched = true;
+                        break;
+                    }
+                }
+                assertTrue("score " + sd.score + " not a pinned score", matched);
+            }
+            reader.close();
+        }
+    }
+
+    public void testMissingDocsAreOmitted() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            // "zzz" and "missing" are not in the index -> should be silently dropped.
+            List<RankDoc> window = List.of(doc("a", 0.9f, 0), doc("missing", 0.8f, 1), doc("b", 0.7f, 2), doc("zzz", 0.6f, 3));
+            TopDocs td = searcher.search(new RankDocsQuery(window, INDEX, SHARD), 10);
+            assertEquals(2, td.totalHits.value());
+            reader.close();
+        }
+    }
+
+    public void testPerShardFilteringDropsOtherShardsAndIndices() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b", "c"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            // Window mixes this shard (products/0), another shard (products/1), and another index (reviews/0).
+            List<RankDoc> window = List.of(
+                new RankDoc("products", 0, "a", 0.9f, 0),
+                new RankDoc("products", 1, "b", 0.8f, 1), // different shard -> filtered out
+                new RankDoc("reviews", 0, "c", 0.7f, 2)   // different index -> filtered out
+            );
+
+            // Filtering to (products, 0) is the builder's job (doToQuery); the query then only holds "a".
+            List<RankDoc> scoped = RankDocsQueryBuilder.filterToShard(window, "products", 0);
+            assertEquals(1, scoped.size());
+
+            RankDocsQuery q = new RankDocsQuery(scoped, "products", 0);
+            TopDocs td = searcher.search(q, 10);
+            assertEquals(1, td.totalHits.value());
+            assertEquals(0.9f, td.scoreDocs[0].score, 0.0f);
+            reader.close();
+        }
+    }
+
+    public void testCrossIndexIdCollisionNotMisscored() throws Exception {
+        // Same _id "1" exists physically in this segment, but the window entry for "1" belongs to a
+        // DIFFERENT index; the builder's shard filter must drop it so it is never scored on (products/0).
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("1", "2"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            List<RankDoc> window = List.of(
+                new RankDoc("reviews", 0, "1", 0.99f, 0), // collision: id "1" but wrong index
+                new RankDoc("products", 0, "2", 0.50f, 1) // correct
+            );
+            List<RankDoc> scoped = RankDocsQueryBuilder.filterToShard(window, "products", 0);
+            assertEquals(1, scoped.size());
+
+            RankDocsQuery q = new RankDocsQuery(scoped, "products", 0);
+            TopDocs td = searcher.search(q, 10);
+            assertEquals(1, td.totalHits.value());
+            assertEquals("only products/0 id 2 should match", 0.50f, td.scoreDocs[0].score, 0.0f);
+            reader.close();
+        }
+    }
+
+    public void testSortByPositionOrdersByRankNotScore() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b", "c"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            // Positions intentionally inverted vs scores: "c" has the lowest score but position 0 (top).
+            List<RankDoc> window = List.of(doc("a", 0.90f, 2), doc("b", 0.80f, 1), doc("c", 0.10f, 0));
+
+            RankDocsQuery q = new RankDocsQuery(window, INDEX, SHARD);
+            Sort sort = new Sort(new RankDocsSortField(window, INDEX, SHARD));
+            TopDocs td = searcher.search(q, 10, sort);
+            assertEquals(3, td.totalHits.value());
+
+            int[] positions = new int[td.scoreDocs.length];
+            for (int i = 0; i < td.scoreDocs.length; i++) {
+                positions[i] = positionOf(searcher, td.scoreDocs[i].doc, window);
+            }
+            for (int i = 1; i < positions.length; i++) {
+                assertTrue("positions not ascending: " + positions[i - 1] + " !<= " + positions[i], positions[i - 1] <= positions[i]);
+            }
+            // Top hit must be position 0 ("c"), despite its low score.
+            assertEquals(0, positions[0]);
+            reader.close();
+        }
+    }
+
+    /** Resolve a hit's retriever position by matching its stored _id back to the window. */
+    private int positionOf(IndexSearcher searcher, int docId, List<RankDoc> window) throws IOException {
+        for (RankDoc rd : window) {
+            TermQuery tq = new TermQuery(new Term(IdFieldMapper.NAME, Uid.encodeId(rd.id())));
+            TopDocs td = searcher.search(new ConstantScoreQuery(tq), 1);
+            if (td.scoreDocs.length > 0 && td.scoreDocs[0].doc == docId) {
+                return rd.position();
+            }
+        }
+        return RankDocsSortField.UNPINNED_POSITION;
+    }
+
+    public void testExplainIsUnsupported() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            RankDocsQuery q = new RankDocsQuery(List.of(doc("a", 0.9f, 0)), INDEX, SHARD);
+            Weight weight = q.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+            LeafReaderContext leaf = searcher.getIndexReader().leaves().get(0);
+            // RankDocsQuery replays a coordinator-computed ranking and has nothing to explain.
+            expectThrows(UnsupportedOperationException.class, () -> weight.explain(leaf, 0));
+            reader.close();
+        }
+    }
+
+    public void testEmptyWindowMatchesNothing() throws Exception {
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            RankDocsQuery q = new RankDocsQuery(List.of(), INDEX, SHARD);
+            TopDocs td = searcher.search(q, 10);
+            assertEquals(0, td.totalHits.value());
+            reader.close();
+        }
+    }
+
+    public void testBoolConstantScoreBaselineMatchesSameDocs() throws Exception {
+        // Sanity: the bool-constant-score alternative selects the same docs (score semantics differ).
+        try (Directory dir = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), dir, new KeywordAnalyzer());
+            indexIds(w, List.of("a", "b", "c", "d"));
+            IndexReader reader = w.getReader();
+            w.close();
+            IndexSearcher searcher = newSearcher(reader);
+
+            List<RankDoc> window = List.of(doc("a", 0.9f, 0), doc("c", 0.7f, 1));
+            long rank = searcher.search(new RankDocsQuery(window, INDEX, SHARD), 10).totalHits.value();
+
+            BooleanQuery.Builder bool = new BooleanQuery.Builder();
+            for (RankDoc rd : window) {
+                TermQuery tq = new TermQuery(new Term(IdFieldMapper.NAME, Uid.encodeId(rd.id())));
+                bool.add(new BoostQuery(new ConstantScoreQuery(tq), rd.score()), BooleanClause.Occur.SHOULD);
+            }
+            long boolCount = searcher.search(bool.build(), 10).totalHits.value();
+            assertEquals(rank, boolCount);
+            reader.close();
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/retriever/RankDocsSortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/retriever/RankDocsSortBuilderTests.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.retriever;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link RankDocsSortBuilder}. Like the {@code rank_docs} query, this sort spec is purely
+ * internal to the retriever framework: it is built in-process and transported over the binary stream, and
+ * can never be authored in a {@code _search} body. These tests pin that contract:
+ * {@link RankDocsSortBuilder#fromXContent} always rejects, while binary serialization and programmatic
+ * construction work. Mirrors {@link RankDocsQueryBuilderTests}.
+ */
+public class RankDocsSortBuilderTests extends OpenSearchTestCase {
+
+    private static final String JSON =
+        "{\"rank_docs_sort\":[{\"index\":\"products\",\"shard\":0,\"id\":\"a\",\"score\":0.9,\"position\":0}]}";
+
+    /** Parser positioned at the START_OBJECT of the sort body, mirroring how the sort registry hands off. */
+    private XContentParser parser(String json) throws Exception {
+        XContentParser parser = createParser(JsonXContent.jsonXContent, json);
+        parser.nextToken(); // START_OBJECT
+        parser.nextToken(); // FIELD_NAME rank_docs_sort
+        return parser;
+    }
+
+    public void testFromXContentAlwaysRejects() throws Exception {
+        // rank_docs_sort is internal-only: authoring it in a _search body must always fail, with a message naming the sort.
+        ParsingException e = expectThrows(
+            ParsingException.class,
+            () -> RankDocsSortBuilder.fromXContent(parser(JSON), RankDocsSortBuilder.NAME)
+        );
+        assertTrue(
+            "message should name the sort and explain it is internal, got: " + e.getMessage(),
+            e.getMessage().contains(RankDocsSortBuilder.NAME) && e.getMessage().contains("internal")
+        );
+    }
+
+    public void testStreamRoundTrip() throws Exception {
+        // The path the coordinator -> data-node hop actually uses (readNamedWriteable -> StreamInput ctor).
+        RankDocsSortBuilder original = new RankDocsSortBuilder(
+            List.of(new RankDoc("products", 0, "a", 0.9f, 0), new RankDoc("reviews", 2, "b", 0.1f, 5))
+        );
+        RankDocsSortBuilder copy;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                copy = new RankDocsSortBuilder(in);
+            }
+        }
+        assertEquals(original, copy);
+    }
+
+    public void testGetWriteableName() {
+        RankDocsSortBuilder b = new RankDocsSortBuilder(List.of(new RankDoc("products", 0, "a", 0.9f, 0)));
+        assertEquals(RankDocsSortBuilder.NAME, b.getWriteableName());
+    }
+}


### PR DESCRIPTION
### Description

When a retriever tree is resolved on the coordinator (fusion, reranking, pinning, etc.), the result is a ranked window of documents — each with a final score and rank position — that the coordinator has already decided on. This PR adds the internal query + sort family that **replays that decided ranking onto an ordinary `_search`** by seeking each document's `_id`, so the ranking survives the trip to the data nodes and back.

#### Example: what the coordinator resolves, and what gets replayed

Say a retriever resolves this window (already scored and ordered on the coordinator):

| position | index    | shard | _id  | score |
|----------|----------|-------|------|-------|
| 0        | products | 0     | "a"  | 0.90  |
| 1        | products | 1     | "c"  | 0.55  |
| 2        | reviews  | 0     | "x"  | 0.10  |

The coordinator turns each row into a `RankDoc` and hands the whole window to a `RankDocsQueryBuilder` (and, when ordering is decoupled from `_score`, a `RankDocsSortBuilder`). These are set on the `SearchSourceBuilder` and broadcast to every shard over the binary stream. **On each shard**, the builder scopes the window to just that shard's docs before building the Lucene query:

- shard `products[0]` only sees `RankDoc("products", 0, "a", 0.90, 0)`
- shard `products[1]` only sees `RankDoc("products", 1, "c", 0.55, 1)`
- shard `reviews[0]`  only sees `RankDoc("reviews", 0, "x", 0.10, 2)`

Each shard then `_id`-seeks its own docs, replays the pre-computed score (query path) and/or
orders by `position` (sort path), and returns them — reassembling the coordinator's ranking.

#### Components

- **`RankDoc`** — one window entry: `(index, shardId, _id, score, position)`. Owns its own wire (`Writeable`) serialization and a one-way `toXContent` rendering (profile-API inspection / debugging only — it is never parsed back from XContent).
- **`RankDocsQuery`** — replays the pre-computed score via an `_id` seek. The builder scopes the window to each shard in `doToQuery`, so the query only holds/resolves its own shard's docs. `explain()` is unsupported (the retriever framework builds the user-facing explanation on the coordinator).
- **`RankDocsResolver`** — the single `_id -> Lucene docId` seek, shared by the query scorer and the position sort, returning docs sorted ascending by docId (the `DocIdSetIterator` contract).
- **`RankDocsSortField` / `RankDocsSortBuilder`** — order by retriever-assigned `position` when order is decoupled from `_score`. The `SortBuilder` is the coordinator-side spec that carries the window and, per shard in `build()`, resolves the `shardId` and produces the scoped `RankDocsSortField`.

#### Internal-only, by construction

`RankDocsQueryBuilder` / `RankDocsSortBuilder` are always registered (as `NamedWriteable` +
`NamedXContent`) so they serialize to data nodes and can be inspected via the profile API,
**but they are purely internal to the retriever framework** — they cannot be authored in a
`_search` body under any circumstance:

- Their `fromXContent` parsers **always reject** with a `ParsingException` (e.g. a request
  containing `{"query": {"rank_docs": {...}}}` or `{"sort": [{"rank_docs_sort": [...]}]}`
  fails to parse).
- They are only ever reconstructed on data nodes over the binary stream
  (`readNamedWriteable` → `StreamInput` constructor), never from XContent.



### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/22861

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

## Benchmarks: RankDocsQuery seek & sort paths

We benchmarked how `RankDocsQuery` re-identifies and orders the pinned window, to decide whether to
invest in a Lucene-doc-id optimization now. **Conclusion up front: not now** — the relative speedup is
large but the absolute latency is sub-millisecond in the common case, and capturing it requires
non-trivial new machinery (see *Why we're not doing it now*).

### Setup

JMH microbenchmarks over a real on-disk Lucene index (`benchmarks` module,
`RankDocsQueryBenchmark`), `numDocs = 1,000,000`, `_id`-only documents, window ids spread pseudo-randomly
across the id space. Each benchmark runs a full `IndexSearcher.search`, so it measures the whole
weight/scorer path. `avgt`, µs/op (lower is better).

- **rankDocs** — current implementation: `RankDocsQuery` re-identifies each windowed doc by seeking its
  `_id` in the `_id` terms dictionary (`TermsEnum.seekExact`), per segment.
- **boolConstantScore** — alternative: a `bool.should` of `ConstantScore(TermQuery(_id))` clauses.
- **rankDocsByLuceneDocId** — hypothetical optimization: the window is pre-resolved to global Lucene doc
  ids once, then the query addresses docs directly by doc id with **no** per-doc term seek. (Benchmark-only
  query; simulates what a PIT-backed doc-id path would carry.)
- **rankDocsSortByPosition** — current position sort: `RankDocsSortField` (orders by retriever-assigned
  `position`; also `_id`-seeks per segment to build the `docId -> position` map).
- **sortByDocValuesField** — baseline: sort by a native numeric doc-values field.

### Results (µs/op)

**Seek / scoring path:**

| rankWindowSize | segments | rankDocs (`_id` seek) | boolConstantScore | rankDocsByLuceneDocId |
|---|---|---|---|---|
| 100 | 1 | 81.5  | 366.1  | 12.7 |
| 100 | 8 | 205.8 | 769.6  | 14.6 |
| 500 | 1 | 428.6 | 1870.9 | 41.4 |
| 500 | 8 | 984.8 | 3790.2 | 36.6 |

**Sort path:**

| rankWindowSize | segments | rankDocsSortByPosition | sortByDocValuesField |
|---|---|---|---|
| 100 | 1 | 158.4  | 88.8   |
| 100 | 8 | 395.9  | 198.7  |
| 500 | 1 | 903.6  | 556.8  |
| 500 | 8 | 1935.9 | 1063.6 |

### Findings

1. **The custom `RankDocsQuery` is the right choice over a bool query.** The `_id`-seek `RankDocsQuery`
   is ~4× faster than `boolConstantScore` at every point — the bool disjunction adds per-clause
   weight/scorer construction and boolean-iteration overhead that the flat custom scorer avoids. Using a
   `bool` query to seek the window would be a regression.

2. **A Lucene-doc-id seek would be substantially faster in relative terms** — ~6–27× vs. the current
   `_id` seek, and it is nearly flat in segment count. The `_id` seek cost grows with **both** window
   size and segment count, because `seekExact` runs per segment against each segment's `_id` dictionary;
   the doc-id path just slices a doc-id array per segment.

3. **The position sort costs ~1.6–2× a native field sort**, for the same reason — `RankDocsSortField`
   also does a per-segment `_id` seek to build its `docId -> position` map. It would benefit from the same
   doc-id optimization.

### Why we're not doing it now

Despite the large relative speedups, we are **not** prioritizing the Lucene-doc-id optimization:

- **Absolute latency is sub-millisecond in the common case.** For typical windows the current `_id`-seek
  path is tens to low-hundreds of microseconds; it only approaches ~1 ms at the extreme (500-doc window
  over 8 segments), and that sits inside a full `_search` alongside `_source` fetch and transport. The
  saving is not material to end-to-end search latency today.

- **It requires PIT.** A Lucene doc id captured in a leg search is only valid in the final
  `RankDocsQuery` search if both read the **same frozen reader** — i.e. under a point-in-time. PIT is
  enabled by default in the retriever framework for correctness (consistent snapshot across legs /
  rounds) — a framework-level decision, not part of this change — so the precondition would be met. But
  a doc id used outside that guarantee would silently address the **wrong** document, whereas the `_id`
  seek fails safe (a missing doc simply drops out).

- **It requires significant new machinery.** We would need to populate each leg search response with its
  hits' Lucene doc ids (a gated, internal fetch step), carry those doc ids through the resolved window,
  and add a doc-id-addressed path to `RankDocsQuery` / the position sort alongside the `_id`-seek path.
  That is a meaningful amount of new, correctness-sensitive code for a sub-ms gain.

**Decision:** keep the `_id`-seek `RankDocsQuery` as-is. Revisit the doc-id optimization only if profiling
on large, many-segment indices shows the seek is a material contributor to end-to-end latency. A cheap
interim lever exists with no code change: the cost is dominated by **per-segment** `_id` seeks, so
reducing segment count (force-merge) directly shrinks both the seek and sort cost.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
