### PR TITLE
Terminate hung snapshot creates and deletes instead of stranding them

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
@@ -9,7 +9,10 @@
 package org.opensearch.snapshots;
 
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.SnapshotDeletionsInProgress;
 import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
@@ -74,8 +77,43 @@ public class SnapshotRepositoryIoTimeoutIT extends AbstractSnapshotIntegTestCase
         assertAcked(client().admin().indices().prepareDelete("test-idx").get());
     }
 
+    public void testHungDeleteTimesOutAndReleasesRepositoryLoop() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        createRepository("test-repo", "mock");
+        assertAcked(prepareCreate("test-idx", 0, indexSettingsNoReplicas(1)));
+        ensureGreen();
+        indexRandomDocs("test-idx", randomIntBetween(10, 50));
+
+        createFullSnapshot("test-repo", "snap-1");
+        createFullSnapshot("test-repo", "snap-2");
+
+        logger.info("--> block the cluster-manager deleting index-N, then start a delete");
+        final String clusterManagerName = internalCluster().getClusterManagerName();
+        final ActionFuture<AcknowledgedResponse> blockedDelete = deleteSnapshotBlockedOnClusterManager("test-repo", "snap-1");
+        waitForBlock(clusterManagerName, "test-repo", TimeValue.timeValueSeconds(30));
+
+        logger.info("--> the io_timeout must terminate the delete and remove its cluster state entry");
+        assertBusy(() -> assertTrue("delete marker should be gone", deletionsInProgress().getEntries().isEmpty()), 60, TimeUnit.SECONDS);
+
+        logger.info("--> the caller is told the delete failed rather than hanging forever");
+        expectThrows(Exception.class, blockedDelete::actionGet);
+
+        logger.info("--> let the orphaned repository worker finish");
+        unblockNode("test-repo", clusterManagerName);
+        assertBusy(() -> assertTrue("delete marker must not reappear", deletionsInProgress().getEntries().isEmpty()), 30, TimeUnit.SECONDS);
+
+        logger.info("--> the repository loop was released, so a further delete can run");
+        assertAcked(client().admin().cluster().prepareDeleteSnapshot("test-repo", "snap-2").get());
+    }
+
     private SnapshotsInProgress snapshotsInProgress() {
         return clusterService().state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+    }
+
+    private SnapshotDeletionsInProgress deletionsInProgress() {
+        return clusterService().state().custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY);
     }
 
     private void assertSnapshotNotRecordedAsSuccessful(String repository, String snapshot) {

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
@@ -108,6 +108,70 @@ public class SnapshotRepositoryIoTimeoutIT extends AbstractSnapshotIntegTestCase
         assertAcked(client().admin().cluster().prepareDeleteSnapshot("test-repo", "snap-2").get());
     }
 
