### PR TITLE
Use any_modified on 'check-files' GitHub action

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -19,7 +19,7 @@ jobs:
   check-files:
     runs-on: ubuntu-latest
     outputs:
-      RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_changed }}
+      RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_modified }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Get changed files


### PR DESCRIPTION
`any_changed` excludes deletes, which are included in [`any_modified`][1].

[1]: https://github.com/tj-actions/changed-files#output_any_modified

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
