### PR TITLE
[Feature] Support LIST merge and sorting

### DIFF
--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/context.rs
@@ -6,6 +6,7 @@
  * compatible open source license.
  */
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
@@ -52,12 +53,59 @@ pub struct MergeContext {
     tracked_writer_bytes: usize,
 }
 
+fn merge_arrow_schemas_with_list_promotion(schemas: Vec<ArrowSchema>) -> MergeResult<ArrowSchema> {
+    let mut list_fields: HashMap<String, Arc<ArrowField>> = HashMap::new();
+    for schema in &schemas {
+        for field in schema.fields() {
+            if matches!(field.data_type(), ArrowDataType::List(_)) {
+                list_fields.insert(field.name().clone(), Arc::clone(field));
+            }
+        }
+    }
+
+    let normalized = schemas
+        .into_iter()
+        .map(|schema| {
+            let fields = schema
+                .fields()
+                .iter()
+                .map(|field| {
+                    let Some(list_field) = list_fields.get(field.name()) else {
+                        return field.as_ref().clone();
+                    };
+                    let ArrowDataType::List(child) = list_field.data_type() else {
+                        return field.as_ref().clone();
+                    };
+                    // child.data_type() in schema with promoted List field would be equal to
+                    // field.data_type in schema containing same field as scaler
+                    if field.data_type() == child.data_type() {
+                        list_field
+                            .as_ref()
+                            .clone()
+                            .with_nullable(list_field.is_nullable() || field.is_nullable())
+                    } else {
+                        field.as_ref().clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+            ArrowSchema::new_with_metadata(fields, schema.metadata().clone())
+        })
+        .collect::<Vec<_>>();
+
+    ArrowSchema::try_merge(normalized).map_err(|e| {
+        MergeError::Logic(format!(
+            "Failed to compute union schema across input files after scalar-to-LIST promotion: {}",
+            e
+        ))
+    })
+}
+
 impl MergeContext {
     /// Creates a new merge context: builds union schemas, opens the output
     /// writer, and spawns the background IO task.
     pub fn new(
         arrow_schemas: Vec<ArrowSchema>,
-        parquet_descriptors: &[SchemaDescriptor],
+        _parquet_descriptors: &[SchemaDescriptor],
         output_path: &str,
         index_name: &str,
         output_flush_rows: usize,
@@ -75,12 +123,7 @@ impl MergeContext {
             }
         }
 
-        let union_data_schema = ArrowSchema::try_merge(arrow_schemas).map_err(|e| {
-            MergeError::Logic(format!(
-                "Failed to compute union schema across input files: {}",
-                e
-            ))
-        })?;
+        let union_data_schema = merge_arrow_schemas_with_list_promotion(arrow_schemas)?;
         let data_schema = Arc::new(union_data_schema);
 
         let mut output_fields: Vec<ArrowField> = data_schema
@@ -95,7 +138,7 @@ impl MergeContext {
         ));
         let output_schema = Arc::new(ArrowSchema::new(output_fields));
 
-        let parquet_root = build_parquet_root_schema(parquet_descriptors)?;
+        let parquet_root = build_parquet_root_schema(output_schema.as_ref())?;
 
         let output_file = File::create(output_path)?;
         let throttled_writer =

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/heap.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/heap.rs
@@ -9,12 +9,16 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use arrow::array::{AsArray, RecordBatch};
+use arrow::array::{
+    Array, ArrayRef, AsArray, GenericListArray, OffsetSizeTrait, RecordBatch, UInt64Array,
+};
+use arrow::compute::take;
 use arrow::datatypes::{
     DataType as ArrowDataType, Date32Type, Date64Type, DurationMicrosecondType,
-    DurationMillisecondType, DurationNanosecondType, DurationSecondType, Float32Type, Float64Type,
-    Int16Type, Int32Type, Int64Type, Int8Type, TimestampMicrosecondType, TimestampMillisecondType,
-    TimestampNanosecondType, TimestampSecondType,
+    DurationMillisecondType, DurationNanosecondType, DurationSecondType, Float16Type, Float32Type,
+    Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
 };
 
 use super::error::{MergeError, MergeResult};
@@ -28,7 +32,9 @@ pub enum SortKey {
     NullFirst,
     NullLast,
     Int(i64),
+    UInt(u64),
     Float(f64),
+    Bool(bool),
     Bytes(Vec<u8>),
 }
 
@@ -50,7 +56,9 @@ impl Ord for SortKey {
             (SortKey::NullLast, _) => Ordering::Greater,
             (_, SortKey::NullLast) => Ordering::Less,
             (SortKey::Int(a), SortKey::Int(b)) => a.cmp(b),
+            (SortKey::UInt(a), SortKey::UInt(b)) => a.cmp(b),
             (SortKey::Float(a), SortKey::Float(b)) => a.total_cmp(b),
+            (SortKey::Bool(a), SortKey::Bool(b)) => a.cmp(b),
             (SortKey::Bytes(a), SortKey::Bytes(b)) => a.cmp(b),
             // Same column always produces the same variant; cross-variant is unreachable.
             _ => Ordering::Equal,
@@ -125,27 +133,69 @@ impl PartialOrd for HeapItem {
 // =============================================================================
 
 #[inline]
-pub fn get_sort_value(
-    batch: &RecordBatch,
-    row: usize,
-    col_idx: usize,
+fn null_sort_key(null_first: bool) -> SortKey {
+    if null_first {
+        SortKey::NullFirst
+    } else {
+        SortKey::NullLast
+    }
+}
+
+fn get_min_value(
+    values: &dyn Array,
+    start: usize,
+    end: usize,
     dtype: &ArrowDataType,
     null_first: bool,
 ) -> MergeResult<SortKey> {
-    let col = batch.column(col_idx);
+    let mut minimum = None;
+    for index in start..end {
+        if values.is_null(index) {
+            continue;
+        }
+        let candidate = get_array_sort_value(values, index, dtype, false)?;
+        if minimum.as_ref().is_none_or(|current| candidate < *current) {
+            minimum = Some(candidate);
+        }
+    }
+    Ok(minimum.unwrap_or_else(|| null_sort_key(null_first)))
+}
+
+fn get_list_min<O: OffsetSizeTrait>(
+    list: &GenericListArray<O>,
+    row: usize,
+    child_type: &ArrowDataType,
+    null_first: bool,
+) -> MergeResult<SortKey> {
+    let offsets = list.value_offsets();
+    get_min_value(
+        list.values().as_ref(),
+        offsets[row].as_usize(),
+        offsets[row + 1].as_usize(),
+        child_type,
+        null_first,
+    )
+}
+
+#[inline]
+fn get_array_sort_value(
+    col: &dyn Array,
+    row: usize,
+    dtype: &ArrowDataType,
+    null_first: bool,
+) -> MergeResult<SortKey> {
     if col.is_null(row) {
-        return Ok(if null_first {
-            SortKey::NullFirst
-        } else {
-            SortKey::NullLast
-        });
+        return Ok(null_sort_key(null_first));
     }
     let key = match dtype {
-        // Integer types → SortKey::Int
         ArrowDataType::Int64 => SortKey::Int(col.as_primitive::<Int64Type>().value(row)),
         ArrowDataType::Int32 => SortKey::Int(col.as_primitive::<Int32Type>().value(row) as i64),
         ArrowDataType::Int16 => SortKey::Int(col.as_primitive::<Int16Type>().value(row) as i64),
         ArrowDataType::Int8 => SortKey::Int(col.as_primitive::<Int8Type>().value(row) as i64),
+        ArrowDataType::UInt64 => SortKey::UInt(col.as_primitive::<UInt64Type>().value(row)),
+        ArrowDataType::UInt32 => SortKey::UInt(col.as_primitive::<UInt32Type>().value(row) as u64),
+        ArrowDataType::UInt16 => SortKey::UInt(col.as_primitive::<UInt16Type>().value(row) as u64),
+        ArrowDataType::UInt8 => SortKey::UInt(col.as_primitive::<UInt8Type>().value(row) as u64),
         ArrowDataType::Date32 => SortKey::Int(col.as_primitive::<Date32Type>().value(row) as i64),
         ArrowDataType::Date64 => SortKey::Int(col.as_primitive::<Date64Type>().value(row)),
         ArrowDataType::Timestamp(unit, _) => SortKey::Int(match unit {
@@ -176,21 +226,38 @@ pub fn get_sort_value(
                 col.as_primitive::<DurationNanosecondType>().value(row)
             }
         }),
-
-        // Float types → SortKey::Float
         ArrowDataType::Float64 => SortKey::Float(col.as_primitive::<Float64Type>().value(row)),
         ArrowDataType::Float32 => {
             SortKey::Float(col.as_primitive::<Float32Type>().value(row) as f64)
         }
-
-        // String types → SortKey::Bytes
+        ArrowDataType::Float16 => {
+            SortKey::Float(col.as_primitive::<Float16Type>().value(row).to_f32() as f64)
+        }
+        ArrowDataType::Boolean => SortKey::Bool(col.as_boolean().value(row)),
         ArrowDataType::Utf8 => {
             SortKey::Bytes(col.as_string::<i32>().value(row).as_bytes().to_vec())
         }
         ArrowDataType::LargeUtf8 => {
             SortKey::Bytes(col.as_string::<i64>().value(row).as_bytes().to_vec())
         }
-
+        ArrowDataType::Binary => SortKey::Bytes(col.as_binary::<i32>().value(row).to_vec()),
+        ArrowDataType::LargeBinary => SortKey::Bytes(col.as_binary::<i64>().value(row).to_vec()),
+        ArrowDataType::List(field) => {
+            get_list_min(col.as_list::<i32>(), row, field.data_type(), null_first)?
+        }
+        ArrowDataType::LargeList(field) => {
+            get_list_min(col.as_list::<i64>(), row, field.data_type(), null_first)?
+        }
+        ArrowDataType::FixedSizeList(field, size) => {
+            let start = row * *size as usize;
+            get_min_value(
+                col.as_fixed_size_list().values().as_ref(),
+                start,
+                start + *size as usize,
+                field.data_type(),
+                null_first,
+            )?
+        }
         other => {
             return Err(MergeError::Logic(format!(
                 "Unsupported sort column type: {:?}",
@@ -199,6 +266,106 @@ pub fn get_sort_value(
         }
     };
     Ok(key)
+}
+
+#[inline]
+pub fn get_sort_value(
+    batch: &RecordBatch,
+    row: usize,
+    col_idx: usize,
+    dtype: &ArrowDataType,
+    null_first: bool,
+) -> MergeResult<SortKey> {
+    get_array_sort_value(batch.column(col_idx).as_ref(), row, dtype, null_first)
+}
+
+fn min_value_index(
+    values: &dyn Array,
+    start: usize,
+    end: usize,
+    dtype: &ArrowDataType,
+) -> MergeResult<Option<u64>> {
+    let mut minimum = None;
+    for index in start..end {
+        if values.is_null(index) {
+            continue;
+        }
+        let candidate = get_array_sort_value(values, index, dtype, false)?;
+        if minimum
+            .as_ref()
+            .is_none_or(|(_, current): &(u64, SortKey)| candidate < *current)
+        {
+            minimum = Some((index as u64, candidate));
+        }
+    }
+    Ok(minimum.map(|(index, _)| index))
+}
+
+fn reduce_list_array<O: OffsetSizeTrait>(
+    list: &GenericListArray<O>,
+    child_type: &ArrowDataType,
+) -> MergeResult<ArrayRef> {
+    let values = list.values();
+    let offsets = list.value_offsets();
+    let indices = (0..list.len())
+        .map(|row| {
+            if list.is_null(row) {
+                Ok(None)
+            } else {
+                min_value_index(
+                    values.as_ref(),
+                    offsets[row].as_usize(),
+                    offsets[row + 1].as_usize(),
+                    child_type,
+                )
+            }
+        })
+        .collect::<MergeResult<Vec<_>>>()?;
+    Ok(take(values.as_ref(), &UInt64Array::from(indices), None)?)
+}
+
+/// Returns the scalar type used as the physical sort key. LIST columns always
+/// reduce to the natural minimum non-null element; no customer-selectable mode
+/// is exposed by the Parquet writer.
+pub(crate) fn min_reduced_sort_type(dtype: &ArrowDataType) -> ArrowDataType {
+    match dtype {
+        ArrowDataType::List(field)
+        | ArrowDataType::LargeList(field)
+        | ArrowDataType::FixedSizeList(field, _) => field.data_type().clone(),
+        _ => dtype.clone(),
+    }
+}
+
+/// Materializes one temporary scalar MIN key per row for Arrow's RowConverter.
+/// The returned array is used only while sorting and is never written to Parquet.
+pub(crate) fn min_reduced_sort_array(array: &ArrayRef) -> MergeResult<ArrayRef> {
+    match array.data_type() {
+        ArrowDataType::List(field) => reduce_list_array(array.as_list::<i32>(), field.data_type()),
+        ArrowDataType::LargeList(field) => {
+            reduce_list_array(array.as_list::<i64>(), field.data_type())
+        }
+        ArrowDataType::FixedSizeList(field, size) => {
+            let list = array.as_fixed_size_list();
+            let values = list.values();
+            let indices = (0..list.len())
+                .map(|row| {
+                    if list.is_null(row) {
+                        Ok(None)
+                    } else {
+                        let start = row * *size as usize;
+                        min_value_index(
+                            values.as_ref(),
+                            start,
+                            start + *size as usize,
+                            field.data_type(),
+                        )
+                    }
+                })
+                .collect::<MergeResult<Vec<_>>>()?;
+            Ok(take(values.as_ref(), &UInt64Array::from(indices), None)?)
+        }
+        _ => Ok(array.clone()),
+    }
 }
 
 #[inline]

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/schema.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/merge/schema.rs
@@ -6,49 +6,26 @@
  * compatible open source license.
  */
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Int64Array, RecordBatch};
-use arrow::datatypes::Schema as ArrowSchema;
-use parquet::basic::Repetition;
+use arrow::array::{ArrayRef, Int64Array, ListArray, RecordBatch};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Schema as ArrowSchema};
+use parquet::arrow::ArrowSchemaConverter;
 use parquet::schema::types::Type;
 
-use super::error::MergeResult;
+use super::error::{MergeError, MergeResult};
 
 /// Reserved column name for the synthetic row identifier added during merge.
 pub const ROW_ID_COLUMN_NAME: &str = "__row_id__";
 
-/// Builds the output Parquet schema as the union of pre-read schema descriptors.
+/// Builds the output Parquet schema from the canonical Arrow merge schema.
 ///
-/// The output schema contains every column seen across all inputs, except:
-/// - Any existing `__row_id__` column is removed.
-/// - A fresh `__row_id__` INT64 REQUIRED column is appended at the end.
-pub fn build_parquet_root_schema(
-    schema_descriptors: &[parquet::schema::types::SchemaDescriptor],
-) -> MergeResult<Arc<Type>> {
-    let mut seen_names: HashSet<String> = HashSet::new();
-    let mut parquet_fields: Vec<Arc<Type>> = Vec::new();
-
-    for descr in schema_descriptors {
-        let root = descr.root_schema();
-        for field in root.get_fields() {
-            if field.name() != ROW_ID_COLUMN_NAME && seen_names.insert(field.name().to_string()) {
-                parquet_fields.push(Arc::new(field.as_ref().clone()));
-            }
-        }
-    }
-
-    let row_id_type = Type::primitive_type_builder(ROW_ID_COLUMN_NAME, parquet::basic::Type::INT64)
-        .with_repetition(Repetition::REQUIRED)
-        .build()?;
-    parquet_fields.push(Arc::new(row_id_type));
-
-    let parquet_root = Type::group_type_builder("schema")
-        .with_fields(parquet_fields)
-        .build()?;
-
-    Ok(Arc::new(parquet_root))
+/// The canonical schema has already promoted compatible scalar/LIST field pairs to LIST, so
+/// deriving the Parquet schema from it avoids selecting an arbitrary first input file's shape.
+pub fn build_parquet_root_schema(schema: &ArrowSchema) -> MergeResult<Arc<Type>> {
+    let descriptor = ArrowSchemaConverter::new().convert(schema)?;
+    Ok(descriptor.root_schema_ptr())
 }
 
 /// Returns column indices that exclude `__row_id__`, for use as a projection mask.
@@ -101,7 +78,10 @@ impl ColumnMapping {
         for (target_idx, field) in target_schema.fields().iter().enumerate() {
             match source_schema.index_of(field.name()) {
                 Ok(src_idx) => {
-                    if is_identity && src_idx != target_idx {
+                    if is_identity
+                        && (src_idx != target_idx
+                            || source_schema.field(src_idx).data_type() != field.data_type())
+                    {
                         is_identity = false;
                     }
                     mapping.push(Some(src_idx));
@@ -130,7 +110,37 @@ impl ColumnMapping {
         let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.mapping.len());
         for (i, entry) in self.mapping.iter().enumerate() {
             match entry {
-                Some(src_idx) => columns.push(batch.column(*src_idx).clone()),
+                Some(src_idx) => {
+                    let source = batch.column(*src_idx);
+                    let target_field = &self.target_schema.fields()[i];
+                    if source.data_type() == target_field.data_type() {
+                        columns.push(source.clone());
+                    } else if let DataType::List(child) = target_field.data_type() {
+                        if source.data_type() != child.data_type() {
+                            return Err(MergeError::Logic(format!(
+                                "Cannot promote field '{}' from {:?} to {:?}",
+                                target_field.name(),
+                                source.data_type(),
+                                target_field.data_type()
+                            )));
+                        }
+                        let offsets =
+                            OffsetBuffer::new((0..=num_rows as i32).collect::<Vec<_>>().into());
+                        columns.push(Arc::new(ListArray::new(
+                            Arc::clone(child),
+                            offsets,
+                            source.clone(),
+                            source.nulls().cloned(),
+                        )));
+                    } else {
+                        return Err(MergeError::Logic(format!(
+                            "Cannot adapt field '{}' from {:?} to {:?}",
+                            target_field.name(),
+                            source.data_type(),
+                            target_field.data_type()
+                        )));
+                    }
+                }
                 None => {
                     let field = &self.target_schema.fields()[i];
                     columns.push(arrow::array::new_null_array(field.data_type(), num_rows));

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/tests/mod.rs
@@ -957,6 +957,349 @@ fn create_test_ipc_file(dir: &Path, ages: &[i64], row_ids: &[i64]) -> String {
     ipc_path
 }
 
+#[test]
+fn test_sort_batch_uses_minimum_list_element() {
+    use arrow::array::{ArrayRef, AsArray, Int64Array, ListArray, RecordBatch, StringArray};
+    use arrow::buffer::{NullBuffer, OffsetBuffer};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    let list = ListArray::new(
+        Arc::new(Field::new("element", DataType::Utf8, true)),
+        OffsetBuffer::new(vec![0_i32, 2, 3, 3, 3, 5, 6].into()),
+        Arc::new(StringArray::from(vec![
+            Some("z"),
+            Some("alpha"),
+            Some("beta"),
+            Some("omega"),
+            Some("gamma"),
+            None,
+        ])),
+        Some(NullBuffer::from(vec![true, true, true, false, true, true])),
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+            true,
+        ),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![10, 20, 30, 40, 50, 60])) as ArrayRef,
+            Arc::new(list) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    let ascending =
+        NativeParquetWriter::sort_batch(&batch, &["tags".to_string()], &[false], &[false]).unwrap();
+    let ascending_ids = ascending
+        .column(0)
+        .as_primitive::<arrow::datatypes::Int64Type>();
+    assert_eq!(
+        (0..3)
+            .map(|row| ascending_ids.value(row))
+            .collect::<Vec<_>>(),
+        vec![10, 20, 50]
+    );
+    let mut ascending_missing = (3..6)
+        .map(|row| ascending_ids.value(row))
+        .collect::<Vec<_>>();
+    ascending_missing.sort_unstable();
+    assert_eq!(ascending_missing, vec![30, 40, 60]);
+
+    let descending =
+        NativeParquetWriter::sort_batch(&batch, &["tags".to_string()], &[true], &[false]).unwrap();
+    let descending_ids = descending
+        .column(0)
+        .as_primitive::<arrow::datatypes::Int64Type>();
+    assert_eq!(
+        (0..3)
+            .map(|row| descending_ids.value(row))
+            .collect::<Vec<_>>(),
+        vec![50, 20, 10]
+    );
+    let mut descending_missing = (3..6)
+        .map(|row| descending_ids.value(row))
+        .collect::<Vec<_>>();
+    descending_missing.sort_unstable();
+    assert_eq!(descending_missing, vec![30, 40, 60]);
+}
+
+#[test]
+fn test_sort_batch_uses_minimum_numeric_list_element() {
+    use arrow::array::{ArrayRef, AsArray, Int32Array, Int64Array, ListArray, RecordBatch};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    let list = ListArray::new(
+        Arc::new(Field::new("element", DataType::Int32, false)),
+        OffsetBuffer::new(vec![0_i32, 2, 4].into()),
+        Arc::new(Int32Array::from(vec![3, 2, 5, 1])),
+        None,
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "values",
+            DataType::List(Arc::new(Field::new("element", DataType::Int32, false))),
+            false,
+        ),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![20, 10])) as ArrayRef,
+            Arc::new(list) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    let sorted =
+        NativeParquetWriter::sort_batch(&batch, &["values".to_string()], &[false], &[false])
+            .unwrap();
+    let ids = sorted
+        .column(0)
+        .as_primitive::<arrow::datatypes::Int64Type>();
+    assert_eq!(
+        (0..2).map(|row| ids.value(row)).collect::<Vec<_>>(),
+        vec![10, 20]
+    );
+}
+
+fn build_nullable_string_list(rows: &[Option<Vec<Option<&str>>>]) -> arrow::array::ListArray {
+    use arrow::array::StringArray;
+    use arrow::buffer::{NullBuffer, OffsetBuffer};
+    use arrow::datatypes::{DataType, Field};
+
+    let mut offsets = vec![0_i32];
+    let mut values = Vec::new();
+    let mut validity = Vec::with_capacity(rows.len());
+    for row in rows {
+        match row {
+            Some(row_values) => {
+                values.extend(
+                    row_values
+                        .iter()
+                        .map(|value| value.map(ToString::to_string)),
+                );
+                validity.push(true);
+            }
+            None => validity.push(false),
+        }
+        offsets.push(values.len() as i32);
+    }
+
+    arrow::array::ListArray::new(
+        Arc::new(Field::new("element", DataType::Utf8, true)),
+        OffsetBuffer::new(offsets.into()),
+        Arc::new(StringArray::from(values)),
+        Some(NullBuffer::from(validity)),
+    )
+}
+
+fn read_nullable_string_lists(
+    batch: &arrow::record_batch::RecordBatch,
+    column: &str,
+) -> Vec<Option<Vec<Option<String>>>> {
+    use arrow::array::{Array, StringArray};
+
+    let lists = batch
+        .column(batch.schema().index_of(column).unwrap())
+        .as_any()
+        .downcast_ref::<arrow::array::ListArray>()
+        .unwrap();
+    (0..lists.len())
+        .map(|row| {
+            if lists.is_null(row) {
+                return None;
+            }
+            let values = lists.value(row);
+            let strings = values.as_any().downcast_ref::<StringArray>().unwrap();
+            Some(
+                (0..strings.len())
+                    .map(|index| {
+                        if strings.is_null(index) {
+                            None
+                        } else {
+                            Some(strings.value(index).to_string())
+                        }
+                    })
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn test_list_sort_null_placement_for_both_directions() {
+    use arrow::array::{ArrayRef, AsArray, Int64Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    let rows = vec![
+        None,
+        Some(vec![]),
+        Some(vec![None]),
+        Some(vec![None, Some("beta")]),
+        Some(vec![Some("alpha")]),
+    ];
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+                true,
+            ),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5])) as ArrayRef,
+            Arc::new(build_nullable_string_list(&rows)) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    for (descending, nulls_first, expected_values) in [
+        (false, true, vec![5, 4]),
+        (false, false, vec![5, 4]),
+        (true, true, vec![4, 5]),
+        (true, false, vec![4, 5]),
+    ] {
+        let sorted = NativeParquetWriter::sort_batch(
+            &batch,
+            &["tags".to_string()],
+            &[descending],
+            &[nulls_first],
+        )
+        .unwrap();
+        let ids = sorted
+            .column(0)
+            .as_primitive::<arrow::datatypes::Int64Type>();
+        let ids = (0..ids.len()).map(|row| ids.value(row)).collect::<Vec<_>>();
+        let (missing, values) = if nulls_first {
+            (&ids[..3], &ids[3..])
+        } else {
+            (&ids[2..], &ids[..2])
+        };
+        let mut missing = missing.to_vec();
+        missing.sort_unstable();
+        assert_eq!(missing, vec![1, 2, 3]);
+        assert_eq!(values, expected_values.as_slice());
+    }
+}
+
+#[test]
+fn test_chunked_writer_sorts_by_list_min_and_preserves_original_lists() {
+    use crate::merge::schema::ROW_ID_COLUMN_NAME;
+    use arrow::array::{Array, ArrayRef, AsArray, Int64Array};
+    use arrow::compute::concat_batches;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+
+    let (_temp_dir, filename) = get_temp_file_path("list_sort_multi_chunk.parquet");
+    let index_name = "test-list-sort-multi-chunk";
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new(ROW_ID_COLUMN_NAME, DataType::Int64, false),
+    ]));
+
+    let mut settings = NativeSettings::default();
+    settings.sort_columns = vec!["tags".to_string()];
+    settings.reverse_sorts = vec![false];
+    settings.nulls_first = vec![false];
+    settings.sort_in_memory_threshold_bytes = Some(1);
+    SETTINGS_STORE.insert(index_name.to_string(), settings);
+
+    let ffi_schema = arrow::ffi::FFI_ArrowSchema::try_from(schema.as_ref()).unwrap();
+    NativeParquetWriter::create_writer(
+        filename.clone(),
+        index_name.to_string(),
+        Box::into_raw(Box::new(ffi_schema)) as i64,
+        vec!["tags".to_string()],
+        vec![false],
+        vec![false],
+        0,
+    )
+    .unwrap();
+
+    let input_rows = vec![
+        Some(vec![Some("z"), Some("delta"), Some("z")]),
+        Some(vec![Some("omega"), Some("alpha")]),
+        Some(vec![Some("gamma"), Some("beta")]),
+        Some(vec![]),
+        None,
+        Some(vec![None, Some("charlie")]),
+    ];
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5, 6])) as ArrayRef,
+            Arc::new(build_nullable_string_list(&input_rows)) as ArrayRef,
+            Arc::new(Int64Array::from(vec![0, 1, 2, 3, 4, 5])) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let struct_array = arrow::array::StructArray::from(batch);
+    let (ffi_array, ffi_schema) = arrow::ffi::to_ffi(&struct_array.to_data()).unwrap();
+    NativeParquetWriter::write_data(
+        filename.clone(),
+        Box::into_raw(Box::new(ffi_array)) as i64,
+        Box::into_raw(Box::new(ffi_schema)) as i64,
+    )
+    .unwrap();
+
+    let finalized = NativeParquetWriter::finalize_writer(filename.clone())
+        .unwrap()
+        .unwrap();
+    let batches = read_parquet_file(&filename);
+    let combined = concat_batches(&batches[0].schema(), &batches).unwrap();
+    let ids = combined
+        .column(combined.schema().index_of("id").unwrap())
+        .as_primitive::<arrow::datatypes::Int64Type>();
+    let ids = (0..ids.len()).map(|row| ids.value(row)).collect::<Vec<_>>();
+    assert_eq!(&ids[..4], &[2, 3, 6, 1]);
+    let mut missing_ids = ids[4..].to_vec();
+    missing_ids.sort_unstable();
+    assert_eq!(missing_ids, vec![4, 5]);
+
+    let lists = read_nullable_string_lists(&combined, "tags");
+    assert_eq!(
+        &lists[..4],
+        &[
+            Some(vec![Some("omega".to_string()), Some("alpha".to_string())]),
+            Some(vec![Some("gamma".to_string()), Some("beta".to_string())]),
+            Some(vec![None, Some("charlie".to_string())]),
+            Some(vec![
+                Some("z".to_string()),
+                Some("delta".to_string()),
+                Some("z".to_string()),
+            ]),
+        ]
+    );
+    let missing_values = ids[4..]
+        .iter()
+        .zip(lists[4..].iter())
+        .map(|(id, tags)| (*id, tags.clone()))
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(missing_values.get(&4), Some(&Some(vec![])));
+    assert_eq!(missing_values.get(&5), Some(&None));
+
+    let row_ids = read_row_ids_from_parquet(&filename);
+    assert_eq!(row_ids, (0..6).collect::<Vec<_>>());
+    let mut permutation = finalized.row_id_mapping.unwrap();
+    permutation.sort_unstable();
+    assert_eq!(permutation, (0..6).collect::<Vec<_>>());
+
+    SETTINGS_STORE.remove(index_name);
+}
+
 // ===== SortingChunkedWriter and finalize_sorted_chunks tests =====
 // These tests exercise the chunked sort path by setting a very small memory threshold
 // to force multiple flush_and_sort_chunk calls, then verify:

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/writer.rs
@@ -22,7 +22,11 @@ use std::sync::{Arc, Mutex};
 
 use crate::crc_writer::CrcWriter;
 use crate::memory::write_pool;
-use crate::merge::{merge_sorted_with_pool, schema::ROW_ID_COLUMN_NAME};
+use crate::merge::{
+    heap::{min_reduced_sort_array, min_reduced_sort_type},
+    merge_sorted_with_pool,
+    schema::ROW_ID_COLUMN_NAME,
+};
 use crate::native_settings::NativeSettings;
 use crate::writer_properties_builder::WriterPropertiesBuilder;
 use crate::{log_debug, log_error, log_info};
@@ -873,7 +877,7 @@ impl NativeParquetWriter {
     /// Sort a batch using RowConverter: converts sort columns into compact
     /// byte-comparable rows, sorts indices by comparing those rows, then
     /// reorders all columns via take.
-    fn sort_batch(
+    pub(crate) fn sort_batch(
         batch: &RecordBatch,
         sort_columns: &[String],
         reverse_sorts: &[bool],
@@ -887,7 +891,7 @@ impl NativeParquetWriter {
                     .schema()
                     .index_of(col_name)
                     .map_err(|_| format!("Sort column '{}' not found in schema", col_name))?;
-                let data_type = batch.schema().field(col_index).data_type().clone();
+                let data_type = min_reduced_sort_type(batch.schema().field(col_index).data_type());
                 let options = arrow::compute::SortOptions {
                     descending: reverse_sorts.get(i).copied().unwrap_or(false),
                     nulls_first: nulls_first.get(i).copied().unwrap_or(false),
@@ -901,10 +905,10 @@ impl NativeParquetWriter {
         let sort_arrays: Vec<Arc<dyn arrow::array::Array>> = sort_columns
             .iter()
             .map(|col_name| {
-                let col_index = batch.schema().index_of(col_name).unwrap();
-                batch.column(col_index).clone()
+                let col_index = batch.schema().index_of(col_name)?;
+                min_reduced_sort_array(batch.column(col_index))
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         let rows = converter.convert_columns(&sort_arrays)?;
         let mut sort_indices: Vec<u32> = (0..batch.num_rows() as u32).collect();

--- a/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/tests/merge_list_column_tests.rs
@@ -1,0 +1,716 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Merge coverage for multi-valued (Arrow LIST / parquet repeated) columns.
+//!
+//! A LIST column breaks the "one leaf value per row" identity every flat column satisfies, so the
+//! merge path needs its own coverage: the k-way merge slices batches by row, appends a fresh
+//! `__row_id__`, and re-encodes each column through `compute_leaves`. All of that must keep a
+//! repeated column's values grouped with their original row.
+
+use std::fs::File;
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use opensearch_parquet_format::merge::{merge_sorted, merge_unsorted};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use tempfile::tempdir;
+
+/// Schema: `id` (sort key, Int64) + `tags` (List<Utf8>) + `__row_id__`.
+fn list_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new("__row_id__", DataType::Int64, false),
+    ]))
+}
+
+/// Build a file where row i has `id = ids[i]` and `tags = rows[i]` (None ⇒ null list).
+fn write_nullable_list_file(path: &str, ids: &[i64], rows: &[Option<Vec<Option<&str>>>]) {
+    assert_eq!(ids.len(), rows.len());
+    let mut values: Vec<Option<String>> = Vec::new();
+    let mut offsets: Vec<i32> = vec![0];
+    let mut validity: Vec<bool> = Vec::new();
+    for row in rows {
+        match row {
+            Some(row_values) => {
+                values.extend(
+                    row_values
+                        .iter()
+                        .map(|value| value.map(ToString::to_string)),
+                );
+                validity.push(true);
+            }
+            None => validity.push(false),
+        }
+        offsets.push(values.len() as i32);
+    }
+    let list = ListArray::new(
+        Arc::new(Field::new("element", DataType::Utf8, true)),
+        arrow::buffer::OffsetBuffer::new(offsets.into()),
+        Arc::new(StringArray::from(values)),
+        Some(arrow::buffer::NullBuffer::from(validity)),
+    );
+    let schema = list_schema();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(list) as ArrayRef,
+            Arc::new(Int64Array::from((0..ids.len() as i64).collect::<Vec<_>>())) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let file = File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// Build a LIST file with non-null child values.
+fn write_list_file(path: &str, ids: &[i64], rows: &[Option<Vec<&str>>]) {
+    let nullable_rows = rows
+        .iter()
+        .map(|row| {
+            row.as_ref()
+                .map(|values| values.iter().map(|value| Some(*value)).collect())
+        })
+        .collect::<Vec<_>>();
+    write_nullable_list_file(path, ids, &nullable_rows);
+}
+
+fn scalar_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("tags", DataType::Utf8, true),
+        Field::new("__row_id__", DataType::Int64, false),
+    ]))
+}
+
+fn write_scalar_file(path: &str, ids: &[i64], rows: &[Option<&str>]) {
+    assert_eq!(ids.len(), rows.len());
+    let schema = scalar_schema();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(StringArray::from(rows.to_vec())) as ArrayRef,
+            Arc::new(Int64Array::from((0..ids.len() as i64).collect::<Vec<_>>())) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let file = File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// Read back `(id, tags)` pairs in file order.
+fn read_nullable_pairs(path: &str) -> Vec<(i64, Option<Vec<Option<String>>>)> {
+    let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+    let mut out = Vec::new();
+    for batch in reader {
+        let batch = batch.unwrap();
+        let ids = batch
+            .column(batch.schema().index_of("id").unwrap())
+            .as_primitive::<arrow::datatypes::Int64Type>();
+        let lists = batch
+            .column(batch.schema().index_of("tags").unwrap())
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("tags must decode as a ListArray");
+        for row in 0..batch.num_rows() {
+            let tags = if lists.is_null(row) {
+                None
+            } else {
+                let values = lists.value(row);
+                let strings = values.as_any().downcast_ref::<StringArray>().unwrap();
+                Some(
+                    (0..strings.len())
+                        .map(|index| {
+                            if strings.is_null(index) {
+                                None
+                            } else {
+                                Some(strings.value(index).to_string())
+                            }
+                        })
+                        .collect(),
+                )
+            };
+            out.push((ids.value(row), tags));
+        }
+    }
+    out
+}
+
+/// Read back `(id, tags)` pairs when all LIST child values are non-null.
+fn read_pairs(path: &str) -> Vec<(i64, Option<Vec<String>>)> {
+    read_nullable_pairs(path)
+        .into_iter()
+        .map(|(id, tags)| {
+            (
+                id,
+                tags.map(|values| {
+                    values
+                        .into_iter()
+                        .map(|value| value.expect("unexpected null LIST child"))
+                        .collect()
+                }),
+            )
+        })
+        .collect()
+}
+
+/// Borrow an owned rows-of-strings structure as the `&str` shape `write_list_file` takes.
+fn as_refs(rows: &[Option<Vec<String>>]) -> Vec<Option<Vec<&str>>> {
+    rows.iter()
+        .map(|r| r.as_ref().map(|v| v.iter().map(|s| s.as_str()).collect()))
+        .collect()
+}
+
+fn v(items: &[&str]) -> Option<Vec<String>> {
+    Some(items.iter().map(|s| (*s).to_string()).collect())
+}
+
+#[test]
+fn unsorted_merge_preserves_list_values() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    // Varying list lengths, a duplicate, an empty list, and a null list.
+    write_list_file(
+        &a,
+        &[1, 2, 3],
+        &[
+            Some(vec!["beta", "alpha", "beta"]),
+            None,
+            Some(vec!["solo"]),
+        ],
+    );
+    write_list_file(&b, &[4, 5], &[Some(vec![]), Some(vec!["x", "y"])]);
+
+    merge_unsorted(&[a, b], &out, "merge-list-unsorted", 0).unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 5, "row count must be preserved");
+    assert_eq!(pairs[0], (1, v(&["beta", "alpha", "beta"])));
+    assert_eq!(pairs[1], (2, None), "null list must stay null");
+    assert_eq!(pairs[2], (3, v(&["solo"])));
+    assert_eq!(pairs[3].0, 4);
+    assert_eq!(pairs[3].1, Some(vec![]), "empty list must stay empty");
+    assert_eq!(pairs[4], (5, v(&["x", "y"])));
+}
+
+#[test]
+fn unsorted_merge_promotes_scalar_values_to_singleton_lists() {
+    let tmp = tempdir().unwrap();
+    let scalar = tmp
+        .path()
+        .join("scalar.parquet")
+        .to_string_lossy()
+        .to_string();
+    let list = tmp
+        .path()
+        .join("list.parquet")
+        .to_string_lossy()
+        .to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    write_scalar_file(&scalar, &[1, 2], &[Some("prod"), None]);
+    write_list_file(
+        &list,
+        &[3, 4],
+        &[Some(vec!["prod", "error"]), Some(vec!["solo"])],
+    );
+
+    merge_unsorted(&[scalar, list], &out, "merge-scalar-list", 0).unwrap();
+
+    assert_eq!(
+        read_pairs(&out),
+        vec![
+            (1, v(&["prod"])),
+            (2, None),
+            (3, v(&["prod", "error"])),
+            (4, v(&["solo"])),
+        ]
+    );
+}
+
+#[test]
+fn sorted_merge_keeps_list_values_with_their_row() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    // Interleaving sort keys force the k-way merge to alternate between cursors, so a row-vs-value
+    // confusion in the LIST column would surface as values attached to the wrong id.
+    write_list_file(
+        &a,
+        &[1, 3, 5],
+        &[
+            Some(vec!["one"]),
+            Some(vec!["three", "iii"]),
+            Some(vec!["five"]),
+        ],
+    );
+    write_list_file(
+        &b,
+        &[2, 4, 6],
+        &[Some(vec!["two", "ii", "2"]), None, Some(vec!["six"])],
+    );
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-sorted",
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 6);
+    // Sort order by id, and every row keeps exactly its own values.
+    assert_eq!(pairs[0], (1, v(&["one"])));
+    assert_eq!(pairs[1], (2, v(&["two", "ii", "2"])));
+    assert_eq!(pairs[2], (3, v(&["three", "iii"])));
+    assert_eq!(pairs[3], (4, None), "null list must stay null");
+    assert_eq!(pairs[4], (5, v(&["five"])));
+    assert_eq!(pairs[5], (6, v(&["six"])));
+}
+
+#[test]
+fn sorted_merge_uses_minimum_list_element_as_sort_key() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let ascending = tmp
+        .path()
+        .join("ascending.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    // Each input is already ordered by its per-row minimum. Source list order is deliberately
+    // different so the merge cannot accidentally use the first element or lexicographic LIST order.
+    write_list_file(
+        &a,
+        &[10, 30, 50],
+        &[Some(vec!["z", "alpha"]), Some(vec!["delta"]), None],
+    );
+    write_list_file(
+        &b,
+        &[20, 40, 60],
+        &[
+            Some(vec!["beta", "zz"]),
+            Some(vec!["omega", "gamma"]),
+            Some(vec![]),
+        ],
+    );
+
+    merge_sorted(
+        &[a, b],
+        &ascending,
+        "merge-list-min-ascending",
+        &["tags".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let ascending_ids: Vec<i64> = read_pairs(&ascending)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert_eq!(&ascending_ids[..4], &[10, 20, 30, 40]);
+    assert!(ascending_ids[4..].contains(&50));
+    assert!(ascending_ids[4..].contains(&60));
+
+    let descending_a = tmp
+        .path()
+        .join("descending_a.parquet")
+        .to_string_lossy()
+        .to_string();
+    let descending_b = tmp
+        .path()
+        .join("descending_b.parquet")
+        .to_string_lossy()
+        .to_string();
+    let descending = tmp
+        .path()
+        .join("descending.parquet")
+        .to_string_lossy()
+        .to_string();
+    write_list_file(
+        &descending_a,
+        &[40, 20, 50],
+        &[Some(vec!["omega", "gamma"]), Some(vec!["beta", "zz"]), None],
+    );
+    write_list_file(
+        &descending_b,
+        &[30, 10, 60],
+        &[Some(vec!["delta"]), Some(vec!["z", "alpha"]), Some(vec![])],
+    );
+
+    merge_sorted(
+        &[descending_a, descending_b],
+        &descending,
+        "merge-list-min-descending",
+        &["tags".to_string()],
+        &[true],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let descending_ids: Vec<i64> = read_pairs(&descending)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert_eq!(&descending_ids[..4], &[40, 30, 20, 10]);
+    assert!(descending_ids[4..].contains(&50));
+    assert!(descending_ids[4..].contains(&60));
+}
+
+#[test]
+fn sorted_merge_orders_scalar_and_list_generations_by_minimum_value() {
+    let tmp = tempdir().unwrap();
+    let scalar = tmp
+        .path()
+        .join("scalar.parquet")
+        .to_string_lossy()
+        .to_string();
+    let list = tmp
+        .path()
+        .join("list.parquet")
+        .to_string_lossy()
+        .to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    write_scalar_file(&scalar, &[10, 30], &[Some("alpha"), Some("delta")]);
+    write_list_file(
+        &list,
+        &[20, 40],
+        &[Some(vec!["zz", "beta"]), Some(vec!["omega", "gamma"])],
+    );
+
+    merge_sorted(
+        &[scalar, list],
+        &out,
+        "merge-scalar-list-sorted",
+        &["tags".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(
+        pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        vec![10, 20, 30, 40]
+    );
+    assert_eq!(pairs[0], (10, v(&["alpha"])));
+    assert_eq!(pairs[1], (20, v(&["zz", "beta"])));
+    assert_eq!(pairs[2], (30, v(&["delta"])));
+    assert_eq!(pairs[3], (40, v(&["omega", "gamma"])));
+}
+
+/// Multi-batch cursors + deferred column decode.
+///
+/// Two settings make this the adversarial case for a repeated column:
+/// `merge_batch_size` small enough that each cursor spans several batches (so the k-way merge
+/// crosses batch boundaries mid-file, exercising `advance`/`load_next_batch` and `take_slice`), and
+/// `merge_deferred_column_threshold = 0` which forces the cursor's *deferred* mode — sort columns
+/// and data columns are read through two independent parquet readers kept in lockstep by batch
+/// index. If a LIST column's leaf desynchronised from the sort reader, the two would drift.
+#[test]
+fn sorted_merge_list_across_batches_in_deferred_mode() {
+    use opensearch_parquet_format::native_settings::NativeSettings;
+    use opensearch_parquet_format::writer::SETTINGS_STORE;
+
+    let index = "merge-list-deferred";
+    SETTINGS_STORE.insert(
+        index.to_string(),
+        NativeSettings {
+            merge_batch_size: Some(4),
+            merge_deferred_column_threshold: Some(0),
+            ..Default::default()
+        },
+    );
+
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    // 40 rows total, interleaved odd/even ids, with per-row list lengths that vary 0..3 so the
+    // value count is unrelated to the row count in every batch.
+    let ids_a: Vec<i64> = (0..20).map(|i| i * 2 + 1).collect();
+    let ids_b: Vec<i64> = (0..20).map(|i| i * 2 + 2).collect();
+    let owned_a: Vec<Option<Vec<String>>> = ids_a
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 4 {
+            0 => None,
+            1 => Some(vec![]),
+            2 => Some(vec![format!("a{id}")]),
+            _ => Some(vec![format!("a{id}"), format!("a{id}b"), format!("a{id}c")]),
+        })
+        .collect();
+    let owned_b: Vec<Option<Vec<String>>> = ids_b
+        .iter()
+        .enumerate()
+        .map(|(i, id)| match i % 3 {
+            0 => Some(vec![format!("b{id}"), format!("b{id}x")]),
+            1 => None,
+            _ => Some(vec![format!("b{id}")]),
+        })
+        .collect();
+    write_list_file(&a, &ids_a, &as_refs(&owned_a));
+    write_list_file(&b, &ids_b, &as_refs(&owned_b));
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        index,
+        &["id".to_string()],
+        &[false],
+        &[false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(pairs.len(), 40, "all rows must survive the merge");
+
+    // Rebuild the expected (id → tags) mapping and check every row independently, so a single
+    // misattached value fails loudly with the offending id.
+    let mut expected: std::collections::HashMap<i64, Option<Vec<String>>> =
+        std::collections::HashMap::new();
+    for (id, tags) in ids_a.iter().zip(owned_a.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+    for (id, tags) in ids_b.iter().zip(owned_b.iter()) {
+        expected.insert(*id, tags.clone());
+    }
+
+    let mut prev_id = i64::MIN;
+    for (id, tags) in &pairs {
+        assert!(
+            *id > prev_id,
+            "output must be sorted by id, saw {id} after {prev_id}"
+        );
+        prev_id = *id;
+        let want = expected
+            .remove(id)
+            .unwrap_or_else(|| panic!("unexpected id {id}"));
+        assert_eq!(
+            tags, &want,
+            "row id={id} changed null/empty state or lost values in the merge"
+        );
+    }
+    assert!(
+        expected.is_empty(),
+        "rows missing from output: {:?}",
+        expected.keys()
+    );
+}
+
+#[test]
+fn unsorted_merge_preserves_null_empty_and_null_children_exactly() {
+    let tmp = tempdir().unwrap();
+    let input = tmp
+        .path()
+        .join("input.parquet")
+        .to_string_lossy()
+        .to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    write_nullable_list_file(
+        &input,
+        &[1, 2, 3, 4],
+        &[
+            None,
+            Some(vec![]),
+            Some(vec![Some("alpha"), None, Some("beta")]),
+            Some(vec![None]),
+        ],
+    );
+
+    merge_unsorted(&[input], &out, "merge-list-null-children", 0).unwrap();
+
+    assert_eq!(
+        read_nullable_pairs(&out),
+        vec![
+            (1, None),
+            (2, Some(vec![])),
+            (
+                3,
+                Some(vec![
+                    Some("alpha".to_string()),
+                    None,
+                    Some("beta".to_string()),
+                ]),
+            ),
+            (4, Some(vec![None])),
+        ]
+    );
+}
+
+#[test]
+fn merge_rejects_incompatible_scalar_and_list_child_types() {
+    let tmp = tempdir().unwrap();
+    let scalar = tmp
+        .path()
+        .join("scalar.parquet")
+        .to_string_lossy()
+        .to_string();
+    let list = tmp
+        .path()
+        .join("list.parquet")
+        .to_string_lossy()
+        .to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    write_scalar_file(&scalar, &[1], &[Some("prod")]);
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("element", DataType::Int32, true))),
+            true,
+        ),
+        Field::new("__row_id__", DataType::Int64, false),
+    ]));
+    let offsets = arrow::buffer::OffsetBuffer::new(vec![0_i32, 2].into());
+    let values = Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef;
+    let lists = ListArray::new(
+        Arc::new(Field::new("element", DataType::Int32, true)),
+        offsets,
+        values,
+        None,
+    );
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![2])) as ArrayRef,
+            Arc::new(lists) as ArrayRef,
+            Arc::new(Int64Array::from(vec![0])) as ArrayRef,
+        ],
+    )
+    .unwrap();
+    let mut writer = ArrowWriter::try_new(File::create(&list).unwrap(), schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let error = match merge_unsorted(&[scalar, list], &out, "merge-incompatible-list-child", 0) {
+        Ok(_) => panic!("Utf8 must not promote to List<Int32>"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("tags") || message.contains("Failed to compute union schema"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn sorted_merge_uses_scalar_tiebreaker_after_list_minimum() {
+    let tmp = tempdir().unwrap();
+    let a = tmp.path().join("a.parquet").to_string_lossy().to_string();
+    let b = tmp.path().join("b.parquet").to_string_lossy().to_string();
+    let out = tmp
+        .path()
+        .join("merged.parquet")
+        .to_string_lossy()
+        .to_string();
+
+    // Each input is sorted by MIN(tags) ASC and then id DESC.
+    write_list_file(
+        &a,
+        &[30, 10, 50],
+        &[
+            Some(vec!["z", "alpha"]),
+            Some(vec!["alpha"]),
+            Some(vec!["beta"]),
+        ],
+    );
+    write_list_file(
+        &b,
+        &[40, 20, 5],
+        &[
+            Some(vec!["alpha", "zz"]),
+            Some(vec!["m", "beta"]),
+            Some(vec!["gamma"]),
+        ],
+    );
+
+    merge_sorted(
+        &[a, b],
+        &out,
+        "merge-list-multi-column",
+        &["tags".to_string(), "id".to_string()],
+        &[false, true],
+        &[false, false],
+        0,
+    )
+    .unwrap();
+
+    let pairs = read_pairs(&out);
+    assert_eq!(
+        pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        vec![40, 30, 10, 50, 20, 5]
+    );
+    assert_eq!(pairs[0], (40, v(&["alpha", "zz"])));
+    assert_eq!(pairs[1], (30, v(&["z", "alpha"])));
+    assert_eq!(pairs[4], (20, v(&["m", "beta"])));
+}


### PR DESCRIPTION
### Description

Adds mixed-generation LIST support to the native Parquet writer and merge paths.

- Promotes compatible scalar `T` and `List<T>` file schemas to one canonical LIST schema and wraps old scalar rows as singleton lists.
- Derives the output Parquet schema from the canonical Arrow schema instead of selecting an input file's physical shape.
- Sorts LIST fields by the minimum non-null element in both in-memory chunk sorting and k-way merge while preserving original element order, duplicates, null children, null lists, and empty lists.
- Adds focused coverage for mixed scalar/LIST generations, ascending and descending fixed-MIN ordering, null placement, multi-column tie-breaking, deferred reads, incompatible schema rejection, and forced multi-chunk writing.

Validation:

- `cargo fmt -p opensearch-parquet-format -- --check`
- `cargo test -p opensearch-parquet-format` (129 library, 28 merge integration, 9 LIST merge, 13 sort type, and 16 writer integration tests passed)
- `./gradlew :sandbox:plugins:parquet-data-format:check -Dsandbox.enabled=true --console=plain`

### Related Issues

Related to #16420 and #22883.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request created, if applicable. Not applicable because this changes internal Parquet storage behavior only.
- [x] Public documentation issue/PR created, if applicable. Not applicable because this introduces no public API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).