### PR TITLE
[Bug] copy inner-hits contexts per fetch to fix concurrent segment search corruption

### DIFF
--- a/modules/parent-join/src/main/java/org/opensearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -91,7 +91,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
         if (joinFieldMapper != null) {
             String name = innerHitBuilder.getName() != null ? innerHitBuilder.getName() : typeName;
             JoinFieldInnerHitSubContext joinFieldInnerHits = new JoinFieldInnerHitSubContext(
-                name,
+                getName(),
                 context,
                 typeName,
                 fetchChildInnerHits,
@@ -122,6 +122,19 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
             this.typeName = typeName;
             this.fetchChildInnerHits = fetchChildInnerHits;
             this.joinFieldMapper = joinFieldMapper;
+        }
+
+        @Override
+        public InnerHitsContext.InnerHitSubContext copy() {
+            JoinFieldInnerHitSubContext copy = new JoinFieldInnerHitSubContext(
+                getName(),
+                context,
+                typeName,
+                fetchChildInnerHits,
+                joinFieldMapper
+            );
+            copyTo(copy);
+            return copy;
         }
 
         @Override
@@ -210,3 +223,4 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
     }
 
 }
+

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -511,6 +511,13 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         public ObjectMapper getChildObjectMapper() {
             return childObjectMapper;
         }
+
+        @Override
+        public InnerHitsContext.InnerHitSubContext copy() {
+            NestedInnerHitSubContext copy = new NestedInnerHitSubContext(getName(), context, parentObjectMapper, childObjectMapper);
+            copyTo(copy);
+            return copy;
+        }
     }
 
     @Override
@@ -524,3 +531,4 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         }
     }
 }
+

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsContext.java
@@ -79,6 +79,20 @@ public final class InnerHitsContext {
         return innerHits;
     }
 
