### PR TITLE
Fix stale bool-query hits golden files failing on main

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_not_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_not_hits.json
@@ -18,8 +18,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[IS NOT TRUE(=($2, CAST('BrandX':VARCHAR):VARCHAR))])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[IS NOT TRUE(=($2, CAST('BrandX':VARCHAR):VARCHAR))])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price", "brand", "rating"],
   "mockResultRows": [
@@ -30,11 +31,29 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 2,
         "relation": "eq"
       },
       "max_score": null,
-      "hits": []
+      "hits": [
+        {
+          "_score": null,
+          "_source": {
+            "name": "laptop",
+            "price": 999,
+            "brand": "BrandA",
+            "rating": 4.5
+          }
+        },
+        {
+          "_score": null,
+          "_source": {
+            "name": "tablet",
+            "price": 499,
+            "rating": 3.0
+          }
+        }
+      ]
     }
   }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_should_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/bool_must_should_hits.json
@@ -22,8 +22,9 @@
     }
   },
   "expectedRelNodePlan": [
-    "LogicalFilter(condition=[=($0, CAST('laptop':VARCHAR):VARCHAR)])",
-    "  LogicalTableScan(table=[[test-index]])"
+    "LogicalSort(fetch=[10])",
+    "  LogicalFilter(condition=[=($0, CAST('laptop':VARCHAR):VARCHAR)])",
+    "    LogicalTableScan(table=[[test-index]])"
   ],
   "mockResultFieldNames": ["name", "price", "brand", "rating"],
   "mockResultRows": [
@@ -33,11 +34,21 @@
     "num_reduce_phases": 0,
     "hits": {
       "total": {
-        "value": 0,
+        "value": 1,
         "relation": "eq"
       },
       "max_score": null,
-      "hits": []
+      "hits": [
+        {
+          "_score": null,
+          "_source": {
+            "name": "laptop",
+            "price": 999,
+            "brand": "BrandA",
+            "rating": 4.5
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
The `bool_must_not_hits` and `bool_must_should_hits` golden files (added by #22604) were not updated when #22722 landed **default pagination** (`LogicalSort(fetch=[10])`) and **hits rendering**. They still expect an unwrapped plan and empty hits, so on current `main` both golden tests fail:
- `SearchSourceConverterTests.testGoldenFileRelNodeGeneration` — plan missing the `LogicalSort` wrapper
- `SearchResponseBuilderTests.testGoldenFileSearchResponseGeneration` — expects empty hits, actual renders the rows

## Fix
Bring both goldens current (test-only, no production change): add the `LogicalSort(fetch=[10])` wrapper to the expected plan and populate the expected hits to match the merged converter + `SearchResponseBuilder` output.

## Verification
`./gradlew :sandbox:plugins:dsl-query-executor:test -Dsandbox.enabled=true` — the two golden tests pass; confirmed the same two fail on unmodified `main` (`8a50f9408a1`).