+    public void testHungDeleteTimesOutBeforeRepositoryIsMutated() throws Exception {
+        final String clusterManagerName = internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        createRepository("test-repo", "mock");
+        createIndexWithContent("test-idx");
+        createFullSnapshot("test-repo", "snap-1");
+
+        // Blocking on the first repository file touched means the delete times out with the snapshot ids still present in the
+        // repository data. The removal must therefore take the failure path, which does not assert their absence.
+        blockNodeOnAnyFiles("test-repo", clusterManagerName);
+        final ActionFuture<AcknowledgedResponse> blockedDelete = deleteSnapshot("test-repo", "snap-1");
+        waitForBlock(clusterManagerName, "test-repo", TimeValue.timeValueSeconds(30));
+
+        assertBusy(() -> assertTrue("delete marker should be gone", deletionsInProgress().getEntries().isEmpty()), 60, TimeUnit.SECONDS);
+        expectThrows(Exception.class, blockedDelete::actionGet);
+
+        unblockNode("test-repo", clusterManagerName);
+        assertBusy(() -> assertTrue("delete marker must not reappear", deletionsInProgress().getEntries().isEmpty()), 30, TimeUnit.SECONDS);
+    }
+
+    public void testHealthyDuplicateDeleteAttachesInsteadOfRedriving() throws Exception {
+        final String clusterManagerName = internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        createRepository("test-repo", "mock");
+        createIndexWithContent("test-idx");
+        createFullSnapshot("test-repo", "snap-1");
+
+        logger.info("--> raise the io_timeout so no timeout fires: this test is about a HEALTHY in-flight delete");
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(
+                    Settings.builder()
+                        .put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(30))
+                        .build()
+                )
+                .get()
+        );
+
+        // Block on the first repository file touched, before the delete mutates the repository data, so a duplicate delete can
+        // still resolve the snapshot name.
+        blockNodeOnAnyFiles("test-repo", clusterManagerName);
+        final ActionFuture<AcknowledgedResponse> firstDelete = deleteSnapshot("test-repo", "snap-1");
+        waitForBlock(clusterManagerName, "test-repo", TimeValue.timeValueSeconds(30));
+
+        logger.info("--> a duplicate delete must attach to the running one, not re-drive it");
+        final ActionFuture<AcknowledgedResponse> duplicateDelete = deleteSnapshot("test-repo", "snap-1");
+        assertBusy(
+            () -> assertEquals("exactly one delete entry expected", 1, deletionsInProgress().getEntries().size()),
+            30,
+            TimeUnit.SECONDS
+        );
+        assertFalse("the duplicate must wait, not complete on its own", duplicateDelete.isDone());
+
+        unblockNode("test-repo", clusterManagerName);
+
+        assertAcked(firstDelete.actionGet());
+        assertAcked(duplicateDelete.actionGet());
+        assertBusy(() -> assertTrue(deletionsInProgress().getEntries().isEmpty()), 30, TimeUnit.SECONDS);
+    }
+
     private SnapshotsInProgress snapshotsInProgress() {
         return clusterService().state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutIT.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+/**
+ * Verifies that a cluster-manager-side repository call that never returns is terminated by
+ * {@link SnapshotsService#SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING} instead of stranding the snapshot in progress forever.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SnapshotRepositoryIoTimeoutIT extends AbstractSnapshotIntegTestCase {
+
+    private static final TimeValue IO_TIMEOUT = TimeValue.timeValueSeconds(5);
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING.getKey(), true).build();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), IO_TIMEOUT)
+            .build();
+    }
+
+    public void testHungFinalizationTimesOutAndClearsMarker() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        createRepository("test-repo", "mock");
+        assertAcked(prepareCreate("test-idx", 0, indexSettingsNoReplicas(1)));
+        ensureGreen();
+        indexRandomDocs("test-idx", randomIntBetween(10, 50));
+
+        logger.info("--> block the cluster-manager writing index-N, without failing it");
+        final String blockedNode = blockClusterManagerOnWriteIndexFile("test-repo");
+
+        client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setWaitForCompletion(false).setIndices("test-idx").get();
+
+        waitForBlock(blockedNode, "test-repo", TimeValue.timeValueSeconds(30));
+
+        logger.info("--> the io_timeout must terminate finalization and remove the in-progress marker");
+        assertBusy(
+            () -> assertTrue("in-progress snapshot marker should be gone", snapshotsInProgress().entries().isEmpty()),
+            60,
+            TimeUnit.SECONDS
+        );
+
+        logger.info("--> let the orphaned repository worker finish; the cluster state must stay authoritative");
+        unblockNode("test-repo", blockedNode);
+
+        assertBusy(() -> assertTrue("marker must not reappear", snapshotsInProgress().entries().isEmpty()), 30, TimeUnit.SECONDS);
+        assertSnapshotNotRecordedAsSuccessful("test-repo", "test-snap");
+
+        logger.info("--> a released repository loop lets the index be deleted");
+        assertAcked(client().admin().indices().prepareDelete("test-idx").get());
+    }
+
+    private SnapshotsInProgress snapshotsInProgress() {
+        return clusterService().state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+    }
+
+    private void assertSnapshotNotRecordedAsSuccessful(String repository, String snapshot) {
+        final GetSnapshotsResponse response = client().admin()
+            .cluster()
+            .prepareGetSnapshots(repository)
+            .setSnapshots(snapshot)
+            .setIgnoreUnavailable(true)
+            .get();
+        if (response.getSnapshots().isEmpty()) {
+            // The timeout removed the entry before the repository recorded it at all, which is the expected common case.
+            return;
+        }
+        final SnapshotState state = response.getSnapshots().get(0).state();
+        assertTrue("snapshot should be completed, was " + state, state.completed());
+        assertNotEquals("a timed-out snapshot must not be reported as successful", SnapshotState.SUCCESS, state);
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotResilienceSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotResilienceSettingsIT.java
@@ -10,6 +10,7 @@ package org.opensearch.snapshots;
 
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -83,6 +84,49 @@ public class SnapshotResilienceSettingsIT extends OpenSearchIntegTestCase {
                 .get()
         );
         assertThat(e.getMessage(), containsString("snapshot.repository.max_outstanding_ops"));
+    }
+
+    public void testIoTimeoutConsumerReceivesDynamicUpdate() {
+        internalCluster().startNode();
+        SnapshotsService snapshotsService = internalCluster().getCurrentClusterManagerNodeInstance(SnapshotsService.class);
+        assertEquals(TimeValue.timeValueMinutes(30), snapshotsService.getIoTimeout());
+
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put("snapshot.repository.io_timeout", "45s").build())
+            .get();
+
+        assertEquals(TimeValue.timeValueSeconds(45), snapshotsService.getIoTimeout());
+    }
+
+    public void testIoTimeoutConsumerPicksUpNodeSetting() {
+        internalCluster().startNode(Settings.builder().put("snapshot.repository.io_timeout", "2m").build());
+        SnapshotsService snapshotsService = internalCluster().getCurrentClusterManagerNodeInstance(SnapshotsService.class);
+        assertEquals(TimeValue.timeValueMinutes(2), snapshotsService.getIoTimeout());
+    }
+
+    public void testNodeStartsWithFeatureFlagDisabled() {
+        // SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING carries a validator that throws while the flag is disabled, and Setting#get
+        // runs validators. A node with the flag off must still start, holding the setting default.
+        internalCluster().startNode(Settings.builder().put(FeatureFlags.SNAPSHOT_RESILIENCE, false).build());
+        SnapshotsService snapshotsService = internalCluster().getCurrentClusterManagerNodeInstance(SnapshotsService.class);
+        assertEquals(TimeValue.timeValueMinutes(30), snapshotsService.getIoTimeout());
+    }
+
+    public void testUnrelatedSettingsUpdateSucceedsWithFeatureFlagDisabled() {
+        // Regression test. AbstractScopedSettings#validateUpdate calls getValue on every registered settings updater for every
+        // cluster settings update, and getValue runs the setting's validator. Registering an io_timeout updater on a flag-off
+        // node therefore used to make every unrelated cluster settings update fail with
+        // "illegal value can't update [snapshot.repository.io_timeout]".
+        internalCluster().startNode(Settings.builder().put(FeatureFlags.SNAPSHOT_RESILIENCE, false).build());
+
+        ClusterUpdateSettingsResponse response = client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put("snapshot.max_concurrent_operations", 500).build())
+            .get();
+        assertTrue(response.isAcknowledged());
     }
 
     public void testSettingsRejectedWhenFlagDisabled() {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -45,6 +45,7 @@ import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotReques
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.ListenerTimeouts;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
@@ -380,6 +381,24 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      */
     TimeValue getIoTimeout() {
         return ioTimeout;
+    }
+
+    /**
+     * Wraps a cluster-manager-side repository listener so that it fails with an {@link org.opensearch.OpenSearchTimeoutException}
+     * if the repository does not answer within {@link #SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING}. A repository worker that completes
+     * after the deadline is dropped by the wrapper, so the listener is invoked exactly once either way.
+     * <p>
+     * The timeout callback is scheduled on {@link ThreadPool.Names#GENERIC} rather than {@link ThreadPool.Names#SNAPSHOT}: the
+     * SNAPSHOT pool is where a hung repository call is already parked, so scheduling there could not fire.
+     * <p>
+     * Returns {@code listener} unchanged while the snapshot resilience feature flag is disabled.
+     */
+    // visible for testing
+    <T> ActionListener<T> withRepositoryIoTimeout(ActionListener<T> listener, String listenerName) {
+        if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING) == false) {
+            return listener;
+        }
+        return ListenerTimeouts.wrapWithTimeout(threadPool, listener, ioTimeout, ThreadPool.Names.GENERIC, listenerName);
     }
 
     /**
@@ -2203,7 +2222,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final String repoName = entry.repository();
         if (tryEnterRepoLoop(repoName)) {
             if (repositoryData == null) {
-                repositoriesService.repository(repoName).getRepositoryData(new ActionListener<RepositoryData>() {
+                // Wrapped at the call site rather than inside BlobStoreRepository#getRepositoryData: the cached fast path
+                // completes inline before the deadline matters, and wrapping inside the repository would affect every caller.
+                repositoriesService.repository(repoName).getRepositoryData(withRepositoryIoTimeout(new ActionListener<RepositoryData>() {
                     @Override
                     public void onResponse(RepositoryData repositoryData) {
                         finalizeSnapshotEntry(entry, metadata, repositoryData);
@@ -2216,7 +2237,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             new FailPendingRepoTasksTask(repoName, e)
                         );
                     }
-                });
+                }, "get repository data for snapshot finalization [" + repoName + "]"));
             } else {
                 finalizeSnapshotEntry(entry, metadata, repositoryData);
             }
@@ -2296,8 +2317,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             } else {
                 metadataListener.onResponse(metadata);
             }
-            metadataListener.whenComplete(
-                meta -> repo.finalizeSnapshot(
+            metadataListener.whenComplete(meta -> {
+                // A hung finalize must self-terminate into the failure cleanup path. The timeout surfaces as an
+                // OpenSearchTimeoutException, which handleFinalizationFailure routes to removeFailedSnapshotFromClusterState,
+                // releasing the repository loop. A late completion from the orphaned worker is dropped by the wrapper.
+                final ActionListener<RepositoryData> finalizeListener = withRepositoryIoTimeout(ActionListener.wrap(newRepoData -> {
+                    completeListenersIgnoringException(endAndGetListenersToResolve(snapshot), Tuple.tuple(newRepoData, snapshotInfo));
+                    logger.info("snapshot [{}] completed with state [{}]", snapshot, snapshotInfo.state());
+                    runNextQueuedOperation(newRepoData, repository, true);
+                }, e -> handleFinalizationFailure(e, entry, repositoryData)), "finalize snapshot [" + snapshot + "]");
+                repo.finalizeSnapshot(
                     shardGenerations,
                     repositoryData.getGenId(),
                     metadataForSnapshot(meta, entry.includeGlobalState(), entry.partial(), entry.dataStreams(), entry.indices()),
@@ -2305,14 +2334,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     entry.version(),
                     state -> stateWithoutSnapshot(state, snapshot),
                     Priority.NORMAL,
-                    ActionListener.wrap(newRepoData -> {
-                        completeListenersIgnoringException(endAndGetListenersToResolve(snapshot), Tuple.tuple(newRepoData, snapshotInfo));
-                        logger.info("snapshot [{}] completed with state [{}]", snapshot, snapshotInfo.state());
-                        runNextQueuedOperation(newRepoData, repository, true);
-                    }, e -> handleFinalizationFailure(e, entry, repositoryData))
-                ),
-                e -> handleFinalizationFailure(e, entry, repositoryData)
-            );
+                    finalizeListener
+                );
+            }, e -> handleFinalizationFailure(e, entry, repositoryData));
         } catch (Exception e) {
             assert false : new AssertionError(e);
             handleFinalizationFailure(e, entry, repositoryData);

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -305,6 +305,12 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private volatile int maxConcurrentOperations;
 
+    /**
+     * Time budget for cluster-manager-side snapshot repository I/O, backed by {@link #SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING}.
+     * Initialized to the setting default so that it is never {@code null} on nodes that are not cluster-manager eligible.
+     */
+    private volatile TimeValue ioTimeout = SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getDefault(Settings.EMPTY);
+
     public SnapshotsService(
         Settings settings,
         ClusterService clusterService,
@@ -352,12 +358,28 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             retryBackoff = SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.get(settings);
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRIES_SETTING, i -> maxRetries = i);
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING, t -> retryBackoff = t);
+            // Only register the io_timeout consumer when the feature flag is on. The setting carries a validator that rejects it
+            // while the flag is disabled, and AbstractScopedSettings#validateUpdate calls every registered updater's getValue --
+            // which runs that validator -- on every cluster settings update. Registering unconditionally would therefore make
+            // any cluster settings update fail on a node with the flag off. The flag is NodeScope, so this is decided once, and
+            // with the flag off the value is never read.
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                ioTimeout = SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.get(settings);
+                clusterService.getClusterSettings().addSettingsUpdateConsumer(SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING, t -> ioTimeout = t);
+            }
         }
 
         // Task is onboarded for throttling, it will get retried from associated TransportClusterManagerNodeAction.
         createSnapshotTaskKey = clusterService.registerClusterManagerTask(CREATE_SNAPSHOT, true);
         deleteSnapshotTaskKey = clusterService.registerClusterManagerTask(DELETE_SNAPSHOT, true);
         updateSnapshotStateTaskKey = clusterService.registerClusterManagerTask(UPDATE_SNAPSHOT_STATE, true);