+    /**
+     * Returns a deep copy of this context. Each inner-hit definition is copied so that a
+     * fetch running on a concurrent segment search slice thread never shares the mutable
+     * {@link InnerHitSubContext} (doc IDs to load, root id, root {@link SourceLookup})
+     * with fetches running on other slices.
+     */
+    public InnerHitsContext copy() {
+        Map<String, InnerHitSubContext> copies = new HashMap<>();
+        for (Map.Entry<String, InnerHitSubContext> entry : innerHits.entrySet()) {
+            copies.put(entry.getKey(), entry.getValue().copy());
+        }
+        return new InnerHitsContext(copies);
+    }
+
     public void addInnerHitDefinition(InnerHitSubContext innerHit) {
         if (innerHits.containsKey(innerHit.getName())) {
             throw new IllegalArgumentException(
@@ -115,6 +129,26 @@ public final class InnerHitsContext {
         }
 
         public abstract TopDocsAndMaxScore topDocs(SearchHit hit) throws IOException;
+
+        /**
+         * Returns a deep copy of this inner-hit definition. The copy keeps the immutable
+         * definition (query, sort, from/size, highlight, fetch configuration) but gets
+         * fresh result holders and per-fetch state, so that concurrent segment search
+         * slice threads never share the mutable fields mutated by
+         * {@link org.opensearch.search.fetch.subphase.InnerHitsPhase#hitExecute}.
+         */
+        public abstract InnerHitSubContext copy();
+
+        /**
+         * Copies the fetch configuration of this context onto a freshly constructed
+         * {@code target} of the same concrete type. Child inner hits are copied recursively.
+         */
+        protected void copyTo(InnerHitSubContext target) {
+            super.copyFetchStateTo(target);
+            if (childInnerHits != null) {
+                target.setChildInnerHits(childInnerHits.copy().getInnerHits());
+            }
+        }
 
         public String getName() {
             return name;
@@ -213,3 +247,4 @@ public final class InnerHitsContext {
         }
     }
 }
+

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsPhase.java
@@ -67,7 +67,12 @@ public final class InnerHitsPhase implements FetchSubPhase {
         if (searchContext.innerHits() == null || searchContext.innerHits().getInnerHits().isEmpty()) {
             return null;
         }
-        Map<String, InnerHitsContext.InnerHitSubContext> innerHits = searchContext.innerHits().getInnerHits();
+        // Each fetch (and therefore each concurrent segment search slice thread) gets its
+        // own copy of the inner-hits contexts. The request-level InnerHitsContext and its
+        // InnerHitSubContext hold mutable per-hit state (docIdsToLoad, root id, root
+        // SourceLookup) that is re-aimed for every hit; sharing it across slice threads
+        // corrupts _source reads and can kill the node (see GH-22868 for root cause).
+        Map<String, InnerHitsContext.InnerHitSubContext> innerHits = searchContext.innerHits().copy().getInnerHits();
         return new FetchSubPhaseProcessor() {
             @Override
             public void setNextReader(LeafReaderContext readerContext) {
@@ -117,3 +122,4 @@ public final class InnerHitsPhase implements FetchSubPhase {
         }
     }
 }
+

--- a/server/src/main/java/org/opensearch/search/internal/SubSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SubSearchContext.java
@@ -377,4 +377,35 @@ public class SubSearchContext extends FilteredSearchContext {
     public long getRelativeTimeInMillis() {
         throw new UnsupportedOperationException("Not supported");
     }
+
+    /**
+     * Copies the fetch configuration of this context onto {@code target}, which must be a
+     * freshly constructed {@link SubSearchContext} of the same concrete type. Result holders
+     * ({@link #fetchSearchResult}, {@link #querySearchResult}) and per-fetch state
+     * (doc IDs to load) are intentionally not copied: every fetch gets its own fresh
+     * instances so that concurrent segment search slice threads never share mutable state.
+     */
+    protected void copyFetchStateTo(SubSearchContext target) {
+        target.from = from;
+        target.size = size;
+        target.sort = sort;
+        target.parsedQuery = parsedQuery;
+        target.query = query;
+        target.storedFields = storedFields;
+        if (scriptFields != null) {
+            for (ScriptFieldsContext.ScriptField field : scriptFields.fields()) {
+                target.scriptFields().add(field);
+            }
+        }
+        target.fetchSourceContext = fetchSourceContext;
+        target.docValuesContext = docValuesContext;
+        target.fetchFieldsContext = fetchFieldsContext;
+        target.highlight = highlight;
+        target.explain = explain;
+        target.trackScores = trackScores;
+        target.includeNamedQueriesScore = includeNamedQueriesScore;
+        target.version = version;
+        target.seqNoAndPrimaryTerm = seqNoAndPrimaryTerm;
+    }
 }
+

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/InnerHitsContextTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/InnerHitsContextTests.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.fetch.subphase;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InnerHitsContextTests extends OpenSearchTestCase {
+
+    public void testCopyProducesIndependentDefinitionInstances() {
+        InnerHitsContext.InnerHitSubContext original = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(original.getName()).thenReturn("inner");
+        InnerHitsContext.InnerHitSubContext copiedValue = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(original.copy()).thenReturn(copiedValue);
+
+        InnerHitsContext context = new InnerHitsContext();
+        context.addInnerHitDefinition(original);
+
+        InnerHitsContext copy = context.copy();
+
+        assertNotSame(context, copy);
+        assertNotSame(context.getInnerHits(), copy.getInnerHits());
+        assertSame(copiedValue, copy.getInnerHits().get("inner"));
+        verify(original).copy();
+    }
+
+    public void testCopyKeepsDefinitionNames() {
+        InnerHitsContext.InnerHitSubContext original = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(original.getName()).thenReturn("innerA");
+        InnerHitsContext.InnerHitSubContext copiedValue = mock(InnerHitsContext.InnerHitSubContext.class);
+        when(original.copy()).thenReturn(copiedValue);
+
+        InnerHitsContext context = new InnerHitsContext();
+        context.addInnerHitDefinition(original);
+
+        InnerHitsContext copy = context.copy();
+
+        assertTrue(copy.getInnerHits().containsKey("innerA"));
+        assertEquals(1, copy.getInnerHits().size());
+    }
+
+    public void testCopyOfEmptyContextIsEmpty() {
+        InnerHitsContext context = new InnerHitsContext();
+        InnerHitsContext copy = context.copy();
+        assertNotSame(context, copy);
+        assertTrue(copy.getInnerHits().isEmpty());
+    }
+}


### PR DESCRIPTION
### Description

Fixes #22868

When concurrent segment search is active (`index.search.concurrent_segment_search.mode=all`), a request carrying both a nested `inner_hits` and a `top_hits` aggregation corrupts `_source` reads and can kill the node.

**Root cause**: every slice thread runs `InnerHitsPhase.hitExecute` on the same request-level `InnerHitsContext`. `InnerHitSubContext` holds mutable per-hit state (`docIdsToLoad`, root `id`, root `SourceLookup`) that is re-aimed for each hit (`InnerHitsPhase.hitExecute` lines ~91-93). Two slice threads interleave those writes, so one thread reads through another thread's `SourceLookup`. `SourceLookup` is documented "Not thread safe" and lazily caches a single Lucene stored-fields merge instance (`Lucene90CompressingStoredFieldsReader.serializedDocument` seeks and resets one shared block state without a lock). The corrupted reads surface as `index_out_of_bounds_exception`, `CorruptIndexException` against checksum-perfect files, or — for the illegal type flags 6/7 under `TYPE_MASK` — `AssertionError: Unknown type flag: N`, which escapes the `catch (Exception)` in `SourceLookup` and kills the node via `OpenSearchUncaughtExceptionHandler`.

**Fix**: `InnerHitsPhase.getProcessor` now deep-copies the inner-hits contexts for each fetch, so every concurrent slice thread works on its own `InnerHitSubContext` instance and never shares mutable per-hit state. This mirrors the rest of the fetch path, which is already per-slice by construction (`SubSearchContext` per slice, `FetchContext` per fetch). The inner-hits contexts were the only piece of per-hit state that escaped that isolation, because `SubSearchContext` inherits `innerHits()` from `FilteredSearchContext`, which forwards to the request-level context.

**Changes**:
- `InnerHitsContext`: new `copy()` returning a deep copy of the definition map; new abstract `InnerHitSubContext.copy()`; `copyTo()` helper replicating fetch configuration (including recursive child inner hits).
- `SubSearchContext`: new `copyFetchStateTo()` that copies fetch configuration (from/size/sort/query/highlight/script fields/fetch source/docvalues/fetch fields) onto a freshly constructed instance, while leaving result holders and per-fetch doc-IDs state untouched.
- `NestedInnerHitSubContext`: implements `copy()`.
- `JoinFieldInnerHitSubContext`: implements `copy()`.
- `InnerHitsPhase`: `getProcessor` uses the deep copy instead of the shared request-level map.

**Testing**: `InnerHitsContextTests` covers the copy semantics (independent maps and definition instances, names preserved, empty context). The reproducible cluster-level scenario from the issue (nested inner_hits + terms→top_hits over high-cardinality field, `mode=all`, `max_slice_count=8`) no longer fails.

Signed-off-by: waterWang <672684719@qq.com>