### PR TITLE
Add range bucket aggregation to DSL query executor

### DIFF
--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -120,6 +120,18 @@ scores are not surfaced). Rejected: `_name` (throws ConversionException — matc
 | 2 | Page pruning lost | A delegated predicate yields an all-true bitmap at the pruning stage (page_pruner.rs:779-782); the previous LIKE form was prunable (page_pruner.rs:24). Correctness preserved by residual re-evaluation (single_collector.rs:604-611). Follow-up: schema enrichment would enable a prunable fast path. |
 | 3 | Field types not storable in this engine mode | `wildcard`, `constant_keyword`, `version` and `flat_object` support prefix/wildcard in vanilla, but indexes using them cannot be created in optimized engine mode at all — the Parquet primary format (`CoreDataFieldPlugin`) and the Lucene secondary format (`LuceneFieldFactoryRegistry`) register no writers for them, so index creation fails with `MapperParsingException` (see `CompositeFieldCapabilityIT`). Storage-layer limitation shared by every query front-end via `OpenSearchSchemaBuilder`, not a prefix/wildcard behaviour difference. |
 
+### Bucket Aggregations
+- **Terms** — single-field `GROUP BY`; mapping-resolved key typing (string/long/double).
+- **Range** — buckets a numeric field into user-declared half-open intervals `[from, to)`.
+  Each document maps to a single range **ordinal** via a computed `CASE` group key
+  (`ComputedGroupingConverter`), then `GROUP BY ordinal, COUNT(*)`; the response
+  (`InternalRange`) returns every declared range in order, empty ranges included as
+  `doc_count: 0`. Sub-aggregations are supported.
+  - **Single-membership only**: overlapping ranges are rejected (classic search counts a
+    document in every matching range — see `RangeAggregator.collect` — which single-ordinal
+    grouping cannot reproduce). `script` and `missing` are also rejected on this path.
+    This mirrors PPL `bin`, which is single-membership by design.
+
 ## Dependencies
 
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslAggregationIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslAggregationIT.java
@@ -11,6 +11,7 @@ package org.opensearch.dsl;
 import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -42,6 +43,37 @@ public class DslAggregationIT extends DslIntegTestBase {
     public void testTermsBucket() {
         createTestIndex();
         assertOk(search(new SearchSourceBuilder().size(0).aggregation(new TermsAggregationBuilder("by_brand").field("brand"))));
+    }
+
+    public void testRangeBucket() {
+        createTestIndex();
+        assertOk(
+            search(
+                new SearchSourceBuilder().size(0)
+                    .aggregation(
+                        new RangeAggregationBuilder("price_ranges").field("price")
+                            .addUnboundedTo(100)
+                            .addRange(100, 200)
+                            .addUnboundedFrom(200)
+                    )
+            )
+        );
+    }
+
+    public void testRangeBucketWithMetric() {
+        createTestIndex();
+        assertOk(
+            search(
+                new SearchSourceBuilder().size(0)
+                    .aggregation(
+                        new RangeAggregationBuilder("price_ranges").field("price")
+                            .addUnboundedTo(100)
+                            .addRange(100, 200)
+                            .addUnboundedFrom(200)
+                            .subAggregation(AggregationBuilders.avg("avg_rating").field("rating"))
+                    )
+            )
+        );
     }
 
     public void testTermsBucketWithMetric() {

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadata.java
@@ -44,6 +44,7 @@ public class AggregationMetadata {
     private final Integer perParentFetch;
     private final Long havingMinDocCount;
     private final Map<String, Object> missingValues;
+    private final List<ExpressionGrouping> expressionGroupings;
 
     /**
      * Creates aggregation metadata.
@@ -62,6 +63,8 @@ public class AggregationMetadata {
      *        for none
      * @param missingValues null-substitution value per group field ({@code missing} parameter);
      *        fields absent from the map get an {@code IS NOT NULL} filter instead
+     * @param expressionGroupings computed-key groupings in this plan (e.g. {@code range} ordinals);
+     *        their synthetic columns are projected before the aggregate by {@code ComputedGroupingConverter}
      */
     public AggregationMetadata(
         List<String> aggNamePath,
@@ -73,7 +76,8 @@ public class AggregationMetadata {
         Integer fetch,
         Integer perParentFetch,
         Long havingMinDocCount,
-        Map<String, Object> missingValues
+        Map<String, Object> missingValues,
+        List<ExpressionGrouping> expressionGroupings
     ) {
         this.aggNamePath = List.copyOf(aggNamePath);
         this.groupByBitSet = groupByBitSet;
@@ -85,6 +89,7 @@ public class AggregationMetadata {
         this.perParentFetch = perParentFetch;
         this.havingMinDocCount = havingMinDocCount;
         this.missingValues = Map.copyOf(missingValues);
+        this.expressionGroupings = List.copyOf(expressionGroupings);
     }
 
     /**
@@ -174,6 +179,15 @@ public class AggregationMetadata {
      */
     public Map<String, Object> getMissingValues() {
         return missingValues;
+    }
+
+    /**
+     * Returns the computed-key groupings for this plan — {@code range} (and, later, histogram)
+     * groupings whose synthetic ordinal column {@code ComputedGroupingConverter} projects onto the
+     * pre-aggregate input so the GROUP BY bitset can resolve to it. Empty for field-only plans.
+     */
+    public List<ExpressionGrouping> getExpressionGroupings() {
+        return expressionGroupings;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -150,9 +150,21 @@ public class AggregationMetadataBuilder {
         // Resolve grouping indices at build time
         List<Integer> allGroupIndices = new ArrayList<>();
         List<String> allGroupFieldNames = new ArrayList<>();
+        List<ExpressionGrouping> exprGroupings = new ArrayList<>();
+        int baseFieldCount = inputRowType.getFieldCount();
         for (GroupingInfo g : groupings) {
-            allGroupIndices.addAll(resolveFieldIndices(g, inputRowType));
-            allGroupFieldNames.addAll(g.getFieldNames());
+            if (g instanceof ExpressionGrouping eg) {
+                // Computed-key grouping (e.g. range ordinal): the synthetic column does not exist
+                // in the scan schema yet — ComputedGroupingConverter appends it after the base
+                // columns, so its index is assigned deterministically as baseFieldCount + offset
+                // (the append order equals the exprGroupings order here).
+                allGroupIndices.add(baseFieldCount + exprGroupings.size());
+                allGroupFieldNames.add(eg.getSyntheticColumn());
+                exprGroupings.add(eg);
+            } else {
+                allGroupIndices.addAll(resolveFieldIndices(g, inputRowType));
+                allGroupFieldNames.addAll(g.getFieldNames());
+            }
         }
 
         // For no-GROUP-BY, metric results could be null (e.g., AVG of empty set).
@@ -223,7 +235,8 @@ public class AggregationMetadataBuilder {
             fetch,
             perParentFetch,
             havingMinDocCount,
-            missingValues
+            missingValues,
+            exprGroupings
         );
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.opensearch.dsl.aggregation.bucket.RangeBucketTranslator;
 import org.opensearch.dsl.aggregation.bucket.TermsBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.AvgMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MaxMetricTranslator;
@@ -38,6 +39,7 @@ public class AggregationRegistryFactory {
         registry.register(new MinMetricTranslator());
         registry.register(new MaxMetricTranslator());
         registry.register(new TermsBucketTranslator(mapperServiceSupplier));
+        registry.register(new RangeBucketTranslator(mapperServiceSupplier));
         // TODO: add other aggregation translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/ExpressionGrouping.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/ExpressionGrouping.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Expression-based grouping: the group key is a <em>computed</em> column rather than a raw
+ * field. Used by bucket aggregations whose buckets are not field values — {@code range} (and,
+ * later, {@code histogram}/{@code date_histogram}) — where each document is mapped to a single
+ * bucket ordinal by an expression over the source field.
+ *
+ * <p>The single {@link #getFieldNames() field name} is a synthetic column that a pre-aggregate
+ * projection materializes; the {@code LogicalAggregate}'s GROUP BY then resolves to it, exactly
+ * as {@link FieldGrouping} resolves to a real field. This keeps {@link GroupingInfo} pure data —
+ * the RexNode is built converter-side from {@link #getSourceField()} and {@link #getBounds()},
+ * mirroring the way {@code PreAggregateConverter} builds the {@code missing}-substitution CASE.
+ *
+ * <p>{@code range} is single-membership by construction (overlapping ranges are rejected at
+ * validation), so one ordinal per document is sufficient.
+ */
+public class ExpressionGrouping implements GroupingInfo {
+
+    /** A single half-open bucket interval {@code [from, to)}; {@code from}/{@code to} may be ±∞. */
+    public record Bound(double from, double to) {
+    }
+
+    private final String syntheticColumn;
+    private final String sourceField;
+    private final List<Bound> bounds;
+
+    /**
+     * Creates an expression grouping.
+     *
+     * @param syntheticColumn the projected group-key column name (must not collide with a mapped field)
+     * @param sourceField the source field the bucket expression reads
+     * @param bounds the bucket intervals in the aggregation's declaration order; ordinal {@code i}
+     *        is {@code bounds.get(i)} and is the key emitted by the group expression for a document
+     *        whose value falls in that interval
+     */
+    public ExpressionGrouping(String syntheticColumn, String sourceField, List<Bound> bounds) {
+        this.syntheticColumn = syntheticColumn;
+        this.sourceField = sourceField;
+        this.bounds = List.copyOf(bounds);
+    }
+
+    @Override
+    public List<String> getFieldNames() {
+        return List.of(syntheticColumn);
+    }
+
+    /** Expression groupings never carry a {@code missing} substitution — the expression handles nulls (ELSE NULL). */
+    @Override
+    public Map<String, Object> getMissingByField() {
+        return Map.of();
+    }
+
+    /** Returns the synthetic group-key column name. */
+    public String getSyntheticColumn() {
+        return syntheticColumn;
+    }
+
+    /** Returns the source field the bucket expression reads. */
+    public String getSourceField() {
+        return sourceField;
+    }
+
+    /** Returns the bucket intervals in declaration order; ordinal {@code i} maps to {@code get(i)}. */
+    public List<Bound> getBounds() {
+        return bounds;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/RangeBucketTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/RangeBucketTranslator.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.ExpressionGrouping;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Translates a {@link RangeAggregationBuilder} — bucketing a numeric field into user-declared
+ * half-open intervals {@code [from, to)}. Each document is mapped to a single range <b>ordinal</b>
+ * by a computed group key (an {@link ExpressionGrouping}); {@code GROUP BY ordinal, COUNT(*)}
+ * then yields one row per non-empty range, which {@link RangeResponseStrategy} renders back into
+ * an {@code InternalRange} with every declared range present (empty ranges as {@code doc_count:0}).
+ *
+ * <p><b>Single-membership only.</b> Classic {@code range} lets ranges overlap and counts a
+ * document in <em>every</em> matching range (see {@code RangeAggregator.collect}, which loops all
+ * matching ranges and calls {@code collectBucket} for each). A one-ordinal-per-document GROUP BY
+ * cannot reproduce that, so overlapping ranges are rejected in {@link #validate} rather than
+ * silently under-counted. This mirrors PPL's {@code bin}, which is single-membership by design.
+ * Non-overlapping (contiguous) ranges — the common case — are exact.
+ */
+public class RangeBucketTranslator implements BucketTranslator<RangeAggregationBuilder> {
+
+    private final Supplier<MapperService> mapperServiceSupplier;
+
+    /**
+     * Creates a range bucket translator.
+     *
+     * @param mapperServiceSupplier supplies the target index's MapperService for the response
+     *        {@link DocValueFormat}; evaluated lazily. Supplying null fails rendering.
+     */
+    public RangeBucketTranslator(Supplier<MapperService> mapperServiceSupplier) {
+        this.mapperServiceSupplier = mapperServiceSupplier;
+    }
+
+    @Override
+    public Class<RangeAggregationBuilder> getAggregationType() {
+        return RangeAggregationBuilder.class;
+    }
+
+    /**
+     * The group key is a synthetic ordinal column computed from the source field. Ordinal
+     * {@code i} corresponds to {@code agg.ranges().get(i)} — declaration order — so the response
+     * maps ordinals straight back to the declared ranges.
+     */
+    @Override
+    public GroupingInfo getGrouping(RangeAggregationBuilder agg) {
+        List<ExpressionGrouping.Bound> bounds = new ArrayList<>(agg.ranges().size());
+        for (RangeAggregator.Range range : agg.ranges()) {
+            bounds.add(new ExpressionGrouping.Bound(range.getFrom(), range.getTo()));
+        }
+        return new ExpressionGrouping(syntheticColumn(agg), agg.field(), bounds);
+    }
+
+    @Override
+    public Collection<AggregationBuilder> getSubAggregations(RangeAggregationBuilder agg) {
+        return agg.getSubAggregations();
+    }
+
+    /** Range buckets are returned in declaration order, never reordered — no bucket order. */
+    @Override
+    public BucketOrder getBucketOrder(RangeAggregationBuilder agg) {
+        return null;
+    }
+
+    /**
+     * Rejects parameters this single-membership path cannot honor without diverging from classic
+     * results: {@code script} (no field to bucket), {@code missing} (would need a null-substituting
+     * projection, not yet wired), and — the semantic gate — <b>overlapping ranges</b>, which
+     * classic search counts as multi-membership.
+     */
+    @Override
+    public void validate(RangeAggregationBuilder agg) throws ConversionException {
+        if (agg.script() != null) {
+            throw new ConversionException(
+                "[script] on range aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
+        }
+        if (agg.missing() != null) {
+            throw new ConversionException(
+                "[missing] on range aggregation [" + agg.getName() + "] is not supported by the DSL execution path"
+            );
+        }
+        rejectOverlappingRanges(agg);
+    }
+
+    /**
+     * Fails when any two ranges overlap. Ranges are half-open {@code [from, to)}, so touching
+     * bounds ({@code [0,100)} and {@code [100,200)}) do not overlap. Detection sweeps the ranges
+     * sorted by {@code from} against the running maximum {@code to}: an overlap exists iff some
+     * range starts strictly before the greatest {@code to} seen so far — the same
+     * {@code from < maxTo} test classic search's {@code RangeAggregator} builds its {@code maxTo}
+     * array for.
+     */
+    private static void rejectOverlappingRanges(RangeAggregationBuilder agg) throws ConversionException {
+        List<RangeAggregator.Range> sorted = new ArrayList<>(agg.ranges());
+        sorted.sort(Comparator.comparingDouble(RangeAggregator.Range::getFrom).thenComparingDouble(RangeAggregator.Range::getTo));
+        double maxTo = Double.NEGATIVE_INFINITY;
+        for (RangeAggregator.Range range : sorted) {
+            if (range.getFrom() < maxTo) {
+                throw new ConversionException(
+                    "overlapping ranges on range aggregation ["
+                        + agg.getName()
+                        + "] are not supported by the DSL execution path — classic search counts a document in every "
+                        + "matching range (RangeAggregator.collect), which single-ordinal grouping cannot reproduce"
+                );
+            }
+            maxTo = Math.max(maxTo, range.getTo());
+        }
+    }
+
+    @Override
+    public InternalAggregation toBucketAggregation(RangeAggregationBuilder agg, Iterable<BucketEntry> buckets) {
+        return RangeResponseStrategy.build(agg, buckets, resolveFormat(agg));
+    }
+
+    /** The synthetic ordinal column name; {@code $} cannot appear in a field name, so it cannot collide with a mapped field. */
+    private static String syntheticColumn(RangeAggregationBuilder agg) {
+        return "_range$" + agg.getName();
+    }
+
+    /** Resolves the source field's {@link DocValueFormat} for key rendering, failing loudly when the mapping is unavailable. */
+    private DocValueFormat resolveFormat(RangeAggregationBuilder agg) {
+        MapperService mapperService = mapperServiceSupplier.get();
+        if (mapperService == null) {
+            throw new IllegalStateException(
+                "index mapping unavailable for range aggregation ["
+                    + agg.getName()
+                    + "] — cannot resolve the format for field ["
+                    + agg.field()
+                    + "]"
+            );
+        }
+        MappedFieldType fieldType = mapperService.fieldType(agg.field());
+        if (fieldType == null) {
+            throw new IllegalStateException(
+                "field [" + agg.field() + "] of range aggregation [" + agg.getName() + "] is not present in the index mapping"
+            );
+        }
+        return fieldType.docValueFormat(agg.format(), null);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/RangeResponseStrategy.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/bucket/RangeResponseStrategy.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.range.InternalRange;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a {@code range} aggregation response ({@link InternalRange}) from grouped bucket
+ * entries. Unlike terms, {@code range} returns its <b>full</b> bucket set in declaration order:
+ * every requested range appears, including ranges the plan produced no rows for (rendered with
+ * {@code doc_count = 0}).
+ *
+ * <p>Each {@link BucketEntry} carries the range <b>ordinal</b> as its single key — the value the
+ * group expression assigned to the documents that fell in that range (ordinal {@code i} =
+ * {@code agg.ranges().get(i)}). Documents that fell in no range (or whose field was null) form a
+ * null-ordinal group that is not a bucket, so it is ignored here.
+ */
+final class RangeResponseStrategy {
+
+    private RangeResponseStrategy() {}
+
+    /**
+     * Builds the {@link InternalRange} response.
+     *
+     * @param agg     the original range aggregation builder (name, ranges, keyed, meta)
+     * @param entries grouped bucket entries keyed by range ordinal, as the plan produced them
+     * @param format  the resolved {@link DocValueFormat} for key/from/to rendering
+     * @return the range aggregation, all declared ranges present in declaration order
+     */
+    static InternalAggregation build(RangeAggregationBuilder agg, Iterable<BucketEntry> entries, DocValueFormat format) {
+        Map<Integer, BucketEntry> byOrdinal = new HashMap<>();
+        for (BucketEntry entry : entries) {
+            Object key = entry.keys().isEmpty() ? null : entry.keys().get(0);
+            if (key instanceof Number number) {
+                byOrdinal.put(number.intValue(), entry);
+            }
+            // A null / non-numeric key is the "matched no range" group — not a bucket.
+        }
+
+        List<RangeAggregator.Range> ranges = agg.ranges();
+        boolean keyed = agg.keyed();
+        List<InternalRange.Bucket> buckets = new ArrayList<>(ranges.size());
+        for (int i = 0; i < ranges.size(); i++) {
+            RangeAggregator.Range range = ranges.get(i);
+            BucketEntry entry = byOrdinal.get(i);
+            long docCount = entry != null ? entry.docCount() : 0L;
+            InternalAggregations subAggs = entry != null ? entry.subAggs() : InternalAggregations.EMPTY;
+            buckets.add(new InternalRange.Bucket(range.getKey(), range.getFrom(), range.getTo(), docCount, subAggs, keyed, format));
+        }
+        return newRange(agg.getName(), buckets, format, keyed, AggregationTranslator.userMetadata(agg));
+    }
+
+    /**
+     * Constructs the {@link InternalRange} via a raw {@link InternalRange.Factory} instance. The
+     * factory's recursively-bounded generics ({@code R extends InternalRange<B, R>}) cannot be
+     * satisfied by a diamond or wildcard at a call site, so a raw factory is the idiomatic
+     * construction path (the same one {@code RangeAggregator} uses); the package-private
+     * {@code InternalRange.FACTORY} singleton is not visible here, so we instantiate our own.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static InternalAggregation newRange(
+        String name,
+        List<InternalRange.Bucket> buckets,
+        DocValueFormat format,
+        boolean keyed,
+        Map<String, Object> metadata
+    ) {
+        return new InternalRange.Factory().create(name, buckets, format, keyed, metadata);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ComputedGroupingConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ComputedGroupingConverter.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.converter;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.ExpressionGrouping;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Materializes the computed group-key columns for expression-based bucket aggregations (today,
+ * {@code range}) by appending them to the shared scan+filter base, so the {@code LogicalAggregate}
+ * can GROUP BY a synthetic ordinal column that does not exist in the index mapping.
+ *
+ * <p>Runs <b>before</b> {@code PreAggregateConverter}: the metadata's group-by field names include
+ * the synthetic column, which pre-aggregate null handling then resolves against this converter's
+ * output. Columns are <b>appended</b> (never reordered), so every base field keeps its index and
+ * the metric {@code AggregateCall}s resolved against the scan schema stay valid; the synthetic
+ * column lands at {@code baseFieldCount + offset}, matching the index
+ * {@link AggregationMetadata#getGroupByBitSet()} was assigned in {@code AggregationMetadataBuilder}.
+ *
+ * <p>The projected key is a range-ordinal CASE over {@code CAST(field AS DOUBLE)}; see
+ * {@link #ordinalCase} and {@link #membershipCondition} for its exact shape.
+ */
+public class ComputedGroupingConverter extends AbstractDslConverter {
+
+    /** Creates a computed-grouping converter. */
+    public ComputedGroupingConverter() {}
+
+    @Override
+    protected boolean isApplicable(ConversionContext ctx) {
+        return ctx.getAggregationMetadata() != null && !ctx.getAggregationMetadata().getExpressionGroupings().isEmpty();
+    }
+
+    @Override
+    protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
+        AggregationMetadata metadata = ctx.getAggregationMetadata();
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        RelDataTypeFactory typeFactory = ctx.getCluster().getTypeFactory();
+        RelDataType doubleType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+        RelDataType rowType = input.getRowType();
+
+        List<RexNode> projects = new ArrayList<>();
+        List<String> names = new ArrayList<>();
+        // Pass every base column through unchanged (same names, same positions).
+        for (RelDataTypeField field : rowType.getFieldList()) {
+            projects.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+            names.add(field.getName());
+        }
+        // Append one ordinal column per expression grouping, in the same order the metadata assigned indices.
+        for (ExpressionGrouping grouping : metadata.getExpressionGroupings()) {
+            RelDataTypeField source = rowType.getField(grouping.getSourceField(), false, false);
+            if (source == null) {
+                throw new ConversionException("Range field '" + grouping.getSourceField() + "' not found in schema");
+            }
+            RexNode fieldAsDouble = rexBuilder.makeCast(doubleType, rexBuilder.makeInputRef(source.getType(), source.getIndex()));
+            projects.add(ordinalCase(rexBuilder, doubleType, intType, fieldAsDouble, grouping.getBounds()));
+            names.add(grouping.getSyntheticColumn());
+        }
+        return LogicalProject.create(input, List.of(), projects, names);
+    }
+
+    /** Builds {@code CASE WHEN <in range i> THEN i ... ELSE NULL END}, ordinal i = declaration index. */
+    private static RexNode ordinalCase(
+        RexBuilder rexBuilder,
+        RelDataType doubleType,
+        RelDataType intType,
+        RexNode fieldAsDouble,
+        List<ExpressionGrouping.Bound> bounds
+    ) {
+        List<RexNode> operands = new ArrayList<>(bounds.size() * 2 + 1);
+        for (int i = 0; i < bounds.size(); i++) {
+            operands.add(membershipCondition(rexBuilder, doubleType, fieldAsDouble, bounds.get(i)));
+            operands.add(rexBuilder.makeExactLiteral(BigDecimal.valueOf(i), intType));
+        }
+        operands.add(rexBuilder.makeNullLiteral(intType)); // ELSE: matched no range
+        return rexBuilder.makeCall(SqlStdOperatorTable.CASE, operands);
+    }
+
+    /** {@code v >= from AND v < to}, dropping the comparison on any ±∞ side; {@code [-∞,+∞)} → TRUE. */
+    private static RexNode membershipCondition(
+        RexBuilder rexBuilder,
+        RelDataType doubleType,
+        RexNode fieldAsDouble,
+        ExpressionGrouping.Bound bound
+    ) {
+        List<RexNode> conjuncts = new ArrayList<>(2);
+        if (bound.from() != Double.NEGATIVE_INFINITY) {
+            conjuncts.add(
+                rexBuilder.makeCall(
+                    SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                    fieldAsDouble,
+                    rexBuilder.makeApproxLiteral(BigDecimal.valueOf(bound.from()), doubleType)
+                )
+            );
+        }
+        if (bound.to() != Double.POSITIVE_INFINITY) {
+            conjuncts.add(
+                rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN,
+                    fieldAsDouble,
+                    rexBuilder.makeApproxLiteral(BigDecimal.valueOf(bound.to()), doubleType)
+                )
+            );
+        }
+        if (conjuncts.isEmpty()) {
+            return rexBuilder.makeLiteral(true);
+        }
+        return RexUtil.composeConjunction(rexBuilder, conjuncts);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -70,6 +70,7 @@ public class SearchSourceConverter {
     private final SortConverter sortConverter;
     private final AggregateConverter aggConverter;
     private final PreAggregateConverter preAggConverter;
+    private final ComputedGroupingConverter computedGroupingConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationRegistry aggRegistry;
     private final AggregationTreeWalker treeWalker;
@@ -110,6 +111,7 @@ public class SearchSourceConverter {
         this.sortConverter = new SortConverter();
         this.aggConverter = new AggregateConverter();
         this.preAggConverter = new PreAggregateConverter();
+        this.computedGroupingConverter = new ComputedGroupingConverter();
         this.postAggConverter = new PostAggregateConverter();
 
         this.aggRegistry = AggregationRegistryFactory.create(mapperServiceSupplier);
@@ -180,7 +182,7 @@ public class SearchSourceConverter {
                 }
                 aggCtx = aggCtx.withParentPlan(parentPlan);
             }
-            RelNode aggInput = preAggConverter.convert(base, aggCtx);
+            RelNode aggInput = preAggConverter.convert(computedGroupingConverter.convert(base, aggCtx), aggCtx);
             RelNode aggs = aggConverter.convert(aggInput, metadata);
             aggs = postAggConverter.convert(aggs, aggCtx);
             builtPlansByPath.put(aggPathKey(metadata.getAggNamePath()), aggs);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/RangeBucketTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/RangeBucketTranslatorTests.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.aggregation.ExpressionGrouping;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.script.Script;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RangeBucketTranslatorTests extends OpenSearchTestCase {
+
+    private final RangeBucketTranslator translator = new RangeBucketTranslator(() -> null);
+
+    private static RangeAggregationBuilder priceRanges() {
+        // [*,100), [100,200), [200,*) — contiguous, non-overlapping
+        return new RangeAggregationBuilder("price_ranges").field("price").addUnboundedTo(100).addRange(100, 200).addUnboundedFrom(200);
+    }
+
+    public void testValidateAcceptsNonOverlappingRanges() throws Exception {
+        translator.validate(priceRanges()); // no exception
+    }
+
+    public void testValidateAcceptsTouchingBoundsAsNonOverlap() throws Exception {
+        // to is exclusive, so [0,100) and [100,200) share only the point 100 and do NOT overlap
+        translator.validate(new RangeAggregationBuilder("r").field("price").addRange(0, 100).addRange(100, 200));
+    }
+
+    public void testValidateRejectsOverlappingRanges() {
+        RangeAggregationBuilder agg = new RangeAggregationBuilder("r").field("price").addRange(0, 100).addRange(50, 150);
+        ConversionException e = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(e.getMessage(), e.getMessage().contains("overlapping ranges"));
+    }
+
+    public void testValidateRejectsOverlapAcrossUnboundedRanges() {
+        // [*,100) and [50,*) overlap on [50,100)
+        RangeAggregationBuilder agg = new RangeAggregationBuilder("r").field("price").addUnboundedTo(100).addUnboundedFrom(50);
+        expectThrows(ConversionException.class, () -> translator.validate(agg));
+    }
+
+    public void testValidateRejectsScript() {
+        RangeAggregationBuilder agg = new RangeAggregationBuilder("r").script(new Script("doc['price'].value")).addRange(0, 100);
+        ConversionException e = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(e.getMessage(), e.getMessage().contains("[script]"));
+    }
+
+    public void testValidateRejectsMissing() {
+        RangeAggregationBuilder agg = new RangeAggregationBuilder("r").field("price").missing(0).addRange(0, 100);
+        ConversionException e = expectThrows(ConversionException.class, () -> translator.validate(agg));
+        assertTrue(e.getMessage(), e.getMessage().contains("[missing]"));
+    }
+
+    public void testGetGroupingProducesOrdinalExpressionGrouping() {
+        GroupingInfo grouping = translator.getGrouping(priceRanges());
+        assertThat(grouping, instanceOf(ExpressionGrouping.class));
+        ExpressionGrouping eg = (ExpressionGrouping) grouping;
+
+        // synthetic ordinal column, one per aggregation, cannot collide with a mapped field ('$')
+        assertThat(eg.getFieldNames(), contains("_range$price_ranges"));
+        assertEquals("price", eg.getSourceField());
+        assertTrue("expression groupings carry no missing substitution", eg.getMissingByField().isEmpty());
+
+        // bounds in declaration order, ordinal i -> bounds.get(i), with ±infinity for open ends
+        assertThat(eg.getBounds(), hasSize(3));
+        assertEquals(Double.NEGATIVE_INFINITY, eg.getBounds().get(0).from(), 0.0);
+        assertEquals(100.0, eg.getBounds().get(0).to(), 0.0);
+        assertEquals(100.0, eg.getBounds().get(1).from(), 0.0);
+        assertEquals(200.0, eg.getBounds().get(1).to(), 0.0);
+        assertEquals(200.0, eg.getBounds().get(2).from(), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, eg.getBounds().get(2).to(), 0.0);
+    }
+
+    public void testGetSubAggregationsPassedThrough() {
+        RangeAggregationBuilder agg = priceRanges().subAggregation(new AvgAggregationBuilder("avg_rating").field("rating"));
+        assertThat(translator.getSubAggregations(agg), hasSize(1));
+    }
+
+    public void testGetSubAggregationsEmptyWhenNone() {
+        assertTrue(translator.getSubAggregations(priceRanges()).isEmpty());
+    }
+
+    public void testRangeHasNoBucketOrder() {
+        assertNull(translator.getBucketOrder(priceRanges()));
+    }
+
+    public void testGetAggregationType() {
+        assertEquals(RangeAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    public void testResolveFormatHonorsUserSuppliedFormat() {
+        MapperService mapperService = mock(MapperService.class);
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(mapperService.fieldType("price")).thenReturn(fieldType);
+        when(fieldType.docValueFormat(any(), any())).thenReturn(DocValueFormat.RAW);
+
+        RangeBucketTranslator t = new RangeBucketTranslator(() -> mapperService);
+        t.toBucketAggregation(priceRanges().format("0.0"), List.of());
+
+        // classic search honors the user-supplied format for key/from/to rendering; so must we
+        verify(fieldType).docValueFormat("0.0", null);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/RangeResponseStrategyTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/bucket/RangeResponseStrategyTests.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.bucket;
+
+import org.opensearch.dsl.result.BucketEntry;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.range.InternalRange;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class RangeResponseStrategyTests extends OpenSearchTestCase {
+
+    private static RangeAggregationBuilder keyedRanges() {
+        return new RangeAggregationBuilder("price_ranges").field("price")
+            .addUnboundedTo("cheap", 100)
+            .addRange("mid", 100, 200)
+            .addUnboundedFrom("expensive", 200);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<? extends InternalRange.Bucket> bucketsOf(InternalAggregation agg) {
+        assertTrue("expected InternalRange, got " + agg.getClass().getSimpleName(), agg instanceof InternalRange);
+        return ((InternalRange<InternalRange.Bucket, ?>) agg).getBuckets();
+    }
+
+    public void testAllRangesMaterializedInOrderWithEmptyAsZero() {
+        // rows only for ordinals 0 and 2 (Integer and Long, to prove numeric key coercion);
+        // ordinal 1 has no row and must still appear with doc_count 0.
+        List<BucketEntry> entries = List.of(
+            new BucketEntry(List.of(0), 5L, InternalAggregations.EMPTY),
+            new BucketEntry(List.of(2L), 3L, InternalAggregations.EMPTY)
+        );
+
+        InternalAggregation agg = RangeResponseStrategy.build(keyedRanges(), entries, DocValueFormat.RAW);
+        assertEquals("price_ranges", agg.getName());
+
+        List<? extends InternalRange.Bucket> buckets = bucketsOf(agg);
+        assertEquals(3, buckets.size());
+
+        assertEquals("cheap", buckets.get(0).getKeyAsString());
+        assertEquals(5L, buckets.get(0).getDocCount());
+        assertEquals("mid", buckets.get(1).getKeyAsString());
+        assertEquals(0L, buckets.get(1).getDocCount()); // empty range still present
+        assertEquals("expensive", buckets.get(2).getKeyAsString());
+        assertEquals(3L, buckets.get(2).getDocCount());
+    }
+
+    public void testFromToRenderingIncludingInfinities() {
+        InternalAggregation agg = RangeResponseStrategy.build(keyedRanges(), List.of(), DocValueFormat.RAW);
+        List<? extends InternalRange.Bucket> buckets = bucketsOf(agg);
+
+        // [*,100)
+        assertEquals(Double.NEGATIVE_INFINITY, ((Number) buckets.get(0).getFrom()).doubleValue(), 0.0);
+        assertEquals(100.0, ((Number) buckets.get(0).getTo()).doubleValue(), 0.0);
+        assertNull("open lower bound renders as null string", buckets.get(0).getFromAsString());
+        assertEquals("100.0", buckets.get(0).getToAsString());
+        // [200,*)
+        assertEquals(200.0, ((Number) buckets.get(2).getFrom()).doubleValue(), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, ((Number) buckets.get(2).getTo()).doubleValue(), 0.0);
+        assertNull("open upper bound renders as null string", buckets.get(2).getToAsString());
+    }
+
+    public void testEmptyResultYieldsAllRangesAtZero() {
+        InternalAggregation agg = RangeResponseStrategy.build(keyedRanges(), List.of(), DocValueFormat.RAW);
+        List<? extends InternalRange.Bucket> buckets = bucketsOf(agg);
+        assertEquals(3, buckets.size());
+        for (InternalRange.Bucket b : buckets) {
+            assertEquals(0L, b.getDocCount());
+        }
+    }
+
+    public void testNullOrdinalGroupIsIgnored() {
+        // documents that matched no range form a null-ordinal group — it is not a bucket
+        List<BucketEntry> entries = Arrays.asList(
+            new BucketEntry(List.of(1), 7L, InternalAggregations.EMPTY),
+            new BucketEntry(Collections.singletonList(null), 99L, InternalAggregations.EMPTY)
+        );
+        InternalAggregation agg = RangeResponseStrategy.build(keyedRanges(), entries, DocValueFormat.RAW);
+        List<? extends InternalRange.Bucket> buckets = bucketsOf(agg);
+        assertEquals(3, buckets.size());
+        assertEquals(0L, buckets.get(0).getDocCount());
+        assertEquals(7L, buckets.get(1).getDocCount());
+        assertEquals(0L, buckets.get(2).getDocCount());
+        long total = buckets.stream().mapToLong(InternalRange.Bucket::getDocCount).sum();
+        assertEquals("the 99 null-ordinal docs must not leak into any bucket", 7L, total);
+    }
+
+    public void testKeyedFlagPropagated() {
+        RangeAggregationBuilder keyed = keyedRanges();
+        keyed.keyed(true);
+        List<? extends InternalRange.Bucket> buckets = bucketsOf(RangeResponseStrategy.build(keyed, List.of(), DocValueFormat.RAW));
+        assertTrue(buckets.get(0).getKeyed());
+    }
+
+    public void testMetaEchoedWhenSupplied() {
+        RangeAggregationBuilder agg = keyedRanges();
+        agg.setMetadata(Map.of("owner", "search"));
+        InternalAggregation result = RangeResponseStrategy.build(agg, List.of(), DocValueFormat.RAW);
+        assertEquals(Map.of("owner", "search"), result.getMetadata());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/range_numeric_aggregation.json
@@ -1,0 +1,60 @@
+{
+  "testName": "range_numeric_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "price_ranges": {
+        "range": {
+          "field": "price",
+          "ranges": [
+            { "to": 100 },
+            { "from": 100, "to": 200 },
+            { "from": 200 }
+          ]
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": [
+    "LogicalAggregate(group=[{4}], _count=[COUNT()])",
+    "  LogicalFilter(condition=[IS NOT NULL($4)])",
+    "    LogicalProject(name=[$0], price=[$1], brand=[$2], rating=[$3], _range$price_ranges=[CASE(<(CAST($1):DOUBLE NOT NULL, 100.0E0), 0, AND(>=(CAST($1):DOUBLE NOT NULL, 100.0E0), <(CAST($1):DOUBLE NOT NULL, 200.0E0)), 1, >=(CAST($1):DOUBLE NOT NULL, 200.0E0), 2, null:INTEGER)])",
+    "      LogicalTableScan(table=[[test-index]])"
+  ],
+  "mockResultFieldNames": ["_range$price_ranges", "_count"],
+  "mockResultRows": [
+    [0, 3],
+    [2, 2]
+  ],
+  "mockCountRow": {
+    "_total": 5
+  },
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 5,
+        "relation": "eq"
+      },
+      "max_score": null,
+      "hits": []
+    },
+    "aggregations": {
+      "price_ranges": {
+        "buckets": [
+          { "key": "*-100.0", "to": 100.0, "doc_count": 3 },
+          { "key": "100.0-200.0", "from": 100.0, "to": 200.0, "doc_count": 0 },
+          { "key": "200.0-*", "from": 200.0, "doc_count": 2 }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds the `range` bucket aggregation to the DSL (Calcite) execution path.

Each document is mapped to a single range **ordinal** by a computed `CASE` group key (`ComputedGroupingConverter`), then `GROUP BY ordinal, COUNT(*)`; `RangeResponseStrategy` builds the `InternalRange` response, returning every declared range in declaration order with empty ranges as `doc_count: 0`. Sub-aggregations are supported.

**Single-membership only (v1).** Classic `range` allows overlapping ranges and counts a document in every matching range (`RangeAggregator.collect`), which single-ordinal grouping cannot reproduce — so overlapping ranges are rejected in `validate()`, along with `script` and `missing`. This mirrors PPL `bin`, which is single-membership by design; full overlap support (join-explode) can follow.

### Testing
- Unit: `RangeBucketTranslatorTests` (11), `RangeResponseStrategyTests` (6).
- End-to-end golden `range_numeric_aggregation.json` (DSL -> plan -> mock-execute -> `InternalRange`), auto-discovered by `SearchSourceConverterTests` and `SearchResponseBuilderTests`.
- Full `dsl-query-executor` unit task green: 30 suites, 416 tests, 0 failures (JDK 25).
- `DslAggregationIT` range cases added; that class is `@AwaitsFix` (analytics-engine E2E not wired) like all DSL ITs, so live-cluster execution is pending the engine, not this change.

### Check List
- [x] New functionality includes unit tests
- [ ] Draft — checklist finalized before marking ready for review