+    }
+
+    /**
+     * The currently effective repository I/O timeout. Visible for testing the settings-update consumer.
+     */
+    TimeValue getIoTimeout() {
+        return ioTimeout;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -3094,6 +3094,23 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 } else {
                     addDeleteListener(newDelete.uuid(), listener);
                     if (reusedExistingDelete) {
+                        // A duplicate delete normally just attaches a listener to the delete already in flight. That is wrong
+                        // when the earlier attempt has terminated without clearing its cluster state entry -- for instance
+                        // after a repository I/O timeout -- because then nothing is driving the entry and the caller would
+                        // wait forever on a delete nobody owns.
+                        //
+                        // Both guards below are required, and they are simultaneously true only in exactly that case:
+                        // isNotRunning says no thread owns this delete, and tryEnterRepoLoop says the repository loop is free.
+                        // A healthy in-flight delete holds at least one of them, so today's attach-and-wait behaviour is kept.
+                        if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)
+                            && newDelete.state() == SnapshotDeletionsInProgress.State.STARTED
+                            && repositoryOperations.isNotRunning(newDelete.uuid())
+                            && tryEnterRepoLoop(repoName)) {
+                            logger.info("Re-driving delete [{}] whose previous attempt terminated without completing", newDelete);
+                            // Reads the repository afresh: the captured repositoryData predates the abandoned attempt, and that
+                            // attempt may have advanced the repository generation before it was dropped.
+                            redriveDeleteFromRepository(newDelete, newState.nodes().getMinNodeVersion());
+                        }
                         return;
                     }
                     if (newDelete.state() == SnapshotDeletionsInProgress.State.STARTED) {
@@ -3175,6 +3192,42 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         + "] in cluster state and ["
                         + repositoryData.getGenId()
                         + "] in the repository";
+                deleteSnapshotsFromRepository(deleteEntry, repositoryData, minNodeVersion);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                clusterService.submitStateUpdateTask(
+                    "fail repo tasks for [" + deleteEntry.repository() + "]",
+                    new FailPendingRepoTasksTask(deleteEntry.repository(), e)
+                );
+            }
+        });
+    }
+
+    /**
+     * Re-drives a delete whose previous attempt terminated without clearing its cluster state entry, for instance after a repository
+     * I/O timeout. The caller must hold the repository loop and must have established that no thread owns the delete.
+     * <p>
+     * This deliberately does not share {@link #deleteSnapshotsFromRepository(SnapshotDeletionsInProgress.Entry, Version)}: that method
+     * asserts the repository generation still matches the one recorded in the delete entry, which is not an invariant here. The
+     * abandoned attempt may have advanced the generation before it was dropped -- indeed it may have completed the repository work
+     * altogether, in which case there is nothing left to delete and only the cluster state entry needs clearing.
+     *
+     * @param deleteEntry    delete entry to re-drive
+     * @param minNodeVersion minimum node version in the cluster
+     */
+    private void redriveDeleteFromRepository(SnapshotDeletionsInProgress.Entry deleteEntry, Version minNodeVersion) {
+        repositoriesService.getRepositoryData(deleteEntry.repository(), new ActionListener<RepositoryData>() {
+            @Override
+            public void onResponse(RepositoryData repositoryData) {
+                if (repositoryData.getSnapshotIds().stream().noneMatch(deleteEntry.getSnapshots()::contains)) {
+                    // The abandoned attempt did reach the repository after all. Removing the entry resolves the waiting
+                    // listeners and releases both the delete bookkeeping and the repository loop.
+                    logger.info("Delete [{}] was already applied to the repository; clearing its cluster state entry", deleteEntry);
+                    removeSnapshotDeletionFromClusterState(deleteEntry, null, repositoryData);
+                    return;
+                }
                 deleteSnapshotsFromRepository(deleteEntry, repositoryData, minNodeVersion);
             }
 

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -200,7 +200,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private final TransportService transportService;
     private final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
 
-    private final OngoingRepositoryOperations repositoryOperations = new OngoingRepositoryOperations();
+    // package-private rather than private so that tests can assert the delete bookkeeping is released exactly once
+    final OngoingRepositoryOperations repositoryOperations = new OngoingRepositoryOperations();
 
     private final ClusterManagerTaskThrottler.ThrottlingKey createSnapshotTaskKey;
     private final ClusterManagerTaskThrottler.ThrottlingKey deleteSnapshotTaskKey;
@@ -2414,7 +2415,19 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * TODO: optimize this to execute in a single CS update together with finalizing the latest snapshot
      */
     private void runReadyDeletions(RepositoryData repositoryData, String repository) {
-        clusterService.submitStateUpdateTask("Run ready deletions", new ClusterStateUpdateTask() {
+        final String source = "Run ready deletions";
+        clusterService.submitStateUpdateTask(source, createRunReadyDeletionsTask(0, repositoryData, repository));
+    }
+
+    /**
+     * Builds the "run ready deletions" {@link ClusterStateUpdateTask}. A fresh instance is required per publish attempt because
+     * {@link org.opensearch.cluster.service.TaskBatcher} rejects resubmitting the same task identity.
+     *
+     * @param attempt zero-based publish attempt, threaded through so a retry can carry {@code attempt + 1}
+     */
+    // visible for testing
+    ClusterStateUpdateTask createRunReadyDeletionsTask(final int attempt, final RepositoryData repositoryData, final String repository) {
+        return new ClusterStateUpdateTask() {
 
             private SnapshotDeletionsInProgress.Entry deletionToRun;
 
@@ -2437,7 +2450,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void onFailure(String source, Exception e) {
                 logger.warn("Failed to run ready delete operations", e);
-                failAllListenersOnMasterFailOver(e);
+                final Runnable fallback = () -> failAllListenersOnMasterFailOver(e);
+                if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                    retryOrFailOnClusterManagerFailOver(
+                        e,
+                        attempt,
+                        source,
+                        () -> createRunReadyDeletionsTask(attempt + 1, repositoryData, repository),
+                        fallback
+                    );
+                } else {
+                    fallback.run();
+                }
             }
 
             @Override
@@ -2448,7 +2472,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     deleteSnapshotsFromRepository(deletionToRun, repositoryData, newState.nodes().getMinNodeVersion());
                 }
             }
-        });
+        };
     }
 
     /**
@@ -3285,12 +3309,31 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         @Nullable final Exception failure,
         final RepositoryData repositoryData
     ) {
-        final ClusterStateUpdateTask clusterStateUpdateTask;
+        final String source = "remove snapshot deletion metadata";
+        clusterService.submitStateUpdateTask(source, createRemoveSnapshotDeletionTask(0, deleteEntry, failure, repositoryData));
+    }
+
+    /**
+     * Builds the {@link ClusterStateUpdateTask} that removes a delete entry from the cluster state. A fresh instance is required per
+     * publish attempt because {@link org.opensearch.cluster.service.TaskBatcher} rejects resubmitting the same task identity.
+     *
+     * @param attempt        zero-based publish attempt, threaded through so a retry can carry {@code attempt + 1}
+     * @param deleteEntry    delete entry to remove from the cluster state
+     * @param failure        failure encountered while executing the delete on the repository, or {@code null} on success
+     * @param repositoryData repository data for the repository the delete ran on
+     */
+    // visible for testing
+    ClusterStateUpdateTask createRemoveSnapshotDeletionTask(
+        final int attempt,
+        final SnapshotDeletionsInProgress.Entry deleteEntry,
+        @Nullable final Exception failure,
+        final RepositoryData repositoryData
+    ) {
         if (failure == null) {
             // If we didn't have a failure during the snapshot delete we will remove all snapshot ids that the delete successfully removed
             // from the repository from enqueued snapshot delete entries during the cluster state update. After the cluster state update we
             // resolve the delete listeners with the latest repository data from after the delete.
-            clusterStateUpdateTask = new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {
+            return new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData, null, attempt) {
                 @Override
                 protected SnapshotDeletionsInProgress filterDeletions(SnapshotDeletionsInProgress deletions) {
                     final SnapshotDeletionsInProgress updatedDeletions = deletionsWithoutSnapshots(
@@ -3312,17 +3355,15 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     completeListenersIgnoringException(deleteListeners, null);
                 }
             };
-        } else {
-            // The delete failed to execute on the repository. We remove it from the cluster state and then fail all listeners associated
-            // with it.
-            clusterStateUpdateTask = new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {
-                @Override
-                protected void handleListeners(List<ActionListener<Void>> deleteListeners) {
-                    failListenersIgnoringException(deleteListeners, failure);
-                }
-            };
         }
-        clusterService.submitStateUpdateTask("remove snapshot deletion metadata", clusterStateUpdateTask);
+        // The delete failed to execute on the repository. We remove it from the cluster state and then fail all listeners associated
+        // with it.
+        return new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData, failure, attempt) {
+            @Override
+            protected void handleListeners(List<ActionListener<Void>> deleteListeners) {
+                failListenersIgnoringException(deleteListeners, failure);
+            }
+        };
     }
 
     /**
@@ -3452,9 +3493,23 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         private final RepositoryData repositoryData;
 
-        RemoveSnapshotDeletionAndContinueTask(SnapshotDeletionsInProgress.Entry deleteEntry, RepositoryData repositoryData) {
+        /** The repository-side delete failure this task reports, or {@code null} when the delete succeeded. */
+        @Nullable
+        private final Exception deleteFailure;
+
+        /** Zero-based cluster state publish attempt, so {@link #onFailure} can resubmit as {@code attempt + 1}. */
+        private final int attempt;
+
+        RemoveSnapshotDeletionAndContinueTask(
+            SnapshotDeletionsInProgress.Entry deleteEntry,
+            RepositoryData repositoryData,
+            @Nullable Exception deleteFailure,
+            int attempt
+        ) {
             this.deleteEntry = deleteEntry;
             this.repositoryData = repositoryData;
+            this.deleteFailure = deleteFailure;
+            this.attempt = attempt;
         }
 
         @Override
