### PR TITLE
Allow index.search.idle.after to be -1 to disable search idle

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -187,7 +187,7 @@ public final class IndexSettings {
     public static final Setting<TimeValue> INDEX_SEARCH_IDLE_AFTER = Setting.timeSetting(
         "index.search.idle.after",
         TimeValue.timeValueSeconds(30),
-        TimeValue.timeValueMinutes(0),
+        TimeValue.MINUS_ONE,
         Property.IndexScope,
         Property.Dynamic
     );

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -5492,10 +5492,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
-     * Returns true if this shards is search idle
+     * Returns true if this shard is search idle
      */
     public final boolean isSearchIdle() {
-        return (threadPool.relativeTimeInMillis() - lastSearcherAccess.get()) >= indexSettings.getSearchIdleAfter().getMillis();
+        long searchIdleAfter = indexSettings.getSearchIdleAfter().getMillis();
+        return searchIdleAfter >= 0 && (threadPool.relativeTimeInMillis() - lastSearcherAccess.get()) >= searchIdleAfter;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4468,10 +4468,7 @@ public class IndexShardTests extends IndexShardTestCase {
             primary.acquireSearcher("test").close();
         } while (primary.isSearchIdle());
 
-        settings = Settings.builder()
-            .put(settings)
-            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.MINUS_ONE)
-            .build();
+        settings = Settings.builder().put(settings).put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.MINUS_ONE).build();
         scopedSettings.applySettings(settings);
         assertFalse(primary.isSearchIdle());
         closeShards(primary);

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4467,6 +4467,13 @@ public class IndexShardTests extends IndexShardTestCase {
             // now loop until we are fast enough... shouldn't take long
             primary.acquireSearcher("test").close();
         } while (primary.isSearchIdle());
+
+        settings = Settings.builder()
+            .put(settings)
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.MINUS_ONE)
+            .build();
+        scopedSettings.applySettings(settings);
+        assertFalse(primary.isSearchIdle());
         closeShards(primary);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]
Currently, OpenSearch sets `index.search.idle.after` to 30s by default. To disable idle time, there is only one way, to set `index.refresh_interval` explicitly. However, `index.refresh_interval` is 1s by default, and we did not want to change it. It is not a good convention to set one variable explicitly for a different behavior (disabling idle).

`-1` is a standard convention to disable something, so this PR is to allow `-1` for `index.search.idle.after` in order to disable idle time.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9707#issuecomment-5368306320
I commented in a closed Issue. I can raised a new Issue if needed.

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. https://github.com/opensearch-project/documentation-website/pull/12992

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
