### PR TITLE
Fix RestClient deprecation message to not recommend RestHighLevelClient

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -137,8 +137,8 @@ import static java.util.Collections.singletonList;
  * <p>
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
  *
- * @deprecated the {@code RestClient} is deprecated is going to be removed in future releases, please consider using official
- * OpenSearch Java Client or {@code RestHighLevelClient}
+ * @deprecated the {@code RestClient} is deprecated and is going to be removed in future releases, please consider using the
+ * official <a href="https://github.com/opensearch-project/opensearch-java">OpenSearch Java client</a>
  */
 @Deprecated
 public class RestClient implements Closeable {

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -64,8 +64,8 @@ import java.util.Optional;
  * creating the underlying {@link HttpAsyncClient}. Also allows to provide an externally created
  * {@link HttpAsyncClient} in case additional customization is needed.
  *
- * @deprecated the {@code RestClient} is deprecated is going to be removed in future releases, please consider using official
- * OpenSearch Java Client or {@code RestHighLevelClient}
+ * @deprecated the {@code RestClient} is deprecated and is going to be removed in future releases, please consider using the
+ * official <a href="https://github.com/opensearch-project/opensearch-java">OpenSearch Java client</a>
  */
 @Deprecated
 public final class RestClientBuilder {


### PR DESCRIPTION
### Description
The deprecation message on RestClient and RestClientBuilder recommended either the official OpenSearch Java client or RestHighLevelClient. The high-level REST client is itself slated for deprecation and removal (#5424), so we don't want to direct the users to use it. This PR directs the users to use only at the official OpenSearch Java client and includes a link to its repository.

Also fixes a missing conjunction in the message ('is deprecated is going to be removed').

### Related Issues
https://github.com/opensearch-project/documentation-website/issues/12993

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. https://github.com/opensearch-project/documentation-website/pull/13000

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