@@ -3476,8 +3531,24 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         @Override
         public void onFailure(String source, Exception e) {
             logger.warn(() -> new ParameterizedMessage("{} failed to remove snapshot deletion metadata", deleteEntry), e);
-            repositoryOperations.finishDeletion(deleteEntry.uuid());
-            failAllListenersOnMasterFailOver(e);
+            // finishDeletion deliberately lives in the fallback rather than running per attempt. Releasing the delete
+            // bookkeeping while a retry is still scheduled would let a subsequent release trip leaveRepoLoop's
+            // "assert removed", so the release happens exactly once, on the final failure.
+            final Runnable fallback = () -> {
+                repositoryOperations.finishDeletion(deleteEntry.uuid());
+                failAllListenersOnMasterFailOver(e);
+            };
+            if (FeatureFlags.isEnabled(FeatureFlags.SNAPSHOT_RESILIENCE_SETTING)) {
+                retryOrFailOnClusterManagerFailOver(
+                    e,
+                    attempt,
+                    source,
+                    () -> createRemoveSnapshotDeletionTask(attempt + 1, deleteEntry, deleteFailure, repositoryData),
+                    fallback
+                );
+            } else {
+                fallback.run();
+            }
         }
 
         protected SnapshotDeletionsInProgress filterDeletions(SnapshotDeletionsInProgress deletions) {
@@ -4454,7 +4525,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }
     }
 
