### PR TITLE
Fix disable_objects object mappers failing when created via dynamic templates

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/130_disable_objects_dynamic_template.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/130_disable_objects_dynamic_template.yml
@@ -1,0 +1,99 @@
+---
+"Dynamic template creating an object with disable_objects flattens nested documents":
+
+  - skip:
+      version: " - 3.8.99"
+      reason: "Fixed in 3.9"
+
+  - do:
+      indices.create:
+        index: test_disable_objects_dynamic_template
+        body:
+          mappings:
+            dynamic_templates: [
+              {
+                attributes_flat: {
+                  "match": "attributes",
+                  "match_mapping_type": "object",
+                  "mapping": {
+                    "type": "object",
+                    "disable_objects": true
+                  }
+                }
+              }
+            ]
+
+  # Indexing nested objects under attributes triggers the dynamic template; the fields
+  # must be mapped as flat dotted names, not nested objects
+  - do:
+      index:
+        index: test_disable_objects_dynamic_template
+        id: "1"
+        body:
+          attributes:
+            foo:
+              bar: baz
+              deep:
+                nested: true
+            key: 1
+
+  - do:
+      indices.refresh:
+        index: test_disable_objects_dynamic_template
+
+  - do:
+      indices.get_mapping:
+        index: test_disable_objects_dynamic_template
+
+  # The dynamically created object must carry disable_objects and contain only flat leaf fields
+  - match: { test_disable_objects_dynamic_template.mappings.properties.attributes.disable_objects: true }
+  - match: { test_disable_objects_dynamic_template.mappings.properties.attributes.properties.foo\.bar.type: text }
+  - match: { test_disable_objects_dynamic_template.mappings.properties.attributes.properties.foo\.deep\.nested.type: boolean }
+  - match: { test_disable_objects_dynamic_template.mappings.properties.attributes.properties.key.type: long }
+  - is_false: test_disable_objects_dynamic_template.mappings.properties.attributes.properties.foo
+
+  - do:
+      search:
+        index: test_disable_objects_dynamic_template
+        body: {
+          query: {
+            match: {
+              "attributes.foo.bar": "baz"
+            }
+          }
+        }
+  - length: { hits.hits: 1 }
+
+  # A second document adding a new nested field must merge into the existing
+  # disable_objects mapper without creating intermediate objects
+  - do:
+      index:
+        index: test_disable_objects_dynamic_template
+        id: "2"
+        body:
+          attributes:
+            extra:
+              field: value
+
+  - do:
+      indices.refresh:
+        index: test_disable_objects_dynamic_template
+
+  - do:
+      indices.get_mapping:
+        index: test_disable_objects_dynamic_template
+
+  - match: { test_disable_objects_dynamic_template.mappings.properties.attributes.properties.extra\.field.type: text }
+  - is_false: test_disable_objects_dynamic_template.mappings.properties.attributes.properties.extra
+
+  - do:
+      search:
+        index: test_disable_objects_dynamic_template
+        body: {
+          query: {
+            match: {
+              "attributes.extra.field": "value"
+            }
+          }
+        }
+  - length: { hits.hits: 1 }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -470,7 +470,17 @@ final class DocumentParser {
             }
 
             if (newMapper instanceof ObjectMapper objectMapper) {
-                parentMappers.add(objectMapper);
+                ObjectMapper lastParent = parentMappers.get(parentMappers.size() - 1);
+                if (objectMapper.name().equals(lastParent.name())) {
+                    // The update is rooted at the mapper already on top of the stack. This happens when a
+                    // disable_objects parent was created dynamically in this same document (e.g. via a dynamic
+                    // template), so createExistingMapperUpdate rooted the update at the last parent itself.
+                    // Pushing it would duplicate the mapper on the stack and popMappers would then nest it
+                    // inside itself, so merge it into the existing entry instead.
+                    parentMappers.set(parentMappers.size() - 1, lastParent.merge(objectMapper));
+                } else {
+                    parentMappers.add(objectMapper);
+                }
             } else {
                 addToLastMapper(parentMappers, newMapper, true);
             }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -2929,6 +2929,66 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertEquals("literalvalue", doc3.rootDoc().getField("outer.literal.field.name").stringValue());
     }
 
