### PR TITLE
Align multi-value query sorting with stored order

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/helper.rs
@@ -115,10 +115,6 @@ pub async fn register_listing_table(
     let mut listing_options = ListingOptions::new(Arc::new(ParquetFormat::new()))
         .with_file_extension(".parquet")
         .with_collect_stat(true);
-    if let Some(sort_exprs) = build_file_sort_order(sort_fields, sort_orders) {
-        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
-    }
-
     let resolved_schema = listing_options
         .infer_schema(&ctx.state(), &table_path)
         .await
@@ -127,6 +123,11 @@ pub async fn register_listing_table(
             e
         })?;
     let resolved_schema = coerce_inferred_schema(resolved_schema);
+    if let Some(sort_exprs) =
+        build_file_sort_order(sort_fields, sort_orders, resolved_schema.as_ref())
+    {
+        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
+    }
 
     let table_config = ListingTableConfig::new(table_path)
         .with_listing_options(listing_options)

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -975,11 +975,17 @@ async unsafe fn execute_indexed_with_context_inner(
     // interpretable by `api::fetch_by_row_ids` (which builds its own segments from
     // `ShardView.object_metas` in catalog order).
     let mut segments = segments;
-    if should_reverse_segments(
-        analyze_top_sort(&logical_plan).as_ref(),
-        &sort_fields,
-        &sort_orders,
-    ) {
+    let lead_sort_is_list = sort_fields
+        .first()
+        .and_then(|field| schema.field_with_name(field).ok())
+        .is_some_and(|field| matches!(field.data_type(), arrow::datatypes::DataType::List(_)));
+    if !lead_sort_is_list
+        && should_reverse_segments(
+            analyze_top_sort(&logical_plan).as_ref(),
+            &sort_fields,
+            &sort_orders,
+        )
+    {
         log_debug!(
             "indexed_executor: reversing segment iteration (catalog leading sort={:?} {:?}, query opposite)",
             sort_fields.first(),

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/segment_info.rs
@@ -208,7 +208,10 @@ fn compute_segment_sort_bounds(
     file_schema: &arrow::datatypes::SchemaRef,
     pq_meta: &ParquetMetaData,
 ) -> (Option<ScalarValue>, Option<ScalarValue>) {
-    if file_schema.index_of(lead_field).is_err() {
+    let Ok(field) = file_schema.field_with_name(lead_field) else {
+        return (None, None);
+    };
+    if matches!(field.data_type(), arrow::datatypes::DataType::List(_)) {
         return (None, None);
     }
 
@@ -524,6 +527,61 @@ mod tests {
             fields_ab, fields_ba,
             "schema order must not depend on object-meta input ordering"
         );
+    }
+
+    #[tokio::test]
+    async fn scalar_and_list_field_promote_to_list_schema() {
+        let dir = tempdir().unwrap();
+        let scalar_schema = Arc::new(Schema::new(vec![Field::new("tags", DataType::Utf8, true)]));
+        let list_child = Arc::new(Field::new("element", DataType::Utf8, true));
+        let list_schema = Arc::new(Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::clone(&list_child)),
+            true,
+        )]));
+        let scalar_path = write_parquet(
+            dir.path(),
+            "a.parquet",
+            scalar_schema,
+            vec![Arc::new(StringArray::from(vec![Some("prod")]))],
+        );
+        let list_path = write_parquet(
+            dir.path(),
+            "b.parquet",
+            list_schema,
+            vec![Arc::new(ListArray::new(
+                list_child,
+                OffsetBuffer::new(vec![0_i32, 2].into()),
+                Arc::new(StringArray::from(vec!["prod", "error"])),
+                None,
+            ))],
+        );
+
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let metas = object_metas(store.as_ref(), &[scalar_path, list_path]).await;
+        let ctx = SessionContext::new();
+        let generations: Vec<i64> = (0..metas.len() as i64).collect();
+        let (segments, schema) = build_segments(
+            &ctx.state(),
+            Arc::clone(&store),
+            &metas,
+            &generations,
+            default_metadata_cache(),
+            &["tags".to_string()],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            segments[1].sort_min.is_none() && segments[1].sort_max.is_none(),
+            "LIST child statistics must not be used as per-row list_min bounds"
+        );
+
+        assert!(matches!(
+            schema.field_with_name("tags").unwrap().data_type(),
+            DataType::List(child)
+                if matches!(child.data_type(), DataType::Utf8 | DataType::Utf8View)
+        ));
     }
 
     /// Incompatible types (Int32 vs Int64 on the same field name) is

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/table_provider.rs
@@ -150,7 +150,18 @@ fn build_projected_lex_ordering(
     let mut exprs: Vec<PhysicalSortExpr> = Vec::with_capacity(sort_fields.len());
     for (i, field) in sort_fields.iter().enumerate() {
         let phys = match physical_col(field, projected_schema) {
-            Ok(e) => e,
+            Ok(expr) => match projected_schema
+                .field_with_name(field)
+                .map(|field| field.data_type())
+            {
+                Ok(DataType::List(_)) => {
+                    match crate::udf::list_min::physical_expr(expr, projected_schema.as_ref()) {
+                        Ok(expr) => expr,
+                        Err(_) => break,
+                    }
+                }
+                _ => expr,
+            },
             Err(_) => break,
         };
         let descending = sort_orders
@@ -864,6 +875,21 @@ mod tests {
             sort_orders: vec![],
             cancellation_token: None,
         }
+    }
+
+    #[test]
+    fn list_sort_key_advertises_list_min_physical_ordering() {
+        let child = Arc::new(Field::new("element", DataType::Utf8View, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(child),
+            true,
+        )]));
+        let ordering =
+            build_projected_lex_ordering(&schema, &["tags".into()], &["desc".into()]).unwrap();
+        assert!(format!("{}", ordering[0].expr).contains("list_min"));
+        assert!(ordering[0].options.descending);
+        assert!(!ordering[0].options.nulls_first);
     }
 
     // QueryShardExec holds an ExecutionPlanMetricsSet (not Clone). We only

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -306,12 +306,6 @@ pub async unsafe fn create_session_context(
         .with_collect_stat(true)
         .with_target_partitions(effective_partitions);
 
-    if let Some(sort_exprs) =
-        build_file_sort_order(&shard_view.sort_fields, &shard_view.sort_orders)
-    {
-        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
-    }
-
     // Register under the planner's logical table name (alias / index pattern / index), shipped
     // explicitly as logicalTableName on the shard-scan instruction node. See
     // resolve_register_name for why we do NOT reverse-engineer this from the plan bytes. The
@@ -368,11 +362,18 @@ pub async unsafe fn create_session_context(
     // failing with "Cannot merge statistics with different number of columns". Non-widened
     // (single-index) scans keep full stats.
     // TODO: re-enable once DataFusion's Statistics::try_merge tolerates a column-count delta.
-    let listing_options = if resolved_schema.fields().len() != inferred_field_count {
+    let mut listing_options = if resolved_schema.fields().len() != inferred_field_count {
         listing_options.with_collect_stat(false)
     } else {
         listing_options
     };
+    if let Some(sort_exprs) = build_file_sort_order(
+        &shard_view.sort_fields,
+        &shard_view.sort_orders,
+        resolved_schema.as_ref(),
+    ) {
+        listing_options = listing_options.with_file_sort_order(vec![sort_exprs]);
+    }
 
     let table_config = ListingTableConfig::new(shard_view.table_path.clone())
         .with_listing_options(listing_options)
@@ -737,6 +738,7 @@ fn try_acquire_budget(
 pub(crate) fn build_file_sort_order(
     sort_fields: &[String],
     sort_orders: &[String],
+    schema: &arrow::datatypes::Schema,
 ) -> Option<Vec<datafusion::logical_expr::SortExpr>> {
     if sort_fields.is_empty() {
         return None;
@@ -749,7 +751,12 @@ pub(crate) fn build_file_sort_order(
         .map(|(name, order)| {
             let ascending = order.eq_ignore_ascii_case("asc");
             let nulls_first = ascending;
-            Expr::Column(Column::from_name(name.clone())).sort(ascending, nulls_first)
+            let column = Expr::Column(Column::from_name(name.clone()));
+            let key = match schema.field_with_name(name).map(|field| field.data_type()) {
+                Ok(arrow::datatypes::DataType::List(_)) => crate::udf::list_min::expr(column),
+                _ => column,
+            };
+            key.sort(ascending, nulls_first)
         })
         .collect();
     Some(sort_exprs)
@@ -771,6 +778,26 @@ mod tests {
 
     use crate::agg_mode::Mode;
     use crate::query_tracker::QueryTrackingContext;
+
+    #[test]
+    fn file_sort_order_uses_fixed_list_min_for_both_directions() {
+        let child = Arc::new(Field::new("element", DataType::Utf8View, true));
+        let schema = Schema::new(vec![
+            Field::new("tags", DataType::List(child), true),
+            Field::new("id", DataType::Int64, true),
+        ]);
+
+        for (order, ascending) in [("asc", true), ("desc", false)] {
+            let ordering =
+                build_file_sort_order(&["tags".into()], &[order.into()], &schema).unwrap();
+            assert!(format!("{}", ordering[0].expr).contains("list_min"));
+            assert_eq!(ordering[0].asc, ascending);
+            assert_eq!(ordering[0].nulls_first, ascending);
+        }
+
+        let scalar = build_file_sort_order(&["id".into()], &["asc".into()], &schema).unwrap();
+        assert!(!format!("{}", scalar[0].expr).contains("list_min"));
+    }
 
     #[tokio::test]
     async fn test_widen_schema_noop_when_plan_empty() {

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/list_min.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/list_min.rs
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{make_comparator, Array, ArrayRef, ListArray, UInt64Array};
+use datafusion::arrow::compute::{take, SortOptions};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::{exec_err, plan_err, Result};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::ScalarFunctionExpr;
+
+use super::udf_identity;
+
+pub fn register_all(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::from(ListMinUdf::new()));
+}
+
+pub fn udf() -> Arc<ScalarUDF> {
+    Arc::new(ScalarUDF::from(ListMinUdf::new()))
+}
+
+pub fn expr(input: Expr) -> Expr {
+    udf().call(vec![input])
+}
+
+pub fn physical_expr(
+    input: Arc<dyn PhysicalExpr>,
+    schema: &Schema,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    Ok(Arc::new(ScalarFunctionExpr::try_new(
+        udf(),
+        vec![input],
+        schema,
+        Arc::new(ConfigOptions::default()),
+    )?))
+}
+
+#[derive(Debug)]
+pub struct ListMinUdf {
+    signature: Signature,
+}
+
+impl ListMinUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+udf_identity!(ListMinUdf, "list_min");
+
+impl ScalarUDFImpl for ListMinUdf {
+    fn name(&self) -> &str {
+        "list_min"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 1 {
+            return plan_err!("list_min expects one argument, got {}", arg_types.len());
+        }
+        match &arg_types[0] {
+            DataType::List(child) => Ok(child.data_type().clone()),
+            other => plan_err!("list_min expects List<T>, got {other:?}"),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        self.return_type(arg_types)?;
+        Ok(arg_types.to_vec())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 1 {
+            return plan_err!("list_min expects one argument, got {}", args.args.len());
+        }
+        let array = args.args[0].clone().into_array(args.number_rows)?;
+        let lists = array.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "list_min expected ListArray, got {:?}",
+                array.data_type()
+            ))
+        })?;
+        Ok(ColumnarValue::Array(min_values(lists)?))
+    }
+}
+
+fn min_values(lists: &ListArray) -> Result<ArrayRef> {
+    let values = lists.values();
+    let compare = make_comparator(
+        values.as_ref(),
+        values.as_ref(),
+        SortOptions {
+            descending: false,
+            nulls_first: false,
+        },
+    )?;
+    let offsets = lists.value_offsets();
+    let mut indices = Vec::with_capacity(lists.len());
+    for row in 0..lists.len() {
+        if lists.is_null(row) {
+            indices.push(None);
+            continue;
+        }
+        let start = offsets[row] as usize;
+        let end = offsets[row + 1] as usize;
+        let mut minimum = None;
+        for index in start..end {
+            if values.is_null(index) {
+                continue;
+            }
+            minimum = Some(match minimum {
+                Some(current) if compare(current, index).is_le() => current,
+                _ => index,
+            });
+        }
+        indices.push(minimum.map(|index| index as u64));
+    }
+    take(values.as_ref(), &UInt64Array::from(indices), None).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{ListBuilder, StringViewArray, StringViewBuilder};
+
+    #[test]
+    fn returns_minimum_non_null_element_per_row() {
+        let mut builder = ListBuilder::new(StringViewBuilder::new());
+        for value in [Some("z"), None, Some("alpha")] {
+            match value {
+                Some(value) => builder.values().append_value(value),
+                None => builder.values().append_null(),
+            }
+        }
+        builder.append(true);
+        builder.append(true);
+        builder.append(false);
+        builder.values().append_null();
+        builder.append(true);
+        for value in ["omega", "beta"] {
+            builder.values().append_value(value);
+        }
+        builder.append(true);
+
+        let result = min_values(&builder.finish()).unwrap();
+        let result = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+        assert_eq!(result.value(0), "alpha");
+        assert!(result.is_null(1));
+        assert!(result.is_null(2));
+        assert!(result.is_null(3));
+        assert_eq!(result.value(4), "beta");
+    }
+
+    #[test]
+    fn rejects_non_list_input_type() {
+        let error = ListMinUdf::new()
+            .return_type(&[DataType::Utf8View])
+            .unwrap_err();
+        assert!(error.to_string().contains("expects List<T>"));
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udf/mod.rs
@@ -144,6 +144,7 @@ pub mod json_keys;
 pub mod json_object;
 pub mod json_set;
 pub mod json_valid;
+pub mod list_min;
 pub mod makedate;
 pub mod maketime;
 pub mod minspan_bucket;
@@ -197,6 +198,7 @@ pub fn register_all(ctx: &SessionContext) {
     json_object::register_all(ctx);
     json_set::register_all(ctx);
     json_valid::register_all(ctx);
+    list_min::register_all(ctx);
     makedate::register_all(ctx);
     maketime::register_all(ctx);
     minspan_bucket::register_all(ctx);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -203,6 +203,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(SqlStdOperatorTable.REPLACE, "replace"),
         FunctionMappings.s(SqlLibraryOperators.REGEXP_REPLACE_3, "regexp_replace"),
         FunctionMappings.s(SqlLibraryOperators.ARRAY_LENGTH, "array_length"),
+        FunctionMappings.s(MultiValueSortRewriter.LIST_MIN_OP, "list_min"),
         FunctionMappings.s(SqlLibraryOperators.ARRAY_SLICE, "array_slice"),
         FunctionMappings.s(SqlLibraryOperators.ARRAY_DISTINCT, "array_distinct"),
         FunctionMappings.s(MakeArrayAdapter.LOCAL_MAKE_ARRAY_OP, "make_array"),
@@ -561,6 +562,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         preprocessed = ItemTypeRebuilder.rewrite(preprocessed);
         preprocessed = CastToVarcharRewriter.rewrite(preprocessed);
         preprocessed = CastTemporalLiteralValidator.rewrite(preprocessed);
+        preprocessed = MultiValueSortRewriter.rewrite(preprocessed);
         return preprocessed;
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueSortRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueSortRewriter.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Rewrites LIST sort keys to fixed {@code MIN(list)} scalar keys. */
+final class MultiValueSortRewriter {
+
+    static final SqlFunction LIST_MIN_OP = new SqlFunction("list_min", SqlKind.OTHER_FUNCTION, opBinding -> {
+        var component = opBinding.getOperandType(0).getComponentType();
+        if (component == null) {
+            throw new IllegalArgumentException("list_min requires an ARRAY operand");
+        }
+        return opBinding.getTypeFactory().createTypeWithNullability(component, true);
+    }, null, OperandTypes.ANY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+
+    private MultiValueSortRewriter() {}
+
+    static RelNode rewrite(RelNode root) {
+        return root.accept(new RelHomogeneousShuttle() {
+            @Override
+            public RelNode visit(RelNode other) {
+                RelNode visited = super.visit(other);
+                return visited instanceof Sort sort ? rewriteSort(sort) : visited;
+            }
+        });
+    }
+
+    private static RelNode rewriteSort(Sort sort) {
+        RelNode input = sort.getInput();
+        List<RelFieldCollation> oldFields = sort.getCollation().getFieldCollations();
+        Map<Integer, Integer> hiddenByInput = new LinkedHashMap<>();
+        for (RelFieldCollation field : oldFields) {
+            int inputIndex = field.getFieldIndex();
+            if (input.getRowType().getFieldList().get(inputIndex).getType().getComponentType() != null) {
+                hiddenByInput.computeIfAbsent(inputIndex, ignored -> input.getRowType().getFieldCount() + hiddenByInput.size());
+            }
+        }
+        if (hiddenByInput.isEmpty()) {
+            return sort;
+        }
+
+        RexBuilder rexBuilder = sort.getCluster().getRexBuilder();
+        List<RexNode> projects = new ArrayList<>(input.getRowType().getFieldCount() + hiddenByInput.size());
+        List<String> names = new ArrayList<>(input.getRowType().getFieldNames());
+        for (int index = 0; index < input.getRowType().getFieldCount(); index++) {
+            projects.add(rexBuilder.makeInputRef(input, index));
+        }
+        for (int inputIndex : hiddenByInput.keySet()) {
+            RexNode list = rexBuilder.makeInputRef(input, inputIndex);
+            projects.add(rexBuilder.makeCall(LIST_MIN_OP, list));
+            names.add("___mv_sort_" + inputIndex);
+        }
+        RelNode withKeys = LogicalProject.create(input, List.of(), projects, names);
+
+        List<RelFieldCollation> newFields = oldFields.stream().map(field -> {
+            Integer hidden = hiddenByInput.get(field.getFieldIndex());
+            return hidden == null ? field : new RelFieldCollation(hidden, field.getDirection(), field.nullDirection);
+        }).toList();
+        RelNode sorted = sort.copy(sort.getTraitSet(), withKeys, RelCollations.of(newFields), sort.offset, sort.fetch);
+
+        List<RexNode> output = new ArrayList<>(input.getRowType().getFieldCount());
+        for (int index = 0; index < input.getRowType().getFieldCount(); index++) {
+            output.add(rexBuilder.makeInputRef(sorted, index));
+        }
+        return LogicalProject.create(sorted, List.of(), output, input.getRowType().getFieldNames());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_scalar_functions.yaml
@@ -587,6 +587,16 @@ scalar_functions:
             name: "input"
         return: i64
 
+  - name: list_min
+    description: >-
+      Fixed minimum non-null element of a LIST value. Used as the hidden query and
+      physical-order key for multi-value keyword sorting in both ASC and DESC directions.
+    impls:
+      - args:
+          - value: "list<any1>"
+            name: "input"
+        return: any1
+
   # ascii(str) — Unicode code point of the first character.
   - name: "ascii"
     description: "Return the unicode code point of the first character of the input string."

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -14,6 +14,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -338,6 +339,45 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
             "the cast must wrap the ORIGINAL input field (index 0), not a lifted/appended column",
             0,
             arg.getCast().getInput().getSelection().getDirectReference().getStructField().getField()
+        );
+    }
+
+    public void testListSortUsesHiddenFixedMinimumKey() throws Exception {
+        RelDataType element = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RelDataType list = typeFactory.createTypeWithNullability(typeFactory.createArrayType(element, -1), true);
+        RelDataType rowType = typeFactory.builder().add("tags", list).build();
+        RelNode scan = new DataFusionFragmentConvertor.StageInputTableScan(cluster, cluster.traitSet(), "test_index", rowType);
+        RelFieldCollation collation = new RelFieldCollation(
+            0,
+            RelFieldCollation.Direction.DESCENDING,
+            RelFieldCollation.NullDirection.LAST
+        );
+        RelNode sort = LogicalSort.create(scan, RelCollations.of(collation), null, null);
+
+        Plan plan = decodeSubstrait(newConvertor().convertFragment(sort));
+        Rel root = rootRel(plan);
+        assertTrue("outer Project must hide the temporary sort key", root.hasProject());
+        Rel sorted = root.getProject().getInput();
+        assertTrue(sorted.hasSort());
+        assertEquals(1, sorted.getSort().getSortsCount());
+        Expression sortKey = sorted.getSort().getSorts(0).getExpr();
+        assertTrue(sortKey.hasSelection());
+        assertEquals(1, sortKey.getSelection().getDirectReference().getStructField().getField());
+        Rel hiddenProject = sorted.getSort().getInput();
+        assertTrue(hiddenProject.hasProject());
+        assertTrue(
+            "hidden LIST sort key must be computed by list_min",
+            hiddenProject.getProject().getExpressionsList().stream().anyMatch(Expression::hasScalarFunction)
+        );
+        assertTrue(sorted.getSort().getSorts(0).getDirection().name().contains("DESC"));
+        assertTrue(
+            "Substrait extensions must declare list_min",
+            plan.getExtensionsList()
+                .stream()
+                .filter(SimpleExtensionDeclaration::hasExtensionFunction)
+                .map(declaration -> declaration.getExtensionFunction().getName())
+                .map(name -> name.contains(":") ? name.substring(0, name.indexOf(':')) : name)
+                .anyMatch("list_min"::equals)
         );
     }
 


### PR DESCRIPTION
### Description
Aligns query sorting for multi-value keyword fields with the physical fixed-`MIN(list)` ordering contract.

This change:
- rewrites Calcite LIST sort keys to hidden `list_min(field)` keys and projects them away after sorting;
- preserves sort direction, null placement, offset, fetch, visible LIST values, and original element order;
- uses the same `list_min` expression in ListingTable and indexed-scan ordering metadata;
- uses `MIN(list)` for both ASC and DESC, with DESC reversing the same minimum key;
- treats null, empty, and all-null lists as null sort keys;
- declines LIST footer-stat segment chaining and segment reversal because child min/max statistics are not per-row `list_min` statistics; and
- leaves scalar sorting unchanged.

This is an independent sibling of the aggregation/row-expansion work. It is based on #22902, so the PR temporarily includes the #22902 foundation commit and will shrink to incremental commit `6677a1d27fb` after #22902 merges. Physical LIST index sorting is tracked by #22899.

### Validation
- DataFusion Rust suite: 1,329 passed, 1 ignored
- `DataFusionFragmentConvertorTests`: passed
- `spotlessJavaCheck`: passed
- `analytics-backend-datafusion:assemble`: passed
- Independent correctness/scope review: approved

### Related Issues
Related to #22902
Related to #22899
Related to #22883

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request is not applicable; no public API is added.
- [x] Public documentation issue/PR is not applicable to this internal query-planning change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).