-    private static final class OngoingRepositoryOperations {
+    // package-private rather than private so that tests can assert the delete bookkeeping is released exactly once
+    static final class OngoingRepositoryOperations {
 
         /**
          * Map of repository name to a deque of {@link SnapshotsInProgress.Entry} that need to be finalized for the repository and the
@@ -4498,6 +4570,14 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         void finishDeletion(String deleteUUID) {
             runningDeletions.remove(deleteUUID);
+        }
+
+        /**
+         * Whether no thread currently owns the execution of the given delete. Combined with a free repository loop this identifies a
+         * delete whose previous attempt has already terminated and released its bookkeeping.
+         */
+        boolean isNotRunning(String deleteUUID) {
+            return runningDeletions.contains(deleteUUID) == false;
         }
 
         synchronized void addFinalization(SnapshotsInProgress.Entry entry, Metadata metadata) {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -3248,14 +3248,24 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
 
             } else {
+                // A hung delete must self-terminate. The timeout routes into the failure arm below, which removes the delete
+                // entry from the cluster state; that release lets a queued delete be promoted instead of queueing forever.
+                // The failure arm deliberately passes the pre-delete repositoryData and does not assert that the snapshot ids
+                // are absent from it, because an interrupted delete may well have left them present.
+                //
+                // Only the standard full-copy path is wrapped. The remote-store shallow-copy branch above is out of scope: its
+                // delete-while-in-progress rejection is a deliberate invariant and is left unchanged.
+                final ActionListener<RepositoryData> deleteListener = withRepositoryIoTimeout(ActionListener.wrap(updatedRepoData -> {
+                    logger.info("snapshots {} deleted", snapshotIds);
+                    removeSnapshotDeletionFromClusterState(deleteEntry, null, updatedRepoData);
+                }, ex -> removeSnapshotDeletionFromClusterState(deleteEntry, ex, repositoryData)),
+                    "delete snapshots " + snapshotIds + " from repository [" + deleteEntry.repository() + "]"
+                );
                 repository.deleteSnapshots(
                     snapshotIds,
                     repositoryData.getGenId(),
                     minCompatibleVersion(minNodeVersion, repositoryData, snapshotIds),
-                    ActionListener.wrap(updatedRepoData -> {
-                        logger.info("snapshots {} deleted", snapshotIds);
-                        removeSnapshotDeletionFromClusterState(deleteEntry, null, updatedRepoData);
-                    }, ex -> removeSnapshotDeletionFromClusterState(deleteEntry, ex, repositoryData))
+                    deleteListener
                 );
             }
         }

--- a/server/src/test/java/org/opensearch/snapshots/DeleteSnapshotRetryTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/DeleteSnapshotRetryTests.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.NotClusterManagerException;
+import org.opensearch.cluster.SnapshotDeletionsInProgress;
+import org.opensearch.cluster.coordination.FailedToCommitClusterStateException;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.repositories.RepositoryData;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the delete-side publish-retry conversions: a retryable publish failure must resubmit a fresh task without releasing the
+ * delete bookkeeping, and only the final failure may release it. Releasing per attempt would let a later release trip
+ * {@code leaveRepoLoop}'s {@code assert removed}.
+ */
+public class DeleteSnapshotRetryTests extends OpenSearchTestCase {
+
+    private TestThreadPool threadPool;
+    private ClusterService clusterService;
+    private SnapshotsService snapshotsService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+        clusterService = mock(ClusterService.class);
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        final TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        final Settings settings = Settings.builder()
+            .put("node.name", "test")
+            .putList("node.roles", "cluster_manager", "data")
+            .put(SnapshotsService.SNAPSHOT_CLEANUP_RETRY_BACKOFF_SETTING.getKey(), "100ms")
+            .build();
+
+        snapshotsService = new SnapshotsService(
+            settings,
+            clusterService,
+            mock(org.opensearch.cluster.metadata.IndexNameExpressionResolver.class),
+            mock(org.opensearch.repositories.RepositoriesService.class),
+            transportService,
+            mock(org.opensearch.action.support.ActionFilters.class),
+            null,
+            new org.opensearch.indices.RemoteStoreSettings(Settings.EMPTY, clusterSettings),
+            null
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    private SnapshotDeletionsInProgress.Entry deleteEntry() {
+        return new SnapshotDeletionsInProgress.Entry(
+            Collections.singletonList(new SnapshotId("snap-1", UUIDs.randomBase64UUID())),
+            "test-repo",
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            SnapshotDeletionsInProgress.State.STARTED
+        );
+    }
+
+    private ClusterStateUpdateTask removalTask(int attempt, SnapshotDeletionsInProgress.Entry entry) {
+        return snapshotsService.createRemoveSnapshotDeletionTask(
+            attempt,
+            entry,
+            new RuntimeException("delete failed"),
+            RepositoryData.EMPTY
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRetryableFailureDoesNotReleaseDeleteBookkeeping() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+        assertTrue(snapshotsService.repositoryOperations.startDeletion(entry.uuid()));
+
+        removalTask(0, entry).onFailure("remove snapshot deletion metadata", new FailedToCommitClusterStateException("publish failed"));
+
+        assertFalse(
+            "a retryable publish failure must not release the delete bookkeeping, or a later release trips leaveRepoLoop's assert",
+            snapshotsService.repositoryOperations.isNotRunning(entry.uuid())
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testExhaustedRetriesReleaseDeleteBookkeeping() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+        assertTrue(snapshotsService.repositoryOperations.startDeletion(entry.uuid()));
+
+        // Default snapshot.cleanup.retries is 3, so attempt 3 is the final failure.
+        removalTask(3, entry).onFailure("remove snapshot deletion metadata", new FailedToCommitClusterStateException("publish failed"));
+
+        assertTrue(
+            "the final failure must release the delete bookkeeping exactly once",
+            snapshotsService.repositoryOperations.isNotRunning(entry.uuid())
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testClusterManagerFailOverReleasesDeleteBookkeepingImmediately() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+        assertTrue(snapshotsService.repositoryOperations.startDeletion(entry.uuid()));
+
+        // Losing the cluster-manager role is not retryable: the next cluster-manager picks the work up.
+        removalTask(0, entry).onFailure("remove snapshot deletion metadata", new NotClusterManagerException("no longer cluster-manager"));
+
+        assertTrue(snapshotsService.repositoryOperations.isNotRunning(entry.uuid()));
+    }
+
+    public void testFeatureFlagDisabledReleasesDeleteBookkeepingImmediately() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+        assertTrue(snapshotsService.repositoryOperations.startDeletion(entry.uuid()));
+
+        removalTask(0, entry).onFailure("remove snapshot deletion metadata", new FailedToCommitClusterStateException("publish failed"));
+
+        assertTrue(
+            "with the flag off the pre-existing behaviour applies: release immediately, no retry",
+            snapshotsService.repositoryOperations.isNotRunning(entry.uuid())
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRemovalTaskFactoryReturnsFreshInstancePerAttempt() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+        // TaskBatcher rejects resubmitting the same task identity, so every retry needs a distinct instance.
+        assertNotSame(removalTask(0, entry), removalTask(1, entry));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testRunReadyDeletionsTaskFactoryReturnsFreshInstancePerAttempt() {
+        assertNotSame(
+            snapshotsService.createRunReadyDeletionsTask(0, RepositoryData.EMPTY, "test-repo"),
+            snapshotsService.createRunReadyDeletionsTask(1, RepositoryData.EMPTY, "test-repo")
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/DeleteSnapshotRetryTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/DeleteSnapshotRetryTests.java
@@ -159,4 +159,26 @@ public class DeleteSnapshotRetryTests extends OpenSearchTestCase {
             snapshotsService.createRunReadyDeletionsTask(1, RepositoryData.EMPTY, "test-repo")
         );
     }
+
+    /**
+     * isNotRunning is one of the two guards on the duplicate-delete re-drive. It must report "not running" only when no thread owns
+     * the delete, which is what distinguishes an abandoned delete from a healthy in-flight one.
+     */
+    public void testIsNotRunningTracksDeleteOwnership() {
+        final SnapshotDeletionsInProgress.Entry entry = deleteEntry();
+
+        assertTrue("an unknown delete is not running", snapshotsService.repositoryOperations.isNotRunning(entry.uuid()));
+
+        assertTrue(snapshotsService.repositoryOperations.startDeletion(entry.uuid()));
+        assertFalse("a delete being executed is running", snapshotsService.repositoryOperations.isNotRunning(entry.uuid()));
+
+        assertFalse(
+            "a second start must not claim an already-running delete",
+            snapshotsService.repositoryOperations.startDeletion(entry.uuid())
+        );
+        assertFalse(snapshotsService.repositoryOperations.isNotRunning(entry.uuid()));
+
+        snapshotsService.repositoryOperations.finishDeletion(entry.uuid());
+        assertTrue("a released delete is available to be re-driven", snapshotsService.repositoryOperations.isNotRunning(entry.uuid()));
+    }
 }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotRepositoryIoTimeoutTests.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.OpenSearchTimeoutException;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link SnapshotsService#withRepositoryIoTimeout(ActionListener, String)} — the wrapper that turns a
+ * cluster-manager-side repository call that never returns into a failure.
+ */
+public class SnapshotRepositoryIoTimeoutTests extends OpenSearchTestCase {
+
+    private TestThreadPool threadPool;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    private SnapshotsService newSnapshotsService(Settings extraSettings) {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final Settings settings = Settings.builder()
+            .put("node.name", "test")
+            .putList("node.roles", "cluster_manager", "data")
+            .put(extraSettings)
+            .build();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        final TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        return new SnapshotsService(
+            settings,
+            clusterService,
+            mock(org.opensearch.cluster.metadata.IndexNameExpressionResolver.class),
+            mock(org.opensearch.repositories.RepositoriesService.class),
+            transportService,
+            mock(org.opensearch.action.support.ActionFilters.class),
+            null,
+            new org.opensearch.indices.RemoteStoreSettings(Settings.EMPTY, clusterSettings),
+            null
+        );
+    }
+
+    public void testWrapIsIdentityWhenFeatureFlagDisabled() {
+        final SnapshotsService snapshotsService = newSnapshotsService(Settings.EMPTY);
+        final ActionListener<String> listener = ActionListener.wrap(r -> {}, e -> {});
+
+        assertSame(
+            "with the feature flag off the listener must be returned unwrapped, preserving the pre-existing code path",
+            listener,
+            snapshotsService.withRepositoryIoTimeout(listener, "test")
+        );
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testWrapFailsListenerAfterTimeout() throws Exception {
+        final SnapshotsService snapshotsService = newSnapshotsService(
+            Settings.builder().put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1)).build()
+        );
+        assertEquals(TimeValue.timeValueSeconds(1), snapshotsService.getIoTimeout());
+
+        final CountDownLatch failed = new CountDownLatch(1);
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+        final ActionListener<String> inner = ActionListener.wrap(r -> { throw new AssertionError("unexpected response"); }, e -> {
+            failure.set(e);
+            failed.countDown();
+        });
+        final ActionListener<String> wrapped = snapshotsService.withRepositoryIoTimeout(inner, "hung repository call");
+
+        assertNotSame("with the flag on the listener must be wrapped", inner, wrapped);
+        assertTrue("listener should have been failed by the timeout", failed.await(30, TimeUnit.SECONDS));
+        assertThat(failure.get(), instanceOf(OpenSearchTimeoutException.class));
+        assertThat(failure.get().getMessage(), containsString("hung repository call"));
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testLateCompletionAfterTimeoutIsDropped() throws Exception {
+        final SnapshotsService snapshotsService = newSnapshotsService(
+            Settings.builder().put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1)).build()
+        );
+
+        final AtomicInteger invocations = new AtomicInteger();
+        final CountDownLatch failed = new CountDownLatch(1);
+        final ActionListener<String> wrapped = snapshotsService.withRepositoryIoTimeout(
+            ActionListener.wrap(r -> { invocations.incrementAndGet(); }, e -> {
+                invocations.incrementAndGet();
+                failed.countDown();
+            }),
+            "hung repository call"
+        );
+
+        assertTrue(failed.await(30, TimeUnit.SECONDS));
+
+        // The orphaned repository worker finishes late. It must not reach the business listener a second time.
+        wrapped.onResponse("late");
+        wrapped.onFailure(new IllegalStateException("late failure"));
+
+        assertEquals("business listener must be invoked exactly once", 1, invocations.get());
+    }
+
+    @LockFeatureFlag(FeatureFlags.SNAPSHOT_RESILIENCE)
+    public void testResponseBeforeTimeoutIsDeliveredAndTimeoutCancelled() throws Exception {
+        final SnapshotsService snapshotsService = newSnapshotsService(
+            Settings.builder().put(SnapshotsService.SNAPSHOT_REPOSITORY_IO_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(30)).build()
+        );
+
+        final AtomicInteger responses = new AtomicInteger();
+        final AtomicInteger failures = new AtomicInteger();
+        final ActionListener<String> wrapped = snapshotsService.withRepositoryIoTimeout(
+            ActionListener.wrap(r -> responses.incrementAndGet(), e -> failures.incrementAndGet()),
+            "healthy repository call"
+        );
+
+        wrapped.onResponse("ok");
+
+        assertEquals(1, responses.get());
+        assertEquals(0, failures.get());
+    }
+}


### PR DESCRIPTION
### Description

A snapshot create or delete whose cluster-manager-side repository call never returns hangs forever. The SDK applies no call-level timeout on the sync S3 client's slow path, so a black-holed request parks a SNAPSHOT thread indefinitely. Nothing then completes the listener, so the `SnapshotsInProgress` / `SnapshotDeletionsInProgress` entry stays in the cluster state, the per-repository loop is never released, and every subsequent snapshot, delete and index-delete queues behind an operation that will never finish. Retrying a stuck delete makes it worse: the retry finds the existing entry and silently attaches to it, so the caller waits on an operation nobody owns.

This PR makes those operations self-terminating. It is the create-side timeout, delete-side timeout and duplicate-delete re-drive from the stuck-snapshot work, on top of the already-merged setting registration (#22516) and publish-retry foundation (#22518).

Everything is gated on the existing `opensearch.experimental.feature.snapshot_resilience.enabled` feature flag, which defaults to `false`. With the flag off every touched site runs its previous code verbatim — the timeout helper returns the listener unwrapped, and both converted `onFailure` sites run their original bodies.

**Five commits, each independently reviewable:**

1. **Consume `snapshot.repository.io_timeout`.** The setting was registered by #22516 but read by nothing, so operators could set it with no effect. Backed by a volatile field behind a settings-update consumer.

2. **Time out hung finalization.** Wraps the two create-path cluster-manager listeners — the `finalizeSnapshot` completion listener and the `getRepositoryData` listener at the `endSnapshot` call site — with `ListenerTimeouts`. A timeout surfaces as `OpenSearchTimeoutException`, which the existing `handleFinalizationFailure` path already routes to `removeFailedSnapshotFromClusterState`, releasing the repository loop. `getRepositoryData` is wrapped at the call site rather than inside `BlobStoreRepository` so the cached fast path and every other caller are untouched. The timeout callback is scheduled on `GENERIC`, never `SNAPSHOT`, because the SNAPSHOT pool is where the hung call is already parked.

3. **Time out hung deletes.** Same wrapper on the full-copy delete listener. The timeout routes into the existing failure arm, which removes the delete entry and lets a queued delete be promoted. That arm deliberately passes the pre-delete repository data and does not assert the deleted ids are absent from it, since an interrupted delete may well have left them present.

4. **Retry delete metadata publishes.** The two remaining delete-side publish failures gave up immediately even when this node was still cluster-manager. Both now route through `retryOrFailOnClusterManagerFailOver`, matching the create-side conversions already merged.

5. **Re-drive an abandoned delete.** A repeat delete request re-drives instead of attaching when the existing delete has no owner.

**Explicitly out of scope.** The remote-store shallow-copy (v2) delete path is untouched: its delete-while-in-progress rejection is a deliberate invariant. No `SnapshotsInProgress` serialization changed, so this is BWC-clean by construction.

### Testing

`SnapshotRepositoryIoTimeoutTests` (new) — the timeout wrapper: identity when the flag is off, failure after the deadline, a late completion dropped so the listener runs exactly once, and a response before the deadline cancelling the timeout.

`DeleteSnapshotRetryTests` (new) — the release-exactly-once invariant across retryable / exhausted / failover / flag-off, fresh task instance per attempt for both converted sites, and `isNotRunning` ownership tracking.

`SnapshotRepositoryIoTimeoutIT` (new) — hung finalization clears the marker and stays cleared once the orphaned worker finishes; hung delete terminates, tells the caller, and releases the loop so a further delete runs; a delete blocked before any repository mutation (ids still present, exercising the no-absence-assert path); a healthy duplicate delete still attaches rather than re-driving.

`SnapshotResilienceSettingsIT` (extended) — the consumer receives dynamic updates and node settings, a flag-off node still starts, and — a regression test for a defect found during this work — an unrelated cluster settings update still succeeds on a flag-off node. Registering the updater unconditionally made `AbstractScopedSettings#validateUpdate` run the setting's flag-gated validator on *every* cluster settings update, failing all of them with `illegal value can't update [snapshot.repository.io_timeout]`. `ConcurrentSnapshotsIT` caught it.

All new and modified tests were run at `-Dtests.iters=20` (280 IT executions, 220 unit executions, all green). Regression suites run clean: `ConcurrentSnapshotsIT`, `DedicatedClusterSnapshotRestoreIT`, `SnapshotResiliencyTests`, `SnapshotCleanupRetryIT`, `RetryOrFailOnClusterManagerFailOverTests`, plus `./gradlew :server:precommit`.

No manual verification beyond the automated suites; the hang is reproduced deterministically by `MockRepository` blocking, so unit and integration coverage is sufficient. No user-visible UI, so no screenshots apply.

### Known follow-ups (deliberately not in this PR)

- `snapshot.repository.max_outstanding_ops` remains registered with no consumer. It was to be consumed by a per-repository circuit breaker that is not part of this change; it needs either that breaker or an unregistration.
- `snapshot.delete.cleanup_stale_blobs` likewise remains inert. Its intended consumer was dropped once we confirmed upstream has invoked `cleanupStaleBlobs` on every successful full-copy delete since ES 7.x.

### Related Issues

Relates to the stuck snapshot create/delete work; builds on #22516 and #22518.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