+    public void testDisableObjectsViaDynamicTemplate() throws Exception {
+        // Ensure disable_objects works when applied through a dynamic template, including on the
+        // first document, where the object mapper and its flattened fields are created together
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
+                {
+                    b.startObject("attributes_flat");
+                    {
+                        b.field("match", "attributes");
+                        b.field("match_mapping_type", "object");
+                        b.startObject("mapping");
+                        {
+                            b.field("type", "object");
+                            b.field("disable_objects", true);
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("attributes");
+            {
+                b.startObject("foo");
+                {
+                    b.field("bar", "baz");
+                    b.startObject("qux");
+                    {
+                        b.field("deep", true);
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+                b.field("count", 42);
+            }
+            b.endObject();
+        }));
+
+        assertNotNull("Field 'attributes.foo.bar' should exist", doc.rootDoc().getField("attributes.foo.bar"));
+        assertNotNull("Field 'attributes.foo.qux.deep' should exist", doc.rootDoc().getField("attributes.foo.qux.deep"));
+        assertNotNull("Field 'attributes.count' should exist", doc.rootDoc().getField("attributes.count"));
+
+        Mapping update = doc.dynamicMappingsUpdate();
+        assertNotNull(update);
+        Mapper attributesMapper = update.root().getMapper("attributes");
+        assertTrue(attributesMapper instanceof ObjectMapper);
+        ObjectMapper attributes = (ObjectMapper) attributesMapper;
+        assertTrue("disable_objects should be set from the dynamic template", attributes.disableObjects());
+        assertNotNull("Flattened leaf 'foo.bar' should be mapped", attributes.getMapper("foo.bar"));
+        assertNotNull("Flattened leaf 'foo.qux.deep' should be mapped", attributes.getMapper("foo.qux.deep"));
+        assertNotNull(attributes.getMapper("count"));
+        assertNull("No intermediate object mapper should be created", attributes.getMapper("foo"));
+    }
+
     public void testRootMapperNameVariations() throws Exception {
         // Test to ensure both empty and "_doc" root mapper names are handled correctly
         // This comprehensively tests the condition: parentPath.isEmpty() || parentPath.equals("_doc")


### PR DESCRIPTION
### Description

Setting `disable_objects: true` using a `dynamic_templates` entry, e.g.

```json
{
  "dynamic_templates": [
    {
      "attributes_flat": {
        "match": "attributes",
        "match_mapping_type": "object",
        "mapping": { "type": "object", "disable_objects": true }
      }
    }
  ]
}
```

failed on the very first document containing nested objects under the matched field.

The same mapping works when attributes is declared explicitly under properties; only the dynamic-template path was broken.

#### Root cause

Document parsing itself handles this case correctly: the dynamic template creates the `attributes` object mapper with `disable_objects: true`, and the nested json is flattened into dotted-leaf field mappers (`attributes.foo.bar`, ...).

The failure happens afterwards in `DocumentParser#createDynamicUpdate`, which folds those dynamic mappers into a mapping update. Because attributes does not exist in the index mapping yet (it was created in this same document), a nested flat field like `attributes.foo.bar` takes the generic path into `createExistingMapperUpdate`, whose `disable_objects` branch returns an update rooted at the parent mapper itself — an ObjectMapper with the same name as the one already on top of the parent stack. The caller unconditionally pushed it onto the stack, so the stack held two entries named attributes; when `popMappers` collapsed the stack, the update was wrapped as a child of itself (attributes inside attributes), which the nested-object validation correctly rejects.

#### Fix

In `createDynamicUpdate`, when the returned `ObjectMapper` has the same name as the current stack top, merge it into that entry instead of pushing it. This situation only arises for `disable_objects` parents created in the same document; all other paths return updates rooted at strictly deeper mappers and are unchanged.

#### Testing

- New unit test `DocumentParserTests#testDisableObjectsViaDynamicTemplate` covering the first-document case
the same parent.
- New REST test index/130_disable_objects_dynamic_template.yml covering the end-to-end path
- Verified manually against a ./gradlew run cluster


### Related Issues
Resolves #22892 

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).