### PR TITLE
Run a DSL aggregation's sub-plans concurrently

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -12,12 +12,15 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.dsl.action.DslExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
 import org.opensearch.dsl.action.TransportDslExecuteAction;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugins.ActionPlugin;
@@ -30,17 +33,22 @@ import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * Plugin entry point. Registers {@link SearchActionFilter} to intercept _search requests
- * and {@link TransportDslExecuteAction} to handle DSL-to-Calcite conversion and execution.
+ * Plugin entry point. Registers {@link SearchActionFilter} to intercept _search requests,
+ * {@link TransportDslExecuteAction} to handle DSL-to-Calcite conversion and execution, the
+ * {@link DslQuerySettings} operator knobs, and {@link DslGateInputs}, the reader for the
+ * cross-plugin inputs the sub-plan fan-out decision needs.
  */
 public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
 
     private SearchActionFilter searchActionFilter;
+    // Held as well as returned: the holder is a component (injected into TransportDslExecuteAction)
+    // and the field keeps it reachable for a later direct reader, the same way getActionFilters()
+    // below reads searchActionFilter.
+    private DslQuerySettings dslQuerySettings;
 
     /** Creates a new plugin instance. */
     public DslQueryExecutorPlugin() {}
@@ -60,7 +68,18 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.searchActionFilter = new SearchActionFilter((NodeClient) client);
-        return Collections.emptyList();
+        // Fan-out additions: the settings holder carries dsl.query.max_parallel_sub_plans, and
+        // DslGateInputs is the only production construction site of the cross-plugin gate-input reader.
+        this.dslQuerySettings = new DslQuerySettings(clusterService);
+        return List.of(dslQuerySettings, new DslGateInputs(clusterService.getClusterSettings()));
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        // The fan-out width knob has to be registered here or it is unsettable in opensearch.yml, a 400
+        // on _cluster/settings, and unresolvable by key from a sibling plugin's classloader — which is how
+        // DslGateInputs reads the analytics plugins' gate inputs across that boundary.
+        return DslQuerySettings.all();
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -31,6 +31,8 @@ import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.dsl.result.SearchResponseBuilder;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -67,6 +69,9 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
      * @param executor analytics engine plan executor
      * @param clusterService cluster service for resolving index aliases
      * @param indexNameExpressionResolver resolves aliases and wildcards to concrete indices
+     * @param threadPool the node's thread pool
+     * @param dslSettings holder of the DSL operator knobs, including the fan-out width setting
+     * @param gateInputs reader for the cross-plugin inputs the fan-out width needs
      */
     @Inject
     public TransportDslExecuteAction(
@@ -77,11 +82,13 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         ClusterService clusterService,
         IndicesService indicesService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        DslQuerySettings dslSettings,
+        DslGateInputs gateInputs
     ) {
         super(DslExecuteAction.NAME, transportService, actionFilters, SearchRequest::new);
         this.contextProvider = contextProvider;
-        this.planExecutor = new DslQueryPlanExecutor(executor);
+        this.planExecutor = new DslQueryPlanExecutor(executor, clusterService, threadPool, dslSettings, gateInputs);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
@@ -92,8 +99,9 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             final long startNanos = System.nanoTime();
-            // One snapshot per request: index resolution, the engine schema, and response
-            // typing all derive from the same immutable cluster state.
+            // One snapshot per request: index resolution, the engine schema, response typing and the
+            // fan-out width's shard-layout term all derive from the same immutable cluster state. A second
+            // read is a TOCTOU where the width is decided against a routing table that never coexisted
             final ClusterState state = clusterService.state();
             final IndexMetadata indexMetadata;
             try {
@@ -103,6 +111,10 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 return;
             }
             final String indexName = indexMetadata.getIndex().getName();
+
+            // `state` and `indexName` are both threaded to the plan executor below, which needs the
+            // resolved name and that snapshot's routing table to read the shard layout the fan-out width
+            // divides by. The fan-out change computed the name as a `concreteIndices.length == 1 ? ... :
 
             // Response typing works off the mapping pinned at request start: one immutable
             // snapshot for conversion and response building, created lazily, and closed when
@@ -129,7 +141,7 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 requestListener.onFailure(e);
                 return;
             }
-            executePlans(plans, request, converter, startNanos, requestListener);
+            executePlans(plans, request, converter, state, indexName, startNanos, requestListener);
         });
     }
 
@@ -143,6 +155,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         QueryPlans plans,
         SearchRequest request,
         SearchSourceConverter converter,
+        ClusterState state,
+        String concreteIndex,
         long startNanos,
         ActionListener<SearchResponse> listener
     ) {
@@ -159,6 +173,8 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
             try {
                 planExecutor.execute(
                     mainPlans,
+                    state,
+                    concreteIndex,
                     ActionListener.wrap(results -> buildAndRespond(results, request, converter, startNanos, listener), listener::onFailure)
                 );
             } catch (Exception e) {
@@ -177,14 +193,16 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
         }, listener::onFailure), 1 + countPlans.size());
 
         try {
-            planExecutor.execute(mainPlans, joined);
+            planExecutor.execute(mainPlans, state, concreteIndex, joined);
         } catch (Exception e) {
             joined.onFailure(e);
         }
 
         for (QueryPlans.QueryPlan countPlan : countPlans) {
             try {
-                planExecutor.execute(new QueryPlans.Builder().add(countPlan).build(), joined);
+                // One plan per call, so each of these is a single-plan execution that never reaches the
+                // fan-out decision. They already run concurrently with the main plans through `joined`.
+                planExecutor.execute(new QueryPlans.Builder().add(countPlan).build(), state, concreteIndex, joined);
             } catch (Exception e) {
                 joined.onFailure(e);
             }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -13,6 +13,7 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -160,24 +161,27 @@ public class AggregationMetadataBuilder {
         boolean noGroupBy = groupings.isEmpty();
         List<AggregateCall> allCalls = new ArrayList<>();
         for (AggregateCall call : aggregateCalls) {
+            RelDataType declared = deriveTypeThroughTypeSystem(call, typeFactory);
             if (noGroupBy) {
-                RelDataType nullableType = typeFactory.createTypeWithNullability(call.getType(), true);
-                allCalls.add(
-                    AggregateCall.create(
-                        call.getAggregation(),
-                        call.isDistinct(),
-                        call.isApproximate(),
-                        call.ignoreNulls(),
-                        call.getArgList(),
-                        call.filterArg,
-                        call.getCollation(),
-                        nullableType,
-                        call.getName()
-                    )
-                );
-            } else {
-                allCalls.add(call);
+                declared = typeFactory.createTypeWithNullability(declared, true);
             }
+            if (declared.equals(call.getType())) {
+                allCalls.add(call);
+                continue;
+            }
+            allCalls.add(
+                AggregateCall.create(
+                    call.getAggregation(),
+                    call.isDistinct(),
+                    call.isApproximate(),
+                    call.ignoreNulls(),
+                    call.getArgList(),
+                    call.filterArg,
+                    call.getCollation(),
+                    declared,
+                    call.getName()
+                )
+            );
         }
         List<String> allFieldNames = new ArrayList<>(aggregateFieldNames);
 
@@ -225,6 +229,26 @@ public class AggregationMetadataBuilder {
             havingMinDocCount,
             missingValues
         );
+    }
+
+    /**
+     * Re-derives a metric call's declared type through the plan's own type system, which is the
+     * authority {@code Aggregate} validates against.
+     *
+     * @param call the translator-produced call
+     * @param typeFactory the plan's type factory, carrying the plan's type system
+     * @return the type the call must declare for {@code Aggregate} to accept it
+     */
+    private static RelDataType deriveTypeThroughTypeSystem(AggregateCall call, RelDataTypeFactory typeFactory) {
+        RelDataTypeSystem typeSystem = typeFactory.getTypeSystem();
+        // Both derivations are idempotent on an already-derived type, so re-deriving a call that was
+        // built correctly is safe; and both carry the argument's nullability, so the noGroupBy rule
+        // the caller applies afterwards still decides nullability on its own.
+        return switch (call.getAggregation().getKind()) {
+            case SUM -> typeSystem.deriveSumType(typeFactory, call.getType());
+            case AVG -> typeSystem.deriveAvgAggType(typeFactory, call.getType());
+            default -> call.getType();
+        };
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -67,7 +67,13 @@ public abstract class AbstractMetricTranslator<T extends ValuesSourceAggregation
             throw new ConversionException("Aggregation field '" + fieldName + "' not found in schema");
         }
 
-        // Calcite enforces the return type to be same as input type; eg: AVG int→double coercion happens in response layer.
+        // A translator says which function over which column, and declares the column's own type; what
+        // type the result actually is stays the type system's call. Where the two differ — SUM, which
+        // DslTypeSystems.NANO_TIMESTAMP widens to the engine's accumulator width, and AVG, which it
+        // declares DOUBLE because the engine reduces an average into a division — the declared type is
+        // reconciled against the type system in AggregationMetadataBuilder#build, the one place every
+        // metric call is assembled into a plan. So nothing here restates a type: declaring the column's
+        // own type for every metric is what keeps that reconciliation the single widening point.
         return AggregateCall.create(
             getAggFunction(),
             false,
@@ -87,8 +93,8 @@ public abstract class AbstractMetricTranslator<T extends ValuesSourceAggregation
     }
 
     /**
-     * Coerces an engine result cell to double. Calcite keeps the input column type (AVG over
-     * an INTEGER column returns an integral value), so the int→double widening happens here.
+     * Coerces an engine result cell to double, which the metric responses this plugin renders
+     * ({@code InternalAvg}, {@code InternalMin}, {@code InternalMax}) all carry.
      *
      * @param value the raw cell value (must be a {@link Number})
      */

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/DslTypeSystems.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/DslTypeSystems.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.dsl.converter;
 
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -15,7 +17,22 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /** Shared type-system constants: default Calcite clamps TIMESTAMP to precision 3, date_nanos needs 9. */
 public final class DslTypeSystems {
 
-    /** TIMESTAMP max precision raised to 9 so date_nanos fields are not silently clamped. */
+    /**
+     * The type system every DSL-emitted plan is built with. It differs from
+     * {@link RelDataTypeSystem#DEFAULT} in exactly three places, all three because Calcite's default
+     * disagrees with what the storage and execution layers actually do:
+     *
+     * <ol>
+     * <li><b>{@code TIMESTAMP} max precision raised to 9</b> so {@code date_nanos} fields are not
+     * silently clamped to milliseconds.</li>
+     * <li><b>{@code SUM}'s derived type widened to the execution engine's accumulator width</b> — see
+     * {@code deriveSumType} below.</li>
+     * <li><b>{@code AVG}'s derived type declared {@code DOUBLE}</b> — see {@code deriveAvgAggType} below.
+     * The two aggregate overrides are one mechanism: {@code AVG} is executed as a rule-generated
+     * {@code SUM}/{@code COUNT}/{@code DIVIDE} plus a CAST back to {@code AVG}'s declared type, so leaving
+     * {@code AVG} at its argument's integral width casts away the widening the line above just applied.</li>
+     * </ol>
+     */
     public static final RelDataTypeSystem NANO_TIMESTAMP = new RelDataTypeSystemImpl() {
         @Override
         public int getMaxPrecision(SqlTypeName typeName) {
@@ -23,6 +40,57 @@ public final class DslTypeSystems {
                 return 9;
             }
             return super.getMaxPrecision(typeName);
+        }
+
+        /**
+         * Widens {@code SUM}'s type to the engine's accumulator width: signed integers to
+         * {@code BIGINT} (i64), approximate numerics to {@code DOUBLE} (f64). Nullability is carried
+         * over from the argument — dropping it would make {@code SUM} over a nullable column
+         * non-nullable and break the empty-group contract Calcite relies on. A type family with no
+         * known accumulator widening (decimal, interval, non-numeric) falls through to Calcite's
+         * default rather than being guessed at.
+         *
+         * @param typeFactory the plan's type factory
+         * @param argumentType the summed column's type
+         * @return the widened sum type, or Calcite's default for a family with no known widening
+         */
+        @Override
+        public RelDataType deriveSumType(RelDataTypeFactory typeFactory, RelDataType argumentType) {
+            SqlTypeName widened = switch (argumentType.getSqlTypeName()) {
+                case TINYINT, SMALLINT, INTEGER, BIGINT -> SqlTypeName.BIGINT;
+                case REAL, FLOAT, DOUBLE -> SqlTypeName.DOUBLE;
+                default -> null;
+            };
+            if (widened == null) {
+                return super.deriveSumType(typeFactory, argumentType);
+            }
+            return typeFactory.createTypeWithNullability(typeFactory.createSqlType(widened), argumentType.isNullable());
+        }
+
+        /**
+         * Declares {@code AVG} (and the other {@code SqlKind#AVG_AGG_FUNCTIONS}) at {@code DOUBLE} for
+         * every numeric argument — both the signed-integer and the approximate-numeric family, unlike
+         * {@code deriveSumType}'s two targets. Nullability is carried over from the argument for the same
+         * reason it is there: a mean over a nullable column really can be null, and the reduced plan the
+         * engine executes contains an explicit {@code CASE WHEN count(...) = 0 THEN NULL ...} guard that a
+         * NOT NULL declaration would license the constant-reduction rules to fold away. A type family with
+         * no known mean type (decimal, interval, non-numeric) falls through to Calcite's default rather
+         * than being guessed at, exactly as above.
+         * @param typeFactory the plan's type factory
+         * @param argumentType the averaged column's type
+         * @return {@code DOUBLE} with the argument's nullability, or Calcite's default for a family with
+         *         no known mean type
+         */
+        @Override
+        public RelDataType deriveAvgAggType(RelDataTypeFactory typeFactory, RelDataType argumentType) {
+            SqlTypeName mean = switch (argumentType.getSqlTypeName()) {
+                case TINYINT, SMALLINT, INTEGER, BIGINT, REAL, FLOAT, DOUBLE -> SqlTypeName.DOUBLE;
+                default -> null;
+            };
+            if (mean == null) {
+                return super.deriveAvgAggType(typeFactory, argumentType);
+            }
+            return typeFactory.createTypeWithNullability(typeFactory.createSqlType(mean), argumentType.isNullable());
         }
     };
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -138,20 +138,22 @@ public class SearchSourceConverter {
         // Request-scoped workspace for the hits/aggregation plans. The count and eligible-count
         // plans below build in their own workspaces: they are submitted to the engine
         // concurrently with these plans and must not share a metadata cache (see newCluster).
-        RelOptCluster cluster = newCluster();
-        ConversionContext ctx = new ConversionContext(searchSource, cluster, table);
-        RelNode base = buildBase(ctx);
-
         int size = searchSource.size() != -1 ? searchSource.size() : SearchService.DEFAULT_SIZE;
         boolean hasAggs = hasAggregations(searchSource);
 
         QueryPlans.Builder builder = new QueryPlans.Builder();
 
+        // Every plan below gets its own workspace — its own cluster and its own Scan → Filter
+        // nodes. The engine plans the plans of one request on different threads, and a plan's
+        // metadata lookups follow the cluster of the nodes they touch, so one shared cluster or
+        // one shared node puts two threads on the same unguarded metadata cache (see newCluster).
+
         // Hits path: Scan → Filter → Project → Sort
         // size=0 skips hits — total doc count comes from analytics plugin metadata
         if (size > 0) {
-            RelNode hits = projectConverter.convert(base, ctx);
-            hits = sortConverter.convert(hits, ctx);
+            ConversionContext hitsCtx = new ConversionContext(searchSource, newCluster(), table);
+            RelNode hits = projectConverter.convert(buildBase(hitsCtx), hitsCtx);
+            hits = sortConverter.convert(hits, hitsCtx);
             builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, hits));
         }
 
@@ -159,27 +161,15 @@ public class SearchSourceConverter {
         // (one plan per bucket aggregation — size, min_doc_count, and order are baked in;
         // nested levels additionally semi-join their parent level's plan for the per-parent bound)
         List<AggregationMetadata> metadataList = hasAggs
-            ? treeWalker.walk(searchSource.aggregations().getAggregatorFactories(), table.getRowType(), cluster.getTypeFactory())
+            ? treeWalker.walk(searchSource.aggregations().getAggregatorFactories(), table.getRowType(), typeFactory)
             : List.of();
-        // The walker emits parents before their children, so a child's parent plan is
-        // always already built when the child needs it as its semi-join input.
-        Map<String, RelNode> builtPlansByPath = new LinkedHashMap<>();
+        // The walker emits parents before their children, so a child's parent metadata is always
+        // already registered by the time the child rebuilds that level in its own workspace.
+        Map<String, AggregationMetadata> metadataByPath = new LinkedHashMap<>();
         for (AggregationMetadata metadata : metadataList) {
-            ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
-            if (metadata.getPerParentFetch() != null) {
-                List<String> path = metadata.getAggNamePath();
-                RelNode parentPlan = builtPlansByPath.get(aggPathKey(path.subList(0, path.size() - 1)));
-                if (parentPlan == null) {
-                    throw new ConversionException(
-                        "Parent plan not built before nested plan [" + String.join(",", path) + "] — walker order broken"
-                    );
-                }
-                aggCtx = aggCtx.withParentPlan(parentPlan);
-            }
-            RelNode aggInput = preAggConverter.convert(base, aggCtx);
-            RelNode aggs = aggConverter.convert(aggInput, metadata);
-            aggs = postAggConverter.convert(aggs, aggCtx);
-            builtPlansByPath.put(aggPathKey(metadata.getAggNamePath()), aggs);
+            metadataByPath.put(aggPathKey(metadata.getAggNamePath()), metadata);
+            ConversionContext planCtx = new ConversionContext(searchSource, newCluster(), table);
+            RelNode aggs = buildAggPlan(metadata, planCtx, buildBase(planCtx), metadataByPath);
             builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, aggs, metadata));
         }
 
@@ -207,7 +197,10 @@ public class SearchSourceConverter {
                 totalServesAsEligibleCount = true;
             } else {
                 String fieldName = metadata.getGroupByFieldNames().get(0);
-                RelDataTypeField field = base.getRowType().getField(fieldName, false, false);
+                // The table's row type, not a plan's: a plan's base is Scan → Filter and a
+                // Filter's row type is its input's, so this is the same row type every plan sees
+                // — and no plan's nodes have to be reachable from here to read an index off it.
+                RelDataTypeField field = table.getRowType().getField(fieldName, false, false);
                 if (field == null) {
                     throw new ConversionException("Group-by field '" + fieldName + "' not found in schema");
                 }
@@ -219,7 +212,50 @@ public class SearchSourceConverter {
             builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.COUNT, flatCountPlan));
         }
 
-        return builder.build();
+        QueryPlans plans = builder.build();
+        // Translating the query clause is what validates it, and every translation now happens
+        // inside some plan's own buildBase. A request that emits no plan at all — size=0, no
+        // aggregations, track_total_hits:false, so not even a COUNT plan — would therefore never
+        // look at its query, and a malformed one would come back as an empty 200 the caller cannot
+        // tell apart from "no results" instead of the 400 the conversion error becomes. Translate
+        // it once here and drop the result: this workspace is fresh and unshared, so it shares no
+        // planning state with anything, and a valid query still yields the normal empty result.
+        if (plans.getAll().isEmpty()) {
+            buildBase(new ConversionContext(searchSource, newCluster(), table));
+        }
+        return plans;
+    }
+
+    /**
+     * Builds one aggregation level's plan inside {@code ctx}'s own workspace, rebuilding any
+     * ancestor level it semi-joins there too.
+     *
+     * @param metadata the level to build
+     * @param ctx this plan's workspace context, carrying neither metadata nor a parent plan
+     * @param base this plan's own {@code Scan → Filter} subtree
+     * @param metadataByPath every level the walker has emitted so far, by canonical path key
+     * @return the level's plan, entirely inside {@code ctx}'s cluster
+     * @throws ConversionException if conversion fails, or the walker emitted a child before its parent
+     */
+    private RelNode buildAggPlan(
+        AggregationMetadata metadata,
+        ConversionContext ctx,
+        RelNode base,
+        Map<String, AggregationMetadata> metadataByPath
+    ) throws ConversionException {
+        ConversionContext aggCtx = ctx.withAggregationMetadata(metadata);
+        if (metadata.getPerParentFetch() != null) {
+            List<String> path = metadata.getAggNamePath();
+            AggregationMetadata parent = metadataByPath.get(aggPathKey(path.subList(0, path.size() - 1)));
+            if (parent == null) {
+                throw new ConversionException(
+                    "Parent plan not built before nested plan [" + String.join(",", path) + "] — walker order broken"
+                );
+            }
+            aggCtx = aggCtx.withParentPlan(buildAggPlan(parent, ctx, base, metadataByPath));
+        }
+        RelNode aggInput = preAggConverter.convert(base, aggCtx);
+        return postAggConverter.convert(aggConverter.convert(aggInput, metadata), aggCtx);
     }
 
     /** Canonical plan key — see {@link AggregationMetadata#pathKey}. */
@@ -228,18 +264,23 @@ public class SearchSourceConverter {
     }
 
     /**
-     * Creates a fresh workspace (cluster) for one plan family. Calcite's per-cluster metadata
-     * cache is not thread-safe, and its cycle detection assumes a single planning thread —
-     * concurrent metadata queries over a shared cache misread each other's in-progress markers
-     * as cycles ({@code CyclicMetadataException}). Plans the engine may plan concurrently must
-     * therefore not share a cluster, nor any {@code RelNode}: a node is permanently bound to
-     * the cluster it was created in, and metadata lookups follow {@code node.getCluster()}.
+     * Creates a fresh workspace (cluster) for one emitted plan — called once per plan, with no
+     * exceptions. Calcite's per-cluster metadata cache is not thread-safe: {@code mq} is neither
+     * volatile nor guarded and {@code getMetadataQuery()} is an unsynchronized check-then-act that
+     * re-reads the field on its return path, so one thread's {@code invalidateMetadataQuery()} —
+     * which the engine and {@code logPlan} both issue per plan — can land inside another's lazy
+     * init and make the call return null. The cache is also the cycle-detection structure, so two
+     * threads sharing it misread each other's in-progress markers as cycles
+     * ({@code CyclicMetadataException}) and clear each other's entries. Plans the engine may plan
+     * concurrently must therefore not share a cluster, nor any {@code RelNode}: a node is
+     * permanently bound to the cluster it was created in, and metadata lookups follow
+     * {@code node.getCluster()}.
      */
     private RelOptCluster newCluster() {
         return RelOptCluster.create(new HepPlanner(HepProgram.builder().build()), new RexBuilder(typeFactory));
     }
 
-    /** Builds a plan family's private base — Scan → Filter — inside the context's own workspace. */
+    /** Builds one plan's private base — Scan → Filter — inside the context's own workspace. */
     private RelNode buildBase(ConversionContext ctx) throws ConversionException {
         RelNode scan = LogicalTableScan.create(ctx.getCluster(), ctx.getTable(), List.of());
         return filterConverter.convert(scan, ctx);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/CoordinatorShardLayout.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/CoordinatorShardLayout.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.routing.GroupShardsIterator;
+import org.opensearch.cluster.routing.OperationRouting;
+import org.opensearch.cluster.routing.ShardIterator;
+import org.opensearch.cluster.routing.ShardRouting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reads how many shards of one index the coordinator would send to the busiest single node
+ * ("S_node"), the input the fan-out width divides by.
+ */
+final class CoordinatorShardLayout {
+
+    private static final Logger logger = LogManager.getLogger(CoordinatorShardLayout.class);
+
+    private CoordinatorShardLayout() {}
+
+    /**
+     * Shards of {@code concreteIndex} on the node carrying the most of them, per the given cluster-state
+     * snapshot.
+     *
+     * @param state the one cluster-state snapshot the whole request is planned against
+     * @param routing the coordinator's operation routing
+     * @param concreteIndex the resolved concrete index name
+     * @return the busiest node's shard count, never 0 — an index whose shards are all unassigned, or a
+     *         routing read that fails outright, yields 1, because a wrong fan-out width must never fail
+     *         a search
+     */
+    static int shardsOnBusiestNode(ClusterState state, OperationRouting routing, String concreteIndex) {
+        try {
+            GroupShardsIterator<ShardIterator> groups = routing.searchShards(state, new String[] { concreteIndex }, null, null);
+            Map<String, Integer> perNode = new HashMap<>();
+            for (ShardIterator shardIt : groups) {
+                // Consuming this iterator is safe: searchShards builds a fresh GroupShardsIterator per
+                // call and nothing else sees ours. Never hand a partly-consumed one on.
+                ShardRouting shard = shardIt.nextOrNull();
+                if (shard == null || shard.currentNodeId() == null) {
+                    // Unassigned or otherwise unplaceable: skip it, never throw. Mirrors the engine's own
+                    // shard-target resolver, which skips on either null.
+                    continue;
+                }
+                perNode.merge(shard.currentNodeId(), 1, Integer::sum);
+            }
+            return perNode.values().stream().mapToInt(Integer::intValue).max().orElse(1);
+        } catch (RuntimeException e) {
+            // Fail secure into the narrowest-fan-out direction rather than onto the query path: this value
+            // only advises how many sub-plans may run at once, so a routing read that throws (a
+            // concurrently deleted index is the realistic one) must degrade, not turn a valid _search into
+            // an error.
+            logger.debug(
+                "the shard layout of [{}] could not be read [{}]; treating the busiest node as holding one shard",
+                concreteIndex,
+                e
+            );
+            return 1;
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -11,51 +11,276 @@ package org.opensearch.dsl.executor;
 import org.apache.calcite.rel.RelNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.analytics.exec.PendingExecutions;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.util.concurrent.OpenSearchThreadPoolExecutor;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.dsl.result.ExecutionResult;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.concurrent.ExecutorService;
 
 /**
- * Iterates over {@link QueryPlans}, delegates each RelNode to the analytics engine's
- * {@link QueryPlanExecutor}, and collects results.
+ * Executes the plans of one DSL query through the analytics engine's {@link QueryPlanExecutor} and
+ * collects their results in plan order.
  */
 public class DslQueryPlanExecutor {
 
     private static final Logger logger = LogManager.getLogger(DslQueryPlanExecutor.class);
 
+    /**
+     * The three non-numeric renderings of a width-line term. Part of SC-10's contract and NOT
+     * interchangeable — {@link #logKEff} documents what each one tells a reader. Kept as constants so the
+     * strings the runbook matches on exist in exactly one place.
+     */
+    private static final String TERM_ABSENT = "absent";
+    private static final String TERM_SKIPPED = "skipped";
+    private static final String TERM_UNAVAILABLE = "unavailable";
+
     private final QueryPlanExecutor<RelNode, Iterable<Object[]>> executor;
+    private final ClusterService clusterService;
+    private final ThreadPool threadPool;
+    private final DslQuerySettings dslSettings;
+    private final DslGateInputs gateInputs;
 
     /**
      * Creates an executor backed by the given analytics engine plan executor.
      *
      * @param executor analytics engine executor that runs individual RelNode plans
+     * @param clusterService supplies the coordinator's operation routing, for the shard-layout input of
+     *                       the fan-out width
+     * @param threadPool supplies the live SEARCH executor, for the pool-size input of the fan-out width
+     * @param dslSettings holder of {@code dsl.query.max_parallel_sub_plans}, read once per query
+     * @param gateInputs reader for the cross-plugin concurrency-gate inputs, read once per query
      */
-    public DslQueryPlanExecutor(QueryPlanExecutor<RelNode, Iterable<Object[]>> executor) {
+    public DslQueryPlanExecutor(
+        QueryPlanExecutor<RelNode, Iterable<Object[]>> executor,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        DslQuerySettings dslSettings,
+        DslGateInputs gateInputs
+    ) {
         this.executor = executor;
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.dslSettings = dslSettings;
+        this.gateInputs = gateInputs;
     }
 
     // TODO: add per-plan error handling so a failure in one plan
     // doesn't prevent returning partial results from other plans (e.g. HITS)
     /**
-     * Executes all plans sequentially and delivers results, in plan order, to the listener.
+     * Executes all plans of one request and delivers their results, in plan order, to the listener.
      *
-     * <p>Plans run one-at-a-time: plan {@code N+1} is dispatched only after plan {@code N}
-     * completes successfully. The first failure aborts the chain — the listener fires
-     * {@code onFailure} with that error and remaining plans do not run.
-     *
-     * @param plans    the query plans to execute
-     * @param listener receives the ordered list of results on success, or the first failure
+     * @param plans the query plans to execute
+     * @param state the request's cluster-state snapshot, read only for the shard-layout width input; a
+     *              {@code null} drops that input
+     * @param concreteIndex the request's single resolved concrete index, used only to read the shard
+     *                      layout the fan-out width divides by; a {@code null} drops that input
+     * @param listener receives the ordered list of results on success, or the failure
      */
-    public void execute(QueryPlans plans, ActionListener<List<ExecutionResult>> listener) {
+    public void execute(QueryPlans plans, ClusterState state, String concreteIndex, ActionListener<List<ExecutionResult>> listener) {
         List<QueryPlans.QueryPlan> queryPlans = plans.getAll();
-        List<ExecutionResult> results = new ArrayList<>(queryPlans.size());
-        executeNext(queryPlans, 0, results, listener);
+        final int n = queryPlans.size();
+        if (n == 0) {
+            listener.onResponse(List.of());
+            return;
+        }
+        if (n == 1) {
+            // Returns before the width decision, so a single-plan query emits NO width line. That absence is
+            // part of the line's contract: it means "not a multi-plan query" and must never come to mean "the
+            // line was dropped", which is what a K_eff=1 line here would make it ambiguous with.
+            executeNext(queryPlans, 0, new ArrayList<>(1), listener);
+            return;
+        }
+        // Read once, here, and threaded on as a boolean so no later frame can ask the question again and get
+        // a different answer for the same query. Read from `plans` because that is the last frame holding the
+        // typed QueryPlans; every frame below carries the untyped list.
+        final boolean hasAggregation = plans.has(QueryPlans.Type.AGGREGATION);
+        final int kEff = decideWidth(n, hasAggregation, state, concreteIndex);
+        if (kEff == 1) {
+            // A width-1 gate is the sequential chain with extra bookkeeping, so take the chain itself. This
+            // is what the shipped default (max_parallel_sub_plans = 1) takes, and it is byte-identical to the
+            // behaviour before the fan-out existed.
+            executeNext(queryPlans, 0, new ArrayList<>(n), listener);
+            return;
+        }
+        dispatchGated(queryPlans, 0, n, new SubPlanResultCollector(n, listener), new PendingExecutions(kEff));
     }
 
+    /**
+     * The {@code K_eff} decision: settles the width (emitting the one observability line for this query on
+     * every path through here) and never throws. Runs on the calling thread, before any plan is dispatched.
+     *
+     * @param n number of plans in this query, all of which go through the gate
+     * @param hasAggregation whether this query carries an AGGREGATION plan; {@code false} settles the width at
+     *                       1 before any input is read
+     * @param state the request's snapshot, source of the shard-layout read
+     * @param concreteIndex the request's resolved concrete index, or null
+     * @return the width to run at, always {@code >= 1}
+     */
+    private int decideWidth(int n, boolean hasAggregation, ClusterState state, String concreteIndex) {
+        // Boxed so "not read yet" is representable: the sentinel renders as the state string below. Today
+        // this read cannot throw (DslQuerySettings caches the value in a volatile field and refreshes it
+        // from a settings-update consumer), which is exactly why it is the read taken FIRST — but a later
+        Integer kSetting = null;
+        SubPlanParallelism.Decision decision = null;
+        String unread = TERM_SKIPPED;
+        try {
+            kSetting = dslSettings.maxParallelSubPlans();
+            // Bound the inline drain depth: PendingExecutions.finishAndRunNext drains the next queued task
+            // on the finishing thread, so a callee that completes inline nests one frame group per plan.
+            boolean tooManyPlans = n > SubPlanParallelism.MAX_FANOUT_PLANS;
+            // Ordered cheapest-decisive-first, deliberately. With no aggregation plan to overlap, at the
+            // shipped default (max_parallel_sub_plans = 1), and above the plan bound, K_eff is 1 whatever
+            // every other term says, so reading them would be pure waste on the query hot path:
+            if (hasAggregation && kSetting > 1 && tooManyPlans == false) {
+                decision = SubPlanParallelism.decide(readInputs(n, kSetting, state, concreteIndex));
+            }
+        } catch (RuntimeException e) {
+            // DEBUG, not WARN: on a node whose registry really did lose a key this fires on every
+            // multi-plan query, and the search itself is unaffected — it just runs sequentially, which is
+            // the shipped default anyway.
+            logger.debug("the fan-out width could not be read; running the sub-plans sequentially", e);
+            decision = null;
+            unread = TERM_UNAVAILABLE;
+        }
+        int kEff = decision == null ? 1 : decision.kEff();
+        logKEff(kSetting, decision, unread, n, kEff);
+        return kEff;
+    }
+
+    /**
+     * Sends plans {@code [from, n)} through one permit gate, reporting each to the collector by its own
+     * plan index. The single copy of the fan-out's permit accounting; today every caller enters at
+     * {@code from = 0}, since every plan is gated.
+     *
+     * @param queryPlans the query's plans
+     * @param from the first plan index to gate
+     * @param n the query's plan count, i.e. the exclusive upper bound of the dispatch
+     * @param collector the collector every gated plan reports to; must be sized for exactly {@code n - from}
+     *                  reports, which is checked before the first dispatch — a mismatch fails the request
+     *                  through the collector rather than hanging it, and nothing is dispatched
+     * @param gate a fresh gate of the settled width, owned by this dispatch alone
+     */
+    private void dispatchGated(
+        List<QueryPlans.QueryPlan> queryPlans,
+        int from,
+        int n,
+        SubPlanResultCollector collector,
+        PendingExecutions gate
+    ) {
+        // The dispatch range and the collector's report count are set independently; a disagreement is a
+        // HANG one way and an early terminal with a duplicate query still in flight the other, never a
+        // merely wrong value. Checked before the loop, so bailing out leaks no permit and abandons no
+        // in-flight plan.
+        if (collector.expectGatedRange(from, n) == false) {
+            return;
+        }
+        for (int i = from; i < n; i++) {
+            final int idx = i;
+            final QueryPlans.QueryPlan plan = queryPlans.get(idx);
+            // notifyOnce is OUTERMOST, and that order is load-bearing. runAfter fires its Runnable from a
+            // finally on EVERY notification and has no once-only guard of its own, so with notifyOnce on the
+            // inside a listener that is notified twice (see the catch below — the engine can complete the
+            // listener and *then* throw) would release the permit twice: finishAndRunNext would decrement
+            // past its own count and drain an extra queued task, admitting one plan more than K_eff.
+            ActionListener<Iterable<Object[]>> perPlan = ActionListener.notifyOnce(
+                ActionListener.runAfter(reportTo(collector, idx, plan), gate::finishAndRunNext)
+            );
+            // PendingExecutions.tryRun takes a BooleanSupplier, and this one returns true on EVERY path
+            // — that is the whole contract with the gate, not a stub. PendingExecutions reads true as
+            // "this work started and owes exactly one finishAndRunNext()", which perPlan pays on every
+            // outcome — engine success, engine failure, and the catch below alike. Returning false would
+            // mean "I started nothing", and the gate would then pass this permit to the next queued plan
+            // ITSELF; since perPlan still releases the permit through runAfter, the window would be
+            // credited twice and admit one plan more than K_eff. There is genuinely no declined path
+            // here: this fan-out always has a plan to dispatch by the time its turn comes (a decline
+            // models work that became unnecessary while queued, e.g. request cancellation, which is not
+            // part of the fan-out).
+            gate.tryRun(() -> {
+                try {
+                    // Same thread, strictly before this plan's dispatch: that program order is the
+                    // happens-before edge that keeps this plan's invalidateMetadataQuery() from racing the
+                    // engine's own invalidate for the same plan. Never in a completion callback, never
+                    // outside tryRun. At the shipped INFO level the whole call costs one isDebugEnabled()
+                    // boolean. Inside the try, not above it: at DEBUG it dereferences the plan's metadata
+                    // provider and renders the plan, and a throw from there escaping this supplier would
+                    // leak the permit it already took and skip the countdown, so the listener would never
+                    // fire and the REST channel would hang. On the drain path the throw would also escape
+                    // into the engine's completion thread through finishAndRunNext.
+                    logPlan(plan.relNode());
+                    // Null context, exactly as the sequential path passes it; see executeNext.
+                    executor.execute(plan.relNode(), null, perPlan);
+                } catch (Throwable t) {
+                    // A plan that cannot be dispatched must still release its permit and count down, or the
+                    // listener never fires and the REST channel hangs. perPlan does both in one call — so
+                    // this path owes a finishAndRunNext exactly like a dispatched plan, hence true below.
+                    //
+                    // Throwable, not Exception: Calcite throws AssertionError outright where its plan
+                    // invariants are violated, and logPlan renders a plan. An Error escaping this supplier
+                    // would strand the permit and the countdown just as surely as an exception would, so the
+                    // cleanup has to run for both.
+                    //
+                    // And it is deliberately NOT rethrown afterwards. Rethrowing propagates out of the
+                    // dispatch loop, so the plans after this one are never dispatched and never count down —
+                    // the collector cannot reach its terminal and the REST channel stays open with nobody to
+                    // answer it, which is the one outcome this block exists to prevent. Reporting an Error as
+                    // a plan failure is a lesser wrong than hanging the request; it is wrapped so the
+                    // listener's Exception contract holds, and the cause carries the original.
+                    perPlan.onFailure(t instanceof Exception e ? e : new RuntimeException(t));
+                }
+                return true;
+            });
+        }
+    }
+
+    /**
+     * One fanned-out plan's outcome, reported to the collector exactly once.
+     *
+     * @param collector the query's result collector
+     * @param idx this plan's index in the query's plan list
+     * @param plan the plan being dispatched, carried into its result
+     * @return the listener to hand to the engine for that plan
+     */
+    private ActionListener<Iterable<Object[]>> reportTo(SubPlanResultCollector collector, int idx, QueryPlans.QueryPlan plan) {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(Iterable<Object[]> rows) {
+                ExecutionResult result;
+                try {
+                    logRows(rows);
+                    result = new ExecutionResult(plan, rows);
+                } catch (Exception e) {
+                    // A failure while handling this plan's rows is this plan's failure, and it has to count
+                    // down like any other or the request never completes.
+                    collector.planFailed(e);
+                    return;
+                }
+                collector.planSucceeded(idx, result);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                collector.planFailed(e);
+            }
+        };
+    }
+
+    /**
+     * The sequential chain: dispatch plan {@code index}, and only from its success callback dispatch
+     * plan {@code index + 1}. The first failure ends the chain — the listener fires {@code onFailure} with
+     * that error and the remaining plans do not run.
+     */
     private void executeNext(
         List<QueryPlans.QueryPlan> queryPlans,
         int index,
@@ -69,12 +294,91 @@ public class DslQueryPlanExecutor {
         QueryPlans.QueryPlan plan = queryPlans.get(index);
         RelNode relNode = plan.relNode();
         logPlan(relNode);
+        // Sequential dispatch: a synchronous throw from here propagates out through the caller's
+        // completion callback, where ActionListener.wrap routes it to the listener's failure arm.
         // TODO: context param is null, may carry execution hints
         executor.execute(relNode, null, ActionListener.wrap(rows -> {
             logRows(rows);
             results.add(new ExecutionResult(plan, rows));
             executeNext(queryPlans, index + 1, results, outer);
         }, outer::onFailure));
+    }
+
+    /**
+     * Builds the fan-out width's inputs once per query, at the decision site, from their named producers.
+     * Read here and not cached: the gate inputs are all dynamic settings, and an operator sweeping them
+     * has to be able to change the width of a running node.
+     */
+    private SubPlanParallelism.Inputs readInputs(int n, int kSetting, ClusterState state, String concreteIndex) {
+        OptionalDouble multiplier = gateInputs.fragmentExecutorMultiplier();
+        return new SubPlanParallelism.Inputs(
+            n,
+            kSetting,
+            Runtime.getRuntime().availableProcessors(),
+            // Deliberately NaN and not 1.0: when the multiplier is absent the gate term is DROPPED, so this
+            // value is never read — and a synthesised 1.0 would be indistinguishable from a genuinely
+            // configured 1.0, i.e. it would clamp the width where the contract says drop the term.
+            multiplier.orElse(Double.NaN),
+            gateInputs.targetPartitions(),
+            multiplier.isPresent(),
+            shardsOnBusiestNode(state, concreteIndex),
+            gateInputs.maxConcurrentShardRequestsPerNode(),
+            searchPoolSize(threadPool.executor(ThreadPool.Names.SEARCH))
+        );
+    }
+
+    /**
+     * Shards of this request's index on the busiest node, read from the <em>request's own</em>
+     * cluster-state snapshot. Not a second {@code clusterService.state()} read: two reads of one request
+     * can straddle a routing change and produce a layout that never existed on any state.
+     */
+    private int shardsOnBusiestNode(ClusterState state, String concreteIndex) {
+        if (state == null || concreteIndex == null) {
+            // No snapshot to read routing from. 1 is the neutral value for a count, and F = max(1, ...)
+            return 1;
+        }
+        return CoordinatorShardLayout.shardsOnBusiestNode(state, clusterService.operationRouting(), concreteIndex);
+    }
+
+    /**
+     * Live maximum size of the SEARCH pool, or empty when it cannot be read.
+     *
+     * @param searchExecutor the SEARCH executor, as returned by {@code ThreadPool.executor}
+     * @return its live maximum pool size, or empty
+     */
+    static OptionalInt searchPoolSize(ExecutorService searchExecutor) {
+        return (searchExecutor instanceof OpenSearchThreadPoolExecutor tpe)
+            ? OptionalInt.of(tpe.getMaximumPoolSize())
+            : OptionalInt.empty();
+    }
+
+    /**
+     * The one line per multi-plan query that makes the fan-out width observable — the rollout steps and
+     * every benchmark cell attribute against it, and without it a run whose width was pinned to 1 by the
+     * gate is indistinguishable from a K=1 baseline.
+     *
+     * @param kSetting the operator's width setting, or null if even that could not be read
+     * @param decision the terms actually computed, or null when they were skipped or unavailable
+     * @param unread how to render the terms {@code decision} does not carry
+     * @param n the query's plan count
+     * @param kEff the width this query runs at
+     */
+    private void logKEff(Integer kSetting, SubPlanParallelism.Decision decision, String unread, int n, int kEff) {
+        logger.info(
+            "dsl.fanout.k_eff K_setting={} A={} F={} K_gate={} K_search={} n={} K_eff={}",
+            kSetting == null ? unread : String.valueOf(kSetting),
+            decision == null ? unread : String.valueOf(decision.a()),
+            decision == null ? unread : String.valueOf(decision.f()),
+            decision == null ? unread : bound(decision.kGate()),
+            decision == null ? unread : bound(decision.kSearch()),
+            n,
+            kEff
+        );
+    }
+
+    /** A droppable term of the width line: its value, or {@link #TERM_ABSENT} when it left the min. */
+    private static String bound(OptionalInt term) {
+        return term.isPresent() ? String.valueOf(term.getAsInt()) : TERM_ABSENT;
     }
 
     private static void logRows(Iterable<Object[]> rows) {
@@ -93,16 +397,28 @@ public class DslQueryPlanExecutor {
         }
     }
 
-    // invalidateMetadataQuery() and THREAD_PROVIDERS are only needed for explain() output
+    /**
+     * Logs a plan's text at DEBUG, and is the reference for how to do that safely.
+     */
     private void logPlan(RelNode relNode) {
         if (logger.isDebugEnabled()) {
-            org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.set(
-                org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.of(
-                    java.util.Objects.requireNonNull(relNode.getCluster().getMetadataProvider())
-                )
-            );
-            relNode.getCluster().invalidateMetadataQuery();
-            logger.debug("Executing RelNode:\n{}", relNode.explain());
+            org.apache.calcite.rel.metadata.JaninoRelMetadataProvider previous =
+                org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.get();
+            try {
+                org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.set(
+                    org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.of(
+                        java.util.Objects.requireNonNull(relNode.getCluster().getMetadataProvider())
+                    )
+                );
+                relNode.getCluster().invalidateMetadataQuery();
+                logger.debug("Executing RelNode:\n{}", relNode.explain());
+            } finally {
+                if (previous == null) {
+                    org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+                } else {
+                    org.apache.calcite.rel.metadata.RelMetadataQueryBase.THREAD_PROVIDERS.set(previous);
+                }
+            }
         }
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/SubPlanParallelism.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/SubPlanParallelism.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import java.util.OptionalInt;
+
+/**
+ * How many sub-plans of one DSL query may run concurrently ("K_eff"), as a pure function over an
+ * injected {@link Inputs} record. Nothing here reads a setting, a thread pool or a cluster state —
+ * every input has a named producer at the call site, which is what makes the whole grid unit-testable
+ * without a live node.
+ */
+public final class SubPlanParallelism {
+
+    /**
+     * SEARCH threads withheld from the fan-out's budget. One is the coordinator's own: the DSL request
+     * runs on a SEARCH thread for the whole fan-out ({@code TransportDslExecuteAction} dispatches onto
+     * {@code ThreadPool.Names.SEARCH}), so that thread is not available to the sub-plans it launches.
+     * The second is headroom, chosen rather than derived. Getting it wrong is bounded in one direction
+     * only: the {@code K_search} term is dropped entirely when the pool size is unreadable, and the
+     * result is floored at 1, so too large a reserve narrows the fan-out and can never widen it.
+     */
+    static final int SEARCH_RESERVE = 2;
+
+    /**
+     * Above this many plans the caller takes the sequential path instead of fanning out.
+     *
+     * <p>Sized against the plan count a request can actually emit, which is
+     * {@code (size > 0 ? 1 : 0) + one per aggregation level + one per root aggregation with
+     * min_doc_count > 1 + (1 flat COUNT)}. A 3-level nested aggregation with hits is 5; four sibling
+     * root aggregations that each need their own HAVING-filtered count is 10. The bound has to sit
+     * above the shapes a user can legitimately write, because a request past it silently never fans
+     * out at any setting — the width line just reports {@code K_eff=1}.
+     *
+     * <p>What it protects is the inline drain: {@code PendingExecutions.finishAndRunNext} runs the next
+     * queued plan on the <i>finishing</i> thread, so a plan that completes synchronously nests one
+     * {@code finishAndRunNext -> tryRun -> run -> execute} frame group. In production that is only
+     * reachable when a plan fails inline; a 64-plan inline test showed the depth itself is comfortable,
+     * so this is headroom against pathological nesting, not a measured stack limit.
+     */
+    static final int MAX_FANOUT_PLANS = 15;
+
+    /**
+     * Hard ceiling on the operator-set K, re-applied here rather than trusted from the setting.
+     * {@code dsl.query.max_parallel_sub_plans} enforces the same maximum in its own {@code Setting},
+     * but this class is handed a plain {@code int}: a caller that ever reads the value from somewhere
+     * else must not be able to widen the fan-out past the ceiling.
+     *
+     * <p><b>Widths above 2 are not yet known-good.</b> The fan-out benchmark measured 0 failures in 80
+     * executions at {@code K <= 2} and 6 in 120 (5.0%) at {@code K >= 3}, where a 3-level aggregation
+     * intermittently returns HTTP 500; the mechanism was not traced. The shipped default is 1, so no
+     * cluster reaches that regime without an operator opting in, and the terms derived from the machine
+     * ({@code K_gate} from the fragment-executor budget, {@code K_search} from the SEARCH pool) clamp
+     * the width down on smaller hosts regardless. Trace and fix the {@code K >= 3} failures before
+     * recommending anything above 2 in an operator runbook.
+     */
+    static final int MAX_K_SETTING = 5;
+
+    private SubPlanParallelism() {}
+
+    /**
+     * Every input the {@code K_eff} decision needs, injected so the formula is testable without a live
+     * node. Each field's producer is named in its own comment; this class reads nothing itself.
+     *
+     * @param n number of plans in the query ({@code QueryPlans.getAll().size()})
+     * @param kSetting the operator's {@code dsl.query.max_parallel_sub_plans}, re-clamped here to
+     *                 {@code [1, MAX_K_SETTING]}
+     * @param vCpu {@code Runtime.getRuntime().availableProcessors()} on the coordinator
+     * @param fragmentExecutorMultiplier the backend's concurrency-gate multiplier, unwrapped;
+     *                                   <b>unread</b> when {@code gateTermPresent} is false, so the
+     *                                   caller passes a deliberately poisonous placeholder there
+     * @param targetPartitions the backend's derived {@code target_partitions}, already {@code >= 1}
+     * @param gateTermPresent whether a backend declared the multiplier at all; {@code false} DROPS the
+     *                        {@code K_gate} term rather than clamping it to 1
+     * @param shardsOnBusiestNode S_node, from live coordinator routing
+     * @param maxConcurrentShardRequestsPerNode the engine's per-node in-flight shard-request cap
+     * @param searchPoolSize live {@code getMaximumPoolSize()} of the SEARCH executor;
+     *                       {@link OptionalInt#empty()} DROPS the {@code K_search} term
+     */
+    public record Inputs(int n, int kSetting, int vCpu, double fragmentExecutorMultiplier, int targetPartitions, boolean gateTermPresent,
+        int shardsOnBusiestNode, int maxConcurrentShardRequestsPerNode, OptionalInt searchPoolSize) {
+    }
+
+    /**
+     * The chosen width together with every intermediate term that produced it, so the one observable
+     * {@code K_eff} log line can report the values actually used instead of recomputing them (a second
+     * computation could disagree with the first and the line would then describe a run that never
+     * happened).
+     *
+     * @param kEff the effective number of sub-plans that may run concurrently, always {@code >= 1}
+     * @param a fragments the concurrency gate admits per node; not meaningful when {@code kGate} is
+     *          empty, because there is then no multiplier to derive it from
+     * @param f fragments one sub-query costs on the busiest node
+     * @param kGate the gate-derived sub-query bound, or empty when that term was dropped
+     * @param kSearch the SEARCH-pool-derived sub-query bound, or empty when that term was dropped
+     */
+    public record Decision(int kEff, int a, int f, OptionalInt kGate, OptionalInt kSearch) {
+    }
+
+    /**
+     * The effective fan-out width for the given inputs.
+     *
+     * @param in the injected inputs
+     * @return {@code K_eff}, always in {@code [1, max(1, n)]}
+     */
+    static int computeKEff(Inputs in) {
+        return decide(in).kEff();
+    }
+
+    /**
+     * The same computation as {@link #computeKEff(Inputs)}, keeping the intermediate terms for the
+     * observability line. All {@code n} of the query's plans go through the permit gate, so the width is
+     * bounded by {@code n} rather than by {@code n - 1}.
+     *
+     * @param in the injected inputs
+     * @return the width plus the terms it was derived from, with {@code kEff} in {@code [1, max(1, n)]}
+     */
+    public static Decision decide(Inputs in) {
+        final int gatedPlans = in.n();
+        // Both belts, deliberately: F feeds two divisions, and a shard count of 0 (red index) or a
+        // relaxed cap on the declaring plugin's side must not reach them.
+        int f = Math.max(1, Math.min(in.shardsOnBusiestNode(), in.maxConcurrentShardRequestsPerNode()));
+
+        int a;
+        OptionalInt kGate;
+        if (in.gateTermPresent()) {
+            // The producer clamps targetPartitions to >= 1; clamped again here because this record is a
+            // seam that another reader could fill differently, and a 0 here would throw on the query
+            // path — the one thing an advisory input must never do.
+            int targetPartitions = Math.max(1, in.targetPartitions());
+            a = Math.max(1, (int) Math.floor(in.vCpu() * in.fragmentExecutorMultiplier() / targetPartitions));
+            kGate = OptionalInt.of(Math.max(1, ceilDiv(a, f)));
+        } else {
+            // No multiplier was declared, so there are no gate-admitted fragments to count. The term is
+            // dropped below; `a` is reported as 1 only so the log line has a number, and the accompanying
+            // `K_gate=absent` is what tells a reader it took no part in the decision. The multiplier
+            a = 1;
+            kGate = OptionalInt.empty();
+        }
+
+        OptionalInt kSearch = in.searchPoolSize().isPresent()
+            ? OptionalInt.of(Math.max(1, (in.searchPoolSize().getAsInt() - SEARCH_RESERVE) / f))
+            : OptionalInt.empty();
+
+        // A query with one plan has no width decision to make, and clamp(..., 1, gatedPlans) would be
+        // malformed at 0 (upper < lower). Returning 1 also keeps the
+        // caller from ever constructing a PendingExecutions(0), whose constructor asserts permits > 0.
+        if (gatedPlans <= 1) {
+            return new Decision(1, a, f, kGate, kSearch);
+        }
+
+        int kEff = Math.min(gatedPlans, Math.max(1, Math.min(MAX_K_SETTING, in.kSetting())));
+        if (kGate.isPresent()) {
+            kEff = Math.min(kEff, kGate.getAsInt());
+        }
+        if (kSearch.isPresent()) {
+            kEff = Math.min(kEff, kSearch.getAsInt());
+        }
+        // Both ends of the clamp: every term above is >= 1, so this only re-states the invariant the
+        // callers rely on (a gate of width 0 or a width above the plan count).
+        kEff = Math.max(1, Math.min(kEff, gatedPlans));
+        return new Decision(kEff, a, f, kGate, kSearch);
+    }
+
+    /** Integer ceiling division for two positive ints. */
+    private static int ceilDiv(int dividend, int divisor) {
+        return (dividend + divisor - 1) / divisor;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/SubPlanResultCollector.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/SubPlanResultCollector.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.util.concurrent.AtomicArray;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.dsl.result.ExecutionResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Gathers the results of one query's concurrently executing sub-plans into <b>plan order</b> and fires
+ * the request's listener exactly once, when the last of them has reported.
+ */
+final class SubPlanResultCollector {
+
+    private static final Logger logger = LogManager.getLogger(SubPlanResultCollector.class);
+
+    private final int n;
+    private final AtomicArray<ExecutionResult> slots;
+    private final AtomicInteger pending;
+    private final ConcurrentLinkedQueue<Exception> failures = new ConcurrentLinkedQueue<>();
+    private final ActionListener<List<ExecutionResult>> outer;
+
+    /**
+     * Every plan of the query is gated, so every plan reports through {@link #planSucceeded} /
+     * {@link #planFailed} and the countdown starts at {@code n}.
+     *
+     * @param n total number of plans in the query; must be at least 2
+     * @param outer the request's listener, fired exactly once
+     * @throws IllegalArgumentException if {@code n < 2}, which would make the countdown unable to complete
+     */
+    SubPlanResultCollector(int n, ActionListener<List<ExecutionResult>> outer) {
+        if (n < 2) {
+            // Rejected rather than tolerated, because the tolerated form is a HANG: with n <= 1 the
+            // countdown starts at or below 0, so finish() never runs, the request's listener is never fired
+            // and the REST channel is held open until it times out.
+            throw new IllegalArgumentException("a fan-out collector needs at least 2 plans, got " + n);
+        }
+        this.n = n;
+        this.slots = new AtomicArray<>(n);
+        this.pending = new AtomicInteger(n);
+        this.outer = outer;
+    }
+
+    /**
+     * Rejects a dispatch that could not drive this countdown to its terminal — checked on the caller's
+     * thread, before the first plan goes out, so nothing is in flight and no permit is held.
+     *
+     * @param from the first plan index the caller is about to dispatch
+     * @param n the caller's plan count, i.e. the exclusive upper bound of its dispatch
+     * @return {@code false} when the pairing cannot terminate, having already failed the request's listener
+     */
+    boolean expectGatedRange(int from, int n) {
+        if (n == this.n && from == 0) {
+            return true;
+        }
+        IllegalStateException e = new IllegalStateException(
+            "a fan-out collector of " + this.n + " plans cannot be driven by a dispatch of plans [" + from + ", " + n + ")"
+        );
+        logger.error("dsl.fanout dispatch/report-count mismatch; the query is failed rather than hung", e);
+        outer.onFailure(e);
+        return false;
+    }
+
+    /**
+     * Records a fanned-out plan's result and counts down.
+     *
+     * @param index the plan's index in {@code QueryPlans.getAll()}
+     * @param result that plan's result
+     */
+    void planSucceeded(int index, ExecutionResult result) {
+        slots.set(index, result);
+        countDown();
+    }
+
+    /**
+     * Records a fanned-out plan's failure and counts down. Called for a plan that failed asynchronously
+     * <i>and</i> for one that could not be dispatched at all — a plan that never decremented would leave
+     * the listener uncompleted, i.e. a hung REST channel.
+     *
+     * @param e the failure
+     */
+    void planFailed(Exception e) {
+        failures.offer(e);
+        countDown();
+    }
+
+    /**
+     * The single terminal. Both the success and the failure path go through here, rather than each
+     * testing the countdown itself, so "fires exactly once" is a property of one line of code.
+     */
+    private void countDown() {
+        if (pending.decrementAndGet() == 0) {
+            finish();
+        }
+    }
+
+    private void finish() {
+        // Drained once, then never read again: poll() hands over the primary and the loop reports the rest,
+        // so no failure is lost and none is reported twice.
+        Exception primary = failures.poll();
+        if (primary != null) {
+            // The siblings are LOGGED, deliberately not attached to the reported exception with
+            // addSuppressed(). OpenSearch's REST error rendering walks the suppressed chain, so attaching
+            // them would emit one internal exception type and message per failed sub-plan to the client:
+            int siblings = 0;
+            for (Exception other = failures.poll(); other != null; other = failures.poll()) {
+                final int sibling = ++siblings;
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "a further sub-plan of this {}-plan query failed (additional failure {}); it is "
+                            + "reported here only, never attached to the failure returned to the client, "
+                            + "which is [{}]",
+                        n,
+                        sibling,
+                        primary
+                    ),
+                    other
+                );
+            }
+            outer.onFailure(primary);
+            return;
+        }
+        // Read by index into a fresh list rather than AtomicArray.asList(): that method SKIPS null slots
+        // and memoizes the result, so an incompletely filled array would hand back a SHORT list that looks
+        // complete — and the wrong value would then be cached forever.
+        List<ExecutionResult> results = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            ExecutionResult result = slots.get(i);
+            if (result == null) {
+                // Unreachable while every plan reports exactly once; kept because the alternative is
+                // delivering a list with a null in it to a caller that indexes into it positionally.
+                outer.onFailure(new IllegalStateException("sub-plan " + i + " of " + n + " reported neither a result nor a failure"));
+                return;
+            }
+            results.add(result);
+        }
+        outer.onResponse(results);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/DslGateInputs.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/DslGateInputs.java
@@ -1,0 +1,249 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.settings;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.search.SearchService;
+
+import java.util.OptionalDouble;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Reads the three cluster-settings inputs the sub-plan fan-out decision needs, and nothing else.
+ */
+public final class DslGateInputs {
+
+    private static final Logger logger = LogManager.getLogger(DslGateInputs.class);
+
+    /**
+     * Key of the sibling DataFusion plugin's concurrency-gate multiplier. Held as a string on
+     * purpose — see the class javadoc; {@code DatafusionSettings} is not referenceable from here.
+     */
+    private static final String FRAGMENT_EXECUTOR_MULTIPLIER_KEY = "datafusion.concurrency.fragment_executor_multiplier";
+
+    /** Key of the parent analytics-engine plugin's per-node in-flight shard-request cap. */
+    private static final String MAX_CONCURRENT_SHARD_REQUESTS_KEY = "analytics.query.max_concurrent_shard_requests_per_node";
+
+    private final ClusterSettings clusterSettings;
+
+    // One-shot latches so the "input unavailable" cases are reported once per node, not per query.
+    // One latch per distinct condition, deliberately: a latch shared between the "key not registered",
+    // "registered with a non-numeric value" and "registered but unreadable" branches would let whichever
+    private final AtomicBoolean multiplierUnregisteredLogged = new AtomicBoolean();
+    private final AtomicBoolean multiplierNonNumericLogged = new AtomicBoolean();
+    private final AtomicBoolean multiplierNonFiniteLogged = new AtomicBoolean();
+    private final AtomicBoolean multiplierNonPositiveLogged = new AtomicBoolean();
+    private final AtomicBoolean multiplierUnreadableLogged = new AtomicBoolean();
+    private final AtomicBoolean shardRequestCapUnregisteredLogged = new AtomicBoolean();
+    private final AtomicBoolean shardRequestCapNonNumericLogged = new AtomicBoolean();
+    private final AtomicBoolean shardRequestCapUnreadableLogged = new AtomicBoolean();
+
+    /**
+     * Creates a reader over the live cluster-settings registry.
+     *
+     * @param clusterSettings the node's single {@link ClusterSettings} instance, holding every
+     *                        {@code NodeScope} setting of every installed plugin
+     */
+    public DslGateInputs(ClusterSettings clusterSettings) {
+        this.clusterSettings = clusterSettings;
+    }
+
+    /**
+     * Live value of {@code datafusion.concurrency.fragment_executor_multiplier}, or empty when no
+     * backend on this node declares it.
+     *
+     * @return the multiplier, always &gt; 0 when present, or {@link OptionalDouble#empty()} if the key is
+     *         unregistered, registered with a non-numeric type, registered with a non-finite or
+     *         non-positive value, or registered with a value the owning {@code Setting} refuses to hand
+     *         over
+     */
+    public OptionalDouble fragmentExecutorMultiplier() {
+        Setting<?> descriptor = clusterSettings.get(FRAGMENT_EXECUTOR_MULTIPLIER_KEY);
+        if (descriptor == null) {
+            if (firstDebugReport(multiplierUnregisteredLogged)) {
+                logger.debug(
+                    "[{}] is not registered on this node (no gated backend installed); the concurrency-gate "
+                        + "term is dropped from the sub-plan fan-out width",
+                    FRAGMENT_EXECUTOR_MULTIPLIER_KEY
+                );
+            }
+            return OptionalDouble.empty();
+        }
+        Object value;
+        try {
+            value = clusterSettings.get(descriptor);
+        } catch (RuntimeException e) {
+            // Registered but unreadable. The descriptor came out of this same registry, so a scope
+            // mismatch cannot happen here — what can is the owning Setting refusing to parse the value it
+            // has been given (AbstractScopedSettings.get(Setting) delegates straight to
+            // setting.get(lastSettingsApplied, settings), which propagates the Setting's own
+            // IllegalArgumentException). Same fail-secure "drop the term" signal as absent: this whole read
+            // path exists to survive another plugin changing its setting under us, so it must not turn that
+            // into a failed query.
+            if (firstDebugReport(multiplierUnreadableLogged)) {
+                logger.debug(
+                    "[{}] is registered but its live value could not be read [{}]; the concurrency-gate term "
+                        + "is dropped from the sub-plan fan-out width",
+                    FRAGMENT_EXECUTOR_MULTIPLIER_KEY,
+                    e
+                );
+            }
+            return OptionalDouble.empty();
+        }
+        if (value instanceof Number number) {
+            double multiplier = number.doubleValue();
+            if (Double.isFinite(multiplier) == false) {
+                // Numeric-typed but unusable, and reachable through the owning descriptor rather than only
+                // through a hypothetical re-declaration: Setting's double parser range-checks with
+                // value < min / value > max, and both comparisons are false for NaN, so an operator PUT of
+                // "NaN" passes DataFusion's own 0.1-to-10.0 bounds. Handing that on would poison every term
+                // derived from it and print as NaN in the fan-out's observability line, so it degrades to the
+                // same absent signal as an unreadable value. Note what that costs and does not cost: the
+                // gate term is dropped, so the fan-out falls back to being bounded by the sub-plan count,
+                // the operator's own cap (max 2, enforced in the Setting) and the search-pool term — it is
+                // NOT substituted with 1.0, the one value this contract forbids synthesising.
+                if (firstDebugReport(multiplierNonFiniteLogged)) {
+                    logger.debug(
+                        "[{}] is registered with a non-finite value [{}]; the concurrency-gate term is dropped "
+                            + "from the sub-plan fan-out width",
+                        FRAGMENT_EXECUTOR_MULTIPLIER_KEY,
+                        multiplier
+                    );
+                }
+                return OptionalDouble.empty();
+            }
+            if (multiplier <= 0.0) {
+                // Domain guard on a single value, the symmetric counterpart of the Math.max(1L, raw) in
+                // maxConcurrentShardRequestsPerNode(): both defend the same hypothesis — a bounds relaxation
+                // or a type change (doubleSetting -> intSetting with a 0 default) on the declaring side,
+                // which is compile-invisible here precisely because the read is by string. A multiplier of 0
+                // or below makes the consumer's gate term vCPU * multiplier / target_partitions zero or
+                // negative, i.e. a permanently killed fan-out or a negative width — the direction this
+                // class's contract says it must never fail into.
+                if (firstDebugReport(multiplierNonPositiveLogged)) {
+                    logger.debug(
+                        "[{}] is registered with a non-positive value [{}]; the concurrency-gate term is dropped "
+                            + "from the sub-plan fan-out width",
+                        FRAGMENT_EXECUTOR_MULTIPLIER_KEY,
+                        multiplier
+                    );
+                }
+                return OptionalDouble.empty();
+            }
+            return OptionalDouble.of(multiplier);
+        }
+        // Registered but not numeric: fail secure with the same "drop the term" signal rather than
+        // throwing a cast exception onto the query path.
+        if (firstDebugReport(multiplierNonNumericLogged)) {
+            logger.debug(
+                "[{}] is registered with a non-numeric value [{}]; the concurrency-gate term is dropped "
+                    + "from the sub-plan fan-out width",
+                FRAGMENT_EXECUTOR_MULTIPLIER_KEY,
+                value
+            );
+        }
+        return OptionalDouble.empty();
+    }
+
+    /**
+     * Live re-derivation of the backend's {@code target_partitions}, clamped to at least 1.
+     *
+     * @return the derived target partition count, always &gt;= 1
+     */
+    public int targetPartitions() {
+        String mode = clusterSettings.get(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE);
+        int maxSliceCount = clusterSettings.get(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING);
+        return Math.max(1, deriveTargetPartitionsMirror(mode, maxSliceCount));
+    }
+
+    /**
+     * Live value of {@code analytics.query.max_concurrent_shard_requests_per_node}, clamped to at
+     * least 1, or {@link Integer#MAX_VALUE} when the key cannot be resolved.
+     *
+     * @return the per-node in-flight shard-request cap, always &gt;= 1
+     */
+    public int maxConcurrentShardRequestsPerNode() {
+        Setting<?> descriptor = clusterSettings.get(MAX_CONCURRENT_SHARD_REQUESTS_KEY);
+        if (descriptor == null) {
+            if (firstDebugReport(shardRequestCapUnregisteredLogged)) {
+                logger.debug(
+                    "[{}] is not registered on this node; treating the per-node shard-request cap as unbounded",
+                    MAX_CONCURRENT_SHARD_REQUESTS_KEY
+                );
+            }
+            return Integer.MAX_VALUE;
+        }
+        Object value;
+        try {
+            value = clusterSettings.get(descriptor);
+        } catch (RuntimeException e) {
+            // Registered but unreadable — see the same branch in fragmentExecutorMultiplier(). Falls back
+            // to the documented MAX_VALUE rather than throwing onto the query path.
+            if (firstDebugReport(shardRequestCapUnreadableLogged)) {
+                logger.debug(
+                    "[{}] is registered but its live value could not be read [{}]; treating the per-node "
+                        + "shard-request cap as unbounded",
+                    MAX_CONCURRENT_SHARD_REQUESTS_KEY,
+                    e
+                );
+            }
+            return Integer.MAX_VALUE;
+        }
+        if (value instanceof Number number) {
+            // Domain guard on a single value, not composition: keeps the consumer's F >= 1 even if
+            // the declaring plugin relaxes the setting's own minimum of 1. Saturating rather than
+            // Number.intValue(): the read is by string, so a type change on the declaring side
+            long raw = number.longValue();
+            return (int) Math.min(Integer.MAX_VALUE, Math.max(1L, raw));
+        }
+        if (firstDebugReport(shardRequestCapNonNumericLogged)) {
+            logger.debug(
+                "[{}] is registered with a non-numeric value [{}]; treating the per-node shard-request cap as unbounded",
+                MAX_CONCURRENT_SHARD_REQUESTS_KEY,
+                value
+            );
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Byte-faithful mirror of the DataFusion backend's {@code deriveTargetPartitions}: mode
+     * {@code "none"} forces 1, a {@code maxSliceCount} of 0 means the backend owns the concurrency
+     * level and uses half the available processors, otherwise the slice count is capped at the
+     * available processors.
+     *
+     * @param mode          value of {@code search.concurrent_segment_search.mode}
+     * @param maxSliceCount value of {@code search.concurrent.max_slice_count}
+     * @return the derived target partition count, which may be 0
+     */
+    static int deriveTargetPartitionsMirror(String mode, int maxSliceCount) {
+        if (SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE.equals(mode)) {
+            return 1;
+        }
+
+        if (maxSliceCount == 0) {
+            return Runtime.getRuntime().availableProcessors() / 2;
+        }
+
+        return Math.min(maxSliceCount, Runtime.getRuntime().availableProcessors());
+    }
+
+    /**
+     * Trips a latch, returning {@code true} only the first time the message can actually be emitted.
+     * These accessors run on every fan-out decision, so an unlatched log line would be per-query noise;
+     * the log calls stay at their call sites (rather than behind a varargs helper) so the logger-usage
+     * checker can see their arity.
+     */
+    private static boolean firstDebugReport(AtomicBoolean latch) {
+        return logger.isDebugEnabled() && latch.compareAndSet(false, true);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/DslQuerySettings.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/DslQuerySettings.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.settings;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+
+import java.util.List;
+
+/**
+ * The cluster-level operator knob for the DSL sub-plan fan-out — its width — plus a live holder for its
+ * value.
+ */
+public final class DslQuerySettings {
+
+    /**
+     * Maximum number of sub-plans a single DSL query may execute concurrently ("K_setting").
+     * Default 1, which is byte-identical to sequential execution; the hard maximum is
+     * {@code SubPlanParallelism.MAX_K_SETTING}, whose javadoc records why widths above 2 are not yet
+     * known-good. Room above 2 exists so an operator on a larger instance can widen without a deploy;
+     * the width actually used is still clamped by the terms derived from the host.
+     *
+     * <p>The bound is spelled as a literal rather than read from {@code SubPlanParallelism}: that class
+     * is deliberately dependency-free and lives in the {@code executor} package, which already depends
+     * on this one, so importing it here would close a package cycle. The two are pinned to each other by
+     * {@code SubPlanParallelismTests#testTheSettingsBoundMatchesTheHardCeiling}.
+     */
+    public static final Setting<Integer> MAX_PARALLEL_SUB_PLANS = Setting.intSetting(
+        "dsl.query.max_parallel_sub_plans",
+        1,
+        1,
+        5,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    // MAX_PARALLEL_SUB_PLANS above is a WIDTH knob, not an off switch, and it is the rollback for the
+    // concurrency added here: its default of 1 IS the sequential path, so the fan-out is opt-in and
+    // putting it back to 1 restores the prior behaviour without a deploy.
+
+    /**
+     * Every setting this plugin registers — {@code DslQueryExecutorPlugin.getSettings()} returns this
+     * list verbatim. A setting missing from here is rejected in
+     * {@code opensearch.yml}, invisible to {@code _cluster/settings} (a PUT of it is a 400), and not
+     * resolvable by key from another plugin's classloader.
+     *
+     * @return the SC-1 width descriptor, the only setting this plugin registers
+     */
+    public static List<Setting<?>> all() {
+        return List.of(MAX_PARALLEL_SUB_PLANS);
+    }
+
+    // Volatile: the update consumer runs on the cluster-applier thread while readers are on SEARCH threads.
+    private volatile int maxParallelSubPlans;
+
+    /**
+     * Reads the settings from the node settings and registers update consumers so later
+     * {@code _cluster/settings} changes are visible to readers without a restart.
+     *
+     * @param clusterService supplies the node settings and the {@link ClusterSettings} registry
+     */
+    public DslQuerySettings(ClusterService clusterService) {
+        this.maxParallelSubPlans = MAX_PARALLEL_SUB_PLANS.get(clusterService.getSettings());
+        ClusterSettings clusterSettings = clusterService.getClusterSettings();
+        clusterSettings.addSettingsUpdateConsumer(MAX_PARALLEL_SUB_PLANS, v -> maxParallelSubPlans = v);
+    }
+
+    /**
+     * Current value of {@code dsl.query.max_parallel_sub_plans} — the "K_setting" term of the
+     * fan-out width. Read this per query rather than caching it at construction time, otherwise the
+     * value freezes for the life of the node and {@code Property.Dynamic} means nothing.
+     *
+     * @return the configured maximum concurrent sub-plans, always in [1, 5]
+     */
+    public int maxParallelSubPlans() {
+        return maxParallelSubPlans;
+    }
+
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/package-info.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/settings/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Operator knobs for the DSL execution path and the readable inputs the fan-out decision needs. */
+package org.opensearch.dsl.settings;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/DslQueryExecutorPluginTests.java
@@ -9,18 +9,38 @@
 package org.opensearch.dsl;
 
 import org.opensearch.action.support.ActionFilter;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.settings.SettingsModule;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.dsl.action.DslExecuteAction;
 import org.opensearch.dsl.action.SearchActionFilter;
 import org.opensearch.dsl.action.TransportDslExecuteAction;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
+
+    /**
+     * The width setting's upper bound, mirroring {@code SubPlanParallelism.MAX_K_SETTING}
+     * (package-private in another package). Pinned to it by
+     * {@code SubPlanParallelismTests#testTheSettingsBoundMatchesTheHardCeiling}.
+     */
+    private static final int CEILING = 5;
 
     private DslQueryExecutorPlugin plugin;
 
@@ -37,11 +57,143 @@ public class DslQueryExecutorPluginTests extends OpenSearchTestCase {
     }
 
     public void testGetActionFiltersAfterCreateComponents() {
-        plugin.createComponents(mock(NodeClient.class), null, null, null, null, null, null, null, null, null, null);
+        createComponents();
 
         List<ActionFilter> filters = plugin.getActionFilters();
         assertEquals(1, filters.size());
         assertTrue(filters.get(0) instanceof SearchActionFilter);
+    }
+
+    /**
+     * A setting missing from {@code getSettings()} is invisible to {@code _cluster/settings} (a PUT of
+     * it is a 400) and not resolvable by key from another plugin's classloader. Spelled out as literal keys
+     * rather than derived from {@code DslQuerySettings.all()}: the keys are the operator-facing contract, so
+     * a rename has to be visible here.
+     */
+    public void testGetSettingsRegistersTheFanOutWidthAndNothingElse() {
+        Set<String> keys = plugin.getSettings().stream().map(Setting::getKey).collect(Collectors.toSet());
+
+        // Exactly one key: the fan-out is configured by a width and by nothing else. assertEquals on the
+        // whole set, not a contains check, so an added registration fails here.
+        assertEquals(Set.of("dsl.query.max_parallel_sub_plans"), keys);
+    }
+
+    /**
+     * Identity, not key equality. {@code Setting.equals} compares keys only, but
+     * {@code ClusterSettings.addSettingsUpdateConsumer} rejects any descriptor that is not the very
+     * instance the node registered (AbstractScopedSettings.java:256). So if {@code getSettings()} handed
+     * out key-equal copies instead of the constants the holder subscribes to, the node would register the
+     * copies and {@code DslQuerySettings}' constructor would throw {@code SettingsException} — the plugin
+     * would fail to load. The key-set assertion above cannot see that; this can.
+     */
+    public void testGetSettingsRegistersTheSameDescriptorsTheHoldersSubscribeTo() {
+        List<Setting<?>> registered = plugin.getSettings();
+
+        assertEquals("getSettings() must register every setting all() declares", DslQuerySettings.all().size(), registered.size());
+        for (Setting<?> declared : DslQuerySettings.all()) {
+            assertSameDescriptorRegistered(registered, declared);
+        }
+    }
+
+    private static void assertSameDescriptorRegistered(List<Setting<?>> registered, Setting<?> declared) {
+        Setting<?> match = registered.stream().filter(s -> s.getKey().equals(declared.getKey())).findFirst().orElse(null);
+        assertNotNull("getSettings() does not register " + declared.getKey(), match);
+        assertSame("getSettings() must register the descriptor instance itself, not a key-equal copy", declared, match);
+    }
+
+    /**
+     * Both holders must be returned so Guice can inject them into the transport action: without the
+     * settings holder the execution path has no route to {@code dsl.query.max_parallel_sub_plans}, and
+     * without the gate-input reader the cross-plugin read path has no production construction site at
+     * all — it would be reachable only from hand-built test registries.
+     */
+    public void testCreateComponentsReturnsDslQuerySettingsAndGateInputs() {
+        Set<Class<?>> types = createComponents().stream().map(Object::getClass).collect(Collectors.toSet());
+
+        assertEquals(
+            "expected exactly the two settings components, got " + types,
+            Set.of(DslQuerySettings.class, DslGateInputs.class),
+            types
+        );
+    }
+
+    private Collection<Object> createComponents() {
+        // createComponents now dereferences clusterService to build the settings holder, so the
+        // previous null here would NPE. The constructor is deliberately not null-tolerant.
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, Set.copyOf(plugin.getSettings())));
+        return plugin.createComponents(mock(NodeClient.class), clusterService, null, null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * The registration mechanism itself, exercised through the class a node builds its registry with.
+     */
+    public void testSettingsModuleMakesTheWidthKeyResolvableByString() {
+        ClusterSettings registered = nodeRegistry(plugin.getSettings());
+
+        assertSame(DslQuerySettings.MAX_PARALLEL_SUB_PLANS, registered.get("dsl.query.max_parallel_sub_plans"));
+        assertNull("no execution shape may be resolvable as a setting", registered.get("dsl.query.fanout_launch"));
+    }
+
+    /**
+     * The cap at the layer a {@code _cluster/settings} PUT actually hits: the transport action validates
+     * the submitted settings against the node's registry before applying them, and that validation is
+     * what turns a {@code 3} into a 400. A cap enforced only by a downstream {@code min} passes
+     * {@code DslQuerySettingsTests} and fails here.
+     */
+    public void testSettingsModuleValidationRejectsAboveTheCeiling() {
+        ClusterSettings registered = nodeRegistry(plugin.getSettings());
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> registered.validate(Settings.builder().put("dsl.query.max_parallel_sub_plans", CEILING + 1).build(), true)
+        );
+        assertTrue("expected an upper-bound message, got: " + e.getMessage(), e.getMessage().contains("must be <= " + CEILING));
+
+        // The accepted leg, so the test cannot pass against a registry that rejects everything.
+        registered.validate(Settings.builder().put("dsl.query.max_parallel_sub_plans", CEILING).build(), true);
+    }
+
+    /**
+     * The execution shape must be <b>unsettable</b> at the layer a real {@code _cluster/settings} PUT is
+     * validated against. An unregistered key is rejected before any value parsing, so this is the check that
+     * would fail if someone re-registered the shape as a setting — which is the whole point of it being a
+     * constant. {@code SettingsException} rather than {@code IllegalArgumentException}: an unknown key never
+     * reaches a parser.
+     */
+    public void testSettingsModuleRejectsTheLaunchShapeAsAnUnknownSetting() {
+        ClusterSettings registered = nodeRegistry(plugin.getSettings());
+
+        SettingsException e = expectThrows(
+            SettingsException.class,
+            () -> registered.validate(Settings.builder().put("dsl.query.fanout_launch", "flat").build(), true)
+        );
+        assertTrue("expected an unknown-setting message, got: " + e.getMessage(), e.getMessage().contains("unknown setting"));
+        assertEquals(RestStatus.BAD_REQUEST, e.status());
+    }
+
+    /**
+     * The other side of the same mechanism, and the reason the sweep harness is blocked until this
+     * plugin registers its settings: without {@code getSettings()} the key is not merely inert, it is
+     * <b>rejected</b> as unknown — a 400 over REST, a startup failure in {@code opensearch.yml}.
+     */
+    public void testKeysAreUnknownToANodeThatDoesNotRegisterThem() {
+        ClusterSettings withoutDslSettings = nodeRegistry(List.of());
+
+        // SettingsException, not IllegalArgumentException: an unregistered key is rejected before any
+        // value parsing happens. It carries RestStatus.BAD_REQUEST all the same, so the operator-visible
+        SettingsException e = expectThrows(
+            SettingsException.class,
+            () -> withoutDslSettings.validate(Settings.builder().put("dsl.query.max_parallel_sub_plans", 2).build(), true)
+        );
+        assertTrue("expected an unknown-setting message, got: " + e.getMessage(), e.getMessage().contains("unknown setting"));
+        assertEquals(RestStatus.BAD_REQUEST, e.status());
+    }
+
+    /** The registry a node ends up with, assembled the way {@code Node} assembles it. */
+    private static ClusterSettings nodeRegistry(List<Setting<?>> pluginSettings) {
+        return new SettingsModule(Settings.EMPTY, pluginSettings, List.of(), Set.of()).getClusterSettings();
     }
 
     public void testRegistersTransportAction() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -26,9 +26,13 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -38,6 +42,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -81,7 +87,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
     }
 
     public void testDoExecuteFailsWhenIndexNotInClusterState() {
-        ClusterService clusterService = mock(ClusterService.class);
+        ClusterService clusterService = clusterService();
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
@@ -95,7 +101,9 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             clusterService,
             mock(IndicesService.class),
             resolver,
-            mockThreadPool()
+            mockThreadPool(),
+            new DslQuerySettings(clusterService),
+            new DslGateInputs(clusterService.getClusterSettings())
         );
 
         TestListener listener = executeWith(action, "bogus-index");
@@ -130,8 +138,12 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
                 false
             );
         }
+        // A real state (not a bare mock): doExecute pins the request's mapping off
+        // state.metadata().getIndexSafe(...), so the resolved indices must actually exist in it.
         ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
-        ClusterService clusterService = mock(ClusterService.class);
+        // A settings-bearing cluster service, not a bare mock: the action now builds a DslQuerySettings
+        // and a DslGateInputs off it.
+        ClusterService clusterService = clusterService();
         when(clusterService.state()).thenReturn(state);
 
         IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
@@ -145,7 +157,9 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             clusterService,
             mock(IndicesService.class),
             resolver,
-            mockThreadPool()
+            mockThreadPool(),
+            new DslQuerySettings(clusterService),
+            new DslGateInputs(clusterService.getClusterSettings())
         );
     }
 
@@ -173,6 +187,20 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             }
         });
         return schema;
+    }
+
+    /**
+     * A mock cluster service with the settings surface both DSL settings holders read at construction:
+     * {@code DslQuerySettings} takes its initial value from the node settings and registers an update
+     * consumer on the registry, and {@code DslGateInputs} reads the registry per call.
+     */
+    private static ClusterService clusterService() {
+        ClusterService clusterService = mock(ClusterService.class);
+        Set<Setting<?>> registered = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        registered.addAll(DslQuerySettings.all());
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, registered));
+        return clusterService;
     }
 
     private static ThreadPool mockThreadPool() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilderTests.java
@@ -8,6 +8,12 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
@@ -50,5 +56,62 @@ public class AggregationMetadataBuilderTests extends OpenSearchTestCase {
         builder.requestImplicitCount();
 
         expectThrows(ConversionException.class, () -> builder.build(ctx.getRowType(), ctx.getCluster().getTypeFactory()));
+    }
+
+    /**
+     * A {@code SUM} over an {@code INTEGER} column must be declared {@code BIGINT} — the width
+     * {@code DslTypeSystems.NANO_TIMESTAMP} derives, and therefore the width
+     * {@code Aggregate.typeMatchesInferred} demands. The metric translators declare the summed
+     * column's own type, so without the reconciliation in {@code build} this plan does not construct
+     * at all: {@code LogicalAggregate.create} throws {@code type mismatch: aggCall type INTEGER,
+     * inferred type BIGINT}. Asserted on the metadata rather than through a built plan so the failure
+     * names the type, not a Calcite assertion.
+     */
+    public void testSumOverAnIntegerColumnIsDeclaredBigint() throws ConversionException {
+        AggregationMetadata metadata = withMetric(SqlStdOperatorTable.SUM, "price", "sum_price");
+
+        AggregateCall reconciled = metadata.getAggregateCalls().get(0);
+        assertEquals(SqlTypeName.BIGINT, reconciled.getType().getSqlTypeName());
+        assertTrue("nullability of the summed column must survive the widening", reconciled.getType().isNullable());
+    }
+
+    /**
+     * The other half of the same contract, and the boundary of it: {@code MIN} and {@code MAX} keep the
+     * column's own type, while {@code AVG} is declared {@code DOUBLE}.
+     */
+    public void testMinAndMaxStayIntegerWhileAvgIsDouble() throws ConversionException {
+        for (SqlAggFunction fn : List.of(SqlStdOperatorTable.MIN, SqlStdOperatorTable.MAX)) {
+            AggregationMetadata metadata = withMetric(fn, "price", fn.getName() + "_price");
+
+            assertEquals(
+                fn.getName() + " must keep the aggregated column's own type",
+                SqlTypeName.INTEGER,
+                metadata.getAggregateCalls().get(0).getType().getSqlTypeName()
+            );
+        }
+
+        AggregationMetadata avg = withMetric(SqlStdOperatorTable.AVG, "price", "avg_price");
+        assertEquals(
+            "AVG must be declared DOUBLE, or the CAST it emits undoes the SUM widening and the mean is truncated",
+            SqlTypeName.DOUBLE,
+            avg.getAggregateCalls().get(0).getType().getSqlTypeName()
+        );
+    }
+
+    /**
+     * One grouped aggregation carrying one metric, built exactly as the metric translators build it:
+     * the call declares the <em>input column's</em> type (see
+     * {@code AbstractMetricTranslator.toAggregateCall}), which is the input the reconciliation exists
+     * to correct.
+     */
+    private AggregationMetadata withMetric(SqlAggFunction fn, String field, String name) throws ConversionException {
+        RelDataTypeField column = ctx.getRowType().getField(field, false, false);
+        AggregationMetadataBuilder builder = new AggregationMetadataBuilder();
+        builder.addGrouping(new FieldGrouping(List.of("brand")));
+        builder.addAggregateCall(
+            AggregateCall.create(fn, false, false, false, List.of(column.getIndex()), -1, RelCollations.EMPTY, column.getType(), name),
+            name
+        );
+        return builder.build(ctx.getRowType(), ctx.getCluster().getTypeFactory());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
@@ -9,7 +9,9 @@
 package org.opensearch.dsl.aggregation.metric;
 
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
@@ -41,6 +43,38 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
 
         assertEquals(SqlKind.SUM, call.getAggregation().getKind());
         assertEquals("total", call.getName());
+    }
+
+    /**
+     * Every metric translator declares the input column's OWN type — {@code sum} included. This is the
+     * "widened exactly once" pin: {@code DslTypeSystems.NANO_TIMESTAMP} widens a {@code SUM} to the
+     * engine's accumulator width, and the ONE place that widening is applied to a declared type is
+     * {@code AggregationMetadataBuilder#build} (see
+     * {@code AggregationMetadataBuilderTests#testSumOverAnIntegerColumnIsDeclaredBigint}). A translator
+     * that also widened would apply {@code deriveSumType} twice on the same call, so this test fails if
+     * that second mechanism is ever reintroduced here.
+     */
+    public void testEveryMetricDeclaresTheInputColumnType() throws ConversionException {
+        RelDataType priceType = ctx.getRowType().getField("price", false, false).getType();
+        assertEquals(SqlTypeName.INTEGER, priceType.getSqlTypeName());
+
+        assertEquals(
+            "sum must NOT widen here — AggregationMetadataBuilder is the single widening point",
+            priceType,
+            new SumMetricTranslator().toAggregateCall(new SumAggregationBuilder("s").field("price"), ctx.getRowType()).getType()
+        );
+        assertEquals(
+            priceType,
+            new AvgMetricTranslator().toAggregateCall(new AvgAggregationBuilder("a").field("price"), ctx.getRowType()).getType()
+        );
+        assertEquals(
+            priceType,
+            new MinMetricTranslator().toAggregateCall(new MinAggregationBuilder("mn").field("price"), ctx.getRowType()).getType()
+        );
+        assertEquals(
+            priceType,
+            new MaxMetricTranslator().toAggregateCall(new MaxAggregationBuilder("mx").field("price"), ctx.getRowType()).getType()
+        );
     }
 
     public void testMinTranslator() throws ConversionException {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/DslTypeSystemsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/DslTypeSystemsTests.java
@@ -1,0 +1,436 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.converter;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.rules.AggregateReduceFunctionsRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * Pins the two AGGREGATE halves of how {@code DslTypeSystems.NANO_TIMESTAMP} differs from
+ * {@link RelDataTypeSystem#DEFAULT}: the width a {@code SUM} is declared with, and the type an {@code AVG}
+ * is declared with. They are pinned in one class because they are one mechanism — the engine reduces an
+ * {@code AVG} into a {@code SUM}/{@code COUNT}/{@code DIVIDE} plus a CAST back to the {@code AVG}'s own
+ * declared type, so an {@code AVG} left at an integral width casts the widened {@code SUM} straight back
+ * down and makes the division integral on top of it. Fixing either alone leaves the other's symptom.
+ */
+public class DslTypeSystemsTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new SqlTypeFactoryImpl(DslTypeSystems.NANO_TIMESTAMP);
+    }
+
+    /**
+     * The failure this whole class exists for: on a {@code price: integer} field the engine's
+     * {@code OpenSearchAggregateReduceRule} turns the DSL's {@code AVG} into an unnamed {@code SUM} plus
+     * an unnamed {@code COUNT}. With Calcite's default type system that {@code SUM} is declared
+     * {@code INTEGER} while the DataFusion backend accumulates it in {@code Int64}, and on a 2-shard
+     * index the cross-fragment schema check rejects the plan
+     * ({@code Field '$f2' ... (Int32) ... table schema (Int64)}). Asserting {@code BIGINT} here is
+     * asserting that plan is accepted.
+     */
+    public void testReducedAvgSumIsBigintOnAnIntegerField() throws ConversionException {
+        RelNode aggPlan = nestedAvgAggregationPlan();
+
+        Aggregate reduced = reduceAggregateFunctions(aggPlan);
+        AggregateCall sum = onlyCallOfKind(reduced, SqlKind.SUM);
+
+        assertEquals(
+            "the reduced AVG's SUM must be declared as wide as the engine accumulates it, or the "
+                + "2-shard exchange schema check rejects the plan",
+            SqlTypeName.BIGINT,
+            sum.getType().getSqlTypeName()
+        );
+        // The count half is already i64 on both sides; asserted so a change that narrows either half of
+        // the decomposition is caught here rather than on a cluster.
+        for (AggregateCall count : callsOfKind(reduced, SqlKind.COUNT)) {
+            assertEquals("every COUNT of the decomposition must stay i64", SqlTypeName.BIGINT, count.getType().getSqlTypeName());
+        }
+    }
+
+    /**
+     * The written-{@code sum} counterpart of the test above, and the regression this pair was missing:
+     * the {@code SUM} a DSL {@code sum} aggregation is translated into directly (no reduction rule
+     * involved) must be DECLARED at the same width the type system INFERS.
+     */
+    public void testWrittenSumOverAnIntegerFieldIsDeclaredBigint() throws ConversionException {
+        RelNode plan = deepestAggregationPlan(
+            new TermsAggregationBuilder("by_brand").field("brand").subAggregation(new SumAggregationBuilder("sum_price").field("price"))
+        );
+
+        AggregateCall sum = onlyCallOfKind(findAggregate(plan), SqlKind.SUM);
+        assertEquals(
+            "a written sum over an integer field must be declared as wide as the type system derives it",
+            SqlTypeName.BIGINT,
+            sum.getType().getSqlTypeName()
+        );
+        assertTrue("nullability must be carried from the summed column", sum.getType().isNullable());
+    }
+
+    /**
+     * Same invariant on the other aggregate shape: a root-level {@code sum} produces a no-GROUP-BY
+     * aggregate, where {@code ReturnTypes.AGG_SUM} forces the inferred type nullable
+     * ({@code groupCount == 0}) and {@code AggregationMetadataBuilder} independently wraps the declared
+     * type nullable. Both have to land on the same type or the plan is rejected, so the widening and
+     * that wrapping are pinned together here rather than assumed to compose.
+     */
+    public void testRootLevelSumOverAnIntegerFieldIsDeclaredNullableBigint() throws ConversionException {
+        RelNode plan = deepestAggregationPlan(new SumAggregationBuilder("sum_price").field("price"));
+
+        AggregateCall sum = onlyCallOfKind(findAggregate(plan), SqlKind.SUM);
+        assertEquals(SqlTypeName.BIGINT, sum.getType().getSqlTypeName());
+        assertTrue("a no-GROUP-BY sum is nullable on both the declared and the inferred side", sum.getType().isNullable());
+    }
+
+    /**
+     * The contrast half of the test above: with Calcite's default type system the same field yields
+     * {@code INTEGER}. Without this, a reader cannot tell whether the assertion above is pinning
+     * anything.
+     */
+    public void testDefaultTypeSystemWouldDeclareTheSumAsInteger() {
+        RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        RelDataType integer = nullable(defaultFactory, SqlTypeName.INTEGER);
+
+        assertEquals(SqlTypeName.INTEGER, defaultFactory.getTypeSystem().deriveSumType(defaultFactory, integer).getSqlTypeName());
+    }
+
+    public void testSignedIntegerFamilyWidensToBigint() {
+        for (SqlTypeName narrower : List.of(SqlTypeName.TINYINT, SqlTypeName.SMALLINT, SqlTypeName.INTEGER, SqlTypeName.BIGINT)) {
+            RelDataType sumType = deriveSum(nullable(typeFactory, narrower));
+            assertEquals(narrower + " must sum as BIGINT", SqlTypeName.BIGINT, sumType.getSqlTypeName());
+        }
+    }
+
+    public void testApproximateNumericFamilyWidensToDouble() {
+        for (SqlTypeName approximate : List.of(SqlTypeName.REAL, SqlTypeName.FLOAT, SqlTypeName.DOUBLE)) {
+            RelDataType sumType = deriveSum(nullable(typeFactory, approximate));
+            assertEquals(approximate + " must sum as DOUBLE", SqlTypeName.DOUBLE, sumType.getSqlTypeName());
+        }
+    }
+
+    /**
+     * Nullability is part of the sum type, not an afterthought: Calcite's empty-group handling reads it,
+     * so a widening that returned a NOT NULL type would change results, not just the declared width.
+     */
+    public void testNullabilityIsCarriedFromTheArgument() {
+        assertTrue(deriveSum(nullable(typeFactory, SqlTypeName.INTEGER)).isNullable());
+        assertFalse(deriveSum(typeFactory.createSqlType(SqlTypeName.INTEGER)).isNullable());
+    }
+
+    /** A family with no known accumulator widening falls through to Calcite, never to a guess. */
+    public void testUnknownFamilyFallsBackToCalciteDefault() {
+        RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        for (SqlTypeName untouched : List.of(SqlTypeName.DECIMAL, SqlTypeName.VARCHAR, SqlTypeName.BOOLEAN)) {
+            RelDataType argument = nullable(typeFactory, untouched);
+            assertEquals(
+                untouched + " must keep Calcite's derivation",
+                defaultFactory.getTypeSystem().deriveSumType(defaultFactory, argument).getSqlTypeName(),
+                deriveSum(argument).getSqlTypeName()
+            );
+        }
+    }
+
+    // ── AVG ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Both numeric families average to {@code DOUBLE}, unlike {@code deriveSumType}'s two separate
+     * targets. A mean is a quotient, not an accumulator: declared anywhere integral, the {@code DIVIDE} the
+     * reduce rule emits is an integer division, which is a wrong number rather than a wrong width.
+     */
+    public void testEveryNumericFamilyAveragesToDouble() {
+        List<SqlTypeName> numeric = List.of(
+            SqlTypeName.TINYINT,
+            SqlTypeName.SMALLINT,
+            SqlTypeName.INTEGER,
+            SqlTypeName.BIGINT,
+            SqlTypeName.REAL,
+            SqlTypeName.FLOAT,
+            SqlTypeName.DOUBLE
+        );
+        for (SqlTypeName argument : numeric) {
+            assertEquals(
+                argument + " must average as DOUBLE, or the reduced AVG's DIVIDE truncates",
+                SqlTypeName.DOUBLE,
+                deriveAvg(nullable(typeFactory, argument)).getSqlTypeName()
+            );
+        }
+    }
+
+    /**
+     * The contrast half of the test above, and the defect stated as a one-liner: Calcite's default returns
+     * the argument type unchanged, so {@code AVG} over an {@code integer} column is declared {@code INTEGER}
+     * and the reduce rule's CAST target is {@code INTEGER}. Without this, a reader cannot tell whether the
+     * assertion above pins anything.
+     */
+    public void testDefaultTypeSystemWouldDeclareTheAvgAsInteger() {
+        RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        RelDataType integer = nullable(defaultFactory, SqlTypeName.INTEGER);
+
+        assertEquals(SqlTypeName.INTEGER, defaultFactory.getTypeSystem().deriveAvgAggType(defaultFactory, integer).getSqlTypeName());
+    }
+
+    /**
+     * Nullability is carried from the argument for {@code AVG} as it is for {@code SUM}, and nothing
+     * downstream would report it if it were not: {@code ReturnTypes.AVG_AGG_FUNCTION} forces nullability
+     * only for an empty group, a filtered call or {@code STDDEV_SAMP}, so in a GROUPED aggregate the
+     * declared and the inferred type both come from this hook — they would AGREE on a NOT NULL type and
+     * {@code Aggregate}'s check would not fire. This assertion is the only guard, which is why it is here
+     * and not left to a plan test.
+     */
+    public void testNullabilityIsCarriedFromTheAveragedArgument() {
+        assertTrue(deriveAvg(nullable(typeFactory, SqlTypeName.INTEGER)).isNullable());
+        assertFalse(deriveAvg(typeFactory.createSqlType(SqlTypeName.INTEGER)).isNullable());
+    }
+
+    /**
+     * A family with no known mean type falls through to Calcite, never to a guess — same discipline as the
+     * {@code SUM} half. {@code DECIMAL} is deliberately in this list rather than mapped to {@code DOUBLE}:
+     * the engine has its own decimal rule ({@code Decimal128(p,s)} averages to
+     * {@code Decimal128(p+4,s+4)}), no OpenSearch field type maps to {@code DECIMAL} today, and inventing
+     * a third answer for an untestable case would contradict the engine.
+     */
+    public void testUnknownFamilyFallsBackToCalciteDefaultForAvg() {
+        RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        for (SqlTypeName untouched : List.of(SqlTypeName.DECIMAL, SqlTypeName.VARCHAR, SqlTypeName.BOOLEAN)) {
+            RelDataType argument = nullable(typeFactory, untouched);
+            assertEquals(
+                untouched + " must keep Calcite's derivation",
+                defaultFactory.getTypeSystem().deriveAvgAggType(defaultFactory, argument).getSqlTypeName(),
+                deriveAvg(argument).getSqlTypeName()
+            );
+        }
+    }
+
+    /**
+     * The written-{@code avg} counterpart of {@link #testWrittenSumOverAnIntegerFieldIsDeclaredBigint()},
+     * and the tripwire for a HALF fix: with the type system overridden but
+     * {@code AggregationMetadataBuilder#deriveTypeThroughTypeSystem} still gating on {@code SUM} alone, the
+     * translator-declared {@code INTEGER} meets the inferred {@code DOUBLE} and building this plan throws
+     * {@code AssertionError: type mismatch: aggCall type: INTEGER inferred type: DOUBLE} from
+     * {@code LogicalAggregate.create}. Constructing the plan is the assertion.
+     */
+    public void testWrittenAvgOverAnIntegerFieldIsDeclaredDouble() throws ConversionException {
+        RelNode plan = deepestAggregationPlan(
+            new TermsAggregationBuilder("by_brand").field("brand").subAggregation(new AvgAggregationBuilder("avg_price").field("price"))
+        );
+
+        AggregateCall avg = onlyCallOfKind(findAggregate(plan), SqlKind.AVG);
+        assertEquals(
+            "a written avg over an integer field must be declared as the type system derives it",
+            SqlTypeName.DOUBLE,
+            avg.getType().getSqlTypeName()
+        );
+        assertTrue("nullability must be carried from the averaged column", avg.getType().isNullable());
+    }
+
+    /**
+     * The reason declaring {@code AVG} {@code DOUBLE} is not merely cosmetic, asserted on the plan the
+     * engine actually executes rather than on the hook: after the reduction there is no {@code AVG} left,
+     * only a {@code SUM}, a {@code COUNT} and a rule-written {@code DIVIDE} wrapped in casts that ALL target
+     * the type {@code AVG} was declared at. So a declaration at the column's own {@code INTEGER} width is
+     * an executable narrowing — it casts the {@code BIGINT} the sum was correctly widened to back down to
+     * i32 (the {@code Can't cast value 6400000000 to type Int32} 500) and makes the division integral (the
+     * {@code 13.0}-instead-of-{@code 13.875} wrong answer). Both assertions below fail with Calcite's
+     * default derivation and neither can be satisfied by fixing {@code deriveSumType} alone.
+     */
+    public void testReducedAvgDividesInDoubleAndNeverCastsBackToAnIntegralWidth() throws ConversionException {
+        RelNode reduced = reducePlan(nestedAvgAggregationPlan());
+
+        List<RexCall> divides = rexCallsOfKind(reduced, SqlKind.DIVIDE);
+        assertFalse("the reduction must emit the AVG's DIVIDE, or this test asserts nothing", divides.isEmpty());
+        for (RexCall divide : divides) {
+            assertEquals(
+                "the reduced AVG's division must be a floating-point division, or the mean is truncated",
+                SqlTypeName.DOUBLE,
+                divide.getType().getSqlTypeName()
+            );
+        }
+        for (RexCall cast : rexCallsOfKind(reduced, SqlKind.CAST)) {
+            assertFalse(
+                "no cast the reduction emits may narrow to an integral width — that is the cast that "
+                    + "undoes deriveSumType's widening: "
+                    + cast,
+                INTEGRAL.contains(cast.getType().getSqlTypeName())
+            );
+        }
+    }
+
+    // ── Harness ─────────────────────────────────────────────────────────────
+
+    /** The widths a reduced {@code AVG}'s cast must never target. */
+    private static final EnumSet<SqlTypeName> INTEGRAL = EnumSet.of(
+        SqlTypeName.TINYINT,
+        SqlTypeName.SMALLINT,
+        SqlTypeName.INTEGER,
+        SqlTypeName.BIGINT
+    );
+
+    private RelDataType deriveSum(RelDataType argumentType) {
+        return typeFactory.getTypeSystem().deriveSumType(typeFactory, argumentType);
+    }
+
+    private RelDataType deriveAvg(RelDataType argumentType) {
+        return typeFactory.getTypeSystem().deriveAvgAggType(typeFactory, argumentType);
+    }
+
+    private static RelDataType nullable(RelDataTypeFactory factory, SqlTypeName typeName) {
+        return factory.createTypeWithNullability(factory.createSqlType(typeName), true);
+    }
+
+    /**
+     * The AGGREGATION plan of {@code terms(brand) > terms(name) > avg(price)} over the mapping the
+     * failing 2-shard IT provisions.
+     */
+    private static RelNode nestedAvgAggregationPlan() throws ConversionException {
+        return deepestAggregationPlan(
+            new TermsAggregationBuilder("by_brand").field("brand")
+                .subAggregation(
+                    new TermsAggregationBuilder("by_name").field("name")
+                        .subAggregation(new AvgAggregationBuilder("avg_price").field("price"))
+                )
+        );
+    }
+
+    /**
+     * The deepest AGGREGATION plan of the given aggregation tree, over the mapping the failing 2-shard
+     * IT provisions: {@code price} integer, {@code brand}/{@code name} keyword, {@code rating} double.
+     * @param rootAggregation the top-level aggregation to translate
+     */
+    private static RelNode deepestAggregationPlan(AggregationBuilder rootAggregation) throws ConversionException {
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add("test-index", new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory factory) {
+                return factory.builder()
+                    .add("name", nullable(factory, SqlTypeName.VARCHAR))
+                    .add("price", nullable(factory, SqlTypeName.INTEGER))
+                    .add("brand", nullable(factory, SqlTypeName.VARCHAR))
+                    .add("rating", nullable(factory, SqlTypeName.DOUBLE))
+                    .build();
+            }
+        });
+        SearchSourceBuilder source = new SearchSourceBuilder().size(10).aggregation(rootAggregation);
+        QueryPlans plans = new SearchSourceConverter(schema).convert(source, "test-index");
+        List<QueryPlans.QueryPlan> aggregations = plans.get(QueryPlans.Type.AGGREGATION);
+        assertFalse("the fixture must emit an aggregation plan", aggregations.isEmpty());
+        // The deepest granularity is the one carrying the metric.
+        return aggregations.get(aggregations.size() - 1).relNode();
+    }
+
+    /**
+     * Runs the reduction the engine runs ({@code AVG} to {@code SUM}/{@code COUNT}) and returns the
+     * aggregate. The rule is built with the same three arguments {@code OpenSearchAggregateReduceRule}
+     * passes, so the reduction under test is the production one.
+     */
+    private static Aggregate reduceAggregateFunctions(RelNode plan) {
+        return findAggregate(reducePlan(plan));
+    }
+
+    /**
+     * The same reduction, returning the WHOLE reduced plan rather than just its aggregate — the casts and
+     * the {@code DIVIDE} the rule writes live in the Project above the aggregate, not in the aggregate.
+     *
+     * @param plan the un-reduced aggregation plan
+     */
+    private static RelNode reducePlan(RelNode plan) {
+        RelOptRule reduceRule = new AggregateReduceFunctionsRule(
+            LogicalAggregate.class,
+            RelBuilder.proto(Contexts.empty()),
+            EnumSet.of(SqlKind.AVG, SqlKind.STDDEV_POP, SqlKind.STDDEV_SAMP, SqlKind.VAR_POP, SqlKind.VAR_SAMP)
+        );
+        HepPlanner planner = new HepPlanner(HepProgram.builder().addRuleInstance(reduceRule).build());
+        planner.setRoot(plan);
+        return planner.findBestExp();
+    }
+
+    /**
+     * Every {@link RexCall} of the given kind anywhere in the plan's expressions, nested calls included.
+     *
+     * @param root the plan to walk
+     * @param kind the call kind to collect
+     */
+    private static List<RexCall> rexCallsOfKind(RelNode root, SqlKind kind) {
+        List<RexCall> collected = new ArrayList<>();
+        Deque<RelNode> queue = new ArrayDeque<>();
+        queue.add(root);
+        while (queue.isEmpty() == false) {
+            RelNode node = queue.removeFirst();
+            node.accept(new RexShuttle() {
+                @Override
+                public RexNode visitCall(RexCall call) {
+                    if (call.getKind() == kind) {
+                        collected.add(call);
+                    }
+                    return super.visitCall(call);
+                }
+            });
+            queue.addAll(node.getInputs());
+        }
+        return collected;
+    }
+
+    private static Aggregate findAggregate(RelNode root) {
+        Deque<RelNode> queue = new ArrayDeque<>();
+        queue.add(root);
+        while (queue.isEmpty() == false) {
+            RelNode node = queue.removeFirst();
+            if (node instanceof Aggregate aggregate) {
+                return aggregate;
+            }
+            queue.addAll(node.getInputs());
+        }
+        throw new AssertionError("no Aggregate in the reduced plan: " + root);
+    }
+
+    private static AggregateCall onlyCallOfKind(Aggregate aggregate, SqlKind kind) {
+        List<AggregateCall> matching = callsOfKind(aggregate, kind);
+        assertEquals("expected exactly one " + kind + " in " + aggregate.getAggCallList(), 1, matching.size());
+        return matching.get(0);
+    }
+
+    private static List<AggregateCall> callsOfKind(Aggregate aggregate, SqlKind kind) {
+        return aggregate.getAggCallList().stream().filter(call -> call.getAggregation().getKind() == kind).toList();
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SearchSourceConverterTests.java
@@ -9,9 +9,18 @@
 package org.opensearch.dsl.converter;
 
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMdUtil;
+import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.SchemaPlus;
@@ -26,6 +35,7 @@ import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.dsl.golden.CalciteTestInfra;
 import org.opensearch.dsl.golden.GoldenFileLoader;
 import org.opensearch.dsl.golden.GoldenTestCase;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -37,20 +47,38 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class SearchSourceConverterTests extends OpenSearchTestCase {
 
+    /** Invalidate/get rounds each plan's thread runs against its own cluster. */
+    private static final int METADATA_ROUNDS = 200;
+
+    /** Bound on the start barrier so a stuck worker fails the test instead of hanging it. */
+    private static final int BARRIER_TIMEOUT_SECONDS = 30;
+
+    /** Bound on joining each worker. */
+    private static final int JOIN_TIMEOUT_SECONDS = 60;
+
+    private SchemaPlus schema;
     private SearchSourceConverter converter;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema = CalciteSchema.createRootSchema(true).plus();
         schema.add("test-index", new AbstractTable() {
             @Override
             public RelDataType getRowType(RelDataTypeFactory typeFactory) {
@@ -60,6 +88,19 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
                     .add("price", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true))
                     .add("brand", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
                     .add("rating", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE), true))
+                    .build();
+            }
+        });
+        // Same fields plus a date one, so the date-math tests can put a `now`-relative range in the
+        // query clause without changing the row type every other test asserts on.
+        schema.add("date-index", new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+                return typeFactory.builder()
+                    .add("name", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("price", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.INTEGER), true))
+                    .add("brand", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("event_time", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 3), true))
                     .build();
             }
         });
@@ -219,9 +260,8 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
     }
 
     public void testMissingWithMinDocCountGetsOwnEligibleCountPlan() throws ConversionException {
-        // missing + min_doc_count together: substitution makes every matching doc form a group,
-        // but the threshold still drops whole groups from eligibility — the eligible count must be
-        // the HAVING-filtered SUM, not COUNT(*) (which would count dropped groups' docs).
+        // The eligible count must exclude below-threshold groups, which COUNT(field)
+        // cannot see — the aggregation gets its own HAVING-filtered SUM plan.
         SearchSourceBuilder source = new SearchSourceBuilder().size(0)
             .aggregation(new TermsAggregationBuilder("by_brand").field("brand").minDocCount(5).missing("N/A"));
         QueryPlans plans = converter.convert(source, "test-index");
@@ -342,6 +382,235 @@ public class SearchSourceConverterTests extends OpenSearchTestCase {
 
         ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
         assertTrue(e.getMessage().contains("include"));
+    }
+
+    // ---- Per-plan planning isolation ----
+
+    public void testEveryEmittedPlanGetsItsOwnCluster() throws ConversionException {
+        List<QueryPlans.QueryPlan> all = converter.convert(nestedThreeLevelSource(), "test-index").getAll();
+        // Non-vacuity: the shape has to actually emit several plans, or "all distinct" is trivial.
+        assertEquals("expected 1 HITS + 2 AGGREGATION + 1 COUNT: " + planTypes(all), 4, all.size());
+
+        Set<RelOptCluster> clusters = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (QueryPlans.QueryPlan plan : all) {
+            clusters.add(plan.relNode().getCluster());
+        }
+        assertEquals("one RelOptCluster per emitted plan, but " + planTypes(all) + " used " + clusters.size(), all.size(), clusters.size());
+    }
+
+    public void testEmittedPlansShareNoRelNodes() throws ConversionException {
+        List<QueryPlans.QueryPlan> all = converter.convert(nestedThreeLevelSource(), "test-index").getAll();
+        assertEquals("expected 1 HITS + 2 AGGREGATION + 1 COUNT: " + planTypes(all), 4, all.size());
+
+        List<Set<RelNode>> nodesPerPlan = all.stream().map(plan -> collectNodes(plan.relNode())).collect(Collectors.toList());
+        for (Set<RelNode> nodes : nodesPerPlan) {
+            // The query clause is a term query, so every plan's base is Scan → Filter. A shared
+            // base would show up as a shared LogicalFilter, so the walk has to reach one — without
+            // this the disjointness assertion could hold over trees that never include the base.
+            assertTrue("plan has no LogicalFilter to share", nodes.stream().anyMatch(n -> n instanceof LogicalFilter));
+        }
+
+        for (int i = 0; i < nodesPerPlan.size(); i++) {
+            for (int j = i + 1; j < nodesPerPlan.size(); j++) {
+                Set<RelNode> shared = Collections.newSetFromMap(new IdentityHashMap<>());
+                shared.addAll(nodesPerPlan.get(i));
+                shared.retainAll(nodesPerPlan.get(j));
+                assertTrue("plans " + i + " and " + j + " share RelNodes: " + shared, shared.isEmpty());
+            }
+        }
+    }
+
+    public void testEveryNodeOfAPlanLivesInThatPlansCluster() throws ConversionException {
+        List<QueryPlans.QueryPlan> all = converter.convert(nestedThreeLevelSource(), "test-index").getAll();
+        assertEquals("expected 1 HITS + 2 AGGREGATION + 1 COUNT: " + planTypes(all), 4, all.size());
+
+        for (QueryPlans.QueryPlan plan : all) {
+            RelOptCluster planCluster = plan.relNode().getCluster();
+            Set<RelNode> nodes = collectNodes(plan.relNode());
+            assertTrue("plan " + plan.type() + " has a single node only", nodes.size() > 1);
+            for (RelNode node : nodes) {
+                // A cross-cluster subtree would leave this plan's metadata lookups on a sibling
+                // plan's cluster, which another thread is concurrently invalidating — the same race
+                assertSame(
+                    "plan " + plan.type() + " reaches a " + node.getRelTypeName() + " in another plan's cluster",
+                    planCluster,
+                    node.getCluster()
+                );
+            }
+        }
+    }
+
+    public void testNestedChildRebuildsTheParentLevelInItsOwnCluster() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .query(QueryBuilders.termQuery("brand", "acme"))
+            .aggregation(
+                new TermsAggregationBuilder("by_brand").field("brand")
+                    .size(2)
+                    .subAggregation(new TermsAggregationBuilder("by_name").field("name").size(3))
+            );
+        List<QueryPlans.QueryPlan> aggPlans = converter.convert(source, "test-index").get(QueryPlans.Type.AGGREGATION);
+        assertEquals(2, aggPlans.size());
+
+        RelNode parent = aggPlans.get(0).relNode();
+        RelNode child = aggPlans.get(1).relNode();
+        RelNode semiJoinRight = semiJoinRightInputOf(child);
+
+        // The parent level is the child's semi-join input. Reusing the emitted parent plan's own
+        // node would put two dispatched plans on one subtree; rebuilding it in the child's cluster
+        assertNotSame("the child must not reuse the emitted parent plan's nodes", parent, semiJoinRight);
+        assertNotSame("the two plans must not share a cluster", parent.getCluster(), child.getCluster());
+        assertSame("the rebuilt parent level must live in the child's cluster", child.getCluster(), semiJoinRight.getCluster());
+        assertEquals("the rebuilt parent level must be identical to the emitted parent plan", parent.explain(), semiJoinRight.explain());
+        assertEquals(parent.getRowType(), semiJoinRight.getRowType());
+    }
+
+    public void testAllPlansShareOneRelOptTable() throws ConversionException {
+        // The deliberately shared half: catalogReader.getTable runs once per request, so every plan
+        // scans the same RelOptTable instance — one interned row type, hence field indices that
+        // agree between a plan and a rebuilt sibling level. Read back out of the emitted RelNodes,
+        // so resolving a table per plan (each getTable builds a fresh RelOptTableImpl) fails this.
+        List<QueryPlans.QueryPlan> all = converter.convert(nestedThreeLevelSource(), "test-index").getAll();
+        assertEquals("expected 1 HITS + 2 AGGREGATION + 1 COUNT: " + planTypes(all), 4, all.size());
+
+        Set<RelOptTable> tables = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (QueryPlans.QueryPlan plan : all) {
+            Set<RelOptTable> planTables = scanTablesOf(plan.relNode());
+            // Every plan must reach a scan, or "one table everywhere" would hold over nothing.
+            assertFalse("plan " + plan.type() + " has no TableScan", planTables.isEmpty());
+            tables.addAll(planTables);
+        }
+        assertEquals("one RelOptTable identity across all plans, but got " + tables, 1, tables.size());
+    }
+
+    /**
+     * Replays, on all plans of one request at once, the pair of calls made per plan on the thread
+     * that dispatches it — set {@code THREAD_PROVIDERS}, then invalidate that plan's metadata query
+     * (see {@code DslQueryPlanExecutor#logPlan}, and the engine's own executor). Without per-plan
+     * isolation those plans share one {@code RelOptCluster} whose {@code mq} field is neither
+     */
+    public void testConcurrentMetadataAccessAcrossPlansIsIsolated() throws Exception {
+        List<QueryPlans.QueryPlan> all = converter.convert(nestedThreeLevelSource(), "test-index").getAll();
+        assertEquals("expected 1 HITS + 2 AGGREGATION + 1 COUNT: " + planTypes(all), 4, all.size());
+
+        Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+        CyclicBarrier barrier = new CyclicBarrier(all.size());
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < all.size(); i++) {
+            RelNode relNode = all.get(i).relNode();
+            threads.add(new Thread(() -> {
+                try {
+                    // A thread that already carries a provider would mask a missing set() below and
+                    // make the probe vacuous.
+                    RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+                    RelOptCluster cluster = relNode.getCluster();
+                    barrier.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    for (int round = 0; round < METADATA_ROUNDS; round++) {
+                        RelMetadataQueryBase.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(cluster.getMetadataProvider()));
+                        cluster.invalidateMetadataQuery();
+                        RelMdUtil.clearCache(relNode);
+                        assertNotNull(cluster.getMetadataQuery().getRowCount(relNode));
+                    }
+                } catch (Throwable t) {
+                    errors.offer(t);
+                } finally {
+                    RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+                }
+            }, "dsl-plan-metadata-" + i));
+        }
+
+        threads.forEach(Thread::start);
+        for (Thread thread : threads) {
+            thread.join(TimeUnit.SECONDS.toMillis(JOIN_TIMEOUT_SECONDS));
+            assertFalse("worker did not finish: " + thread.getName(), thread.isAlive());
+        }
+        assertTrue(errors.toString(), errors.isEmpty());
+    }
+
+    // ---- Query validation on the zero-plan path ----
+
+    public void testSizeZeroNoAggsWithInvalidQueryIsRejected() {
+        // Translating the query clause is what validates it, and after per-plan isolation that only
+        // happens inside a plan's own base. This shape still emits the flat COUNT plan, so its base
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).query(QueryBuilders.termQuery("nope", "x"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
+        assertTrue(e.getMessage(), e.getMessage().contains("nope"));
+    }
+
+    public void testZeroPlanRequestWithInvalidQueryIsRejectedNotAnsweredEmpty() {
+        // size=0 + no aggregations + track_total_hits:false is the one request that emits no plan
+        // at all — not even a COUNT plan — so nothing translates its query unless convert() does so
+        // deliberately. Without that, a malformed query is an empty 200 a caller cannot tell apart
+        // from "no results" instead of the 400 this ConversionException becomes at the transport.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0).trackTotalHits(false).query(QueryBuilders.termQuery("nope", "x"));
+
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(source, "test-index"));
+        assertTrue(e.getMessage(), e.getMessage().contains("nope"));
+    }
+
+    public void testZeroPlanRequestWithValidQueryStillProducesNoPlans() throws ConversionException {
+        // The guard above must not start rejecting legitimate empty requests: a resolvable query on
+        // the zero-plan path is still a normal empty result, not a failure.
+        SearchSourceBuilder source = new SearchSourceBuilder().size(0)
+            .trackTotalHits(false)
+            .query(QueryBuilders.termQuery("brand", "acme"));
+
+        assertEquals(0, converter.convert(source, "test-index").getAll().size());
+    }
+
+    /** 3-level nesting with hits: emits HITS, AGGREGATION(by_brand), AGGREGATION(by_brand,by_name), COUNT. */
+    private static SearchSourceBuilder nestedThreeLevelSource() {
+        return new SearchSourceBuilder().size(10)
+            .query(QueryBuilders.termQuery("brand", "acme"))
+            .aggregation(
+                new TermsAggregationBuilder("by_brand").field("brand")
+                    .subAggregation(
+                        new TermsAggregationBuilder("by_name").field("name")
+                            .subAggregation(new AvgAggregationBuilder("avg_price").field("price"))
+                    )
+            );
+    }
+
+    /** Plan types in emit order, for assertion messages. */
+    private static String planTypes(List<QueryPlans.QueryPlan> plans) {
+        return plans.stream().map(p -> p.type().name()).collect(Collectors.joining(","));
+    }
+
+    /** Collects a plan's RelNodes into an identity set. */
+    private static Set<RelNode> collectNodes(RelNode root) {
+        Set<RelNode> nodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        Deque<RelNode> pending = new ArrayDeque<>();
+        pending.push(root);
+        while (pending.isEmpty() == false) {
+            RelNode current = pending.pop();
+            if (nodes.add(current)) {
+                current.getInputs().forEach(pending::push);
+            }
+        }
+        return nodes;
+    }
+
+    /** Returns the identity set of tables scanned anywhere in a plan — all branches, not just input 0. */
+    private static Set<RelOptTable> scanTablesOf(RelNode root) {
+        Set<RelOptTable> tables = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (RelNode node : collectNodes(root)) {
+            if (node instanceof TableScan) {
+                tables.add(node.getTable());
+            }
+        }
+        return tables;
+    }
+
+    /** Returns the right input of the plan's single semi-join — the parent level a nested plan bounds against. */
+    private static RelNode semiJoinRightInputOf(RelNode root) {
+        List<RelNode> rights = new ArrayList<>();
+        for (RelNode node : collectNodes(root)) {
+            if (node instanceof Join join && join.getJoinType() == JoinRelType.SEMI) {
+                rights.add(join.getInput(1));
+            }
+        }
+        assertEquals("expected exactly one semi-join in " + root.explain(), 1, rights.size());
+        return rights.get(0);
     }
 
     // ---- Golden file driven RelNode generation tests ----

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/CoordinatorShardLayoutTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/CoordinatorShardLayoutTests.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.routing.OperationRouting;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The {@code S_node} read: shards of one index on the <em>busiest node</em>, from live routing.
+ */
+public class CoordinatorShardLayoutTests extends OpenSearchTestCase {
+
+    private static final String INDEX = "products";
+
+    private OperationRouting routing;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        routing = ShardLayouts.routing();
+    }
+
+    /**
+     * The value that matters: 6 shards split 4/2 is a busiest node of 4, not 6 (the index's shard count)
+     * and not 3 (an average). Substituting the index-wide count would inflate the per-sub-query fragment
+     * cost on every multi-node cluster and silently pin the fan-out at 1.
+     */
+    public void testBusiestNodeCountOnSkewedPlacement() {
+        ClusterState state = state(List.of("node-0", "node-0", "node-0", "node-0", "node-1", "node-1"));
+        assertEquals(4, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, INDEX));
+    }
+
+    public void testBusiestNodeCountIsOneOnSingleShardIndex() {
+        ClusterState state = state(List.of("node-0"), "node-0", "node-1");
+        assertEquals(1, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, INDEX));
+    }
+
+    /** The co-located-coordinator case: F is largest here, so K_gate is smallest. */
+    public void testAllShardsOnOneNodeReturnsShardCount() {
+        ClusterState state = state(List.of("node-0", "node-0", "node-0", "node-0"), "node-0");
+        assertEquals(4, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, INDEX));
+    }
+
+    public void testUnassignedShardsAreSkippedNotCounted() {
+        // Arrays.asList, not List.of: a null placement is the point of this case.
+        ClusterState state = state(Arrays.asList("node-0", "node-0", "node-0", null));
+        assertEquals(3, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, INDEX));
+    }
+
+    /** Never 0: the width formula divides by this value. */
+    public void testNoAssignedShardReturnsOneNotZero() {
+        ClusterState state = state(Arrays.asList(null, null, null));
+        assertEquals(1, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, INDEX));
+    }
+
+    /**
+     * A routing read that throws outright — the realistic cause is an index deleted between this
+     * request's cluster-state snapshot and the read — must degrade to the neutral 1, not fail the search.
+     * An advisory input has no business turning a valid {@code _search} into an error.
+     */
+    public void testUnknownIndexReturnsOneRatherThanThrowing() {
+        ClusterState state = state(List.of("node-0", "node-0"));
+        assertEquals(1, CoordinatorShardLayout.shardsOnBusiestNode(state, routing, "no-such-index"));
+    }
+
+    /** Placements for shard 0..n-1; a null entry leaves that shard unassigned. */
+    private static ClusterState state(List<String> placements, String... extraNodes) {
+        return ShardLayouts.clusterState(INDEX, placements, extraNodes);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
@@ -8,15 +8,109 @@
 
 package org.opensearch.dsl.executor;
 
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.analytics.QueryRequestContext;
+import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.CheckedRunnable;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.util.concurrent.OpenSearchThreadPoolExecutor;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.SearchSourceConverter;
+import org.opensearch.dsl.golden.CalciteTestInfra;
 import org.opensearch.dsl.result.ExecutionResult;
+import org.opensearch.dsl.settings.DslGateInputs;
+import org.opensearch.dsl.settings.DslQuerySettings;
+import org.opensearch.search.SearchService;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.junit.annotations.TestLogging;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the sub-plan fan-out.
+ */
 public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
+
+    private static final String MULTIPLIER_KEY = "datafusion.concurrency.fragment_executor_multiplier";
+    private static final String SHARD_REQUEST_CAP_KEY = "analytics.query.max_concurrent_shard_requests_per_node";
+    private static final String MAX_SLICE_COUNT_KEY = SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey();
+
+    /** Same key/type/bounds as the sibling DataFusion plugin's descriptor, which is unreachable from here. */
+    private static final Setting<Double> MULTIPLIER_COPY = Setting.doubleSetting(
+        MULTIPLIER_KEY,
+        1.5,
+        0.1,
+        10.0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /** Same key/type/bounds as the parent analytics-engine plugin's descriptor. */
+    private static final Setting<Integer> SHARD_REQUEST_CAP_COPY = Setting.intSetting(
+        SHARD_REQUEST_CAP_KEY,
+        5,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /** The fixed leading token of the width line — what the runbook and the benchmark cells grep for. */
+    private static final String K_EFF_TOKEN = "dsl.fanout.k_eff";
+
+    /** The index the shard-layout tests route against; it exists only in their cluster-state fixture. */
+    private static final String ROUTED_INDEX = "products";
+
+    /** One log line per emitted plan, from {@code logPlan}. */
+    private static final String PLAN_LOG_MARKER = "Executing RelNode";
+
+    private static final String LOGGER_NAME = "org.opensearch.dsl.executor";
+    private static final String DEBUG_LOGGING = LOGGER_NAME + ":DEBUG";
+    private static final String DEBUG_REASON = "logPlan and logRows are DEBUG-level, so the level has to be raised to reach them";
 
     private LogicalTableScan scan;
 
@@ -26,14 +120,16 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
         scan = TestUtils.createTestRelNode();
     }
 
+    // ── The sequential contract (the shipped default) ───────────────────────
+
     public void testExecuteDelegatesEachPlanToExecutor() {
         List<Object[]> expectedRows = List.<Object[]>of(new Object[] { "laptop", 1200 });
 
-        DslQueryPlanExecutor executor = new DslQueryPlanExecutor((plan, ctx, listener) -> listener.onResponse(expectedRows));
+        DslQueryPlanExecutor executor = executor((plan, ctx, listener) -> listener.onResponse(expectedRows), 1);
         QueryPlans plans = new QueryPlans.Builder().add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan)).build();
 
         PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
-        executor.execute(plans, future);
+        executor.execute(plans, null, "test-index", future);
         List<ExecutionResult> results = future.actionGet();
 
         assertEquals(1, results.size());
@@ -67,6 +163,1753 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
         );
     }
 
-    // TODO: add test with multiple plans (HITS + AGGREGATION) to verify iteration order
-    // TODO: add test for executor failure
+    /**
+     * Every plan of a request — plan 0 and each fanned-out sibling alike — is dispatched with the same
+     * engine context the sequential path has always used, which on this branch is {@code null}.
+     */
+    public void testDispatchesEveryPlanWithANullEngineContext() {
+        ClusterState state = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-1"));
+
+        List<Object> seen = Collections.synchronizedList(new ArrayList<>());
+        DslQueryPlanExecutor executor = executor((plan, ctx, listener) -> {
+            // Recorded rather than asserted inline: an assertion throwing here would be routed to the
+            // request's failure arm and reported as a plan failure instead of as a test failure.
+            seen.add(ctx);
+            listener.onResponse(List.<Object[]>of());
+        }, 2);
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor.execute(plans(3), state, ROUTED_INDEX, future);
+        assertEquals(3, future.actionGet().size());
+
+        assertEquals("every plan must be dispatched", 3, seen.size());
+        for (int i = 0; i < seen.size(); i++) {
+            assertNull(
+                "plan "
+                    + i
+                    + " must reach the engine with the same null context the sequential path passes, "
+                    + "on the gated route too, got: "
+                    + seen.get(i),
+                seen.get(i)
+            );
+        }
+    }
+
+    /**
+     * Iteration order is part of the contract: results come back in plan order, and this test is the only
+     * thing that says so (see the class javadoc).
+     */
+    public void testExecuteRunsPlansInPlanOrder() {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, 1).execute(plans, null, "test-index", future);
+        List<ExecutionResult> results = future.actionGet();
+
+        assertEquals(List.of(0, 1, 2), stub.dispatchOrder());
+        assertEquals(3, results.size());
+        for (int i = 0; i < 3; i++) {
+            assertSame("result " + i + " must be plan " + i + "'s", plans.getAll().get(i).relNode(), results.get(i).getPlan().relNode());
+        }
+    }
+
+    /**
+     * The invariant the fan-out deliberately breaks, pinned here at the shipped default: plan {@code i+1}
+     * is dispatched only after plan {@code i} has reported, so exactly one plan is ever outstanding.
+     */
+    public void testExecuteDispatchesPlanNPlusOneOnlyAfterPlanN() {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 1).execute(plans, null, "test-index", listener);
+
+        for (int i = 0; i < 3; i++) {
+            assertEquals("plan " + i + " must be the only one outstanding", 1, stub.inFlight.get());
+            assertEquals(i + 1, stub.dispatchOrder().size());
+            stub.completeParked(i);
+        }
+        assertEquals(1, stub.highWater.get());
+        assertEquals(3, listener.results.size());
+    }
+
+    /**
+     * The abort arm: the first failure ends the chain — the listener gets that exception, no results, and
+     * the plan after the failing one is never dispatched. The fan-out path deliberately differs (it waits
+     * for the siblings), which is why this pin is taken at {@code K_setting = 1}.
+     */
+    public void testExecuteAbortsChainOnFirstPlanFailure() {
+        RuntimeException boom = new RuntimeException("plan 1 failed");
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.failInline.put(1, boom);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 1).execute(plans, null, "test-index", listener);
+
+        assertSame("the first failure must reach the listener unchanged", boom, listener.failure);
+        assertNull("a failed chain must not also deliver results", listener.results);
+        assertEquals("the plan after the failing one must not be dispatched", List.of(0, 1), stub.dispatchOrder());
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+    }
+
+    /** The same fail-fast contract when it is plan 0 that fails: nothing else is dispatched at all. */
+    public void testExecuteFailureOnFirstPlanDispatchesNothingElse() {
+        RuntimeException boom = new RuntimeException("plan 0 failed");
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.failInline.put(0, boom);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 1).execute(plans, null, "test-index", listener);
+
+        assertSame(boom, listener.failure);
+        assertNull(listener.results);
+        assertEquals("only plan 0 may be dispatched", List.of(0), stub.dispatchOrder());
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+    }
+
+    /** At the shipped default the call sequence is the sequential one, in plan order. */
+    public void testDegreeOneIsSequentialAndOrdered() {
+        QueryPlans plans = plans(4);
+        Stub stub = new Stub(plans);
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, 1).execute(plans, null, "test-index", future);
+        List<ExecutionResult> results = future.actionGet();
+
+        assertEquals(1, stub.highWater.get());
+        assertEquals(List.of(0, 1, 2, 3), stub.dispatchOrder());
+        assertPlanOrder(plans, results);
+    }
+
+    // ── The fan-out ─────────────────────────────────────────────────────────
+
+    /**
+     * No short-circuit: a failure must not be reported while sibling sub-plans are still running, because
+     * firing the listener early abandons distributed queries that have nobody left to report to.
+     */
+    public void testAllPlansCompleteBeforeFailureIsReported() {
+        QueryPlans plans = plans(3);
+        // One stamp source shared by the stub and the listener, so "after" is asserted on a real ordering
+        // rather than on a sleep.
+        AtomicInteger stamps = new AtomicInteger();
+        Stub stub = new Stub(plans, stamps);
+        stub.failInline.put(1, new RuntimeException("plan 1 failed"));
+        stub.defer.add(2);
+
+        CapturingListener listener = new CapturingListener(stamps);
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("plan 1 failed, but plan 2 is still running", 0, listener.terminalCalls);
+        assertEquals(List.of(0, 1, 2), stub.dispatchOrder());
+        int beforePlanTwo = stamps.get();
+        stub.completeParked(2);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNotNull(listener.failure);
+        assertTrue("the failure must be reported after plan 2 finished", listener.terminalStamp > beforePlanTwo);
+    }
+
+    /** A plan that throws out of its dispatch still releases its permit and drives the countdown. */
+    public void testSynchronousThrowMidFanOutStillCompletesListener() {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.throwInline.put(1, new IllegalStateException("dispatch of plan 1 threw"));
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNotNull(listener.failure);
+        assertTrue("plan 2 must still run", stub.dispatchOrder().contains(2));
+    }
+
+    /**
+     * Every fan-out plan failing pre-dispatch still ends in exactly <b>one</b> failure reaching the request,
+     * carrying nothing else with it.
+     */
+    public void testPreDispatchFailureDrivesCountdownToZero() {
+        QueryPlans plans = plans(4);
+        Stub stub = new Stub(plans);
+        for (int i = 1; i < 4; i++) {
+            stub.throwInline.put(i, new IllegalStateException("dispatch of plan " + i + " threw"));
+        }
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNotNull(listener.failure);
+        assertEquals(
+            "one _search must not carry K internal exceptions to the client: " + Arrays.toString(listener.failure.getSuppressed()),
+            0,
+            listener.failure.getSuppressed().length
+        );
+    }
+
+    /**
+     * The listener-notified-twice path, which nothing else covers: the engine completes the per-plan
+     * listener and <em>then</em> throws, so the loop's {@code catch} calls {@code onFailure} on an
+     * already-completed listener.
+     */
+    public void testCompleteThenThrowDoesNotDoubleReleaseThePermit() {
+        QueryPlans plans = plans(5);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+        stub.completeThenThrow.add(1);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+        stub.completeParked(0);
+
+        // Plan 1 completed and threw, releasing its one permit; plans 2 and 3 hold the two permits and plan
+        // 4 is queued behind them. A double release would have admitted plan 4 as well.
+        assertEquals("a second permit release would have admitted a third plan at once", 2, stub.highWater.get());
+        assertEquals(List.of(0, 1, 2, 3), stub.dispatchOrder());
+
+        while (listener.terminalCalls == 0) {
+            stub.completeAnyParked();
+            assertTrue("in-flight " + stub.inFlight.get() + " exceeded K_eff", stub.inFlight.get() <= 2);
+        }
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertNotNull("the fan-out must complete: " + listener.failure, listener.results);
+        assertPlanOrder(plans, listener.results);
+        assertEquals(2, stub.highWater.get());
+    }
+
+    /**
+     * A throw out of the <em>request's own</em> listener must not come back as a second report for the plan
+     * that happened to be last. That is what {@code ActionListener.wrap} would do: the countdown call sits in
+     * its success body, so the terminal's throw would be routed to the same wrapper's failure arm, the plan
+     * would count down twice, the countdown would drop below zero — permanently past the terminal it tests
+     * for — and the exception would be parked unread in the collector's failure queue with nothing left to
+     * fire it at. It is a silent loss, not a hang, which is exactly why nothing else here notices it.
+     *
+     * <p>The discriminating observation is that the throw <b>propagates to whoever completed the plan</b>.
+     * The plans are parked and completed by the test rather than inline, so there is no dispatch
+     * {@code catch} in between to absorb it: with the report outside the try the completion throws, and with
+     * it inside the try the completion returns normally and the exception disappears.
+     */
+    public void testAThrowFromTheRequestListenerIsNotReportedAsAPlanFailure() {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.defer.add(1);
+        stub.defer.add(2);
+
+        ThrowingListener listener = new ThrowingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+        assertEquals("both fan-out plans must be outstanding at width 2", List.of(0, 1, 2), stub.dispatchOrder());
+
+        // Plan 1 only counts down; the terminal is plan 2's, and the request listener throws out of it.
+        stub.completeParked(1);
+        assertEquals("the terminal must not have fired yet", 0, listener.terminalCalls);
+
+        IllegalStateException thrown = expectThrows(IllegalStateException.class, () -> stub.completeParked(2));
+        assertEquals("the request listener's own failure", thrown.getMessage());
+        assertEquals("the request listener must still have been notified exactly once", 1, listener.terminalCalls);
+        assertEquals("its failure arm must not be reached — it is not the query that failed", 0, listener.failureCalls);
+    }
+
+    /**
+     * An empty plan set completes with an empty list. It cannot arrive from the converter today, but the
+     * branch is explicit code with a real alternative: falling through would index plan 0 of nothing, and
+     * failing would turn a query the old sequential chain answered into an error.
+     */
+    public void testEmptyPlanSetCompletesWithAnEmptyList() {
+        QueryPlans plans = new QueryPlans.Builder().build();
+        Stub stub = new Stub(plans);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNull("an empty query is not a failure: " + listener.failure, listener.failure);
+        assertEquals(List.of(), listener.results);
+        assertEquals("nothing may be dispatched for an empty query", List.of(), stub.dispatchOrder());
+    }
+
+    /**
+     * Above the inline-drain bound the executor takes the sequential path. The stub completes inline, which
+     * is the only way to make this assertion mean anything: in production the engine forks onto SEARCH
+     * before executing, so the nesting this bounds does not appear there at all.
+     */
+    public void testLargePlanCountFallsBackToSequential() {
+        QueryPlans plans = plans(64);
+        Stub stub = new Stub(plans);
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, 2).execute(plans, null, "test-index", future);
+        List<ExecutionResult> results = future.actionGet();
+
+        assertEquals("the fallback must be sequential, not a width-2 gate", 1, stub.highWater.get());
+        assertPlanOrder(plans, results);
+    }
+
+    // ── The fan-out ─────────────────────────────────────────────────────────
+
+    /**
+     * <b>The reason every plan is gated.</b> A 2-plan query — a 2-level nested aggregation with
+     * {@code size: 0}, the measured production shape — is the common case. Gating both plans is what makes
+     * {@code K_eff} 2 so they are genuinely in flight together; a shape that ran plan 0 alone first would
+     * clamp the width to {@code n - 1 == 1} and never overlap anything here.
+     */
+    public void testTwoPlansRunBothConcurrently() {
+        QueryPlans plans = plans(2);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("both plans must be dispatched before either completes", List.of(0, 1), stub.dispatchOrder());
+        assertEquals("K_eff = 2 at n = 2, the common production shape", 2, stub.inFlight.get());
+        assertEquals(2, stub.highWater.get());
+
+        stub.completeParked(1);
+        assertNull("the listener must wait for plan 0", listener.results);
+        stub.completeParked(0);
+
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertPlanOrder(plans, listener.results);
+    }
+
+    /**
+     * Slotting by plan index, proved by completing the plans in an order unrelated to their plan order —
+     * including plan 0 <b>last</b>, which is only expressible because plan 0 goes through the gate and
+     * has already completed before its collector exists.
+     */
+    public void testResultsInPlanOrderWhenCompletionOrderShuffled() {
+        QueryPlans plans = plans(4);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        // K_eff = 2, so plans 0 and 1 are in flight and plans 2 and 3 are queued behind them.
+        assertEquals(List.of(0, 1), stub.dispatchOrder());
+        stub.completeParked(1);
+        assertEquals("finishing plan 1 must admit the queued plan 2", List.of(0, 1, 2), stub.dispatchOrder());
+        stub.completeParked(2);
+        assertEquals("finishing plan 2 must admit the queued plan 3", List.of(0, 1, 2, 3), stub.dispatchOrder());
+        stub.completeParked(3);
+        assertNull("the listener must wait for plan 0", listener.results);
+        stub.completeParked(0);
+
+        assertEquals(1, listener.terminalCalls);
+        assertPlanOrder(plans, listener.results);
+    }
+
+    /** The gate's whole job. Run with {@code -Dtests.iters=100}. */
+    public void testNeverMoreThanKEffInFlight() {
+        QueryPlans plans = plans(6);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals(2, stub.inFlight.get());
+        while (listener.terminalCalls == 0) {
+            stub.completeAnyParked();
+            assertTrue("in-flight " + stub.inFlight.get() + " exceeded K_eff", stub.inFlight.get() <= 2);
+        }
+        assertEquals("high-water must not exceed K_eff", 2, stub.highWater.get());
+        assertPlanOrder(plans, listener.results);
+    }
+
+    /**
+     * A mid-flight failure: the listener still fires exactly once, still carries the
+     * first failure, and still fires only after every sibling has reported — firing early would abandon
+     * distributed queries with nobody left to report to.
+     */
+    public void testCompletesListenerExactlyOnceOnMidFlightFailure() {
+        RuntimeException boom = new RuntimeException("plan 1 failed");
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.defer.add(0);
+        stub.failInline.put(1, boom);
+        stub.defer.add(2);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("plan 1's failure released its permit, so plan 2 must have been admitted", List.of(0, 1, 2), stub.dispatchOrder());
+        assertEquals("plans 0 and 2 are still running", 0, listener.terminalCalls);
+
+        stub.completeParked(2);
+        assertEquals("plan 0 is still running", 0, listener.terminalCalls);
+        stub.completeParked(0);
+
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertSame("the first failure must reach the listener unchanged", boom, listener.failure);
+        assertNull("a failed query must not also deliver results", listener.results);
+    }
+
+    /**
+     * A plan-0 failure does not suppress the other plans, pinned so it is a decision rather than a
+     * surprise. They are already dispatched by the time it reports, so the collector waits for them and
+     * reports plan 0's failure exactly once.
+     */
+    public void testDispatchesEveryPlanEvenWhenPlanZeroFails() {
+        RuntimeException boom = new RuntimeException("plan 0 failed");
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        stub.failInline.put(0, boom);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("plan 0 is dispatched through the gate like any other plan", List.of(0, 1, 2), stub.dispatchOrder());
+        assertEquals(1, listener.terminalCalls);
+        assertSame(boom, listener.failure);
+        assertEquals("no plan may be left in flight", 0, stub.inFlight.get());
+    }
+
+    /**
+     * Turning the arm on is not by itself a widening: at the shipped {@code max_parallel_sub_plans = 1} the
+     * fan-out settles on width 1 and takes the plain sequential chain from plan 0. That is what makes
+     * {@code K = 1} a byte-identical baseline rather than a second,
+     * untested behaviour.
+     */
+    public void testWidthOneIsTheSequentialChain() {
+        QueryPlans plans = plans(4);
+        Stub stub = new Stub(plans);
+
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, 1).execute(plans, null, "test-index", future);
+        List<ExecutionResult> results = future.actionGet();
+
+        assertEquals("width 1 must never have two plans outstanding", 1, stub.highWater.get());
+        assertEquals(List.of(0, 1, 2, 3), stub.dispatchOrder());
+        assertPlanOrder(plans, results);
+    }
+
+    /**
+     * The inline-drain bound counts gated plans, and every plan is gated. At
+     * {@code n == MAX_FANOUT_PLANS} the query still fans out; at {@code n == MAX_FANOUT_PLANS + 1} it must
+     * fall back to sequential, because the inline drain would otherwise nest one frame group per plan.
+     */
+    public void testInlineDrainBoundCountsEveryPlan() {
+        QueryPlans atBound = plans(SubPlanParallelism.MAX_FANOUT_PLANS);
+        Stub atBoundStub = new Stub(atBound);
+        atBoundStub.deferAll = true;
+        CapturingListener atBoundListener = new CapturingListener();
+        executor(atBoundStub, 2).execute(atBound, null, "test-index", atBoundListener);
+        assertEquals("exactly MAX_FANOUT_PLANS gated plans must still fan out", 2, atBoundStub.inFlight.get());
+        while (atBoundListener.terminalCalls == 0) {
+            atBoundStub.completeAnyParked();
+        }
+        assertPlanOrder(atBound, atBoundListener.results);
+
+        QueryPlans pastBound = plans(SubPlanParallelism.MAX_FANOUT_PLANS + 1);
+        Stub pastBoundStub = new Stub(pastBound);
+        pastBoundStub.deferAll = true;
+        CapturingListener pastBoundListener = new CapturingListener();
+        executor(pastBoundStub, 2).execute(pastBound, null, "test-index", pastBoundListener);
+        assertEquals("one gated plan past the bound must be sequential", 1, pastBoundStub.inFlight.get());
+        assertEquals(List.of(0), pastBoundStub.dispatchOrder());
+        while (pastBoundListener.terminalCalls == 0) {
+            pastBoundStub.completeAnyParked();
+            assertTrue("the sequential path must never have two plans outstanding", pastBoundStub.inFlight.get() <= 1);
+        }
+        assertEquals(1, pastBoundStub.highWater.get());
+        assertPlanOrder(pastBound, pastBoundListener.results);
+    }
+
+    /**
+     * The payload contract under <b>real</b> concurrency, and the one that matters most for a measurement
+     * tool: a racy fan-out would produce fast numbers that are quietly wrong, which is worse than no
+     * fan-out at all. Every other fan-out test here completes the parked plans from the test thread, so the
+     * gate's release and the collector's slotting are never actually concurrent there.
+     *
+     * <p>Run at the widest fan-out the inline-drain bound allows ({@code n == MAX_FANOUT_PLANS}, all of them
+     * gated), with more drainers than permits so two releases overlap inside the gate. It pins that every
+     * plan's payload lands in its own slot (nothing lost, duplicated or reordered), that the terminal fires
+     * exactly once, and that concurrent releases cannot admit a plan past {@code K_eff} — including for
+     * plan 0, which is a gated plan like any other. Run with {@code -Dtests.iters=100}.
+     */
+    public void testConcurrentCompletionsSlotEveryPlanExactlyOnce() throws Exception {
+        QueryPlans plans = plans(SubPlanParallelism.MAX_FANOUT_PLANS);
+        final int gatedPlans = plans.getAll().size();
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+        // The dispatch loop runs on this thread and parks plans 0 and 1 before any drainer starts, so the
+        // high-water mark of K_eff is reached deterministically and the assertion at the end is about the
+        // gate never going *above* it under contention.
+        assertEquals(2, stub.highWater.get());
+
+        AtomicInteger completed = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        List<Thread> drainers = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            Thread drainer = new Thread(() -> {
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                while (completed.get() < gatedPlans && System.nanoTime() < deadlineNanos) {
+                    if (stub.completeAnyParkedIfPresent()) {
+                        completed.incrementAndGet();
+                    } else {
+                        // Nothing parked yet: a permit is held by a plan another drainer is still dispatching.
+                        Thread.yield();
+                    }
+                }
+            }, "fan-out-drainer-" + i);
+            drainers.add(drainer);
+            drainer.start();
+        }
+        start.countDown();
+        for (Thread drainer : drainers) {
+            drainer.join(TimeUnit.SECONDS.toMillis(30));
+            assertFalse("drainer " + drainer.getName() + " did not finish", drainer.isAlive());
+        }
+
+        // Asserted on the test thread, not inside the drainers: a bare assert in a spawned thread depends on
+        // the runner's uncaught-exception handling to be seen, and a deadlocked fan-out has to fail on this
+        // count rather than hang the suite.
+        assertEquals("every gated plan must have completed", gatedPlans, completed.get());
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertNull("no plan failed: " + listener.failure, listener.failure);
+        assertPlanOrder(plans, listener.results);
+        assertEquals("concurrent releases must not admit a plan past K_eff", 2, stub.highWater.get());
+    }
+
+    // ── The aggregation-only gate ───────────────────────────────────────────
+
+    /**
+     * <b>A request with no aggregation plan must never fan out.</b> The overlap exists to run AGGREGATION
+     * sub-plans at the same time, so a batch that carries none takes the sequential chain however wide the
+     * gate is set.
+     */
+    public void testNonAggregationQueryNeverFansOut() {
+        QueryPlans plans = hitsAndCountPlans(1);
+        Stub stub = new Stub(plans);
+        stub.deferAll = true;
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        // Before any completion: every gated plan is dispatched up front, so one dispatched plan
+        // is the whole claim. A fanned-out run cannot produce this state at any width above 1.
+        assertEquals("a non-aggregation query must dispatch plan 0 alone", List.of(0), stub.dispatchOrder());
+        assertEquals(1, stub.inFlight.get());
+
+        while (listener.terminalCalls == 0) {
+            stub.completeAnyParked();
+            assertTrue("the sequential path must never have two plans outstanding", stub.inFlight.get() <= 1);
+        }
+        assertEquals(1, stub.highWater.get());
+        assertEquals("every plan must still run, just one at a time", List.of(0, 1), stub.dispatchOrder());
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertPlanOrder(plans, listener.results);
+
+        // The control: the same n, the same setting, the same arm — one AGGREGATION plan instead of the
+        // COUNT plan — must still overlap. The gate closes a request shape, it does not disable the feature.
+        QueryPlans aggregation = plans(2);
+        Stub aggregationStub = new Stub(aggregation);
+        aggregationStub.deferAll = true;
+        executor(aggregationStub, 2).execute(aggregation, null, "test-index", new CapturingListener());
+        assertEquals("an aggregation query at the same settings must still fan out", List.of(0, 1), aggregationStub.dispatchOrder());
+        assertEquals(2, aggregationStub.highWater.get());
+    }
+
+    /**
+     * The two real request shapes, from the real converter, at one set of settings: the fan-out's reason for
+     * existing still overlaps, and a plain search does not. {@code size: 0} plus a 2-level nested aggregation
+     * is the measured production shape and emits no HITS plan at all, so this also pins that the eligibility
+     * predicate asks whether <em>an</em> AGGREGATION plan is present rather than whether every plan is one —
+     * the aggregation batch here carries the request-totals COUNT plan alongside its two aggregation plans,
+     * and a stricter predicate would have disqualified the very shape the feature was built for.
+     */
+    public void testMeasuredAggregationShapeFansOutButAPlainSearchDoesNot() throws Exception {
+        QueryPlans aggregation = sizeZeroNestedAggregationPlans();
+        assertFalse("size: 0 emits no hits plan", aggregation.has(QueryPlans.Type.HITS));
+        assertTrue("the fixture must be an aggregation request", aggregation.has(QueryPlans.Type.AGGREGATION));
+        assertTrue("and a multi-plan one, or there is nothing to overlap", aggregation.getAll().size() >= 2);
+
+        Stub aggregationStub = new Stub(aggregation);
+        aggregationStub.deferAll = true;
+        CapturingListener aggregationListener = new CapturingListener();
+        executor(aggregationStub, 2).execute(aggregation, null, "test-index", aggregationListener);
+
+        assertEquals("the measured production shape must still overlap", 2, aggregationStub.inFlight.get());
+        assertEquals(2, aggregationStub.highWater.get());
+        while (aggregationListener.terminalCalls == 0) {
+            aggregationStub.completeAnyParked();
+        }
+        assertEquals(1, aggregationListener.terminalCalls);
+        assertNull("no plan failed: " + aggregationListener.failure, aggregationListener.failure);
+
+        QueryPlans plain = convert(new SearchSourceBuilder());
+        assertFalse("a plain search converts to no aggregation plan", plain.has(QueryPlans.Type.AGGREGATION));
+        assertEquals("the hits plan plus the COUNT plan that supplies hits.total", 2, plain.getAll().size());
+
+        Stub plainStub = new Stub(plain);
+        plainStub.deferAll = true;
+        CapturingListener plainListener = new CapturingListener();
+        executor(plainStub, 2).execute(plain, null, "test-index", plainListener);
+
+        assertEquals("a plain search's two engine calls must not overlap", 1, plainStub.inFlight.get());
+        while (plainListener.terminalCalls == 0) {
+            plainStub.completeAnyParked();
+            assertTrue("the sequential path must never have two plans outstanding", plainStub.inFlight.get() <= 1);
+        }
+        assertEquals(1, plainStub.highWater.get());
+        assertEquals(1, plainListener.terminalCalls);
+    }
+
+    /**
+     * SC-10 survives the gate: an ineligible multi-plan query is still measured exactly once. The line's
+     * <em>absence</em> means "not a multi-plan query" and must keep meaning only that, so the gate sits at
+     * the width decision rather than short-circuiting in front of it — a whole class of multi-plan queries
+     * silently dropping out of the log would make every scraped cell unattributable.
+     */
+    public void testNonAggregationQueryIsStillMeasured() throws Exception {
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .build();
+        ClusterSettings clusterSettings = registry(nodeSettings, SHARD_REQUEST_CAP_COPY);
+        ClusterService clusterService = clusterService(nodeSettings, clusterSettings);
+
+        QueryPlans plans = hitsAndCountPlans(1);
+        Stub stub = new Stub(plans);
+        DslQueryPlanExecutor executor = executor(stub, clusterService, new DslGateInputs(clusterSettings), mockThreadPool());
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        ClusterState placed = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-0", "node-1"));
+
+        List<String> lines = capturingLogs(K_EFF_TOKEN, () -> executor.execute(plans, placed, ROUTED_INDEX, future));
+
+        assertPlanOrder(plans, future.actionGet());
+        assertEquals(1, stub.highWater.get());
+        verify(clusterService, never()).operationRouting();
+
+        assertEquals("an ineligible multi-plan query is still measured", 1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("the operator's setting is reported as it is, not as the gate made it", "2", fields.get("K_setting"));
+        assertEquals("2", fields.get("n"));
+        assertEquals("1", fields.get("K_eff"));
+        for (String term : List.of("A", "F", "K_gate", "K_search")) {
+            assertEquals("a term the gate never reached must render as skipped, not as a number", "skipped", fields.get(term));
+        }
+    }
+
+    // ── D2.2: the live SEARCH pool-size read ────────────────────────────────
+
+    /**
+     * The size has to come off the executor, live. {@code ThreadPool.info} is built once at node start and
+     * never rebuilt, so it goes stale the moment the pool is resized — the second assertion here is what
+     * makes this a regression guard for that rather than a tautology.
+     */
+    public void testSearchPoolSizeTracksLiveMaximumPoolSize() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool(getTestName());
+        try {
+            ExecutorService searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+            OptionalInt before = DslQueryPlanExecutor.searchPoolSize(searchExecutor);
+            assertTrue("SEARCH is always an OpenSearchThreadPoolExecutor on a real node", before.isPresent());
+            int original = before.getAsInt();
+
+            ((OpenSearchThreadPoolExecutor) searchExecutor).setMaximumPoolSize(original + 3);
+
+            assertEquals(original + 3, DslQueryPlanExecutor.searchPoolSize(searchExecutor).getAsInt());
+            assertEquals(
+                "threadPool.info() is the stale reading this method exists to avoid",
+                original,
+                threadPool.info(ThreadPool.Names.SEARCH).getMax()
+            );
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    /**
+     * The absent case, which cannot be provoked on a real node — SEARCH is always built as a resizable
+     * {@code OpenSearchThreadPoolExecutor} — so an in-process injection is the only way to reach it. The
+     * load-bearing half is that the term is then <b>dropped</b> from the width rather than replaced with a
+     * guessed pool size; the paired assertion lives in
+     * {@link SubPlanParallelismTests#testKEffDropsSearchTermWhenPoolSizeAbsent}. Neither half may be
+     * deleted alone.
+     */
+    public void testSearchPoolSizeAbsentWhenExecutorIsNotOpenSearchThreadPoolExecutor() {
+        ExecutorService plain = Executors.newFixedThreadPool(4);
+        try {
+            assertEquals(OptionalInt.empty(), DslQueryPlanExecutor.searchPoolSize(plain));
+        } finally {
+            plain.shutdownNow();
+        }
+    }
+
+    // ── D2.4: the SC-9 mapping, observed through the width line ─────────────
+
+    /**
+     * Every gate input reaches the formula: with the multiplier at 3.0 and {@code target_partitions} at 1,
+     * the reported fragment count is {@code vCpu * 3} and the reported sub-query bound is that over
+     * {@code F}. Asserting through the width line rather than through a test-only accessor keeps the
+     * production surface unchanged — and the line is the contract anyway.
+     */
+    public void testInputsPopulatedFromGateInputs() throws Exception {
+        // max_slice_count = 1 pins target_partitions at 1 whatever this machine's core count is (the
+        // mirror is min(sliceCount, vCpu), and the "none" mode forces 1 too), so the expected A below is a
+        // function of the multiplier alone.
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2)
+            .put(MULTIPLIER_KEY, 3.0)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .put(MAX_SLICE_COUNT_KEY, 1)
+            .build();
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, nodeSettings, MULTIPLIER_COPY, SHARD_REQUEST_CAP_COPY), plans, K_EFF_TOKEN);
+
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        int vCpu = Runtime.getRuntime().availableProcessors();
+        int expectedA = Math.max(1, (int) Math.floor(vCpu * 3.0 / 1));
+        // No cluster-state snapshot on this request, so the shard layout is the neutral 1 and F is 1.
+        assertEquals("2", fields.get("K_setting"));
+        assertEquals(String.valueOf(expectedA), fields.get("A"));
+        assertEquals("1", fields.get("F"));
+        assertEquals("the gate term must be present, not absent", String.valueOf(expectedA), fields.get("K_gate"));
+        assertEquals("the mock SEARCH executor has no readable size", "absent", fields.get("K_search"));
+        assertEquals("3", fields.get("n"));
+        assertEquals(String.valueOf(Math.min(2, expectedA)), fields.get("K_eff"));
+    }
+
+    /**
+     * The D-side half of the "absent is not 1.0" contract: with no backend declaring the multiplier the
+     * gate term is <b>dropped</b>, which the line reports as {@code absent}. A synthesised 1.0 would be
+     * indistinguishable from a configured 1.0 and would clamp the width instead.
+     */
+    public void testEmptyMultiplierSetsGateTermAbsentNotOne() throws Exception {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("absent", fields.get("K_gate"));
+        assertNotEquals("a dropped term must never render as a number", "1", fields.get("K_gate"));
+        assertEquals("dropping the term must not narrow the width", "2", fields.get("K_eff"));
+    }
+
+    /**
+     * Read once per query, not once per plan: the gate inputs are dynamic settings, so they are read at the
+     * decision site — but a read inside the fan-out loop would multiply the cost by the plan count and make
+     * the reported width disagree with the one that ran.
+     */
+    public void testGateInputsReadOncePerQueryNotPerPlan() throws Exception {
+        AtomicInteger parses = new AtomicInteger();
+        Setting<Double> countingMultiplier = new Setting<>(MULTIPLIER_KEY, "1.5", raw -> {
+            parses.incrementAndGet();
+            return Double.parseDouble(raw);
+        }, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+        Settings nodeSettings = Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2).build();
+        ClusterSettings registry = registry(nodeSettings, countingMultiplier, SHARD_REQUEST_CAP_COPY);
+        DslGateInputs gateInputs = new DslGateInputs(registry);
+
+        // Calibrated rather than hardcoded: the cost of ONE accessor call on this registry, whatever the
+        // settings machinery does internally.
+        parses.set(0);
+        gateInputs.fragmentExecutorMultiplier();
+        int perRead = parses.get();
+        assertTrue("the counting parser must actually be exercised", perRead > 0);
+
+        QueryPlans plans = plans(4);
+        Stub stub = new Stub(plans);
+        parses.set(0);
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, nodeSettings, registry, gateInputs).execute(plans, null, "test-index", future);
+        assertEquals(4, future.actionGet().size());
+
+        assertEquals("the multiplier must be read once for the whole query, not once per plan", perRead, parses.get());
+    }
+
+    // ── D2.5: the shard-layout input, wired ─────────────────────────────────
+
+    /**
+     * The wiring of the busiest-node shard count into the width, which {@link CoordinatorShardLayoutTests}
+     * covers only as a standalone function. Without a test that gets <em>here</em>, replacing the whole
+     * routing read with {@code return 1} keeps every other test in this class green, because they all hand
+     * the executor a null cluster-state snapshot and therefore take the neutral fallback.
+     */
+    public void testShardLayoutTermIsReadFromLiveRoutingNotAConstant() throws Exception {
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .build();
+        ClusterState skewed = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-0", "node-0", "node-0", "node-1", "node-1"));
+
+        QueryPlans plans = plans(3);
+        List<String> lines = runCapturingLogs(
+            executor(new Stub(plans), nodeSettings, SHARD_REQUEST_CAP_COPY),
+            plans,
+            K_EFF_TOKEN,
+            skewed,
+            ROUTED_INDEX
+        );
+        assertEquals(1, lines.size());
+        assertEquals(
+            "F must be the busiest node's shard count from live routing — not 1 (the no-snapshot fallback), "
+                + "not 6 (the index's shard count) and not 2 (the other node's share)",
+            "4",
+            parseKEffLine(lines.get(0)).get("F")
+        );
+
+        QueryPlans control = plans(3);
+        List<String> withoutSnapshot = runCapturingLogs(
+            executor(new Stub(control), nodeSettings, SHARD_REQUEST_CAP_COPY),
+            control,
+            K_EFF_TOKEN,
+            null,
+            ROUTED_INDEX
+        );
+        assertEquals(1, withoutSnapshot.size());
+        assertEquals(
+            "with no snapshot to read there is nothing to divide by, so the neutral 1 stands",
+            "1",
+            parseKEffLine(withoutSnapshot.get(0)).get("F")
+        );
+    }
+
+    /**
+     * A resolved index name is one of the two things the routing read needs, so a query that arrives without
+     * one must degrade to the neutral fallback rather than fail the search on an advisory input.
+     */
+    public void testShardLayoutFallsBackToOneWhenTheIndexNameIsAbsent() throws Exception {
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .build();
+        ClusterState skewed = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-0", "node-0", "node-0"));
+
+        QueryPlans plans = plans(3);
+        List<String> lines = runCapturingLogs(
+            executor(new Stub(plans), nodeSettings, SHARD_REQUEST_CAP_COPY),
+            plans,
+            K_EFF_TOKEN,
+            skewed,
+            null
+        );
+
+        assertEquals(1, lines.size());
+        assertEquals("1", parseKEffLine(lines.get(0)).get("F"));
+    }
+
+    // ── The width decision never fails a search, and reads nothing it cannot use ──
+
+    /**
+     * The tenet, at the <em>composition</em> site rather than at one input: <b>a wrong fan-out width must
+     * never fail a search.</b> Each input is already fail-secure on its own — {@code DslGateInputs} catches
+     * per key, {@code CoordinatorShardLayout} degrades to 1 — but the composition runs inside plan 0's
+     * success callback, where {@code ActionListener.wrap} routes a throw to the request's failure arm. So
+     * before the catch, a read that threw here turned a search whose plan 0 had already succeeded into a
+     * 500.
+     *
+     * <p>The throw is provoked the way it would really arrive: {@code targetPartitions()} resolves two
+     * {@code :server} settings <b>typed</b>, and {@code ClusterSettings.get(Setting)} throws
+     * {@code SettingsException("setting ... has not been registered")} when a key stops being registered (an
+     * upgrade that moves or renames it). Unlike the multiplier read, that one is not wrapped by its own
+     * producer. Note the shape the production catch has to be written for: {@code SettingsException} is an
+     * {@code OpenSearchException}, i.e. a {@code RuntimeException} but <b>not</b> an
+     * {@code IllegalArgumentException}.
+     *
+     * <p>What makes this test discriminating is what it asserts <em>past</em> the absence of a failure: the
+     * full ordered result list is delivered, and the query ran sequentially. Without the catch,
+     * {@code actionGet()} rethrows the {@code IllegalArgumentException} and the test fails there.
+     */
+    public void testAThrowingWidthReadRunsSequentiallyInsteadOfFailingTheSearch() throws Exception {
+        Settings nodeSettings = Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2).build();
+        // Registers the DSL settings only, so DslQuerySettings still works while the two :server settings
+        // targetPartitions() reads typed are missing.
+        ClusterSettings partial = new ClusterSettings(nodeSettings, new HashSet<>(DslQuerySettings.all()));
+        DslGateInputs unreadable = new DslGateInputs(partial);
+        // The premise of the test, asserted rather than assumed: this really is a throwing read.
+        expectThrows(SettingsException.class, unreadable::targetPartitions);
+
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        DslQueryPlanExecutor executor = executor(stub, nodeSettings, partial, unreadable);
+
+        List<String> lines = capturingLogs(K_EFF_TOKEN, () -> executor.execute(plans, null, "test-index", future));
+
+        assertPlanOrder(plans, future.actionGet());
+        assertEquals("the degraded path is the sequential one", 1, stub.highWater.get());
+        assertEquals(List.of(0, 1, 2), stub.dispatchOrder());
+
+        assertEquals("a query that degraded is still measured", 1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("the setting is read before the terms, so it is still reportable", "2", fields.get("K_setting"));
+        for (String term : List.of("A", "F", "K_gate", "K_search")) {
+            assertEquals("a term whose read threw must not render as a number or as absent", "unavailable", fields.get(term));
+        }
+        assertEquals("1", fields.get("K_eff"));
+    }
+
+    /**
+     * The same degrade for the other unguarded read at that site: {@code threadPool.executor(SEARCH)} throws
+     * if that pool is not registered.
+     */
+    public void testAThrowingSearchPoolReadRunsSequentially() {
+        Settings nodeSettings = Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2).build();
+        ClusterSettings clusterSettings = registry(nodeSettings);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(any())).thenThrow(new IllegalArgumentException("no executor service found for [search]"));
+
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor(stub, clusterService(nodeSettings, clusterSettings), new DslGateInputs(clusterSettings), threadPool).execute(
+            plans,
+            null,
+            "test-index",
+            future
+        );
+
+        assertPlanOrder(plans, future.actionGet());
+        assertEquals(1, stub.highWater.get());
+    }
+
+    /**
+     * At the shipped default the expensive inputs are <b>not read at all</b>. {@code K_eff} is 1 whatever
+     * they say once {@code K_setting} is 1, and reading them costs an {@code OperationRouting.searchShards}
+     * over every shard of the index plus four settings lookups on the query hot path, all discarded.
+     */
+    public void testWidthTermsAreNotReadAtTheShippedDefault() throws Exception {
+        AtomicInteger parses = new AtomicInteger();
+        Setting<Double> countingMultiplier = new Setting<>(MULTIPLIER_KEY, "1.5", raw -> {
+            parses.incrementAndGet();
+            return Double.parseDouble(raw);
+        }, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 1)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .build();
+        ClusterSettings clusterSettings = registry(nodeSettings, countingMultiplier, SHARD_REQUEST_CAP_COPY);
+        ClusterService clusterService = clusterService(nodeSettings, clusterSettings);
+
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        DslQueryPlanExecutor executor = executor(stub, clusterService, new DslGateInputs(clusterSettings), mockThreadPool());
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        ClusterState placed = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-0", "node-1"));
+
+        parses.set(0);
+        List<String> lines = capturingLogs(K_EFF_TOKEN, () -> executor.execute(plans, placed, ROUTED_INDEX, future));
+
+        assertPlanOrder(plans, future.actionGet());
+        verify(clusterService, never()).operationRouting();
+        assertEquals("no gate setting may be read once K_setting has already settled the width", 0, parses.get());
+
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("1", fields.get("K_setting"));
+        for (String term : List.of("A", "F", "K_gate", "K_search")) {
+            assertEquals(
+                "an unread term must render as skipped — `absent` means READ AND DROPPED, the opposite claim",
+                "skipped",
+                fields.get(term)
+            );
+        }
+        assertEquals("1", fields.get("K_eff"));
+    }
+
+    /** The other early-out: above the inline-drain bound the width is 1, so the terms are not read either. */
+    public void testWidthTermsAreNotReadAboveThePlanBound() throws Exception {
+        Settings nodeSettings = Settings.builder()
+            .put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), 2)
+            .put(SHARD_REQUEST_CAP_KEY, 5)
+            .build();
+        ClusterSettings clusterSettings = registry(nodeSettings, SHARD_REQUEST_CAP_COPY);
+        ClusterService clusterService = clusterService(nodeSettings, clusterSettings);
+
+        QueryPlans plans = plans(SubPlanParallelism.MAX_FANOUT_PLANS + 2);
+        Stub stub = new Stub(plans);
+        DslQueryPlanExecutor executor = executor(stub, clusterService, new DslGateInputs(clusterSettings), mockThreadPool());
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        ClusterState placed = ShardLayouts.clusterState(ROUTED_INDEX, List.of("node-0", "node-0", "node-1"));
+
+        List<String> lines = capturingLogs(K_EFF_TOKEN, () -> executor.execute(plans, placed, ROUTED_INDEX, future));
+
+        assertPlanOrder(plans, future.actionGet());
+        verify(clusterService, never()).operationRouting();
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("2", fields.get("K_setting"));
+        assertEquals("skipped", fields.get("F"));
+        assertEquals("1", fields.get("K_eff"));
+    }
+
+    // ── D4.4: SC-10, the observable width ───────────────────────────────────
+
+    public void testKEffLineEmittedExactlyOncePerQuery() throws Exception {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertEquals("exactly one width line per multi-plan query", 1, lines.size());
+    }
+
+    /**
+     * The line's field set and order, pinned as a contract: seven fields, these names, these positions, and
+     * the line <em>ends</em> after {@code K_eff}. A scraper anchored to the leading
+     * {@code dsl.fanout.k_eff} token depends on all of it, so a reordering or an appended field fails here.
+     */
+    public void testKEffLineCarriesEveryContractFieldInOrder() throws Exception {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertEquals(1, lines.size());
+        String line = lines.get(0);
+        assertTrue(
+            "the eight fields must appear in contract order, got: " + line,
+            Pattern.compile(
+                "^"
+                    + Pattern.quote(K_EFF_TOKEN)
+                    + " K_setting=(\\S+) A=(\\S+) F=(\\S+) K_gate=(\\S+) K_search=(\\S+) n=(\\S+) K_eff=(\\S+)$"
+            ).matcher(line).matches()
+        );
+        Map<String, String> fields = parseKEffLine(line);
+        assertEquals("2", fields.get("K_setting"));
+        assertEquals("1", fields.get("F"));
+        assertEquals("3", fields.get("n"));
+        assertEquals("2", fields.get("K_eff"));
+    }
+
+    public void testKEffLineRendersDroppedTermsAsAbsent() throws Exception {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("absent", fields.get("K_gate"));
+        assertEquals("absent", fields.get("K_search"));
+        assertNotEquals("1", fields.get("K_gate"));
+        assertNotEquals("1", fields.get("K_search"));
+    }
+
+    /** A query too wide to fan out is still measured — otherwise it looks unmeasured, not unfanned. */
+    public void testKEffLineEmittedOnSequentialFallback() throws Exception {
+        QueryPlans plans = plans(64);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertEquals(1, lines.size());
+        Map<String, String> fields = parseKEffLine(lines.get(0));
+        assertEquals("64", fields.get("n"));
+        assertEquals("1", fields.get("K_eff"));
+    }
+
+    /**
+     * A single-plan query never reaches the fan-out decision, so it emits nothing. An absent line means
+     * "not a multi-plan query", never "the line was dropped" — the rollout steps read it that way.
+     */
+    public void testNoKEffLineForSinglePlanQuery() throws Exception {
+        QueryPlans plans = plans(1);
+        Stub stub = new Stub(plans);
+
+        List<String> lines = runCapturingLogs(executor(stub, 2), plans, K_EFF_TOKEN);
+
+        assertTrue("a single-plan query must emit no width line, got: " + lines, lines.isEmpty());
+    }
+
+    // ── D4.3: logPlan's kept set -> invalidate -> explain sequence ───────────
+
+    /**
+     * The regression pin for the NPE class this whole plugin keeps warning about: {@code RelWriterImpl}
+     * asks the cluster for a metadata query while rendering, and one built on a thread whose
+     * {@code THREAD_PROVIDERS} ThreadLocal is unset NPEs. {@code logPlan} is safe only because it sets that
+     * ThreadLocal itself, on the dispatching thread, before it explains.
+     */
+    @TestLogging(reason = DEBUG_REASON, value = DEBUG_LOGGING)
+    public void testLogPlanOnColdThreadDoesNotNpe() throws Exception {
+        QueryPlans plans = nestedAggregationPlans();
+        assertTrue("the fixture must produce a fan-out, got " + plans.getAll().size() + " plan(s)", plans.getAll().size() >= 2);
+
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+        Queue<Thread> threads = new ConcurrentLinkedQueue<>();
+        DslQueryPlanExecutor executor = executor((plan, ctx, listener) -> {
+            // A genuinely fresh thread, never a pooled one: a pooled thread may already be primed.
+            Thread thread = new Thread(() -> {
+                try {
+                    RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+                    assertNull("the dispatching thread must start cold", RelMetadataQueryBase.THREAD_PROVIDERS.get());
+                    listener.onResponse(List.<Object[]>of());
+                } catch (Throwable t) {
+                    failures.add(t);
+                }
+            }, "cold-dispatch");
+            threads.add(thread);
+            thread.start();
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+        }, 2);
+
+        CapturingListener listener = new CapturingListener();
+        RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+        assertNull(RelMetadataQueryBase.THREAD_PROVIDERS.get());
+        executor.execute(plans, null, "test-index", listener);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        if (failures.isEmpty() == false) {
+            throw new AssertionError("plan logging failed on a cold thread", failures.peek());
+        }
+        assertNull("no failure may reach the listener: " + failures, listener.failure);
+        assertNotNull(listener.results);
+        assertEquals(plans.getAll().size(), listener.results.size());
+    }
+
+    /**
+     * The guard-regression pin, and the only mechanical protection for the cost decision: at INFO the block
+     * must not execute at all, so the ThreadLocal it would have written must still be unset afterwards.
+     * <b>This is the test that fails if the guard is reverted to {@code isInfoEnabled()}.</b>
+     */
+    public void testLogPlanIsOffAtInfoLevel() throws Exception {
+        QueryPlans plans = nestedAggregationPlans();
+        Stub stub = new Stub(plans);
+
+        RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+        assertNull(RelMetadataQueryBase.THREAD_PROVIDERS.get());
+        List<String> planLines = runCapturingLogs(executor(stub, 2), plans, PLAN_LOG_MARKER);
+
+        assertNull("at INFO the plan-log block must not run", RelMetadataQueryBase.THREAD_PROVIDERS.get());
+        assertTrue("at INFO nothing may be logged, got: " + planLines, planLines.isEmpty());
+    }
+
+    /**
+     * The ThreadLocal must not outlive the call. {@code fanOut} is reached from plan 0's completion
+     * callback, so {@code logPlan} runs on a pooled ENGINE/TRANSPORT thread: a bare
+     * {@code THREAD_PROVIDERS.set} leaves a {@code JaninoRelMetadataProvider} — and transitively this
+     * query's {@code RelOptCluster}, {@code SchemaPlus} and {@code ClusterState} — pinned to a shared thread
+     * after the request ends, where a later unrelated query can observe it.
+     *
+     * <p>The stub completes inline, so every plan of this query is dispatched on the test thread and the
+     * assertion is about the thread that really ran {@code logPlan}. It is genuinely failable: with the
+     * {@code set} unpaired the ThreadLocal is still populated here.
+     */
+    @TestLogging(reason = DEBUG_REASON, value = DEBUG_LOGGING)
+    public void testLogPlanLeavesNoProviderPinnedToTheDispatchingThread() throws Exception {
+        QueryPlans plans = nestedAggregationPlans();
+        Stub stub = new Stub(plans);
+
+        RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+        assertNull(RelMetadataQueryBase.THREAD_PROVIDERS.get());
+        List<String> planLines = runCapturingLogs(executor(stub, 2), plans, PLAN_LOG_MARKER);
+
+        // Without this the assertion below could pass on a query that never logged a plan at all.
+        assertFalse("the plan-log block must have run, or this proves nothing", planLines.isEmpty());
+        assertNull("logPlan must not leave a metadata provider pinned to a pooled thread", RelMetadataQueryBase.THREAD_PROVIDERS.get());
+    }
+
+    /**
+     * The other half of the restore: a thread that arrives with its own provider set — the engine's own
+     * planning threads do — must leave with the same one, not with this query's and not with none.
+     */
+    @TestLogging(reason = DEBUG_REASON, value = DEBUG_LOGGING)
+    public void testLogPlanRestoresAProviderTheThreadAlreadyHad() throws Exception {
+        QueryPlans plans = nestedAggregationPlans();
+        Stub stub = new Stub(plans);
+        JaninoRelMetadataProvider caller = JaninoRelMetadataProvider.of(TestUtils.createTestRelNode().getCluster().getMetadataProvider());
+
+        JaninoRelMetadataProvider after;
+        RelMetadataQueryBase.THREAD_PROVIDERS.set(caller);
+        try {
+            List<String> planLines = runCapturingLogs(executor(stub, 2), plans, PLAN_LOG_MARKER);
+            assertFalse("the plan-log block must have run, or this proves nothing", planLines.isEmpty());
+            after = RelMetadataQueryBase.THREAD_PROVIDERS.get();
+        } finally {
+            RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+        }
+        assertSame("the caller's own provider must be restored, not removed and not replaced", caller, after);
+    }
+
+    /**
+     * The hard invariant: {@code logPlan(plan)} runs on the same thread as, and strictly before, the
+     * dispatch of that <em>same</em> plan. Asserted per plan rather than "does it log at all" — a later
+     * refactor that moved the call into a completion callback, or out of the gate's runnable, would still
+     * log the same number of lines.
+     */
+    @TestLogging(reason = DEBUG_REASON, value = DEBUG_LOGGING)
+    public void testLogPlanPrecedesDispatchForEachPlan() throws Exception {
+        QueryPlans plans = nestedAggregationPlans();
+        int n = plans.getAll().size();
+        Stub stub = new Stub(plans);
+        AtomicInteger planLogsSeen = new AtomicInteger();
+        stub.planLogsSeen = planLogsSeen;
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(DslQueryPlanExecutor.class))) {
+            appender.addExpectation(new CountingExpectation(PLAN_LOG_MARKER, planLogsSeen));
+            CapturingListener listener = new CapturingListener();
+            executor(stub, 2).execute(plans, null, "test-index", listener);
+            assertNotNull("the fan-out must complete: " + listener.failure, listener.results);
+        }
+
+        assertEquals("every plan must have been dispatched", n, stub.logsSeenAtEntry.size());
+        for (Map.Entry<Integer, Integer> entry : stub.logsSeenAtEntry.entrySet()) {
+            assertEquals(
+                "plan " + entry.getKey() + " must be dispatched after its own plan-log line and before the next plan's",
+                Integer.valueOf(stub.dispatchOrder().indexOf(entry.getKey()) + 1),
+                entry.getValue()
+            );
+        }
+        assertEquals("one plan-log line per plan", n, planLogsSeen.get());
+    }
+
+    /**
+     * {@code logPlan} is a throwing call — at DEBUG it dereferences the plan's metadata provider and
+     * renders the plan — so it has to sit <em>inside</em> the dispatch {@code try}, next to
+     * {@code executor.execute}. Outside it, a throw escapes the gate's runnable after the permit was
+     * taken: nothing releases the permit, nothing counts the plan down, the collector's terminal can never
+     * fire and the request hangs; on the drain path the same throw escapes into an engine completion
+     * thread through {@code finishAndRunNext}.
+     *
+     * <p>The discriminating assertion is that the <em>other</em> fan-out plans still ran. With the call
+     * outside the {@code try} the throw unwinds the dispatch loop itself, so plans 2..4 are never
+     * dispatched at all — and the terminal callback count alone would not show it, because the escape is
+     * caught one frame up by plan 0's listener and reported as a failure either way.
+     *
+     * <p>No other test reaches this path: the stub's {@code throwInline} / {@code failInline} fire from
+     * {@code execute}, which is already inside the {@code try}, and
+     * {@link #testLogPlanOnColdThreadDoesNotNpe()} only asserts the happy path.
+     */
+    @TestLogging(reason = DEBUG_REASON, value = DEBUG_LOGGING)
+    public void testPlanLogFailureIsReportedAndDoesNotStrandTheFanOut() {
+        // A real plan (Mockito cannot mock Calcite classes here — see TestUtils) whose own cluster has no
+        // metadata provider, so logPlan's requireNonNull throws: the same NullPointerException shape the
+        // fan-out IT scrapes the node log for. createTestRelNode builds a fresh cluster per call, so this
+        // cripples this plan only.
+        RelNode unloggable = TestUtils.createTestRelNode();
+        unloggable.getCluster().setMetadataProvider(null);
+        QueryPlans.Builder builder = new QueryPlans.Builder();
+        builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan));
+        builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, unloggable));
+        for (int i = 2; i < 5; i++) {
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, TestUtils.createTestRelNode()));
+        }
+        QueryPlans plans = builder.build();
+        Stub stub = new Stub(plans);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("exactly one terminal callback", 1, listener.terminalCalls);
+        assertNotNull("the plan-log failure must be reported, not swallowed", listener.failure);
+        assertFalse("the plan whose logging threw cannot have been dispatched", stub.dispatchOrder().contains(1));
+        assertEquals("every other fan-out plan must still have been dispatched", List.of(0, 2, 3, 4), stub.dispatchOrder());
+        assertEquals("no plan may be left in flight", 0, stub.inFlight.get());
+    }
+
+    /**
+     * An {@code Error} out of a dispatch must still release the permit and drive the countdown. Calcite
+     * throws {@code AssertionError} outright where its plan invariants are violated, so this is reachable
+     * from {@code logPlan} and from the engine call itself, and a {@code catch (Exception)} would let it
+     * past — stranding the permit and the countdown and leaving the REST channel open with nobody to answer
+     * it. That hang is the one failure this class exists to make impossible, so it must not depend on the
+     * throwable being an {@code Exception}.
+     *
+     * <p>The {@code Error} is deliberately not rethrown: rethrowing would abandon the dispatch loop, so the
+     * plans after this one would never be dispatched and never count down — reintroducing the very hang the
+     * catch prevents. The assertions below pin that trade: the request completes, and the siblings still ran.
+     */
+    public void testAnErrorDuringDispatchStillReleasesThePermitAndCountsDown() {
+        QueryPlans plans = plans(3);
+        Stub stub = new Stub(plans);
+        AssertionError boom = new AssertionError("Calcite plan invariant violated");
+        stub.errorInline.put(0, boom);
+
+        CapturingListener listener = new CapturingListener();
+        executor(stub, 2).execute(plans, null, "test-index", listener);
+
+        assertEquals("the request must be completed exactly once, not hung", 1, listener.terminalCalls);
+        assertNotNull("the failing plan must be reported, not swallowed", listener.failure);
+        assertSame("the Error must be carried as the cause rather than lost", boom, listener.failure.getCause());
+        assertEquals("no plan may be left in flight", 0, stub.inFlight.get());
+        // The discriminating assertion: had the permit leaked, or had the Error escaped the loop, the
+        // siblings would never have been admitted and dispatchOrder would stop at 0.
+        assertEquals("the surviving plans must still have been dispatched", List.of(0, 1, 2), stub.dispatchOrder());
+    }
+
+    // ── Harness ─────────────────────────────────────────────────────────────
+
+    /**
+     * Asserts the whole slotting contract: slot {@code i} carries plan {@code i}'s <em>plan</em> and plan
+     * {@code i}'s <em>payload</em>.
+     */
+    private static void assertPlanOrder(QueryPlans plans, List<ExecutionResult> results) {
+        assertNotNull(results);
+        assertEquals(plans.getAll().size(), results.size());
+        for (int i = 0; i < results.size(); i++) {
+            assertSame("result " + i + " must be plan " + i + "'s", plans.getAll().get(i).relNode(), results.get(i).getPlan().relNode());
+            assertEquals("result " + i + " must carry plan " + i + "'s rows", Stub.tag(i), Stub.tagOf(results.get(i)));
+        }
+    }
+
+    /**
+     * One HITS plan plus {@code n - 1} AGGREGATION plans, each with its own distinct RelNode — which is what
+     * every assertion here identifies a plan by (the stub's dispatch index and its payload tag both derive
+     * from it). The plans carry no {@code AggregationMetadata}: the fan-out never reads it, and a plan is
+     * only required to carry a type and a RelNode.
+     */
+    private QueryPlans plans(int n) {
+        QueryPlans.Builder builder = new QueryPlans.Builder();
+        builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan));
+        for (int i = 1; i < n; i++) {
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, TestUtils.createTestRelNode()));
+        }
+        return builder.build();
+    }
+
+    /**
+     * A batch with <b>no</b> aggregation plan: one HITS plan plus {@code countPlans} COUNT plans, each with
+     * its own distinct RelNode, exactly as {@link #plans(int)} builds its aggregation batches. This is the
+     * shape the fan-out must refuse — {@code countPlans == 1} is what a plain search converts to.
+     */
+    private QueryPlans hitsAndCountPlans(int countPlans) {
+        QueryPlans.Builder builder = new QueryPlans.Builder();
+        builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan));
+        for (int i = 0; i < countPlans; i++) {
+            builder.add(new QueryPlans.QueryPlan(QueryPlans.Type.COUNT, TestUtils.createTestRelNode()));
+        }
+        QueryPlans plans = builder.build();
+        assertFalse("the fixture must carry no aggregation plan", plans.has(QueryPlans.Type.AGGREGATION));
+        assertEquals(1 + countPlans, plans.getAll().size());
+        return plans;
+    }
+
+    /**
+     * The multi-plan fixture the plan-logging tests need: real converter output for a nested aggregation,
+     * so the plans have the shape whose {@code explain()} actually reaches Calcite's metadata handlers.
+     */
+    private static QueryPlans nestedAggregationPlans() throws Exception {
+        return convert(new SearchSourceBuilder().size(10).aggregation(nestedTermsAggregation()));
+    }
+
+    /**
+     * The measured production shape: {@code size: 0} plus a 2-level nested aggregation. Emits no HITS plan,
+     * so it is also the fixture that proves the eligibility predicate is not accidentally keyed on plan 0.
+     */
+    private static QueryPlans sizeZeroNestedAggregationPlans() throws Exception {
+        return convert(new SearchSourceBuilder().size(0).aggregation(nestedTermsAggregation()));
+    }
+
+    private static TermsAggregationBuilder nestedTermsAggregation() {
+        return new TermsAggregationBuilder("by_brand").field("brand")
+            .subAggregation(
+                new TermsAggregationBuilder("by_name").field("name").subAggregation(new AvgAggregationBuilder("avg_price").field("price"))
+            );
+    }
+
+    /**
+     * Real converter output for one request against the shared three-field test mapping. Used where the
+     * request <em>shape</em> is the thing under test, so that the plan set is the one a real search produces
+     * rather than one this class asserted into existence.
+     */
+    private static QueryPlans convert(SearchSourceBuilder source) throws Exception {
+        Map<String, String> mapping = new LinkedHashMap<>();
+        mapping.put("name", "VARCHAR");
+        mapping.put("price", "INTEGER");
+        mapping.put("brand", "VARCHAR");
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping("test-index", mapping);
+        return new SearchSourceConverter(infra.schema()).convert(source, "test-index");
+    }
+
+    // Most tests hand the executor a null cluster state, which is the no-snapshot shape: the shard-layout
+    // input then degrades to the neutral 1 rather than reading a second, unrelated snapshot, so the width
+    // does not depend on the machine running the test. The tests that care about the routing read build a
+    // real snapshot with ShardLayouts.clusterState and pass it directly.
+
+    /** The executor at a given width, over a real settings registry. */
+    private DslQueryPlanExecutor executor(QueryPlanExecutor<RelNode, Iterable<Object[]>> stub, int kSetting) {
+        return executor(stub, Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), kSetting).build());
+    }
+
+    /**
+     * Builds the executor over a real settings registry. The concurrency-gate multiplier is registered only
+     * when a test passes its descriptor, so by default that term is absent and the width is
+     * {@code min(n - 1, K_setting)} on every host.
+     */
+    private DslQueryPlanExecutor executor(
+        QueryPlanExecutor<RelNode, Iterable<Object[]>> stub,
+        Settings nodeSettings,
+        Setting<?>... extras
+    ) {
+        ClusterSettings clusterSettings = registry(nodeSettings, extras);
+        return executor(stub, nodeSettings, clusterSettings, new DslGateInputs(clusterSettings));
+    }
+
+    private DslQueryPlanExecutor executor(
+        QueryPlanExecutor<RelNode, Iterable<Object[]>> stub,
+        Settings nodeSettings,
+        ClusterSettings clusterSettings,
+        DslGateInputs gateInputs
+    ) {
+        return executor(stub, clusterService(nodeSettings, clusterSettings), gateInputs, mockThreadPool());
+    }
+
+    /** The widest seam: every collaborator injected, for the tests that assert on what was NOT read. */
+    private DslQueryPlanExecutor executor(
+        QueryPlanExecutor<RelNode, Iterable<Object[]>> stub,
+        ClusterService clusterService,
+        DslGateInputs gateInputs,
+        ThreadPool threadPool
+    ) {
+        return new DslQueryPlanExecutor(stub, clusterService, threadPool, new DslQuerySettings(clusterService), gateInputs);
+    }
+
+    /**
+     * The mock coordinator, returned rather than hidden so a test can {@code verify} which of its reads the
+     * width decision performed.
+     */
+    private static ClusterService clusterService(Settings nodeSettings, ClusterSettings clusterSettings) {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(nodeSettings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        // A real routing service, not a mock: the shard-layout read is only reached when the request carries a
+        // cluster-state snapshot, and the test that does that has to reach the production read rather than a
+        // stubbed answer. On the null-snapshot requests the rest of the class uses, this is never consulted.
+        when(clusterService.operationRouting()).thenReturn(ShardLayouts.routing());
+        return clusterService;
+    }
+
+    /** The server's built-in settings plus any local descriptor copies standing in for another plugin's. */
+    private static ClusterSettings registry(Settings nodeSettings, Setting<?>... extras) {
+        Set<Setting<?>> registered = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        registered.addAll(DslQuerySettings.all());
+        registered.addAll(Set.of(extras));
+        return new ClusterSettings(nodeSettings, registered);
+    }
+
+    /**
+     * A thread pool whose SEARCH executor is deliberately <em>not</em> an
+     * {@code OpenSearchThreadPoolExecutor}, so the pool-size term is absent and the fan-out width does not
+     * depend on the machine running the test.
+     */
+    private static ThreadPool mockThreadPool() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(any())).thenReturn(mock(ExecutorService.class));
+        return threadPool;
+    }
+
+    /** Runs one query with the class's logger captured, returning the messages carrying {@code marker}. */
+    private static List<String> runCapturingLogs(DslQueryPlanExecutor executor, QueryPlans plans, String marker) throws Exception {
+        return runCapturingLogs(executor, plans, marker, null, "test-index");
+    }
+
+    /**
+     * The same capture around an arbitrary run, for the tests that assert on the delivered result list as
+     * well as on the line — {@link #runCapturingLogs} owns its listener, so it cannot hand one back.
+     */
+    private static List<String> capturingLogs(String marker, CheckedRunnable<Exception> query) throws Exception {
+        List<String> captured = Collections.synchronizedList(new ArrayList<>());
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(DslQueryPlanExecutor.class))) {
+            appender.addExpectation(new CapturingExpectation(marker, captured));
+            query.run();
+        }
+        return captured;
+    }
+
+    /** The same, for a query whose cluster-state snapshot and index name matter (the shard-layout read). */
+    private static List<String> runCapturingLogs(
+        DslQueryPlanExecutor executor,
+        QueryPlans plans,
+        String marker,
+        ClusterState state,
+        String concreteIndex
+    ) throws Exception {
+        List<String> captured = Collections.synchronizedList(new ArrayList<>());
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(DslQueryPlanExecutor.class))) {
+            appender.addExpectation(new CapturingExpectation(marker, captured));
+            PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+            executor.execute(plans, state, concreteIndex, future);
+            assertEquals(plans.getAll().size(), future.actionGet().size());
+        }
+        return captured;
+    }
+
+    private static Map<String, String> parseKEffLine(String line) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        Matcher matcher = Pattern.compile("(\\w+)=(\\S+)").matcher(line);
+        while (matcher.find()) {
+            fields.put(matcher.group(1), matcher.group(2));
+        }
+        // Seven fields, in the contract order testKEffLineCarriesEveryContractFieldInOrder pins.
+        // Pinned as a count so a field cannot be silently dropped or added without a test saying so.
+        assertEquals("the line must carry exactly the seven contract fields: " + line, 7, fields.size());
+        return fields;
+    }
+
+    /**
+     * Captures every message carrying a marker. A counting/capturing expectation is required because the
+     * framework's built-in {@code SeenEventExpectation} records only <em>whether</em> an event was seen, so
+     * it would pass on three width lines as happily as on one.
+     */
+    private static class CapturingExpectation implements MockLogAppender.LoggingExpectation {
+
+        private final String marker;
+        private final List<String> captured;
+
+        CapturingExpectation(String marker, List<String> captured) {
+            this.marker = marker;
+            this.captured = captured;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            String message = event.getMessage().getFormattedMessage();
+            if (message.contains(marker)) {
+                captured.add(message);
+            }
+        }
+
+        @Override
+        public void assertMatched() {
+            // Nothing to assert here: the count and the contents are what the tests assert, and an
+            // expectation that failed on "no events" would make the INFO-level test unwritable.
+        }
+    }
+
+    /** Counts messages carrying a marker, so the count can be read while the query is still running. */
+    private static class CountingExpectation implements MockLogAppender.LoggingExpectation {
+
+        private final String marker;
+        private final AtomicInteger seen;
+
+        CountingExpectation(String marker, AtomicInteger seen) {
+            this.marker = marker;
+            this.seen = seen;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            if (event.getMessage().getFormattedMessage().contains(marker)) {
+                seen.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void assertMatched() {}
+    }
+
+    /**
+     * Stub engine with in-flight accounting. Per-plan behaviour is configured by index before the run:
+     * complete inline (the default), park the listener for the test to complete later, fail inline, throw
+     * out of the dispatch, or complete <em>and then</em> throw.
+     */
+    private static class Stub implements QueryPlanExecutor<RelNode, Iterable<Object[]>> {
+
+        private final List<RelNode> planOrder;
+        private final List<Integer> dispatched = Collections.synchronizedList(new ArrayList<>());
+        private final Map<Integer, ActionListener<Iterable<Object[]>>> parked = new ConcurrentHashMap<>();
+
+        final AtomicInteger inFlight = new AtomicInteger();
+        final AtomicInteger highWater = new AtomicInteger();
+        /** Monotonic stamp source, so orderings can be asserted without sleeping. */
+        final AtomicInteger sequence;
+        /** Plan-log lines already emitted when each plan's dispatch was entered. */
+        final Map<Integer, Integer> logsSeenAtEntry = new ConcurrentHashMap<>();
+
+        /** Park every plan's listener rather than completing it. */
+        boolean deferAll;
+        /** Park only these plans' listeners. */
+        final Set<Integer> defer = Collections.synchronizedSet(new HashSet<>());
+        final Map<Integer, RuntimeException> failInline = new ConcurrentHashMap<>();
+        final Map<Integer, RuntimeException> throwInline = new ConcurrentHashMap<>();
+        /** Like {@code throwInline}, but an {@code Error} — the dispatch path must clean up for those too. */
+        final Map<Integer, Error> errorInline = new ConcurrentHashMap<>();
+        final Set<Integer> completeThenThrow = Collections.synchronizedSet(new HashSet<>());
+        AtomicInteger planLogsSeen;
+
+        Stub(QueryPlans plans) {
+            this(plans, new AtomicInteger());
+        }
+
+        Stub(QueryPlans plans, AtomicInteger sequence) {
+            this.planOrder = plans.getAll().stream().map(QueryPlans.QueryPlan::relNode).toList();
+            this.sequence = sequence;
+        }
+
+        List<Integer> dispatchOrder() {
+            return List.copyOf(dispatched);
+        }
+
+        @Override
+        public void execute(RelNode plan, QueryRequestContext ctx, ActionListener<Iterable<Object[]>> listener) {
+            int index = planOrder.indexOf(plan);
+            assertTrue("the stub was handed a RelNode that is not one of the query's plans", index >= 0);
+            dispatched.add(index);
+            sequence.incrementAndGet();
+            if (planLogsSeen != null) {
+                logsSeenAtEntry.put(index, planLogsSeen.get());
+            }
+            int now = inFlight.incrementAndGet();
+            highWater.updateAndGet(previous -> Math.max(previous, now));
+
+            RuntimeException thrown = throwInline.get(index);
+            if (thrown != null) {
+                inFlight.decrementAndGet();
+                throw thrown;
+            }
+            Error error = errorInline.get(index);
+            if (error != null) {
+                inFlight.decrementAndGet();
+                throw error;
+            }
+            if (completeThenThrow.contains(index)) {
+                // The shape only this configuration produces, and it overrides deferral because the point is
+                // that the throw lands on an ALREADY-completed listener: the loop's catch then notifies it a
+                // second time.
+                inFlight.decrementAndGet();
+                listener.onResponse(rows(index));
+                throw new IllegalStateException("plan " + index + " completed and then threw");
+            }
+            RuntimeException failure = failInline.get(index);
+            if (failure != null) {
+                inFlight.decrementAndGet();
+                listener.onFailure(failure);
+                return;
+            }
+            if (deferAll || defer.contains(index)) {
+                parked.put(index, listener);
+                return;
+            }
+            inFlight.decrementAndGet();
+            listener.onResponse(rows(index));
+        }
+
+        void completeParked(int index) {
+            ActionListener<Iterable<Object[]>> listener = parked.remove(index);
+            assertNotNull("plan " + index + " was not parked", listener);
+            inFlight.decrementAndGet();
+            sequence.incrementAndGet();
+            listener.onResponse(rows(index));
+        }
+
+        void completeAnyParked() {
+            Optional<Integer> next = parked.keySet().stream().findFirst();
+            assertTrue("nothing left to complete", next.isPresent());
+            completeParked(next.get());
+        }
+
+        /**
+         * Takes one parked plan and completes it, or reports that none is parked — the multi-threaded form of
+         * {@link #completeAnyParked()}. The take has to be the {@code remove}, not the {@code keySet} read:
+         * two drainers that both saw the same key would otherwise both complete that plan's listener, which
+         * would inject the very double-notification the fan-out is supposed to survive and make the test
+         *
+         * @return true if a plan was completed, false if nothing was parked at that moment
+         */
+        boolean completeAnyParkedIfPresent() {
+            for (Integer index : parked.keySet()) {
+                ActionListener<Iterable<Object[]>> listener = parked.remove(index);
+                if (listener == null) {
+                    continue;   // another drainer took this one first
+                }
+                inFlight.decrementAndGet();
+                sequence.incrementAndGet();
+                listener.onResponse(rows(index));
+                return true;
+            }
+            return false;
+        }
+
+        private static List<Object[]> rows(int index) {
+            return List.<Object[]>of(new Object[] { tag(index) });
+        }
+
+        /** The payload tag this stub produces for a plan — unique per plan, so a mis-slot is visible. */
+        static String tag(int index) {
+            return String.format(Locale.ROOT, "plan-%d", index);
+        }
+
+        /** The payload tag carried by a delivered result, i.e. which plan's rows actually landed in a slot. */
+        static String tagOf(ExecutionResult result) {
+            Iterator<Object[]> rows = result.getRows().iterator();
+            assertTrue("a delivered result carried no rows at all", rows.hasNext());
+            Object[] row = rows.next();
+            assertFalse("the fixture emits exactly one row per plan", rows.hasNext());
+            return (String) row[0];
+        }
+    }
+
+    /**
+     * A request listener that throws out of {@code onResponse} — the shape a downstream response builder
+     * takes when it fails on results it has just been handed. It counts its own notifications so a
+     * conversion of that throw into a plan failure is visible as a second one.
+     */
+    private static class ThrowingListener implements ActionListener<List<ExecutionResult>> {
+
+        private int terminalCalls;
+        private int failureCalls;
+
+        @Override
+        public void onResponse(List<ExecutionResult> results) {
+            terminalCalls++;
+            throw new IllegalStateException("the request listener's own failure");
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            terminalCalls++;
+            failureCalls++;
+        }
+    }
+
+    /** Records the single terminal callback, so a double completion or a silent success is visible. */
+    private static class CapturingListener implements ActionListener<List<ExecutionResult>> {
+
+        /** Shared with the stub when a test needs to order the terminal against a plan's completion. */
+        private final AtomicInteger stamps;
+
+        private List<ExecutionResult> results;
+        private Exception failure;
+        private int terminalCalls;
+        private int terminalStamp;
+
+        CapturingListener() {
+            this(new AtomicInteger());
+        }
+
+        CapturingListener(AtomicInteger stamps) {
+            this.stamps = stamps;
+        }
+
+        @Override
+        public void onResponse(List<ExecutionResult> executionResults) {
+            terminalCalls++;
+            terminalStamp = stamps.incrementAndGet();
+            this.results = executionResults;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            terminalCalls++;
+            terminalStamp = stamps.incrementAndGet();
+            this.failure = e;
+        }
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/ShardLayouts.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/ShardLayouts.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.OperationRouting;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * Cluster states with an <b>explicitly chosen</b> shard placement, for the tests that assert on the
+ * shard-layout input of the fan-out width.
+ */
+final class ShardLayouts {
+
+    private ShardLayouts() {}
+
+    /** A routing service over stock settings — the same construction the coordinator's own read uses. */
+    static OperationRouting routing() {
+        return new OperationRouting(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+    }
+
+    /**
+     * A cluster state holding one index whose shard {@code i} sits on {@code placements.get(i)}.
+     *
+     * @param index the index name
+     * @param placements node id per shard, in shard order; a {@code null} entry leaves that shard
+     *                   unassigned
+     * @param extraNodes further nodes that exist but hold no shard of this index
+     * @return the state
+     */
+    static ClusterState clusterState(String index, List<String> placements, String... extraNodes) {
+        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
+        placements.stream().filter(node -> node != null).distinct().forEach(node -> nodes.add(newNode(node)));
+        for (String extra : extraNodes) {
+            if (placements.contains(extra) == false) {
+                nodes.add(newNode(extra));
+            }
+        }
+        nodes.localNodeId("node-0");
+        nodes.clusterManagerNodeId("node-0");
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(index)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, placements.size())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_CREATION_DATE, System.currentTimeMillis())
+            )
+            .build();
+        Index resolved = indexMetadata.getIndex();
+
+        IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(resolved);
+        for (int shard = 0; shard < placements.size(); shard++) {
+            ShardId shardId = new ShardId(resolved, shard);
+            String node = placements.get(shard);
+            IndexShardRoutingTable.Builder shardRouting = new IndexShardRoutingTable.Builder(shardId);
+            shardRouting.addShard(
+                node == null
+                    ? TestShardRouting.newShardRouting(shardId, null, true, ShardRoutingState.UNASSIGNED)
+                    : TestShardRouting.newShardRouting(shardId, node, true, ShardRoutingState.STARTED)
+            );
+            indexRoutingTable.addIndexShard(shardRouting.build());
+        }
+
+        return ClusterState.builder(new ClusterName("test"))
+            .nodes(nodes)
+            .metadata(Metadata.builder().put(indexMetadata, false).generateClusterUuidIfNeeded())
+            .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
+            .build();
+    }
+
+    private static DiscoveryNode newNode(String id) {
+        return new DiscoveryNode(id, OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/SubPlanParallelismTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/SubPlanParallelismTests.java
@@ -1,0 +1,344 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.dsl.settings.DslQuerySettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+/**
+ * The {@code K_eff} formula, pinned cell by cell.
+ *
+ * <p>Every input is injected, so these tests need no node, no settings registry and no thread pool —
+ * which is the whole reason the formula lives in a class of its own.
+ */
+public class SubPlanParallelismTests extends OpenSearchTestCase {
+
+    /** The DataFusion backend's shipped multiplier default. */
+    private static final double MULTIPLIER = 1.5;
+
+    /** The engine's shipped per-node in-flight shard-request cap. */
+    private static final int SHARD_REQUEST_CAP = 5;
+
+    /**
+     * One row of the design's gain grid: the inputs, the width they must produce, and the speedup the
+     * gain model predicts for that cell — carried in the source so the join between formula and model is
+     * visible to whoever edits either.
+     *
+     * @param vCpu coordinator vCPU count
+     * @param expectedA the fragment count the gate admits, pinned so an edit to the A term is visible
+     * @param poolSize the SEARCH pool size for that vCPU count, written as a literal
+     * @param shardsOnBusiestNode S_node
+     * @param expectedKEff the width the formula must produce
+     * @param modelledSpeedup the gain model's K=2 column for this cell
+     */
+    private record GridCell(int vCpu, int expectedA, int poolSize, int shardsOnBusiestNode, int expectedKEff, String modelledSpeedup) {
+    }
+
+    /**
+     * The 4 vCPU counts x 5 shard placements of the design's gain grid, at {@code K_setting = 2} and
+     * {@code n = 3}.
+     */
+    private static final List<GridCell> GRID = List.of(
+        // 8 vCPU: A = floor(8 * 1.5 / 4) = 3
+        new GridCell(8, 3, 13, 1, 2, "1.50"),
+        new GridCell(8, 3, 13, 2, 2, "1.50"),
+        new GridCell(8, 3, 13, 4, 1, "1.00"),
+        new GridCell(8, 3, 13, 8, 1, "1.00"),
+        new GridCell(8, 3, 13, 16, 1, "1.00"),
+        // 16 vCPU: A = 6
+        new GridCell(16, 6, 25, 1, 2, "1.50"),
+        new GridCell(16, 6, 25, 2, 2, "1.50"),
+        new GridCell(16, 6, 25, 4, 2, "1.50"),
+        new GridCell(16, 6, 25, 8, 2, "1.20"),
+        new GridCell(16, 6, 25, 16, 2, "1.20"),
+        // 32 vCPU: A = 12
+        new GridCell(32, 12, 49, 1, 2, "1.50"),
+        new GridCell(32, 12, 49, 2, 2, "1.50"),
+        new GridCell(32, 12, 49, 4, 2, "1.50"),
+        new GridCell(32, 12, 49, 8, 2, "1.50"),
+        new GridCell(32, 12, 49, 16, 2, "1.50"),
+        // 64 vCPU: A = 24
+        new GridCell(64, 24, 97, 1, 2, "1.50"),
+        new GridCell(64, 24, 97, 2, 2, "1.50"),
+        new GridCell(64, 24, 97, 4, 2, "1.50"),
+        new GridCell(64, 24, 97, 8, 2, "1.50"),
+        new GridCell(64, 24, 97, 16, 2, "1.50")
+    );
+
+    public void testKEffGridMatchesGainModel() {
+        for (GridCell cell : GRID) {
+            SubPlanParallelism.Inputs in = gridInputs(cell);
+            SubPlanParallelism.Decision decision = SubPlanParallelism.decide(in);
+            String where = cell.vCpu() + " vCPU / S=" + cell.shardsOnBusiestNode() + " (model " + cell.modelledSpeedup() + "x)";
+            assertEquals("A at " + where, cell.expectedA(), decision.a());
+            assertEquals("K_eff at " + where, cell.expectedKEff(), decision.kEff());
+            assertEquals("computeKEff must agree with decide at " + where, cell.expectedKEff(), SubPlanParallelism.computeKEff(in));
+        }
+        assertEquals("every cell of the 4x5 grid needs an assertion", 20, GRID.size());
+    }
+
+    /** Every 1.00x cell — and only those — is a K_eff of 1. Fails if ceil(A/F) is turned back into A. */
+    public void testGridOnesAreExactlyTheNoGainCells() {
+        for (GridCell cell : GRID) {
+            boolean noModelledGain = "1.00".equals(cell.modelledSpeedup());
+            int kEff = SubPlanParallelism.computeKEff(gridInputs(cell));
+            assertEquals(
+                "cell " + cell.vCpu() + " vCPU / S=" + cell.shardsOnBusiestNode() + " must be 1 iff the model says 1.00x",
+                noModelledGain,
+                kEff == 1
+            );
+        }
+    }
+
+    // ── The bounds ─────────────────────────────────────────────────────────
+
+    public void testKEffClampsToSettingAndPlanCount() {
+        // n = 2 gates both plans, so K_setting = 2 is reachable.
+        assertEquals(2, SubPlanParallelism.computeKEff(inputs(2, 2, 64, true, 1, OptionalInt.of(97))));
+        // K_setting = 1 is the shipped default and binds on any machine.
+        assertEquals(1, SubPlanParallelism.computeKEff(inputs(3, 1, 64, true, 1, OptionalInt.of(97))));
+        // A single-plan query never reaches a fan-out decision; clamp(..., 1, 0) would be malformed.
+        assertEquals(1, SubPlanParallelism.computeKEff(inputs(1, 2, 64, true, 1, OptionalInt.of(97))));
+        assertEquals(1, SubPlanParallelism.computeKEff(inputs(0, 2, 64, true, 1, OptionalInt.of(97))));
+    }
+
+    /**
+     * The width is bounded by the query's plan count, because every plan goes through the gate. A 2-plan
+     * query — a 2-level nested aggregation with {@code size: 0}, the common production shape — therefore
+     * reaches a width of 2, and every other term still binds above it.
+     */
+    public void testWidthClampsToTheWholePlanCount() {
+        assertEquals(
+            "both plans are gated, so a 2-plan query runs at width 2",
+            2,
+            SubPlanParallelism.decide(inputs(2, 2, 64, true, 1, OptionalInt.of(97))).kEff()
+        );
+
+        // The operator's own setting still binds above it: at K_setting = 2, a 3-plan query does not buy
+        // a width of 3. Asserted as the literal 2 rather than as MAX_K_SETTING, because what binds here
+        // is the setting passed in, and the two stopped being the same number once the ceiling rose.
+        assertEquals(2, SubPlanParallelism.decide(inputs(3, 2, 64, true, 1, OptionalInt.of(97))).kEff());
+        // And so does every other term — a narrow SEARCH pool pins the width regardless of the plan count.
+        assertEquals(1, SubPlanParallelism.decide(inputs(2, 2, 32, true, 8, OptionalInt.of(3))).kEff());
+    }
+
+    /** The width, pinned against the frozen table. */
+    public void testWidthMatchesTheFrozenGrid() {
+        for (GridCell cell : GRID) {
+            SubPlanParallelism.Inputs in = gridInputs(cell);
+            String where = cell.vCpu() + " vCPU / S=" + cell.shardsOnBusiestNode();
+            assertEquals("width at " + where, cell.expectedKEff(), SubPlanParallelism.decide(in).kEff());
+        }
+    }
+
+    /**
+     * The {@code Setting}'s upper bound and this class's ceiling are two literals in two packages (no
+     * import between them, to keep {@code SubPlanParallelism} dependency-free and the packages acyclic),
+     * so nothing but this test stops them drifting apart. Asserted behaviourally because {@code Setting}
+     * exposes no getter for its maximum: the ceiling itself must be accepted and one past it rejected.
+     */
+    public void testTheSettingsBoundMatchesTheHardCeiling() {
+        int ceiling = SubPlanParallelism.MAX_K_SETTING;
+
+        assertEquals(
+            "the setting must accept the ceiling this class clamps to",
+            Integer.valueOf(ceiling),
+            DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(
+                Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), ceiling).build()
+            )
+        );
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(
+                Settings.builder().put(DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey(), ceiling + 1).build()
+            )
+        );
+        assertTrue(
+            "one past the ceiling must be rejected by the setting, got: " + e.getMessage(),
+            e.getMessage().contains("must be <= " + ceiling)
+        );
+    }
+
+    /** The operator cap is re-applied here, not merely trusted from the setting. */
+    public void testKSettingIsReclampedToTheHardMaximum() {
+        // n = 9 so neither n - 1 nor any other term can be what limits the result to 2.
+        assertEquals(SubPlanParallelism.MAX_K_SETTING, SubPlanParallelism.computeKEff(inputs(9, 7, 64, true, 1, OptionalInt.of(97))));
+        assertEquals(1, SubPlanParallelism.computeKEff(inputs(9, 0, 64, true, 1, OptionalInt.of(97))));
+    }
+
+    /**
+     * FIX 0, directly: {@code K_gate} counts sub-queries, so it is {@code ceil(A / F)}. At 8 vCPU the gate
+     * admits 3 fragments; 2 shards on the busiest node makes a sub-query cost 2 of them (fits twice), 4
+     * shards makes it cost 4 (fits once).
+     */
+    public void testKGateIsCeilOfFragmentsOverF() {
+        SubPlanParallelism.Decision twoShards = SubPlanParallelism.decide(inputs(3, 2, 8, true, 2, OptionalInt.of(13)));
+        assertEquals(3, twoShards.a());
+        assertEquals(2, twoShards.f());
+        assertEquals(OptionalInt.of(2), twoShards.kGate());
+        assertEquals(2, twoShards.kEff());
+
+        SubPlanParallelism.Decision fourShards = SubPlanParallelism.decide(inputs(3, 2, 8, true, 4, OptionalInt.of(13)));
+        assertEquals(3, fourShards.a());
+        assertEquals(4, fourShards.f());
+        assertEquals("ceil(3/4) is 1 — a floor would agree here, but see the 2-shard cell", OptionalInt.of(1), fourShards.kGate());
+        assertEquals(1, fourShards.kEff());
+    }
+
+    /** A floor would pin the 8 vCPU / 2 shard cell — the one the model predicts 1.50x for — at 1. */
+    public void testCeilRatherThanFloorIsWhatKeepsTheGainCellOpen() {
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(inputs(3, 2, 8, true, 2, OptionalInt.of(13)));
+        int floorWouldBe = Math.max(1, decision.a() / decision.f());
+        assertEquals("floor(3/2) is 1, so a floor here would close the 1.50x cell", 1, floorWouldBe);
+        assertEquals(2, decision.kGate().getAsInt());
+    }
+
+    // ── The two droppable terms ────────────────────────────────────────────
+
+    /**
+     * With no gated backend installed the gate term LEAVES the {@code min}. The 8 vCPU / 8 shard cell is
+     * the discriminator: with the term present it is 1, so a 2 here can only mean the term was dropped
+     * rather than clamped.
+     */
+    public void testKEffDropsGateTermWhenBackendAbsent() {
+        SubPlanParallelism.Inputs present = inputs(3, 2, 8, true, 8, OptionalInt.of(13));
+        assertEquals(1, SubPlanParallelism.computeKEff(present));
+
+        SubPlanParallelism.Inputs absent = inputs(3, 2, 8, false, 8, OptionalInt.of(13));
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(absent);
+        assertEquals("the gate term must be reported as dropped, not as 1", OptionalInt.empty(), decision.kGate());
+        assertEquals(2, decision.kEff());
+    }
+
+    /** The multiplier is never read when the gate term is absent, so a poisoned placeholder is harmless. */
+    public void testAbsentGateTermNeverReadsTheMultiplier() {
+        SubPlanParallelism.Inputs poisoned = new SubPlanParallelism.Inputs(
+            3,
+            2,
+            8,
+            Double.NaN,
+            4,
+            false,
+            8,
+            SHARD_REQUEST_CAP,
+            OptionalInt.of(13)
+        );
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(poisoned);
+        assertEquals(2, decision.kEff());
+        assertEquals(OptionalInt.empty(), decision.kGate());
+    }
+
+    public void testKSearchBindsWhenPoolIsSmall() {
+        // 32 vCPU puts K_gate at 3, so the pool term is the only thing that can produce a 1 here.
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(inputs(3, 2, 32, true, 8, OptionalInt.of(3)));
+        assertEquals(5, decision.f());
+        assertEquals(OptionalInt.of(3), decision.kGate());
+        assertEquals(OptionalInt.of(1), decision.kSearch());
+        assertEquals(1, decision.kEff());
+    }
+
+    /** The reserve is subtracted before the division, and the 10-thread cell is what proves it. */
+    public void testSearchReserveIsSubtracted() {
+        assertEquals(OptionalInt.of(1), SubPlanParallelism.decide(inputs(3, 2, 32, true, 8, OptionalInt.of(7))).kSearch());
+        // floor((10 - 2) / 5) = 1. Without the reserve it would be floor(10 / 5) = 2, which is the whole
+        // point of this cell: the assertion changes if SEARCH_RESERVE is dropped or zeroed.
+        assertEquals(OptionalInt.of(1), SubPlanParallelism.decide(inputs(3, 2, 32, true, 8, OptionalInt.of(10))).kSearch());
+        assertEquals(1, SubPlanParallelism.computeKEff(inputs(3, 2, 32, true, 8, OptionalInt.of(10))));
+        // floor((12 - 2) / 5) = 2 — the first pool size at which the SEARCH term stops binding.
+        assertEquals(OptionalInt.of(2), SubPlanParallelism.decide(inputs(3, 2, 32, true, 8, OptionalInt.of(12))).kSearch());
+        assertEquals(2, SubPlanParallelism.computeKEff(inputs(3, 2, 32, true, 8, OptionalInt.of(12))));
+    }
+
+    /**
+     * The anti-guess assertion, and the other half of
+     * {@code DslQueryPlanExecutorTests#testSearchPoolSizeAbsentWhenExecutorIsNotOpenSearchThreadPoolExecutor}:
+     * an unreadable pool size DROPS its term. Same inputs as {@link #testKSearchBindsWhenPoolIsSmall},
+     * which yields 1 — so a 2 here proves the term was dropped rather than replaced by any default.
+     */
+    public void testKEffDropsSearchTermWhenPoolSizeAbsent() {
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(inputs(3, 2, 32, true, 8, OptionalInt.empty()));
+        assertEquals(OptionalInt.empty(), decision.kSearch());
+        assertEquals(2, decision.kEff());
+    }
+
+    public void testBothTermsDroppedLeavesSettingAndPlanCount() {
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(inputs(3, 2, 8, false, 16, OptionalInt.empty()));
+        assertEquals(OptionalInt.empty(), decision.kGate());
+        assertEquals(OptionalInt.empty(), decision.kSearch());
+        assertEquals(2, decision.kEff());
+    }
+
+    // ── Degenerate inputs must not throw on the query path ─────────────────
+
+    /** F is guarded at both ends, so a red index (0 shards found) cannot divide by zero. */
+    public void testZeroShardsOnBusiestNodeIsTreatedAsOne() {
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(inputs(3, 2, 8, true, 0, OptionalInt.of(13)));
+        assertEquals(1, decision.f());
+        assertEquals(2, decision.kEff());
+    }
+
+    /** The producer clamps target_partitions, but this record is a seam — a 0 must not throw here. */
+    public void testZeroTargetPartitionsDoesNotDivideByZero() {
+        SubPlanParallelism.Inputs in = new SubPlanParallelism.Inputs(
+            3,
+            2,
+            8,
+            MULTIPLIER,
+            0,
+            true,
+            1,
+            SHARD_REQUEST_CAP,
+            OptionalInt.of(13)
+        );
+        SubPlanParallelism.Decision decision = SubPlanParallelism.decide(in);
+        assertEquals(12, decision.a());
+        assertEquals(2, decision.kEff());
+    }
+
+    private static SubPlanParallelism.Inputs gridInputs(GridCell cell) {
+        return new SubPlanParallelism.Inputs(
+            3,
+            2,
+            cell.vCpu(),
+            MULTIPLIER,
+            4,
+            true,
+            cell.shardsOnBusiestNode(),
+            SHARD_REQUEST_CAP,
+            OptionalInt.of(cell.poolSize())
+        );
+    }
+
+    /** The grid's fixed multiplier / target_partitions / cap, with the varying inputs as arguments. */
+    private static SubPlanParallelism.Inputs inputs(
+        int n,
+        int kSetting,
+        int vCpu,
+        boolean gateTermPresent,
+        int shardsOnBusiestNode,
+        OptionalInt searchPoolSize
+    ) {
+        return new SubPlanParallelism.Inputs(
+            n,
+            kSetting,
+            vCpu,
+            MULTIPLIER,
+            4,
+            gateTermPresent,
+            shardsOnBusiestNode,
+            SHARD_REQUEST_CAP,
+            searchPoolSize
+        );
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/SubPlanResultCollectorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/SubPlanResultCollectorTests.java
@@ -1,0 +1,297 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.result.ExecutionResult;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The collector's three contracts: one terminal, plan order regardless of completion order, and no
+ * short-circuit on a failure.
+ */
+public class SubPlanResultCollectorTests extends OpenSearchTestCase {
+
+    /** Bound on the concurrent test's start barrier and joins, so a stuck thread fails rather than hangs. */
+    private static final int TIMEOUT_SECONDS = 30;
+
+    /**
+     * A plan count the countdown could never work for is rejected at construction, from the collector's own
+     * side. Two callers keep it from happening today — the single-plan early return and the sequential branch
+     * taken at width 1 — but neither of them pins it here, and the tolerated form of this bug is the worst
+     * one available: with the countdown starting at or below zero nothing would ever reach the terminal, the
+     * request's listener would never be notified, and its REST channel would stay open forever. Failing loudly
+     * is also the fail-secure direction, because the caller constructs the collector inside a completion
+     * callback whose wrapper turns a throw into the request's failure.
+     */
+    public void testRejectsAPlanCountThatCouldNeverCompleteTheCountdown() {
+        for (int n : new int[] { -1, 0, 1 }) {
+            CapturingListener listener = new CapturingListener();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new SubPlanResultCollector(n, listener));
+            assertEquals("a fan-out collector needs at least 2 plans, got " + n, e.getMessage());
+            assertEquals("the listener must not have been touched", 0, listener.terminalCalls);
+        }
+        // The boundary the other side of it: 2 is the smallest workable count and must construct.
+        assertNotNull(new SubPlanResultCollector(2, new CapturingListener()));
+    }
+
+    /**
+     * Every plan is gated, so the countdown waits for all {@code n} reports — including plan 0's. The
+     * discriminating assertion is the middle one: a countdown started at {@code n - 1} would fire the
+     * terminal one report early and deliver a list with a null in slot 0.
+     */
+    public void testTerminalWaitsForEveryPlanIncludingPlanZero() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+
+        ExecutionResult zero = result();
+        ExecutionResult one = result();
+        ExecutionResult two = result();
+        // Plan 0 arrives like any other gated plan, and deliberately not first.
+        collector.planSucceeded(2, two);
+        collector.planSucceeded(1, one);
+        assertEquals("the terminal must wait for plan 0 as well", 0, listener.terminalCalls);
+
+        collector.planSucceeded(0, zero);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNull("no plan failed: " + listener.failure, listener.failure);
+        assertEquals(List.of(zero, one, two), listener.results);
+    }
+
+    /**
+     * The dispatch range and the collector must agree, and this check is the only thing stopping them from
+     * disagreeing. A dispatch that skips plan 0 leaves the countdown one report short forever — a REST
+     * channel held open — so it is failed loudly instead, and a plan count that is not this collector's own
+     * is the same class of bug one argument further out.
+     */
+    public void testRejectsADispatchRangeTheCountdownCouldNotComplete() {
+        CapturingListener skipsPlanZero = new CapturingListener();
+        assertFalse(new SubPlanResultCollector(3, skipsPlanZero).expectGatedRange(1, 3));
+        assertEquals("the request must be failed, exactly once", 1, skipsPlanZero.terminalCalls);
+        assertEquals("a fan-out collector of 3 plans cannot be driven by a dispatch of plans [1, 3)", skipsPlanZero.failure.getMessage());
+
+        CapturingListener wrongPlanCount = new CapturingListener();
+        assertFalse(new SubPlanResultCollector(3, wrongPlanCount).expectGatedRange(0, 4));
+        assertEquals(1, wrongPlanCount.terminalCalls);
+
+        // The real pairing must pass, or the check would break the dispatch it protects.
+        CapturingListener ok = new CapturingListener();
+        assertTrue(new SubPlanResultCollector(3, ok).expectGatedRange(0, 3));
+        assertEquals("a matching pairing must not touch the listener", 0, ok.terminalCalls);
+    }
+
+    public void testFiresOnceWhenAllSlotsFilled() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+
+        ExecutionResult zero = result();
+        ExecutionResult one = result();
+        ExecutionResult two = result();
+        collector.planSucceeded(0, zero);
+        // Reverse completion order on purpose: the emitted order is by plan index, not by arrival.
+        collector.planSucceeded(2, two);
+        assertEquals("the listener must not fire before the last plan reports", 0, listener.terminalCalls);
+        collector.planSucceeded(1, one);
+
+        assertEquals(1, listener.terminalCalls);
+        assertNull(listener.failure);
+        assertEquals(List.of(zero, one, two), listener.results);
+    }
+
+    public void testDoesNotShortCircuitOnFailure() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+        collector.planSucceeded(0, result());
+
+        collector.planFailed(new IllegalStateException("plan 1 failed"));
+        assertEquals("short-circuiting would abandon plan 2 while it is still running", 0, listener.terminalCalls);
+
+        collector.planSucceeded(2, result());
+        assertEquals(1, listener.terminalCalls);
+        assertNotNull(listener.failure);
+    }
+
+    /**
+     * One failed {@code _search}, <b>one</b> internal exception on the wire — never one per sub-plan.
+     */
+    public void testSiblingFailuresAreLoggedNotCarriedToTheClient() throws Exception {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+        collector.planSucceeded(0, result());
+
+        IllegalStateException first = new IllegalStateException("first");
+        IllegalStateException second = new IllegalStateException("second");
+        List<Throwable> logged = new ArrayList<>();
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(SubPlanResultCollector.class))) {
+            appender.addExpectation(new ThrownCapturingExpectation(logged));
+            collector.planFailed(first);
+            collector.planFailed(second);
+        }
+
+        assertSame("the first failure offered is the one the request reports", first, listener.failure);
+        assertEquals(
+            "a sibling attached with addSuppressed would be rendered to the client too: "
+                + Arrays.toString(listener.failure.getSuppressed()),
+            0,
+            listener.failure.getSuppressed().length
+        );
+        assertEquals("the sibling must be reported server-side, or the fix loses it: " + logged, List.of(second), logged);
+        assertEquals(1, listener.terminalCalls);
+    }
+
+    /** A plan that could not be dispatched at all still has to drive the countdown to zero. */
+    public void testPreDispatchFailureStillDrivesCountdownToZero() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(2, listener);
+        collector.planSucceeded(0, result());
+
+        collector.planFailed(new IllegalStateException("never dispatched"));
+
+        assertEquals("an undispatched plan must not leave the listener uncompleted", 1, listener.terminalCalls);
+        assertNotNull(listener.failure);
+    }
+
+    /**
+     * The {@code AtomicArray.asList()} hazard, stated as a test: on a partial failure nothing may escape
+     * through {@code onResponse}, least of all a list shorter than the plan count that looks complete.
+     */
+    public void testNeverReturnsShortListOnPartialFailure() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+        collector.planSucceeded(0, result());
+
+        collector.planSucceeded(1, result());
+        collector.planFailed(new IllegalStateException("plan 2 failed"));
+
+        assertNull("a partial failure must not deliver results", listener.results);
+        assertNotNull(listener.failure);
+        assertEquals(1, listener.terminalCalls);
+    }
+
+    /**
+     * The fail-secure guard on the success branch: a slot that was never filled (a wiring bug, not a
+     * runtime condition) fails the request rather than handing a caller a list with a null in it, which
+     * the caller reads positionally.
+     */
+    public void testMissingSlotFailsRatherThanDeliveringNulls() {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(3, listener);
+        // Three reports drive the countdown to its terminal, but one plan reports twice and slot 0 is never
+        // filled -- the shape a mis-wired dispatch produces. Plan 0 is deliberately never reported.
+        collector.planSucceeded(1, result());
+        collector.planSucceeded(2, result());
+        collector.planSucceeded(2, result());
+
+        assertNull(listener.results);
+        assertTrue(listener.failure instanceof IllegalStateException);
+        assertEquals(1, listener.terminalCalls);
+    }
+
+    /** n = 9, nine reporters, one terminal. Run with {@code -Dtests.iters=100} for the race. */
+    public void testConcurrentReportsFireListenerExactlyOnce() throws Exception {
+        CapturingListener listener = new CapturingListener();
+        SubPlanResultCollector collector = new SubPlanResultCollector(9, listener);
+
+        CountDownLatch start = new CountDownLatch(1);
+        List<Thread> threads = new ArrayList<>();
+        List<ExecutionResult> expected = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            final int idx = i;
+            ExecutionResult result = result();
+            expected.add(result);
+            Thread thread = new Thread(() -> {
+                try {
+                    assertTrue(start.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+                collector.planSucceeded(idx, result);
+            }, "reporter-" + idx);
+            threads.add(thread);
+            thread.start();
+        }
+        start.countDown();
+        for (Thread thread : threads) {
+            thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertFalse("reporter thread did not finish", thread.isAlive());
+        }
+
+        assertEquals(1, listener.terminalCalls);
+        assertNotNull(listener.results);
+        assertEquals(9, listener.results.size());
+        for (int i = 0; i < 9; i++) {
+            assertSame("slot " + i + " must hold its own plan's result", expected.get(i), listener.results.get(i));
+        }
+    }
+
+    /** Collects the {@code thrown} of every event the collector logs, i.e. the failures it reported itself. */
+    private static class ThrownCapturingExpectation implements MockLogAppender.LoggingExpectation {
+
+        private final List<Throwable> thrown;
+
+        ThrownCapturingExpectation(List<Throwable> thrown) {
+            this.thrown = thrown;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            if (event.getThrown() != null) {
+                thrown.add(event.getThrown());
+            }
+        }
+
+        @Override
+        public void assertMatched() {
+            // The test asserts the contents; an expectation that failed on "no events" would say the same
+            // thing twice and with a worse message.
+        }
+    }
+
+    private static ExecutionResult result() {
+        return new ExecutionResult(
+            new QueryPlans.QueryPlan(QueryPlans.Type.AGGREGATION, TestUtils.createTestRelNode(), null),
+            List.<Object[]>of(new Object[] { COUNTER.incrementAndGet() })
+        );
+    }
+
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+
+    /** Records the single terminal callback, so a double completion or a silent success is visible. */
+    private static class CapturingListener implements ActionListener<List<ExecutionResult>> {
+
+        private List<ExecutionResult> results;
+        private Exception failure;
+        private int terminalCalls;
+
+        @Override
+        public void onResponse(List<ExecutionResult> executionResults) {
+            terminalCalls++;
+            this.results = executionResults;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            terminalCalls++;
+            this.failure = e;
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/DslGateInputsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/DslGateInputsTests.java
@@ -1,0 +1,711 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.settings;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.SearchService;
+import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.junit.annotations.TestLogging;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Unit coverage for the three gate-input reads. The cross-plugin registrations are faked here with
+ * local descriptor copies — a unit test cannot prove the real classloader graph resolves the keys,
+ * which is what {@code DslQuerySettingsRestIT} is for. What these tests do pin is the semantics:
+ * absent multiplier is empty (never 1.0), the derived partition count is never 0, and the missing
+ * shard-request cap falls back to {@code MAX_VALUE} (never a duplicated literal 5).
+ */
+public class DslGateInputsTests extends OpenSearchTestCase {
+
+    private static final String MULTIPLIER_KEY = "datafusion.concurrency.fragment_executor_multiplier";
+    private static final String SHARD_REQUEST_CAP_KEY = "analytics.query.max_concurrent_shard_requests_per_node";
+    private static final String MAX_SLICE_COUNT_KEY = SearchService.CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY;
+    private static final String MODE_KEY = "search.concurrent_segment_search.mode";
+
+    /**
+     * Same key/type/bounds/properties as {@code DatafusionSettings.CONCURRENCY_DATANODE_MULTIPLIER} in the
+     * sibling {@code analytics-backend-datafusion} plugin, transcribed by hand. Nothing verifies the two
+     * still agree: this plugin does not depend on that one, so a rename or a changed default there leaves
+     * these tests green while {@code DslGateInputs}' by-key read silently stops resolving and the fan-out's
+     * gate term drops out. Re-check by hand when touching either side.
+     */
+    private static final Setting<Double> MULTIPLIER_DESCRIPTOR_COPY = Setting.doubleSetting(
+        MULTIPLIER_KEY,
+        1.5,
+        0.1,
+        10.0,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Same key/type/bounds/properties as
+     * {@code AnalyticsQuerySettings.MAX_CONCURRENT_SHARD_REQUESTS_PER_NODE}, transcribed by hand and
+     * unverified against the owner for the same reason as the multiplier above — a drift there makes this
+     * read fall back to {@code Integer.MAX_VALUE}, i.e. the widest F and the widest fan-out.
+     */
+    private static final Setting<Integer> SHARD_REQUEST_CAP_DESCRIPTOR_COPY = Setting.intSetting(
+        SHARD_REQUEST_CAP_KEY,
+        5,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    // ── B2.0 — the SC-9 surface ────────────────────────────────────────────
+
+    /**
+     * Mechanises the "no arithmetic in this class" acceptance check: a fourth public accessor (or a
+     * changed return type) fails here, which is the signal that the shared-contract row needs
+     * updating rather than being silently widened.
+     */
+    public void testGateInputsExposesExactlyTheThreeSc9Accessors() {
+        Map<String, String> publicApi = new TreeMap<>();
+        // getMethods() (not getDeclaredMethods(), which is a forbidden API here) returns inherited
+        // members too, so filter down to what this class itself declares.
+        for (Method method : DslGateInputs.class.getMethods()) {
+            if (method.getDeclaringClass() == DslGateInputs.class && method.isSynthetic() == false) {
+                publicApi.put(method.getName(), method.getReturnType().getName());
+            }
+        }
+
+        assertEquals(
+            "the SC-9 surface is exactly three accessors, got " + publicApi,
+            Map.of(
+                "fragmentExecutorMultiplier",
+                OptionalDouble.class.getName(),
+                "targetPartitions",
+                "int",
+                "maxConcurrentShardRequestsPerNode",
+                "int"
+            ),
+            publicApi
+        );
+    }
+
+    /** All three values come off one registry — no accessor needs its own wiring. */
+    public void testAllThreeAccessorsReadFromTheSameClusterSettings() {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, MULTIPLIER_DESCRIPTOR_COPY, SHARD_REQUEST_CAP_DESCRIPTOR_COPY));
+
+        assertEquals(OptionalDouble.of(1.5), inputs.fragmentExecutorMultiplier());
+        assertEquals(
+            expectedTargetPartitions(SearchService.CONCURRENT_SEGMENT_SEARCH_DEFAULT_SLICE_COUNT_VALUE),
+            inputs.targetPartitions()
+        );
+        assertEquals(5, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    // ── B2.1 — the untyped multiplier read ────────────────────────────────
+
+    public void testMultiplierReadWhenDatafusionSettingRegistered() {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, MULTIPLIER_DESCRIPTOR_COPY));
+
+        // 1.5 comes from the registered descriptor's own default, not from a literal in main code.
+        assertEquals(OptionalDouble.of(1.5), inputs.fragmentExecutorMultiplier());
+    }
+
+    /**
+     * The 1.5 asserted above <i>is</i> the canonical default, so a hardcoded
+     * {@code return OptionalDouble.of(1.5)} would satisfy that test on the un-overridden read path — the
+     * path a stock cluster actually takes. Registering a descriptor whose default is deliberately not the
+     * canonical one pins where the value comes from: the owning plugin's own {@code Setting}, which is what
+     * makes this half of the read path drift-proof rather than a duplicated literal.
+     */
+    public void testMultiplierComesFromTheRegisteredDescriptorNotALocalDefault() {
+        Setting<Double> nonCanonicalDefault = Setting.doubleSetting(
+            MULTIPLIER_KEY,
+            2.5,
+            0.1,
+            10.0,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, nonCanonicalDefault));
+
+        OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+        assertEquals(OptionalDouble.of(2.5), multiplier);
+        assertNotEquals("the owning plugin's default must not be duplicated here", OptionalDouble.of(1.5), multiplier);
+    }
+
+    /** The read must be live, not a startup snapshot — this key is swept while the node runs. */
+    public void testMultiplierReadsDynamicOverride() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, MULTIPLIER_DESCRIPTOR_COPY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, 3.0).build());
+
+        assertEquals(OptionalDouble.of(3.0), inputs.fragmentExecutorMultiplier());
+    }
+
+    public void testMultiplierAbsentWhenSettingNotRegistered() {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY));
+
+        OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+        assertTrue("an unregistered key must read as empty, got " + multiplier, multiplier.isEmpty());
+        assertNotEquals("an absent multiplier must never be synthesised as 1.0", OptionalDouble.of(1.0), multiplier);
+    }
+
+    public void testMultiplierEmptyWhenRegisteredTypeIsNotNumeric() {
+        Setting<String> wrongType = Setting.simpleString(
+            MULTIPLIER_KEY,
+            "not-a-number",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, wrongType));
+
+        assertTrue(inputs.fragmentExecutorMultiplier().isEmpty());
+    }
+
+    /**
+     * {@code NaN} is numeric-typed but unusable, and it is <b>reachable through the real descriptor</b>:
+     * {@code Setting}'s double parser range-checks with {@code value < min} / {@code value > max}, and both
+     * comparisons are false for {@code NaN}, so an operator PUT of {@code "NaN"} passes the owning plugin's
+     * own 0.1-to-10.0 bounds. Handed on as {@code of(NaN)} it would poison every term derived from it and
+     * print as {@code NaN} in the fan-out's observability line. It degrades to the same absent signal as an
+     * unreadable value instead — <b>not</b> to 1.0, which is the one substitution this contract forbids.
+     */
+    public void testMultiplierEmptyWhenRegisteredValueIsNotFinite() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, MULTIPLIER_DESCRIPTOR_COPY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, Double.NaN).build());
+
+        // Pins that this is a real hazard and not a hypothetical one: the owning descriptor accepts it.
+        assertTrue(
+            "the owning Setting's own bounds are expected to accept NaN",
+            Double.isNaN(clusterSettings.get(MULTIPLIER_DESCRIPTOR_COPY))
+        );
+
+        OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+        assertTrue("a non-finite multiplier must degrade to the absent signal, got " + multiplier, multiplier.isEmpty());
+        assertNotEquals("and must never be substituted with 1.0", OptionalDouble.of(1.0), multiplier);
+    }
+
+    /**
+     * A zero or negative multiplier is numeric, finite and unusable: the consuming gate term is
+     * {@code vCPU * multiplier / target_partitions}, so {@code 0} kills the fan-out permanently and a
+     * negative value makes the width negative — the two directions this read path must never fail into.
+     * The relaxed descriptor is the same hypothesis the sibling accessor's {@code Math.max(1L, raw)}
+     */
+    public void testMultiplierEmptyWhenRegisteredValueIsNotPositive() {
+        Setting<Double> negativeAllowingCopy = negativeAllowingMultiplierCopy();
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, negativeAllowingCopy);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        for (double unusable : new double[] { 0.0, -0.0, -1.5, -10.0 }) {
+            clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, unusable).build());
+
+            // Pins that the guard in the accessor, not the descriptor's own bounds, is what rejects this.
+            assertEquals(
+                "the relaxed descriptor is expected to accept " + unusable,
+                unusable,
+                clusterSettings.get(negativeAllowingCopy),
+                0.0
+            );
+
+            OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+            assertTrue("a non-positive multiplier must degrade to the absent signal, got " + multiplier, multiplier.isEmpty());
+            assertNotEquals("and must never be substituted with 1.0", OptionalDouble.of(1.0), multiplier);
+        }
+
+        // The smallest value the real descriptor allows still reads through: the guard is on the sign.
+        clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, 0.1).build());
+        assertEquals(OptionalDouble.of(0.1), inputs.fragmentExecutorMultiplier());
+    }
+
+    /**
+     * The same guard reached through the other compile-invisible drift shape: the declaring side changing
+     * the descriptor's type ({@code doubleSetting} to {@code intSetting}), which hands back a {@code Number}
+     * that is not a {@code Double} and whose own default is out of the gate's domain.
+     */
+    public void testMultiplierEmptyWhenDeclaringTypeChangeYieldsZero() {
+        Setting<Integer> intTypedCopy = Setting.intSetting(MULTIPLIER_KEY, 0, -10, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, intTypedCopy));
+
+        OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+        assertTrue("a zero multiplier must degrade to the absent signal, got " + multiplier, multiplier.isEmpty());
+        assertNotEquals("and must never be substituted with 1.0", OptionalDouble.of(1.0), multiplier);
+    }
+
+    // ── B2.3 — the anti-clamp rule as its own contract ────────────────────
+
+    /**
+     * The paired half of this rule — the fan-out width computed with the gate term <b>dropped</b>
+     * rather than with a gate term of 1 — is a unit test on the consuming side. Neither half may be
+     * deleted alone.
+     */
+    public void testAbsentMultiplierIsEmptyNotOne() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        for (String mode : List.of(
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_AUTO,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_ALL,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE
+        )) {
+            for (int sliceCount : new int[] { 0, 1, 2, 8, 1024 }) {
+                clusterSettings.applySettings(Settings.builder().put(MODE_KEY, mode).put(MAX_SLICE_COUNT_KEY, sliceCount).build());
+
+                OptionalDouble multiplier = inputs.fragmentExecutorMultiplier();
+                String cell = String.format(Locale.ROOT, "mode=%s sliceCount=%d", mode, sliceCount);
+                assertFalse("no code path may synthesise a multiplier (" + cell + ")", multiplier.isPresent());
+                assertNotEquals("must never be clamped to 1.0 (" + cell + ")", OptionalDouble.of(1.0), multiplier);
+            }
+        }
+    }
+
+    // ── B2.2 — the locally re-derived target_partitions ───────────────────
+
+    public void testTargetPartitionsIsOneWhenConcurrentSearchModeNone() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        for (int sliceCount : new int[] { 0, 1, 2, 8, 1024 }) {
+            clusterSettings.applySettings(
+                Settings.builder()
+                    .put(MODE_KEY, SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE)
+                    .put(MAX_SLICE_COUNT_KEY, sliceCount)
+                    .build()
+            );
+
+            assertEquals("mode=none forces 1 regardless of slice count " + sliceCount, 1, inputs.targetPartitions());
+        }
+    }
+
+    public void testTargetPartitionsCapsAtAvailableProcessors() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_SLICE_COUNT_KEY, 1024).build());
+
+        assertEquals(Runtime.getRuntime().availableProcessors(), inputs.targetPartitions());
+    }
+
+    public void testTargetPartitionsUsesHalfProcessorsWhenSliceCountZero() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_SLICE_COUNT_KEY, 0).build());
+
+        assertEquals(Math.max(1, Runtime.getRuntime().availableProcessors() / 2), inputs.targetPartitions());
+    }
+
+    /**
+     * Documents the divide-by-zero hazard: the mirror is allowed to return 0 (1-vCPU host with
+     * {@code maxSliceCount == 0}) and the accessor is the only thing that clamps it.
+     */
+    public void testTargetPartitionsNeverZero() {
+        int mirrored = DslGateInputs.deriveTargetPartitionsMirror(SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_AUTO, 0);
+        assertEquals(
+            "the mirror must stay bit-faithful, including the 0 it can return",
+            Runtime.getRuntime().availableProcessors() / 2,
+            mirrored
+        );
+
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+        clusterSettings.applySettings(Settings.builder().put(MAX_SLICE_COUNT_KEY, 0).build());
+
+        assertEquals(Math.max(1, mirrored), inputs.targetPartitions());
+        assertTrue("the accessor consumers divide by must never be 0", inputs.targetPartitions() >= 1);
+    }
+
+    /**
+     * Guards against a {@code clusterService.getSettings()} regression, which would keep returning the
+     * node's static default. (On a 1-vCPU host every branch collapses to 1, so the discrimination
+     * comes from the dynamic-override tests on the other two inputs.)
+     */
+    public void testTargetPartitionsFollowsDynamicUpdate() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        ClusterSettings clusterSettings = registry(Settings.EMPTY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        int atDefault = inputs.targetPartitions();
+        assertEquals(expectedTargetPartitions(SearchService.CONCURRENT_SEGMENT_SEARCH_DEFAULT_SLICE_COUNT_VALUE), atDefault);
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_SLICE_COUNT_KEY, 1024).build());
+
+        assertEquals(Math.max(1, processors), inputs.targetPartitions());
+        if (processors >= 2) {
+            assertNotEquals("a static-snapshot read would still report the node default", atDefault, inputs.targetPartitions());
+        }
+    }
+
+    // ── B2.4 — the shard-request cap ──────────────────────────────────────
+
+    public void testShardRequestCapReadWhenAnalyticsSettingRegistered() {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, SHARD_REQUEST_CAP_DESCRIPTOR_COPY));
+
+        // 5 comes from the registered descriptor's own default, not from a literal in main code.
+        assertEquals(5, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    /**
+     * Same shape as the multiplier's guard: the 5 asserted above is the canonical default, so a hardcoded
+     * {@code return 5} would pass it on the un-overridden read path. This pins the value to the registered
+     * descriptor, which is the whole reason the fallback below is {@code MAX_VALUE} and not a copy of 5.
+     */
+    public void testShardRequestCapComesFromTheRegisteredDescriptorNotALocalDefault() {
+        Setting<Integer> nonCanonicalDefault = Setting.intSetting(
+            SHARD_REQUEST_CAP_KEY,
+            7,
+            1,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, nonCanonicalDefault));
+
+        int cap = inputs.maxConcurrentShardRequestsPerNode();
+        assertEquals(7, cap);
+        assertNotEquals("the owning plugin's default must not be duplicated here", 5, cap);
+    }
+
+    public void testShardRequestCapReadsDynamicOverride() {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, SHARD_REQUEST_CAP_DESCRIPTOR_COPY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(SHARD_REQUEST_CAP_KEY, 2).build());
+
+        assertEquals(2, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    public void testShardRequestCapFallsBackToMaxValueWhenKeyMissing() {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY));
+
+        int cap = inputs.maxConcurrentShardRequestsPerNode();
+        assertEquals(Integer.MAX_VALUE, cap);
+        assertNotEquals("the owning plugin's default must never be duplicated here", 5, cap);
+    }
+
+    public void testShardRequestCapMaxValueWhenRegisteredTypeIsNotNumeric() {
+        Setting<String> wrongType = Setting.simpleString(
+            SHARD_REQUEST_CAP_KEY,
+            "not-a-number",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, wrongType));
+
+        assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    /**
+     * A cap above the {@code int} range must saturate, not wrap. The read is by string, so a type change
+     * on the declaring side ({@code intSetting} to {@code longSetting}) is as invisible here as the rename
+     * the {@code MAX_VALUE} fallback defends against — and {@code Number.intValue()} would turn such a
+     * value into a small or negative cap, i.e. the <i>smallest</i> F and therefore the <i>widest</i>
+     * gate-derived fan-out. That is the one direction this read path must never fail into, so the
+     * assertion is on the saturated value and explicitly not on the wrapped one.
+     */
+    public void testShardRequestCapSaturatesInsteadOfWrappingAboveIntRange() {
+        Setting<Long> longTypedCopy = Setting.longSetting(
+            SHARD_REQUEST_CAP_KEY,
+            5L,
+            1L,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        long aboveIntRange = Integer.MAX_VALUE + 1_000L;
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, longTypedCopy);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(SHARD_REQUEST_CAP_KEY, aboveIntRange).build());
+
+        assertEquals("a cap above the int range must saturate at MAX_VALUE", Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode());
+        assertNotEquals(
+            "intValue() would wrap this to " + (int) aboveIntRange + ", which clamps to the narrowest cap and widens the fan-out",
+            1,
+            inputs.maxConcurrentShardRequestsPerNode()
+        );
+    }
+
+    /** Pins the consumer's {@code F >= 1} from this side even if the declaring plugin relaxes its min. */
+    public void testShardRequestCapNeverBelowOne() {
+        Setting<Integer> zeroAllowingCopy = Setting.intSetting(
+            SHARD_REQUEST_CAP_KEY,
+            5,
+            0,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, zeroAllowingCopy);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+
+        clusterSettings.applySettings(Settings.builder().put(SHARD_REQUEST_CAP_KEY, 0).build());
+
+        assertEquals(1, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    // ── The one-shot diagnostics — one latch per condition ────────────────
+
+    private static final String LOGGER_NAME = "org.opensearch.dsl.settings.DslGateInputs";
+    private static final String TEST_LOGGING = LOGGER_NAME + ":DEBUG";
+    private static final String LOGGING_REASON = "the absence diagnostics are DEBUG-level and latched, so they need the level raised";
+
+    private static final String MULTIPLIER_UNREGISTERED_MESSAGE = "is not registered on this node (no gated backend installed); "
+        + "the concurrency-gate term is dropped";
+    private static final String MULTIPLIER_NON_NUMERIC_MESSAGE = "is registered with a non-numeric value [not-a-number]; "
+        + "the concurrency-gate term is dropped";
+    private static final String MULTIPLIER_NON_FINITE_MESSAGE = "is registered with a non-finite value [NaN]; "
+        + "the concurrency-gate term is dropped";
+    private static final String MULTIPLIER_NON_POSITIVE_MESSAGE = "is registered with a non-positive value [0.0]; "
+        + "the concurrency-gate term is dropped";
+    private static final String CAP_UNREGISTERED_MESSAGE = "is not registered on this node; treating the per-node shard-request cap "
+        + "as unbounded";
+    private static final String CAP_NON_NUMERIC_MESSAGE = "is registered with a non-numeric value [not-a-number]; treating the "
+        + "per-node shard-request cap as unbounded";
+
+    /**
+     * The unregistered branch must report the condition that is actually true, and must do so once —
+     * this accessor runs on every fan-out decision, so an unlatched line would be per-query noise.
+     */
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testUnregisteredMultiplierLogsOnlyTheUnregisteredMessageOnce() throws Exception {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY));
+
+        assertLogsOnFirstReadOnly(
+            () -> assertTrue(inputs.fragmentExecutorMultiplier().isEmpty()),
+            MULTIPLIER_UNREGISTERED_MESSAGE,
+            MULTIPLIER_NON_NUMERIC_MESSAGE
+        );
+    }
+
+    /**
+     * The non-numeric branch has its own latch, so it reports the wrong-type cause rather than
+     * inheriting the unregistered branch's wording.
+     */
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testNonNumericMultiplierLogsOnlyTheNonNumericMessageOnce() throws Exception {
+        Setting<String> wrongType = Setting.simpleString(
+            MULTIPLIER_KEY,
+            "not-a-number",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, wrongType));
+
+        assertLogsOnFirstReadOnly(
+            () -> assertTrue(inputs.fragmentExecutorMultiplier().isEmpty()),
+            MULTIPLIER_NON_NUMERIC_MESSAGE,
+            MULTIPLIER_UNREGISTERED_MESSAGE
+        );
+    }
+
+    /**
+     * The non-finite branch has its own latch too, so the log names the cause that is actually true: a
+     * value that is there and numeric but unusable, not a key that is missing.
+     */
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testNonFiniteMultiplierLogsOnlyTheNonFiniteMessageOnce() throws Exception {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, MULTIPLIER_DESCRIPTOR_COPY);
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+        clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, Double.NaN).build());
+
+        assertLogsOnFirstReadOnly(
+            () -> assertTrue(inputs.fragmentExecutorMultiplier().isEmpty()),
+            MULTIPLIER_NON_FINITE_MESSAGE,
+            MULTIPLIER_UNREGISTERED_MESSAGE
+        );
+    }
+
+    /**
+     * The non-positive branch has its own latch too, so an operator raising the level sees the domain
+     * failure named rather than the non-finite branch's wording.
+     */
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testNonPositiveMultiplierLogsOnlyTheNonPositiveMessageOnce() throws Exception {
+        ClusterSettings clusterSettings = registry(Settings.EMPTY, negativeAllowingMultiplierCopy());
+        DslGateInputs inputs = new DslGateInputs(clusterSettings);
+        clusterSettings.applySettings(Settings.builder().put(MULTIPLIER_KEY, 0.0).build());
+
+        assertLogsOnFirstReadOnly(
+            () -> assertTrue(inputs.fragmentExecutorMultiplier().isEmpty()),
+            MULTIPLIER_NON_POSITIVE_MESSAGE,
+            MULTIPLIER_NON_FINITE_MESSAGE
+        );
+    }
+
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testUnregisteredShardRequestCapLogsOnlyTheUnregisteredMessageOnce() throws Exception {
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY));
+
+        assertLogsOnFirstReadOnly(
+            () -> assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode()),
+            CAP_UNREGISTERED_MESSAGE,
+            CAP_NON_NUMERIC_MESSAGE
+        );
+    }
+
+    @TestLogging(reason = LOGGING_REASON, value = TEST_LOGGING)
+    public void testNonNumericShardRequestCapLogsOnlyTheNonNumericMessageOnce() throws Exception {
+        Setting<String> wrongType = Setting.simpleString(
+            SHARD_REQUEST_CAP_KEY,
+            "not-a-number",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+        DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY, wrongType));
+
+        assertLogsOnFirstReadOnly(
+            () -> assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode()),
+            CAP_NON_NUMERIC_MESSAGE,
+            CAP_UNREGISTERED_MESSAGE
+        );
+    }
+
+    /**
+     * The latch must not be spendable by a read that logs nothing. Every test above raises the level
+     * <i>before</i> the first read, which is the one ordering a production node never uses: it runs at
+     * INFO, takes its first fan-out decision at startup, and only then does an operator raise the level
+     * to find out why the fan-out is narrow. A latch tripped before the level check is already gone by
+     * then and the diagnostic is unreachable for the life of the node.
+     */
+    public void testAbsenceDiagnosticSurvivesAReadAtInfo() throws Exception {
+        Logger logger = LogManager.getLogger(LOGGER_NAME);
+        Level original = logger.getLevel();
+        try {
+            Loggers.setLevel(logger, Level.INFO);
+            DslGateInputs inputs = new DslGateInputs(registry(Settings.EMPTY));
+
+            // The read a production node makes first, at the level a production node runs at.
+            assertTrue(inputs.fragmentExecutorMultiplier().isEmpty());
+            assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode());
+
+            Loggers.setLevel(logger, Level.DEBUG);
+            try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+                appender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(
+                        MULTIPLIER_UNREGISTERED_MESSAGE,
+                        LOGGER_NAME,
+                        Level.DEBUG,
+                        MULTIPLIER_UNREGISTERED_MESSAGE
+                    )
+                );
+                appender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(CAP_UNREGISTERED_MESSAGE, LOGGER_NAME, Level.DEBUG, CAP_UNREGISTERED_MESSAGE)
+                );
+
+                assertTrue(inputs.fragmentExecutorMultiplier().isEmpty());
+                assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode());
+
+                appender.assertAllExpectationsMatched();
+            }
+        } finally {
+            Loggers.setLevel(logger, original);
+        }
+    }
+
+    // ── Registered but unreadable — no throw onto the query path ──────────
+
+    /**
+     * The cast guard covers a value of the wrong <i>type</i>; this covers a value of the right type that
+     * the owning {@code Setting} refuses to hand over. {@code ClusterSettings.get(Setting)} delegates
+     * straight to {@code setting.get(lastSettingsApplied, settings)}, so a stored value that fails the
+     * descriptor's own parse/validate surfaces as an {@code IllegalArgumentException} on the caller's
+     * thread — which, for these accessors, is a SEARCH thread mid-query.
+     */
+    public void testMultiplierEmptyWhenRegisteredValueCannotBeParsed() {
+        DslGateInputs inputs = new DslGateInputs(unparseableRegistry(MULTIPLIER_KEY, MULTIPLIER_DESCRIPTOR_COPY));
+
+        assertTrue("an unreadable value must degrade to the absent signal", inputs.fragmentExecutorMultiplier().isEmpty());
+    }
+
+    public void testShardRequestCapMaxValueWhenRegisteredValueCannotBeParsed() {
+        DslGateInputs inputs = new DslGateInputs(unparseableRegistry(SHARD_REQUEST_CAP_KEY, SHARD_REQUEST_CAP_DESCRIPTOR_COPY));
+
+        assertEquals(Integer.MAX_VALUE, inputs.maxConcurrentShardRequestsPerNode());
+    }
+
+    /**
+     * Pins that this is a real hazard and not a hypothetical one: the same registry, read through the
+     * typed API the accessors use internally, does throw.
+     */
+    public void testUnparseableValueReallyThrowsThroughTheTypedRead() {
+        ClusterSettings clusterSettings = unparseableRegistry(MULTIPLIER_KEY, MULTIPLIER_DESCRIPTOR_COPY);
+
+        expectThrows(IllegalArgumentException.class, () -> clusterSettings.get(MULTIPLIER_DESCRIPTOR_COPY));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * The multiplier key re-declared with a relaxed minimum, standing in for the declaring plugin loosening
+     * its own {@code 0.1} bound. The accessor's sign guard exists for exactly this: the read is by string, so
+     * a bounds change on that side reaches this plugin without a compile error.
+     */
+    private static Setting<Double> negativeAllowingMultiplierCopy() {
+        return Setting.doubleSetting(MULTIPLIER_KEY, 1.5, -10.0, 10.0, Setting.Property.NodeScope, Setting.Property.Dynamic);
+    }
+
+    /**
+     * A registry where {@code key} is registered but its stored value is not of the descriptor's type.
+     * The value goes in through the node settings rather than {@code applySettings} on purpose —
+     * {@code applySettings} validates and would reject it, which is exactly why the accessors cannot
+     * assume a registered key is a readable one.
+     */
+    private static ClusterSettings unparseableRegistry(String key, Setting<?> descriptor) {
+        return registry(Settings.builder().put(key, "not-parseable-as-a-number").build(), descriptor);
+    }
+
+    /**
+     * Reads twice: the first read must emit {@code expected} and never {@code otherCondition}'s wording,
+     * and the second must be silent because the condition's own latch has tripped.
+     */
+    private static void assertLogsOnFirstReadOnly(Runnable read, String expected, String otherCondition) throws Exception {
+        Logger logger = LogManager.getLogger(LOGGER_NAME);
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(expected, LOGGER_NAME, Level.DEBUG, expected));
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(otherCondition, LOGGER_NAME, Level.DEBUG, otherCondition));
+
+            read.run();
+
+            appender.assertAllExpectationsMatched();
+        }
+
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(expected, LOGGER_NAME, Level.DEBUG, expected));
+
+            read.run();
+
+            appender.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Builds the one shared registry every accessor reads through: the server's built-in settings
+     * (which already include both concurrent-segment-search settings) plus any local descriptor
+     * copies standing in for another plugin's registration.
+     */
+    private static ClusterSettings registry(Settings nodeSettings, Setting<?>... extras) {
+        Set<Setting<?>> registered = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        registered.addAll(Set.of(extras));
+        return new ClusterSettings(nodeSettings, registered);
+    }
+
+    private static int expectedTargetPartitions(int maxSliceCount) {
+        return Math.max(1, Math.min(maxSliceCount, Runtime.getRuntime().availableProcessors()));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/DslQuerySettingsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/DslQuerySettingsTests.java
@@ -1,0 +1,205 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.settings;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DslQuerySettingsTests extends OpenSearchTestCase {
+
+    private static final String MAX_PARALLEL_KEY = "dsl.query.max_parallel_sub_plans";
+
+    /**
+     * The setting's upper bound. Mirrors {@code SubPlanParallelism.MAX_K_SETTING}, which is
+     * package-private in another package; the two are pinned together by
+     * {@code SubPlanParallelismTests#testTheSettingsBoundMatchesTheHardCeiling}.
+     */
+    private static final int CEILING = 5;
+
+    // ── The setting descriptors ────────────────────────────────────────────
+
+    public void testMaxParallelSubPlansDefaultIsOne() {
+        assertEquals(MAX_PARALLEL_KEY, DslQuerySettings.MAX_PARALLEL_SUB_PLANS.getKey());
+        assertEquals(Integer.valueOf(1), DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(Settings.EMPTY));
+    }
+
+    public void testMaxParallelSubPlansRejectsZero() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(Settings.builder().put(MAX_PARALLEL_KEY, 0).build())
+        );
+        assertTrue("expected a lower-bound message, got: " + e.getMessage(), e.getMessage().contains("must be >= 1"));
+    }
+
+    /**
+     * The cap has to be enforced by the {@code Setting} itself, not by a downstream {@code min} — this
+     * is the assertion that fails if someone "relaxes" it.
+     */
+    public void testMaxParallelSubPlansRejectsAboveTheCeiling() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(Settings.builder().put(MAX_PARALLEL_KEY, CEILING + 1).build())
+        );
+        assertTrue("expected an upper-bound message, got: " + e.getMessage(), e.getMessage().contains("must be <= " + CEILING));
+    }
+
+    /** Every width in range parses, so the bound is a ceiling and not an accidental exact-value check. */
+    public void testMaxParallelSubPlansAcceptsEveryWidthUpToTheCeiling() {
+        for (int k = 1; k <= CEILING; k++) {
+            assertEquals(
+                "width " + k + " must be accepted",
+                Integer.valueOf(k),
+                DslQuerySettings.MAX_PARALLEL_SUB_PLANS.get(Settings.builder().put(MAX_PARALLEL_KEY, k).build())
+            );
+        }
+    }
+
+    /**
+     * Guards against a setting being added without {@code getSettings()} being updated: an unregistered key
+     * is rejected in {@code opensearch.yml} and is a 400 through {@code _cluster/settings}, so a descriptor
+     * that never reaches this list is not merely inert but unusable.
+     */
+    public void testAllContainsExactlyTheWidthSetting() {
+        List<Setting<?>> all = DslQuerySettings.all();
+        assertEquals("all() must contain exactly the width setting, got " + keysOf(all), 1, all.size());
+        assertEquals(Set.of(MAX_PARALLEL_KEY), Set.copyOf(keysOf(all)));
+    }
+
+    /**
+     * The width is the only knob. There is one execution shape and no launch-mode setting, so a stray
+     * registration would turn an internal execution strategy into a public, permanently supported API —
+     * this asserts on the registry the plugin hands the node, which is the layer that decides whether a
+     * key works or is a 400.
+     */
+    public void testNoLaunchShapeSettingIsRegistered() {
+        assertFalse(
+            "no registered setting may own an execution shape, got " + keysOf(DslQuerySettings.all()),
+            keysOf(DslQuerySettings.all()).stream().anyMatch(k -> k.contains("launch"))
+        );
+    }
+
+    /** A lost {@code Dynamic} silently turns the width knob into a restart-only one. */
+    public void testSettingsAreNodeScopeAndDynamic() {
+        for (Setting<?> setting : DslQuerySettings.all()) {
+            assertTrue(setting.getKey() + " must be NodeScope", setting.hasNodeScope());
+            assertTrue(setting.getKey() + " must be Dynamic", setting.isDynamic());
+            assertFalse(setting.getKey() + " must not be IndexScope", setting.hasIndexScope());
+            assertFalse(setting.getKey() + " must not be Final", setting.getProperties().contains(Setting.Property.Final));
+        }
+    }
+
+    // ── The live holder ────────────────────────────────────────────────────
+
+    /**
+     * The node-settings value differs from the default ({@code 1}) on purpose: at the default this test
+     * would also pass against a holder that ignored the node settings entirely.
+     */
+    public void testHolderReadsInitialValueFromNodeSettings() {
+        Settings nodeSettings = Settings.builder().put(MAX_PARALLEL_KEY, 2).build();
+        DslQuerySettings holder = new DslQuerySettings(clusterService(nodeSettings));
+
+        assertEquals(2, holder.maxParallelSubPlans());
+    }
+
+    /** Sequential-by-default: an unset key must not widen the fan-out. */
+    public void testHolderDefaultsToSequential() {
+        DslQuerySettings holder = new DslQuerySettings(clusterService(Settings.EMPTY));
+
+        assertEquals(1, holder.maxParallelSubPlans());
+    }
+
+    public void testDynamicUpdateWritesVolatileMaxParallelSubPlans() {
+        ClusterSettings clusterSettings = registry();
+        DslQuerySettings holder = new DslQuerySettings(clusterService(Settings.EMPTY, clusterSettings));
+
+        assertEquals("default before the update", 1, holder.maxParallelSubPlans());
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, 2).build());
+
+        assertEquals("update consumer must have written the volatile", 2, holder.maxParallelSubPlans());
+    }
+
+    /**
+     * A one-directional test would pass against a latch-style bug (a consumer that only ever widens),
+     * so assert narrowing back and the fall-back-to-default too. Narrowing is the operator's rollback
+     * path for the fan-out now that there is no separate {@code enabled} lever here: {@code 1} is
+     * byte-identical to sequential execution.
+     */
+    public void testDynamicUpdateWritesVolatileMaxParallelSubPlansBothWays() {
+        ClusterSettings clusterSettings = registry();
+        DslQuerySettings holder = new DslQuerySettings(clusterService(Settings.EMPTY, clusterSettings));
+
+        assertEquals("the sequential default", 1, holder.maxParallelSubPlans());
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, 2).build());
+        assertEquals("widening must take effect", 2, holder.maxParallelSubPlans());
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, 1).build());
+        assertEquals("narrowing back to sequential must take effect", 1, holder.maxParallelSubPlans());
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, 2).build());
+        assertEquals("widening again must take effect", 2, holder.maxParallelSubPlans());
+
+        clusterSettings.applySettings(Settings.EMPTY);
+        assertEquals("clearing the transient value must fall back to the default", 1, holder.maxParallelSubPlans());
+    }
+
+    /** Fail secure: a rejected update must not partially apply. */
+    public void testDynamicUpdateRejectsAboveTheCeilingAtClusterSettingsLayer() {
+        ClusterSettings clusterSettings = registry();
+        DslQuerySettings holder = new DslQuerySettings(clusterService(Settings.EMPTY, clusterSettings));
+
+        clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, 2).build());
+        assertEquals(2, holder.maxParallelSubPlans());
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.applySettings(Settings.builder().put(MAX_PARALLEL_KEY, CEILING + 1).build())
+        );
+        // The updater wraps the Setting's own parse failure; the bound is in the cause.
+        assertTrue("expected the rejected key to be named, got: " + e.getMessage(), e.getMessage().contains(MAX_PARALLEL_KEY));
+        assertNotNull("the Setting itself must be the thing that rejected 3", e.getCause());
+        assertTrue(
+            "expected an upper-bound message on the cause, got: " + e.getCause().getMessage(),
+            e.getCause().getMessage().contains("must be <= " + CEILING)
+        );
+        assertEquals("the rejected value must not have been applied", 2, holder.maxParallelSubPlans());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static List<String> keysOf(List<Setting<?>> settings) {
+        return settings.stream().map(Setting::getKey).collect(Collectors.toList());
+    }
+
+    private static ClusterSettings registry() {
+        return new ClusterSettings(Settings.EMPTY, Set.copyOf(DslQuerySettings.all()));
+    }
+
+    private static ClusterService clusterService(Settings nodeSettings) {
+        return clusterService(nodeSettings, new ClusterSettings(nodeSettings, Set.copyOf(DslQuerySettings.all())));
+    }
+
+    private static ClusterService clusterService(Settings nodeSettings, ClusterSettings clusterSettings) {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(nodeSettings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        return clusterService;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/TargetPartitionsDriftTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/settings/TargetPartitionsDriftTests.java
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.settings;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.SearchService;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * {@link DslGateInputs#deriveTargetPartitionsMirror(String, int)}, pinned against the formula it copies.
+ *
+ * <p><b>This is a copy, and nothing here verifies the original.</b> The mirror reproduces
+ * {@code DatafusionSettings.deriveTargetPartitions} in the sibling {@code analytics-backend-datafusion}
+ * plugin, whose classes this plugin deliberately does not depend on. The expectations below are therefore
+ * the formula written out by hand, not read from the owner — so these tests catch an edit to <i>our</i>
+ * copy, and cannot catch the owner changing <i>theirs</i>. If the backend's derivation changes, this file
+ * stays green while the fan-out's {@code A = vCPU * multiplier / target_partitions} is computed from a
+ * wrong divisor; re-check it by hand when touching either side.
+ */
+public class TargetPartitionsDriftTests extends OpenSearchTestCase {
+
+    private static final String MODE_KEY = "search.concurrent_segment_search.mode";
+    private static final String MAX_SLICE_COUNT_KEY = SearchService.CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY;
+
+    private static final String DRIFT_MESSAGE = "DslGateInputs.deriveTargetPartitionsMirror no longer matches the "
+        + "DatafusionSettings.deriveTargetPartitions formula it copies — re-check the fan-out's "
+        + "A = vCPU * multiplier / target_partitions";
+
+    /** {@code Runtime.availableProcessors()} — the mirror reads it, so the expectations must too. */
+    private static final int VCPU = Runtime.getRuntime().availableProcessors();
+
+    /** Mode {@code none} disables concurrent segment search, so the engine plans a single partition. */
+    public void testModeNoneIsAlwaysOnePartition() {
+        for (int sliceCount : new int[] { 0, 1, 2, 8, 1024 }) {
+            assertMirror(SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE, sliceCount, 1);
+        }
+    }
+
+    /**
+     * An unset slice count ({@code 0}) means "let the server decide", which is half the cores.
+     *
+     * <p>On a single-vCPU host {@code VCPU / 2} is 0 and the mirror returns 0 too, so the assertion would
+     * hold without proving anything. The second half pins the halving itself against a value that cannot
+     * collapse that way, and the accessor's {@code >= 1} clamp is covered by
+     * {@link #testAccessorReadsTheModeAndSliceCountSettings}.
+     */
+    public void testZeroSliceCountIsHalfTheCores() {
+        for (String mode : concurrentModes()) {
+            assertMirror(mode, 0, VCPU / 2);
+        }
+        assumeTrue("halving is only observable above one core", VCPU > 1);
+        assertTrue("half of " + VCPU + " cores must be below the core count", VCPU / 2 < VCPU);
+        assertTrue("half of " + VCPU + " cores must be at least 1", VCPU / 2 >= 1);
+    }
+
+    /**
+     * A set slice count is capped by the core count. Both sides of the {@code min} are covered: 1 and 2 are
+     * below it on any host CI runs on, and 1024 is above it — so a dropped {@code min} fails here.
+     */
+    public void testSetSliceCountIsCappedByTheCoreCount() {
+        for (String mode : concurrentModes()) {
+            assertMirror(mode, 1, Math.min(1, VCPU));
+            assertMirror(mode, 2, Math.min(2, VCPU));
+            assertMirror(mode, VCPU, VCPU);
+            assertMirror(mode, 1024, VCPU);
+        }
+        assertEquals("1024 must exceed the core count for the cap to be exercised", VCPU, Math.min(1024, VCPU));
+    }
+
+    /** The cell an operator actually runs: the server's own defaults for both settings. */
+    public void testDefaultsResolveThroughTheMirror() {
+        String defaultMode = SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE.get(Settings.EMPTY);
+        int defaultSliceCount = SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.get(Settings.EMPTY);
+
+        assertEquals(
+            DRIFT_MESSAGE + " [defaults: mode=" + defaultMode + " sliceCount=" + defaultSliceCount + "]",
+            expected(defaultMode, defaultSliceCount),
+            DslGateInputs.deriveTargetPartitionsMirror(defaultMode, defaultSliceCount)
+        );
+    }
+
+    /**
+     * The tests above pin the derivation <i>function</i>; this pins the two settings the accessor is
+     * <i>fed from</i>. A read of the wrong key would resolve to that setting's default and diverge from
+     * the value computed here from the node settings directly.
+     */
+    public void testAccessorReadsTheModeAndSliceCountSettings() {
+        for (String mode : List.of(
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_AUTO,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_ALL,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE
+        )) {
+            for (int sliceCount : new int[] { 0, 1, 2, 8, 1024 }) {
+                Settings nodeSettings = Settings.builder().put(MODE_KEY, mode).put(MAX_SLICE_COUNT_KEY, sliceCount).build();
+                // Both concurrent-segment-search settings are in BUILT_IN_CLUSTER_SETTINGS, so the accessor's
+                // typed reads resolve against a plain built-in registry.
+                DslGateInputs inputs = new DslGateInputs(new ClusterSettings(nodeSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+
+                assertEquals(
+                    String.format(Locale.ROOT, "%s [accessor, mode=%s sliceCount=%d]", DRIFT_MESSAGE, mode, sliceCount),
+                    Math.max(1, expected(mode, sliceCount)),
+                    inputs.targetPartitions()
+                );
+            }
+        }
+    }
+
+    private static List<String> concurrentModes() {
+        return List.of(SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_AUTO, SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_ALL);
+    }
+
+    private void assertMirror(String mode, int sliceCount, int expected) {
+        assertEquals(
+            String.format(Locale.ROOT, "%s [mode=%s sliceCount=%d]", DRIFT_MESSAGE, mode, sliceCount),
+            expected,
+            DslGateInputs.deriveTargetPartitionsMirror(mode, sliceCount)
+        );
+    }
+
+    /**
+     * The copied formula, written out independently of the mirror so the two can disagree. Kept in one
+     * place because {@link #testAccessorReadsTheModeAndSliceCountSettings} needs it across a whole grid.
+     */
+    private static int expected(String mode, int sliceCount) {
+        if (SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_NONE.equals(mode)) {
+            return 1;
+        }
+        return sliceCount == 0 ? VCPU / 2 : Math.min(sliceCount, VCPU);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -152,6 +152,14 @@ integTest {
     exclude '**/YmlOversamplingIT.class'
     exclude '**/*NoMergeIT.class'
     exclude '**/planshape/*IT.class'
+    // DSL-path ITs, each on its own cluster below. DslFanOutIT mutates cluster-wide dynamic
+    // setting (dsl.query.max_parallel_sub_plans) and would leak it
+    // into the ~150 siblings that share this single-fork cluster; the other two are excluded so
+    // each DSL IT runs in exactly one task and its provisioning cannot race a sibling's.
+    // Named individually rather than as '**/Dsl*IT.class' — that glob would also pull the
+    // pre-existing DslClickBenchIT out of this task, where it currently runs.
+    exclude '**/DslFanOutIT.class'
+    exclude '**/DslMultiShardSumWideningIT.class'
 
     // Note: parallel forks against the same 2-node testCluster slow the suite down
     // (cluster is the bottleneck, not JVM startup) and cause cross-fork data races
@@ -364,6 +372,55 @@ testClusters.integTestYmlOversampling {
     numberOfNodes = 2
     configureAnalyticsCluster(delegate)
     setting 'analytics.shard_bucket_oversampling_factor', '2.0'
+}
+
+// ── DSL sub-plan fan-out variant: 2 nodes, own cluster because it mutates settings ──
+// DslFanOutIT drives dsl.query.max_parallel_sub_plans over
+// _cluster/settings. AnalyticsRestTestCase preserves the cluster on completion, so the framework
+// never wipes cluster settings for this suite — the IT clears both keys itself in an @After, and
+// running it on its own cluster keeps a mid-test failure from reaching the default integTest's
+// siblings. It is excluded from integTest above.
+task integTestDslFanout(type: RestIntegTestTask) {
+    description = 'Runs the DSL sub-plan fan-out IT, which mutates cluster-wide dsl.query.* settings'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    filter {
+        includeTestsMatching 'org.opensearch.analytics.qa.DslFanOutIT'
+    }
+    systemProperty 'tests.security.manager', 'false'
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+check.dependsOn(integTestDslFanout)
+
+testClusters.integTestDslFanout {
+    numberOfNodes = 2
+    configureAnalyticsCluster(delegate)
+}
+
+// ── DSL SUM-widening variant: 2 nodes, 2-shard index, PARTIAL/FINAL exchange ──
+// DslMultiShardSumWideningIT needs its 2-shard index's PARTIAL/FINAL split to cross a real
+// exchange between two nodes, which is where a sum declared narrower than DataFusion's
+// accumulator is rejected. It changes no cluster setting; it gets its own task so the shard
+// layout of its index is not competing with the default suite's provisioning.
+task integTestDslSumWidening(type: RestIntegTestTask) {
+    description = 'Runs the DSL SUM-widening IT against a 2-shard index on a 2-node cluster'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    filter {
+        includeTestsMatching 'org.opensearch.analytics.qa.DslMultiShardSumWideningIT'
+    }
+    systemProperty 'tests.security.manager', 'false'
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+check.dependsOn(integTestDslSumWidening)
+
+testClusters.integTestDslSumWidening {
+    numberOfNodes = 2
+    configureAnalyticsCluster(delegate)
 }
 
 // Run against an external cluster (no testClusters lifecycle):

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DslFanOutIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DslFanOutIT.java
@@ -1,0 +1,407 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.After;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST integration test for the DSL sub-plan fan-out on a live cluster: it drives
+ * {@code dsl.query.max_parallel_sub_plans} over
+ * {@code _cluster/settings} and asserts that <b>widening the fan-out never changes the answer</b>.
+ */
+public class DslFanOutIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "dsl_fanout_it";
+
+    /** The only setting the fan-out reads; there is one execution shape and no setting for it. */
+    private static final String WIDTH_SETTING = "dsl.query.max_parallel_sub_plans";
+
+    /** The width setting's upper bound, mirroring {@code SubPlanParallelism.MAX_K_SETTING}. */
+    private static final int CEILING = 5;
+
+    /**
+     * Plain search: no aggregations, {@code size > 0}. The {@code term} filter is load-bearing — it makes the
+     * expected total 7 rather than the index's 10, so a dropped filter cannot pass as a correct answer.
+     */
+    private static final String PLAIN_SEARCH = "{\"size\": 5, \"query\": {\"term\": {\"region\": \"east\"}}}";
+
+    /**
+     * {region, service, latency}. Every doc_count that a bucket ordering depends on is distinct (7/3 at the
+     * root, 4/3 and 2/1 within the two parents), so the default {@code doc_count desc} order is fully
+     * determined. {@code latency} is an {@code integer} field whose per-bucket sums exceed
+     * {@code Integer.MAX_VALUE}: the engine accumulates a widened sum in Int64, and an accumulator that
+     * stayed 32-bit wraps to a negative number here instead of returning a wrong-but-plausible total.
+     */
+    private static final String[][] DOCS = {
+        { "east", "api", "600000000" },
+        { "east", "api", "600000000" },
+        { "east", "api", "600000000" },
+        { "east", "api", "600000000" },
+        { "east", "db", "100000000" },
+        { "east", "db", "100000000" },
+        { "east", "db", "100000000" },
+        { "west", "api", "700000000" },
+        { "west", "api", "700000000" },
+        { "west", "cache", "50000000" } };
+
+    private static boolean dataProvisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (dataProvisioned == false) {
+            createFanOutIndex();
+            ingestDocs();
+            dataProvisioned = true;
+        }
+    }
+
+    /**
+     * Clears the width knob. {@link #preserveClusterUponCompletion()} is true for this suite, so nothing in
+     * the framework clears cluster settings for us and a leaked value would reach whatever runs next. Kept as
+     * a loop over keys so adding a second knob cannot silently skip clearing it, and so a mid-test failure —
+     * a failed assertion, a 500 out of a search — still leaves the cluster at its defaults.
+     */
+    @After
+    public void clearFanOutSettings() {
+        List<String> failures = new ArrayList<>();
+        for (String key : List.of(WIDTH_SETTING)) {
+            try {
+                Response response = putTransientSetting(key, "null");
+                int status = response.getStatusLine().getStatusCode();
+                if (status != 200) {
+                    failures.add(key + " -> HTTP " + status);
+                }
+            } catch (Exception e) {
+                failures.add(key + " -> " + e);
+            }
+        }
+        if (failures.isEmpty() == false) {
+            fail("Failed to clear the DSL fan-out cluster settings; a later test would inherit them: " + failures);
+        }
+    }
+
+    // ── Fan-out parity ─────────────────────────────────────────────────────
+
+    /**
+     * A 2-plan nested aggregation — the common production shape, and where a width of 2 first becomes
+     * reachable. Repeated at width 2 because a fan-out
+     * race — a torn collector slot, one plan's rows landing in another plan's slot — need not reproduce on
+     * the first attempt.
+     */
+    public void testNestedAggregationWidth2MatchesWidth1() throws Exception {
+        assertNestedAggregationWidthParity(nestedAggregationBody(0), 3, "2 plans");
+    }
+
+
+
+    /** The widest arrangement available: all 3 plans gated, so nothing runs alone first. */
+    public void testHitsAndNestedAggregationWidth2MatchesWidth1() throws Exception {
+        assertNestedAggregationWidthParity(nestedAggregationBody(5), 2, "3 plans");
+    }
+
+    // ── The aggregation-only gate ──────────────────────────────────────────
+
+    /**
+     * An ordinary search still answers correctly with the knob turned up. Its main batch is one HITS plan,
+     * so it never reaches the width decision at all — which is exactly the claim: an operator who widens the
+     * fan-out for the aggregations must not change what a plain search returns, and must not turn its engine
+     * call into a concurrent one.
+     */
+    public void testPlainSearchIsUnaffectedByTheFanOutWidth() throws Exception {
+        String baseline = "plain search at width=1";
+        Map<String, Object> sequential = dslSearch(PLAIN_SEARCH, 1, baseline);
+        assertEquals(baseline + ": hits.total.value", 7L, totalHits(sequential, baseline));
+        assertNull(baseline + ": a request with no aggs must carry no aggregations", sequential.get("aggregations"));
+
+        String widened = "plain search at width=2";
+        Map<String, Object> fannedOut = dslSearch(PLAIN_SEARCH, 2, widened);
+        assertEquals(widened + ": hits.total.value", 7L, totalHits(fannedOut, widened));
+        assertNull(widened + ": a request with no aggs must carry no aggregations", fannedOut.get("aggregations"));
+
+        assertEquals(
+            "the widest fan-out setting must answer a plain search exactly as the default does",
+            stableView(sequential),
+            stableView(fannedOut)
+        );
+    }
+
+    // ── The knobs' own contracts ───────────────────────────────────────────
+
+    /** A width above the ceiling is a 400, never a silent clamp to something inside it. */
+    public void testWidthAboveTheMaximumIsRejected() throws Exception {
+        ResponseException e = expectThrows(ResponseException.class, () -> putTransientSetting(WIDTH_SETTING, String.valueOf(CEILING + 1)));
+        assertEquals("a width above the ceiling must be a client error", 400, e.getResponse().getStatusLine().getStatusCode());
+        String body = EntityUtils.toString(e.getResponse().getEntity());
+        assertTrue("rejection should name the setting, got: " + body, body.contains(WIDTH_SETTING));
+        assertTrue("rejection should name the maximum, got: " + body, body.contains("must be <= " + CEILING));
+    }
+
+
+    // ── Parity harness ─────────────────────────────────────────────────────
+
+    /**
+     * Runs {@code body} once at width 1, then {@code repeats} times at width 2, and asserts every response
+     * carries the expected buckets and matches the width-1 response field for field. Width is the only
+     * variable: same body, same index, same cluster.
+     *
+     * @param body the search body, unchanged across widths
+     * @param repeats how many times to re-run the fanned-out width
+     * @param context short description of the shape, used in failure messages
+     */
+    private void assertNestedAggregationWidthParity(String body, int repeats, String context) throws IOException {
+        String baseline = context + " at width=1";
+        Map<String, Object> sequential = dslSearch(body, 1, baseline);
+        assertExpectedNestedAggregation(sequential, baseline);
+
+        for (int attempt = 1; attempt <= repeats; attempt++) {
+            String widened = context + " at width=2 (attempt " + attempt + ")";
+            Map<String, Object> fannedOut = dslSearch(body, 2, widened);
+            // Both halves matter: the absolute values catch a width that corrupted the result the same way
+            // every time, the comparison catches a width that answered differently from the sequential path.
+            assertExpectedNestedAggregation(fannedOut, widened);
+            assertEquals(widened + ": must match the width=1 response", stableView(sequential), stableView(fannedOut));
+        }
+    }
+
+    /**
+     * Every bucket value {@link #DOCS} implies, asserted absolutely rather than only against another run —
+     * two runs that are wrong in the same way still agree with each other.
+     */
+    private void assertExpectedNestedAggregation(Map<String, Object> response, String context) {
+        Map<String, Object> aggregations = aggregations(response, context);
+        List<Map<String, Object>> regions = buckets(aggregations, "by_region", context);
+        assertEquals(context + ": by_region bucket count", 2, regions.size());
+        // The terms size (10) is above the distinct region count, so nothing was truncated: the COUNT plan's
+        // eligible-doc total must exactly cover the buckets returned. A non-zero value means docs went
+        assertEquals(context + ": by_region sum_other_doc_count", 0L, sumOtherDocCount(aggregations, "by_region"));
+
+        Map<String, Object> east = regions.get(0);
+        assertEquals(context + ": first region key", "east", east.get("key"));
+        assertEquals(context + ": east doc_count", 7L, docCount(east));
+
+        List<Map<String, Object>> eastServices = buckets(east, "by_service", context);
+        assertEquals(context + ": east by_service bucket count", 2, eastServices.size());
+        assertEquals(context + ": east first service key", "api", eastServices.get(0).get("key"));
+        assertEquals(context + ": east/api doc_count", 4L, docCount(eastServices.get(0)));
+        assertEquals(context + ": east/api total_latency", 2_400_000_000.0, metricValue(eastServices.get(0), "total_latency"), 0.0);
+        assertEquals(context + ": east second service key", "db", eastServices.get(1).get("key"));
+        assertEquals(context + ": east/db doc_count", 3L, docCount(eastServices.get(1)));
+        assertEquals(context + ": east/db total_latency", 300_000_000.0, metricValue(eastServices.get(1), "total_latency"), 0.0);
+
+        Map<String, Object> west = regions.get(1);
+        assertEquals(context + ": second region key", "west", west.get("key"));
+        assertEquals(context + ": west doc_count", 3L, docCount(west));
+
+        List<Map<String, Object>> westServices = buckets(west, "by_service", context);
+        assertEquals(context + ": west by_service bucket count", 2, westServices.size());
+        assertEquals(context + ": west first service key", "api", westServices.get(0).get("key"));
+        assertEquals(context + ": west/api doc_count", 2L, docCount(westServices.get(0)));
+        assertEquals(context + ": west/api total_latency", 1_400_000_000.0, metricValue(westServices.get(0), "total_latency"), 0.0);
+        assertEquals(context + ": west second service key", "cache", westServices.get(1).get("key"));
+        assertEquals(context + ": west/cache doc_count", 1L, docCount(westServices.get(1)));
+        assertEquals(context + ": west/cache total_latency", 50_000_000.0, metricValue(westServices.get(1), "total_latency"), 0.0);
+
+        // Every doc is accounted for regardless of the request's `size`, so the hits total is comparable
+        // across the size=0 and size>0 shapes of this same aggregation.
+        assertEquals(context + ": hits.total.value", (long) DOCS.length, totalHits(response, context));
+    }
+
+    /**
+     * The comparable part of a search response. {@code took} is a wall-clock measurement and is the one field
+     * two runs of the same request are expected to disagree on; everything else — hits total, shard counts,
+     * every bucket and every metric — must match, so it is compared rather than enumerated.
+     */
+    private static Map<String, Object> stableView(Map<String, Object> response) {
+        Map<String, Object> comparable = new HashMap<>(response);
+        comparable.remove("took");
+        return comparable;
+    }
+
+    // ── Request helpers ────────────────────────────────────────────────────
+
+    /**
+     * The 2-level terms aggregation, parameterised only by the request's {@code size} so the HITS plan is the
+     * single difference between the 2-plan and 3-plan shapes.
+     *
+     * @param size the request size; 0 emits no HITS plan
+     * @return the search body as JSON
+     */
+    private static String nestedAggregationBody(int size) {
+        return "{"
+            + "\"size\": " + size + ","
+            + "\"aggs\": {"
+            + "  \"by_region\": {"
+            + "    \"terms\": { \"field\": \"region\", \"size\": 10 },"
+            + "    \"aggs\": {"
+            + "      \"by_service\": {"
+            + "        \"terms\": { \"field\": \"service\", \"size\": 10 },"
+            + "        \"aggs\": { \"total_latency\": { \"sum\": { \"field\": \"latency\" } } }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}"
+            + "}";
+    }
+
+    /** Sets both knobs, then runs {@code body} against the index and asserts HTTP 200. */
+    private Map<String, Object> dslSearch(String body, int width, String context) throws IOException {
+        setFanOutWidth(width);
+        Request request = new Request("POST", "/" + INDEX + "/_search");
+        request.setJsonEntity(body);
+        return assertOkAndParse(client().performRequest(request), context);
+    }
+
+    /**
+     * One PUT per key, mirroring {@link #clearFanOutSettings()}. No polling afterwards is needed and none is
+     * used: a {@code _cluster/settings} update is acked only once every node has applied the new cluster
+     * state, and each node's settings-update consumer runs during that application — so a search issued
+     * after this returns is guaranteed to read the values just set.
+     */
+    private void setFanOutWidth(int width) throws IOException {
+        assertOkAndParse(putTransientSetting(WIDTH_SETTING, String.valueOf(width)), "PUT width=" + width);
+    }
+
+    /**
+     * @param key the setting key
+     * @param jsonValue the value as a JSON token — a bare number, a quoted string, or {@code null} to clear
+     * @return the raw response; a rejected value arrives as a {@link ResponseException}, not as a status code
+     */
+    private Response putTransientSetting(String key, String jsonValue) throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\": {\"" + key + "\": " + jsonValue + "}}");
+        return client().performRequest(request);
+    }
+
+    // ── Response readers ───────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> aggregations(Map<String, Object> response, String context) {
+        Map<String, Object> aggregations = (Map<String, Object>) response.get("aggregations");
+        assertNotNull(context + ": response carries no aggregations", aggregations);
+        return aggregations;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> buckets(Map<String, Object> owner, String aggName, String context) {
+        Map<String, Object> agg = (Map<String, Object>) owner.get(aggName);
+        assertNotNull(context + ": aggregation [" + aggName + "] missing, present keys " + owner.keySet(), agg);
+        List<Map<String, Object>> buckets = (List<Map<String, Object>>) agg.get("buckets");
+        assertNotNull(context + ": aggregation [" + aggName + "] carries no buckets", buckets);
+        return buckets;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static long sumOtherDocCount(Map<String, Object> owner, String aggName) {
+        Map<String, Object> agg = (Map<String, Object>) owner.get(aggName);
+        return ((Number) agg.get("sum_other_doc_count")).longValue();
+    }
+
+    private static long docCount(Map<String, Object> bucket) {
+        return ((Number) bucket.get("doc_count")).longValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static double metricValue(Map<String, Object> bucket, String metricName) {
+        Map<String, Object> metric = (Map<String, Object>) bucket.get(metricName);
+        assertNotNull("metric [" + metricName + "] missing from bucket [" + bucket.get("key") + "]", metric);
+        return ((Number) metric.get("value")).doubleValue();
+    }
+
+    /**
+     * {@code hits.total.value}, asserting the relation is exact on the way past. Hit <em>documents</em> are
+     * still stubbed on this branch ({@code SearchResponseBuilder.buildHits} returns an empty
+     * {@code SearchHit[]}), so the total is the only part of the hits section there is anything true to
+     * assert about; asserting on {@code hits.hits} would be asserting a behaviour that does not exist yet.
+     */
+    @SuppressWarnings("unchecked")
+    private static long totalHits(Map<String, Object> response, String context) {
+        Map<String, Object> hits = (Map<String, Object>) response.get("hits");
+        assertNotNull(context + ": response carries no hits section", hits);
+        Map<String, Object> total = (Map<String, Object>) hits.get("total");
+        assertNotNull(context + ": hits section carries no total", total);
+        assertEquals(context + ": hits.total.relation", "eq", total.get("relation"));
+        return ((Number) total.get("value")).longValue();
+    }
+
+    // ── Index setup ────────────────────────────────────────────────────────
+
+    /**
+     * Two shards on purpose: a multi-shard aggregation is the shape that goes through the engine's
+     * PARTIAL/FINAL exchange, so the fan-out is measured against the distributed path rather than a
+     * single-shard shortcut.
+     */
+    private void createFanOutIndex() throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + INDEX));
+        } catch (Exception ignored) {
+            // index may not exist
+        }
+
+        String body = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 2,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": \"lucene\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"region\": { \"type\": \"keyword\" },"
+            + "    \"service\": { \"type\": \"keyword\" },"
+            + "    \"latency\": { \"type\": \"integer\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request create = new Request("PUT", "/" + INDEX);
+        create.setJsonEntity(body);
+        Map<String, Object> response = assertOkAndParse(client().performRequest(create), "Create index");
+        assertEquals("Index creation should be acknowledged", true, response.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + INDEX);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+        logger.info("Created fan-out index [{}] with 2 shards", INDEX);
+    }
+
+    private void ingestDocs() throws IOException {
+        StringBuilder ndjson = new StringBuilder();
+        for (String[] doc : DOCS) {
+            // No explicit _id: index.append_only.enabled rejects one per item on this index (see DOCS).
+            ndjson.append("{\"index\": {}}\n");
+            ndjson.append("{\"region\": \"").append(doc[0]).append("\"")
+                .append(", \"service\": \"").append(doc[1]).append("\"")
+                .append(", \"latency\": ").append(doc[2])
+                .append("}\n");
+        }
+
+        Request bulk = new Request("POST", "/" + INDEX + "/_bulk");
+        bulk.setJsonEntity(ndjson.toString());
+        bulk.addParameter("refresh", "true");
+        bulk.setOptions(bulk.getOptions().toBuilder().addHeader("Content-Type", "application/x-ndjson").build());
+        Map<String, Object> response = assertOkAndParse(client().performRequest(bulk), "Bulk index");
+        // A _bulk that reports errors answers HTTP 200 with per-item statuses, so the only way to learn what
+        // was rejected is to print the items. Failing on a bare boolean tells a reader nothing.
+        assertEquals("Bulk indexing reported item errors: " + response.get("items"), false, response.get("errors"));
+        logger.info("Indexed {} documents into [{}]", DOCS.length, INDEX);
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DslMultiShardSumWideningIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/DslMultiShardSumWideningIT.java
@@ -1,0 +1,555 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end guard for the DSL type system's SUM widening on a <b>2-shard</b> index:
+ * {@code DslTypeSystems.NANO_TIMESTAMP.deriveSumType} maps TINYINT/SMALLINT/INTEGER/BIGINT to
+ * {@code BIGINT} and REAL/FLOAT/DOUBLE to {@code DOUBLE}, because the DataFusion backend accumulates
+ * every signed-integer sum in {@code Int64} and every floating-point sum in {@code Float64}.
+ */
+public class DslMultiShardSumWideningIT extends AnalyticsRestTestCase {
+
+    private static final String INDEX = "dsl_sum_widening_2shard";
+
+    /**
+     * A 1-shard control index holding the same 8 documents. Its only job is to say whether an answer that
+     * is wrong at 2 shards is wrong because of the shard count: a single shard keeps the aggregate SINGLE,
+     * so no PARTIAL/FINAL split and no exchange are involved, and anything still wrong here is wrong
+     * everywhere rather than only on a multi-shard index.
+     */
+    private static final String ONE_SHARD_INDEX = "dsl_sum_widening_1shard";
+
+    private static final int DOCS_PER_TENANT = 4;
+    private static final int TOTAL_DOCS = 2 * DOCS_PER_TENANT;
+
+    // integer-mapped column. Both subtotals and the grand total exceed Integer.MAX_VALUE (2147483647),
+    // so no asserted value below is reachable by a 32-bit accumulator. Every individual document value
+    private static final long ALPHA_INT_TOTAL = 4_000_000_000L; // 1.3e9 + 1.1e9 + 0.9e9 + 0.7e9
+    private static final long BETA_INT_TOTAL = 2_400_000_000L;  // 1.0e9 + 0.8e9 + 0.4e9 + 0.2e9
+    private static final long INT_TOTAL = ALPHA_INT_TOTAL + BETA_INT_TOTAL; // 6_400_000_000
+    private static final long INT_MEAN = INT_TOTAL / TOTAL_DOCS; // 800_000_000
+    private static final long INT_LOWEST = 200_000_000L;
+    private static final long INT_HIGHEST = 1_300_000_000L;
+
+    // float-mapped column. Every document value is a power of two, so it is exact in f32 and the value
+    // DataFusion reads back is the literal that was indexed; every total is a sum of powers of two well
+    private static final double ALPHA_FLOAT_TOTAL = 2_684_354_560.0d; // 2^30 + 3 * 2^29
+    private static final double BETA_FLOAT_TOTAL = 3_221_225_472.0d;  // 2 * 2^30 + 2 * 2^29
+    private static final double FLOAT_TOTAL = ALPHA_FLOAT_TOTAL + BETA_FLOAT_TOTAL; // 5_905_580_032
+    private static final double ALPHA_FLOAT_MEAN = ALPHA_FLOAT_TOTAL / DOCS_PER_TENANT; // 671_088_640
+    private static final double BETA_FLOAT_MEAN = BETA_FLOAT_TOTAL / DOCS_PER_TENANT;   // 805_306_368
+    private static final double FLOAT_MEAN = FLOAT_TOTAL / TOTAL_DOCS;                  // 738_197_504
+
+    // A second integer-mapped column whose totals stay far below Integer.MAX_VALUE, so nothing about it
+    // can be explained by an accumulator width. Its means are deliberately NOT whole numbers: an avg
+    private static final double SMALL_TOTAL = 111.0d;                 // 1+2+3+4 + 10+20+30+41
+    private static final double SMALL_MEAN = SMALL_TOTAL / TOTAL_DOCS; // 13.875, exact in IEEE-754
+    private static final double ALPHA_SMALL_MEAN = 2.5d;               // (1+2+3+4) / 4
+    private static final double BETA_SMALL_MEAN = 25.25d;              // (10+20+30+41) / 4
+
+    /**
+     * 8 documents, 4 per tenant, with auto-generated ids so they spread across both shards by the
+     * default {@code _id} hash. The per-document values are spelled out rather than generated so the
+     * expected totals above can be added up by hand.
+     */
+    private static final String BULK_BODY = "{\"index\":{}}\n"
+        + "{\"tenant\":\"alpha\",\"int_amount\":1300000000,\"float_amount\":1073741824.0,\"small_amount\":1}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"alpha\",\"int_amount\":1100000000,\"float_amount\":536870912.0,\"small_amount\":2}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"alpha\",\"int_amount\":900000000,\"float_amount\":536870912.0,\"small_amount\":3}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"alpha\",\"int_amount\":700000000,\"float_amount\":536870912.0,\"small_amount\":4}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"beta\",\"int_amount\":1000000000,\"float_amount\":1073741824.0,\"small_amount\":10}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"beta\",\"int_amount\":800000000,\"float_amount\":1073741824.0,\"small_amount\":20}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"beta\",\"int_amount\":400000000,\"float_amount\":536870912.0,\"small_amount\":30}\n"
+        + "{\"index\":{}}\n"
+        + "{\"tenant\":\"beta\",\"int_amount\":200000000,\"float_amount\":536870912.0,\"small_amount\":41}\n";
+
+    private static volatile boolean provisioned = false;
+
+    @Override
+    protected void onBeforeQuery() throws IOException {
+        if (provisioned == false) {
+            provision();
+            provisioned = true;
+        }
+    }
+
+    // ── Preconditions the rest of the class depends on ──────────────────────────────
+
+    /**
+     * The two properties that make every other test in this class meaningful: the index really has 2
+     * shards (1 shard keeps the aggregate SINGLE and the defect is unreachable) with parquet as the
+     * primary data format, and all 8 documents are visible to the query.
+     */
+    public void testTwoShardParquetIndexHoldsEveryDocument() throws Exception {
+        Response settingsResponse = client().performRequest(new Request("GET", "/" + INDEX + "/_settings"));
+        Map<String, Object> settingsBody = assertOkAndParse(settingsResponse, "GET /" + INDEX + "/_settings");
+        Map<String, Object> index = asObject(asObject(asObject(settingsBody.get(INDEX)).get("settings")).get("index"));
+
+        assertEquals(
+            "number_of_shards must stay 2 — OpenSearchAggregateSplitRule only splits the aggregate into "
+                + "PARTIAL/FINAL at 2+ shards, and without that split there is no exchange to reject a narrow sum",
+            "2",
+            index.get("number_of_shards")
+        );
+        assertEquals(
+            "parquet must be the primary data format — the Int64/Float64 accumulator widths this class pins are "
+                + "DataFusion's, and the DataFusion path is what a parquet-primary composite index takes",
+            "parquet",
+            asObject(index.get("composite")).get("primary_data_format")
+        );
+
+        Request search = new Request("POST", "/" + INDEX + "/_search");
+        search.setJsonEntity("{\"size\": 0, \"track_total_hits\": true}");
+        Map<String, Object> searchBody = assertOkAndParse(client().performRequest(search), "hits.total on " + INDEX);
+        Map<String, Object> total = asObject(asObject(searchBody.get("hits")).get("total"));
+        assertEquals(
+            "every indexed document must be visible, otherwise the exact totals asserted by the other tests are unreachable",
+            TOTAL_DOCS,
+            ((Number) total.get("value")).intValue()
+        );
+    }
+
+    // ── Root-level metrics: one no-GROUP-BY plan, one exchange ─────────────────────
+
+    /**
+     * The written {@code sum} over the {@code integer}-mapped column, on its own. This is the aggregation
+     * whose declared type {@code AggregationMetadataBuilder} reconciles, and the total exceeds
+     * {@code Integer.MAX_VALUE}, so a 32-bit declaration cannot produce it.
+     */
+    public void testIntegerSumExceedsIntMaxAcrossTwoShards() throws Exception {
+        Map<String, Object> aggs = aggregations(searchAggregations("{\"int_total\": {\"sum\": {\"field\": \"int_amount\"}}}"));
+
+        assertEquals(
+            "sum(int_amount) over " + TOTAL_DOCS + " docs on a 2-shard index must be the exact 64-bit total; an "
+                + "Int32-declared sum that survives the PARTIAL/FINAL exchange wraps it to " + (int) INT_TOTAL,
+            (double) INT_TOTAL,
+            metricValue(aggs, "int_total"),
+            0.0d
+        );
+    }
+
+    /**
+     * {@code avg} over the {@code integer}-mapped column, whose <em>intermediate</em> sum
+     * (6,400,000,000) exceeds {@code Integer.MAX_VALUE} while the mean it produces (800,000,000) fits an
+     * {@code int} comfortably. That gap is the point: only the rule-generated intermediate is oversized,
+     * so this test can only fail on how the intermediate is typed.
+     */
+    public void testIntegerAvgWhoseIntermediateSumExceedsIntMax() throws Exception {
+        Map<String, Object> aggs = aggregations(searchAggregations("{\"int_mean\": {\"avg\": {\"field\": \"int_amount\"}}}"));
+
+        assertEquals(
+            "avg(int_amount) must be the exact mean. Its own result fits an int, so a failure here is about the "
+                + "rule-generated intermediate SUM (" + INT_TOTAL + "), not about the mean",
+            (double) INT_MEAN,
+            metricValue(aggs, "int_mean"),
+            0.0d
+        );
+    }
+
+    /**
+     * {@code avg} over an integer column whose every total stays far below {@code Integer.MAX_VALUE}, so
+     * no accumulator width is involved and the only thing under test is the <em>width of the quotient</em>:
+     * the true mean of {@code small_amount} is 13.875, which is not an integer.
+     */
+    public void testIntegerAvgIsNotTruncatedToAnIntegerAcrossTwoShards() throws Exception {
+        Map<String, Object> aggs = aggregations(searchAggregations("{\"small_mean\": {\"avg\": {\"field\": \"small_amount\"}}}"));
+
+        assertEquals(
+            "avg(small_amount) over " + TOTAL_DOCS + " docs must be the true fractional mean " + SMALL_MEAN + " (total "
+                + SMALL_TOTAL + "); " + (long) SMALL_MEAN + " would mean the quotient was declared at the column's own "
+                + "integer width and truncated",
+            SMALL_MEAN,
+            metricValue(aggs, "small_mean"),
+            0.0d
+        );
+    }
+
+    /**
+     * The same pair over the {@code float}-mapped column, which Calcite types {@code REAL} (Float32)
+     * against DataFusion's Float64 accumulator. Its failure mode is the exchange-schema rejection rather
+     * than a wrap, so the value assertion here is what proves the total survived the exchange intact.
+     */
+    public void testFloatSumAndAvgAcrossTwoShards() throws Exception {
+        Map<String, Object> aggs = aggregations(
+            searchAggregations(
+                "{\"float_total\": {\"sum\": {\"field\": \"float_amount\"}},"
+                    + " \"float_mean\": {\"avg\": {\"field\": \"float_amount\"}}}"
+            )
+        );
+
+        assertEquals(
+            "sum(float_amount): a float-mapped column is Calcite REAL (Float32) while DataFusion accumulates in "
+                + "Float64, so deriveSumType must widen REAL to DOUBLE or the exchange input is rejected",
+            FLOAT_TOTAL,
+            metricValue(aggs, "float_total"),
+            0.0d
+        );
+        assertEquals(
+            "avg(float_amount) reduces to a rule-generated SUM/COUNT pair over the same Float32 column",
+            FLOAT_MEAN,
+            metricValue(aggs, "float_mean"),
+            0.0d
+        );
+    }
+
+    /**
+     * Root-level metrics share one no-GROUP-BY plan, so this single request puts a widened BIGINT sum, a
+     * widened DOUBLE sum and two <em>un</em>widened metrics in the same aggregate and the same exchange.
+     */
+    public void testWidenedAndUnwidenedMetricsShareOneExchangeAcrossTwoShards() throws Exception {
+        Map<String, Object> aggs = aggregations(
+            searchAggregations(
+                "{\"int_total\": {\"sum\": {\"field\": \"int_amount\"}},"
+                    + " \"int_low\": {\"min\": {\"field\": \"int_amount\"}},"
+                    + " \"int_high\": {\"max\": {\"field\": \"int_amount\"}},"
+                    + " \"float_total\": {\"sum\": {\"field\": \"float_amount\"}}}"
+            )
+        );
+
+        assertEquals(
+            "sum(int_amount) alongside unwidened metrics must still be the exact 64-bit total, not " + (int) INT_TOTAL,
+            (double) INT_TOTAL,
+            metricValue(aggs, "int_total"),
+            0.0d
+        );
+        assertEquals(
+            "min(int_amount) keeps the column's own width — deriveSumType must not touch it",
+            (double) INT_LOWEST,
+            metricValue(aggs, "int_low"),
+            0.0d
+        );
+        assertEquals(
+            "max(int_amount) keeps the column's own width — deriveSumType must not touch it",
+            (double) INT_HIGHEST,
+            metricValue(aggs, "int_high"),
+            0.0d
+        );
+        assertEquals(
+            "sum(float_amount) sharing an exchange with an Int64 sum and two Int32 extrema",
+            FLOAT_TOTAL,
+            metricValue(aggs, "float_total"),
+            0.0d
+        );
+    }
+
+    // ── 1-shard controls: is the shard count what makes an answer wrong? ───────────
+
+    /**
+     * {@code sum} over the {@code integer}-mapped column on the <b>1-shard</b> control index. This is the
+     * shape the widening is <em>not</em> needed for — a single shard keeps the aggregate SINGLE, so nothing
+     * crosses an exchange — and asserting the same total here is what turns
+     * {@link #testIntegerSumExceedsIntMaxAcrossTwoShards} into a statement about the split rule: the shard
+     * count must not change the answer.
+     */
+    public void testOneShardIntegerSumMatchesTheTwoShardTotal() throws Exception {
+        Map<String, Object> aggs = aggregations(
+            searchAggregationsOn(ONE_SHARD_INDEX, "{\"int_total\": {\"sum\": {\"field\": \"int_amount\"}}}")
+        );
+
+        assertEquals(
+            "sum(int_amount) must be the same exact total at 1 shard as at 2 — the PARTIAL/FINAL split is an "
+                + "execution detail, not an arithmetic one",
+            (double) INT_TOTAL,
+            metricValue(aggs, "int_total"),
+            0.0d
+        );
+    }
+
+    /**
+     * {@code avg} over the small integer column on the <b>1-shard</b> control index. This is the assertion
+     * that decides the blast radius of a truncated mean: if it is wrong here too, then the shard count and
+     * the exchange have nothing to do with it and every {@code avg} over an integer-mapped field is
+     * affected, not only the ones on a multi-shard index.
+     */
+    public void testOneShardIntegerAvgIsNotTruncated() throws Exception {
+        Map<String, Object> aggs = aggregations(
+            searchAggregationsOn(ONE_SHARD_INDEX, "{\"small_mean\": {\"avg\": {\"field\": \"small_amount\"}}}")
+        );
+
+        assertEquals(
+            "avg(small_amount) on a 1-shard index must be the true fractional mean " + SMALL_MEAN + "; the same wrong "
+                + "value here and at 2 shards means the defect is in AVG's declared type, not in the split",
+            SMALL_MEAN,
+            metricValue(aggs, "small_mean"),
+            0.0d
+        );
+    }
+
+    // ── Grouped plan: the sum crosses the exchange inside a GROUP BY ───────────────
+
+    /**
+     * {@code terms(tenant)} with sub-{@code sum}, so the widened sums cross the exchange inside a grouped
+     * plan (a non-empty groupSet, PARTIAL keyed by the term) rather than the flat single-row one. Both
+     * per-tenant integer subtotals also exceed {@code Integer.MAX_VALUE}, so the wrap is caught per bucket
+     * and not only in aggregate. {@code avg(float_amount)} rides along because the float column's avg does
+     * survive the reduce, so it pins the grouped avg path that works.
+     */
+    public void testTermsSubSumsCrossTheExchangeInAGroupedPlan() throws Exception {
+        Map<String, Object> body = searchAggregations(
+            "{\"by_tenant\": {\"terms\": {\"field\": \"tenant\"},"
+                + " \"aggregations\": {"
+                + "   \"int_total\": {\"sum\": {\"field\": \"int_amount\"}},"
+                + "   \"float_total\": {\"sum\": {\"field\": \"float_amount\"}},"
+                + "   \"float_mean\": {\"avg\": {\"field\": \"float_amount\"}}}}}"
+        );
+
+        // Keyed by term rather than read positionally: both tenants hold 4 docs, so pinning the default
+        // count-descending order would pin a tie-break instead of the arithmetic under test.
+        Map<String, Map<String, Object>> buckets = bucketsByKey(body, "by_tenant");
+        assertEquals("terms(tenant) must return exactly the two indexed tenants, got " + buckets.keySet(), 2, buckets.size());
+        assertTenantBucket(buckets, "alpha", ALPHA_INT_TOTAL, ALPHA_FLOAT_TOTAL, ALPHA_FLOAT_MEAN);
+        assertTenantBucket(buckets, "beta", BETA_INT_TOTAL, BETA_FLOAT_TOTAL, BETA_FLOAT_MEAN);
+    }
+
+    /**
+     * {@code terms(tenant)} with a sub-{@code avg} over the small integer column, so the quotient's width
+     * is pinned inside a grouped plan too. Both per-tenant means are fractional (2.5 and 25.25), and
+     * neither is reachable by truncation of the other, so a bucket that came back whole is a truncation
+     * and not a mislabelled bucket.
+     */
+    public void testTermsSubAvgIsNotTruncatedInAGroupedPlan() throws Exception {
+        Map<String, Object> body = searchAggregations(
+            "{\"by_tenant\": {\"terms\": {\"field\": \"tenant\"},"
+                + " \"aggregations\": { \"small_mean\": {\"avg\": {\"field\": \"small_amount\"}}}}}"
+        );
+
+        Map<String, Map<String, Object>> buckets = bucketsByKey(body, "by_tenant");
+        assertEquals("terms(tenant) must return exactly the two indexed tenants, got " + buckets.keySet(), 2, buckets.size());
+        assertEquals(
+            "bucket [alpha] avg(small_amount) must be the true fractional mean, not a truncated 2",
+            ALPHA_SMALL_MEAN,
+            metricValue(bucketOf(buckets, "alpha"), "small_mean"),
+            0.0d
+        );
+        assertEquals(
+            "bucket [beta] avg(small_amount) must be the true fractional mean, not a truncated 25",
+            BETA_SMALL_MEAN,
+            metricValue(bucketOf(buckets, "beta"), "small_mean"),
+            0.0d
+        );
+    }
+
+    private static void assertTenantBucket(
+        Map<String, Map<String, Object>> buckets,
+        String tenant,
+        long intTotal,
+        double floatTotal,
+        double floatMean
+    ) {
+        Map<String, Object> bucket = bucketOf(buckets, tenant);
+        assertEquals(
+            "bucket [" + tenant + "] must hold every document of its tenant",
+            DOCS_PER_TENANT,
+            ((Number) bucket.get("doc_count")).intValue()
+        );
+        assertEquals(
+            "bucket [" + tenant + "] sum(int_amount) crosses the exchange inside a GROUP BY plan and still exceeds "
+                + "Integer.MAX_VALUE; an Int32-declared sum wraps it to " + (int) intTotal,
+            (double) intTotal,
+            metricValue(bucket, "int_total"),
+            0.0d
+        );
+        assertEquals("bucket [" + tenant + "] sum(float_amount)", floatTotal, metricValue(bucket, "float_total"), 0.0d);
+        assertEquals("bucket [" + tenant + "] avg(float_amount)", floatMean, metricValue(bucket, "float_mean"), 0.0d);
+    }
+
+    private static Map<String, Object> bucketOf(Map<String, Map<String, Object>> buckets, String tenant) {
+        Map<String, Object> bucket = buckets.get(tenant);
+        assertNotNull("terms(tenant) is missing bucket [" + tenant + "], got " + buckets.keySet(), bucket);
+        return bucket;
+    }
+
+    // ── Request / response helpers ─────────────────────────────────────────────────
+
+    /**
+     * Runs {@code POST /{index}/_search} with {@code size: 0} and the given aggregation tree, asserting
+     * HTTP 200. A non-2xx status arrives as a {@link ResponseException}, so it is turned into a failure
+     * that names the two 500s this index is known to be able to produce — a future reader who sees this
+     * test go red should not have to rediscover what a 500 here means. The node's own log carries the real
+     * cause; the REST body is only {@code Internal error [task_id=N]}.
+     */
+    private Map<String, Object> searchAggregations(String aggregationsJson) throws IOException {
+        return searchAggregationsOn(INDEX, aggregationsJson);
+    }
+
+    /** {@link #searchAggregations} against a named index, so the 1-shard control can share the diagnostics. */
+    private Map<String, Object> searchAggregationsOn(String index, String aggregationsJson) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_search");
+        request.setJsonEntity("{\"size\": 0, \"aggregations\": " + aggregationsJson + "}");
+        Response response;
+        try {
+            response = client().performRequest(request);
+        } catch (ResponseException e) {
+            throw new AssertionError(
+                "DSL _search on the index "
+                    + index
+                    + " did not answer HTTP 200 for aggregations "
+                    + aggregationsJson
+                    + ".\nThe REST body only carries [Internal error [task_id=N]] — grep the node log for that task id. "
+                    + "Two causes are known:\n"
+                    + "(1) [Arrow error: Cast error: Can't cast value <total> to type Int32] out of "
+                    + "DatafusionReduceSink.reduce, for an aggregations tree containing avg over an integer-mapped "
+                    + "column. DslTypeSystems.NANO_TIMESTAMP overrides deriveSumType but not deriveAvgAggType, so AVG "
+                    + "is declared at the column's own Int32 while OpenSearchAggregateReduceRule rewrites it into "
+                    + "SUM/COUNT/DIVIDE/CAST and casts the correctly widened Int64 intermediate back to that Int32.\n"
+                    + "(2) [Failed to create exchange sink for stageId=1] or [Substrait schema has a different type "
+                    + "(Int32) than the corresponding field in the table schema (Int64)] — then SUM is no longer "
+                    + "declared at the width the engine accumulates in: DslTypeSystems.deriveSumType must widen "
+                    + "TINYINT/SMALLINT/INTEGER/BIGINT to BIGINT and REAL/FLOAT/DOUBLE to DOUBLE. At 2+ shards "
+                    + "OpenSearchAggregateSplitRule splits the aggregate into PARTIAL/FINAL and the coordinator "
+                    + "registers the exchange input with the PARTIAL's lowered (Int64/Float64) schema, so a FINAL whose "
+                    + "Substrait declares Calcite's narrower view is rejected.\n"
+                    + e.getMessage(),
+                e
+            );
+        }
+        return assertOkAndParse(response, "DSL _search on " + index + " with aggregations " + aggregationsJson);
+    }
+
+    /** The response's {@code aggregations} section, which must be present for every request here. */
+    private static Map<String, Object> aggregations(Map<String, Object> body) {
+        Object aggs = body.get("aggregations");
+        assertNotNull("response must carry an aggregations section, got keys " + body.keySet(), aggs);
+        return asObject(aggs);
+    }
+
+    /** A single-value metric's {@code value}, from either the response root or a bucket. */
+    private static double metricValue(Map<String, Object> holder, String name) {
+        Object metric = holder.get(name);
+        assertNotNull("missing aggregation [" + name + "], present: " + holder.keySet(), metric);
+        Object value = asObject(metric).get("value");
+        assertNotNull("aggregation [" + name + "] returned a null value — no matching docs reached the reduce", value);
+        return ((Number) value).doubleValue();
+    }
+
+    /** A terms aggregation's buckets keyed by term, with the no-dropped-bucket invariant asserted. */
+    private static Map<String, Map<String, Object>> bucketsByKey(Map<String, Object> body, String termsAggName) {
+        Object terms = aggregations(body).get(termsAggName);
+        assertNotNull("missing terms aggregation [" + termsAggName + "]", terms);
+        Map<String, Object> termsAgg = asObject(terms);
+        assertEquals(
+            "terms [" + termsAggName + "] must not discard a tail — a non-zero sum_other_doc_count means the asserted "
+                + "subtotals cover only part of the data",
+            0,
+            ((Number) termsAgg.get("sum_other_doc_count")).intValue()
+        );
+
+        Object rawBuckets = termsAgg.get("buckets");
+        assertTrue("terms [" + termsAggName + "] must carry a buckets array, got " + rawBuckets, rawBuckets instanceof List);
+        Map<String, Map<String, Object>> byKey = new HashMap<>();
+        for (Object rawBucket : (List<?>) rawBuckets) {
+            Map<String, Object> bucket = asObject(rawBucket);
+            byKey.put((String) bucket.get("key"), bucket);
+        }
+        return byKey;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asObject(Object value) {
+        assertTrue("expected a JSON object, got " + value, value instanceof Map);
+        return (Map<String, Object>) value;
+    }
+
+    // ── Provisioning ──────────────────────────────────────────────────────────────
+
+    /**
+     * Creates the 2-shard composite/parquet-primary index and bulk-indexes the fixture inline — the
+     * dataset is 8 documents, so it does not justify a {@link DatasetProvisioner} resource. Runs once per
+     * JVM via {@link #onBeforeQuery()}; the leading DELETE only matters when a preserved cluster still
+     * holds the index from an earlier run.
+     */
+    private void provision() throws IOException {
+        provisionIndex(INDEX, 2);
+        provisionIndex(ONE_SHARD_INDEX, 1);
+    }
+
+    /**
+     * Creates one composite/parquet-primary index at the given shard count and loads {@link #BULK_BODY}
+     * into it. The two indices differ in nothing but {@code number_of_shards}, which is what lets the
+     * 1-shard control tests attribute a difference to the shard count and nothing else.
+     *
+     * @param index the index name
+     * @param shards the primary shard count
+     */
+    private void provisionIndex(String index, int shards) throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (ResponseException ignored) {
+            // 404 on a fresh cluster — nothing to clean up.
+        }
+
+        // int_amount is mapped integer, not long or double: that is what makes Calcite declare Int32
+        // while DataFusion accumulates the sum in Int64. float_amount is mapped float, not double, for
+        // the same reason one width up: Calcite REAL (Float32) against DataFusion's Float64.
+        String mapping = "{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": " + shards + ","
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\","
+            + "  \"index.composite.secondary_data_formats\": [\"lucene\"]"
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"tenant\":       { \"type\": \"keyword\" },"
+            + "    \"int_amount\":   { \"type\": \"integer\" },"
+            + "    \"float_amount\": { \"type\": \"float\" },"
+            + "    \"small_amount\": { \"type\": \"integer\" }"
+            + "  }"
+            + "}"
+            + "}";
+
+        Request create = new Request("PUT", "/" + index);
+        create.setJsonEntity(mapping);
+        Map<String, Object> createResponse = assertOkAndParse(client().performRequest(create), "create " + index);
+        assertEquals("index creation must be acknowledged", true, createResponse.get("acknowledged"));
+
+        Request health = new Request("GET", "/_cluster/health/" + index);
+        health.addParameter("wait_for_status", "green");
+        health.addParameter("timeout", "30s");
+        client().performRequest(health);
+
+        Request bulk = new Request("POST", "/" + index + "/_bulk");
+        bulk.setJsonEntity(BULK_BODY);
+        bulk.addParameter("refresh", "true");
+        Map<String, Object> bulkResponse = assertOkAndParse(client().performRequest(bulk), "_bulk " + index);
+        // The item statuses are the only place a rejection says why, so print them rather than a boolean.
+        assertEquals("bulk ingest reported item errors: " + bulkResponse.get("items"), Boolean.FALSE, bulkResponse.get("errors"));
+        client().performRequest(new Request("POST", "/" + index + "/_flush?force=true"));
+
+        // Logged, not asserted: the _id hash decides the split and every total asserted here is
+        // spread-invariant, so an assertion on the split would pin the hash rather than the arithmetic.
+        Request shards2 = new Request("GET", "/_cat/shards/" + index);
+        shards2.addParameter("h", "shard,docs,node");
+        Response shardsResponse = client().performRequest(shards2);
+        try (InputStream is = shardsResponse.getEntity().getContent()) {
+            String spread = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            logger.info("[{}] shard doc distribution (shard/docs/node):\n{}", index, spread);
+        }
+    }
+}


### PR DESCRIPTION
### Description
<h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1. Problem</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A single <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_search</code> over the DSL path decomposes into several sub-plans — one per aggregation granularity — and they ran <strong>strictly serially</strong>: sub-plan N+1 was dispatched only after N completed. A 3-level nested aggregation therefore paid the sum of its levels' latencies even though the levels are independent and the node had idle capacity.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Three latent defects made overlapping them unsafe, so each had to be fixed before any concurrency could be turned on:</p><ul style="padding-inline-start: 2em; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>Calcite planning state was shared between sub-plans of one request.</strong><span> </span>Two<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RelNode</code>s shared a<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RelOptCluster</code>, whose metadata fields (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mq</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mqSupplier</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">metadataProvider</code>) are private, non-final, non-volatile and guarded by no synchronization.<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getMetadataQuery()</code><span> </span>is an unsynchronized check-then-act that re-reads the field on the way out.</li><li style="unicode-bidi: plaintext;"><strong><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SUM</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code><span> </span>were declared narrower than the engine accumulates in.</strong><span> </span>The plan declared the aggregated column's own width while the backend accumulates integer sums in<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Int64</code><span> </span>and float sums in<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Float64</code>.</li><li style="unicode-bidi: plaintext;"><strong>The date-math anchor was resolved per sub-plan</strong>, so<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">now-1h</code><span> </span>meant a different window in each sub-plan of the same search.</li></ul><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">2. Solution</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Run a request's aggregation sub-plans <strong>concurrently</strong>, behind an opt-in width setting, and fix the three preconditions.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Which path this runs on:</strong> only the <strong>DSL Calcite → DataFusion</strong> path — a <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_search</code> intercepted by <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SearchActionFilter</code> and executed through <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslExecuteAction</code> → <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SearchSourceConverter</code> → <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslQueryPlanExecutor</code> against a composite (parquet-primary) index. <strong>The legacy Lucene aggregation path is untouched</strong>, including the fallback taken when interception is off.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Only a request that aggregates fans out.</strong> A plain search has nothing worth overlapping, so it settles at width 1 explicitly. Previously it stayed sequential only because it happened to emit one plan — a property of today's plan shapes, not a rule; a second non-aggregation plan beside it would have fanned out unasked.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The width actually used is the minimum of the operator's setting, the plans available to gate, the engine's fragment-executor budget and the SEARCH pool headroom — so a wrong setting <strong>narrows</strong> the fan-out, it never fails a search. Reading the width cannot throw: each input degrades to 1 independently.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A failure in one sub-plan does not short-circuit its siblings — they are already in flight, and abandoning them would leave distributed queries running — so the collector waits for all of them and reports the first failure once. A mismatched fan-out fails the request rather than hanging it.</p><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">3. Changes done</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>One new cluster setting</strong> (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NodeScope</code> + <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Dynamic</code>, registered via the plugin's <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getSettings()</code>, so it works in <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">opensearch.yml</code> and over <code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_cluster/settings</code>):</p>
setting | default | meaning
-- | -- | --
dsl.query.max_parallel_sub_plans | 1 | how many sub-plans may run at once. 1 is the existing sequential path, so the change is opt-in and putting it back to 1 is the rollback — no deploy needed. Hard maximum 2; a PUT of 3 is a 400.

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Deliberately not settings:</strong></p><ul style="padding-inline-start: 2em; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>The launch shape</strong><span> </span>is a compile-time constant,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslQuerySettings.FANOUT_LAUNCH</code>, shipped as<span> </span><strong><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">FLAT</code></strong><span> </span>— all<span> </span><em>n</em><span> </span>plans go through the gate from the start, so the width can reach<span> </span><em>n</em><span> </span>and a 2-plan query (a 2-level nested aggregation with<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">size: 0</code>, the common production shape) can run at width 2. The alternative<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">STAGED</code><span> </span>holds plan 0 back to warm the data node's parquet metadata, lowering the expected number of concurrent unbudgeted queries but costing the first wave. The two trade the same resource in opposite directions and only a benchmark on a given corpus can say which is right — so it is not an operator decision, and a wrong value would not fail, it would quietly change measured behaviour.<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">STAGED</code><span> </span>stays fully implemented and unit-tested, so switching is a one-line change. It is threaded into the executor at construction so both paths stay reachable from tests.</li><li style="unicode-bidi: plaintext;"><strong>The effective width</strong><span> </span>is logged once per multi-plan query as<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dsl.fanout.k_eff</code>, carrying every term that fed the decision (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K_setting</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">n</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K_gate</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K_search</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">launch</code>). Fixed leading token, treated as a grep contract — the only observable a rollout can attribute against.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Code changes:</strong></p><ul style="padding-inline-start: 2em; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;">Bounded-concurrency dispatch of sub-plans through a permit gate, with per-plan result collection that preserves plan order and fires the request's listener exactly once.</li><li style="unicode-bidi: plaintext;">Aggregation-eligibility read once per request at the single site that decides the width. The capacity formula deliberately does not carry a plan-type term — it answers "how wide may this run", never "may this run at all".</li><li style="unicode-bidi: plaintext;"><strong>Per-plan<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RelOptCluster</code></strong>, minted where each plan is built. What stays shared was checked safe: one<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RelOptTable</code><span> </span>identity per request, and the type factory — which<span> </span><em>must</em><span> </span>stay shared, since interning is what keeps a plan's field indices agreeing with a rebuilt ancestor's.</li><li style="unicode-bidi: plaintext;"><strong><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SUM</code><span> </span>widened</strong><span> </span>to the accumulator width (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">BIGINT</code>/<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DOUBLE</code>) and<span> </span><strong><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code><span> </span>declared<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DOUBLE</code></strong>. One mechanism, not two:<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code><span> </span>executes as a rule-generated<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SUM</code>/<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">COUNT</code>/<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DIVIDE</code><span> </span>plus a CAST back to<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code>'s declared type, so leaving<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code><span> </span>integral casts the widening straight back down and keeps the divide integral —<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">avg</code><span> </span>over<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[1,2,3,4,10,20,30,41]</code><span> </span>answering<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">2.0</code><span> </span>where the mean is<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">2.5</code>. Reconciled where the aggregate calls are assembled, so the type system stays the single authority on result width.</li><li style="unicode-bidi: plaintext;"><strong>Date-math anchor read once per request</strong><span> </span>and carried on the conversion context. This also closes a narrower pre-existing case: the COUNT plans each resolved their own anchor, so<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">hits.total</code><span> </span>could describe a different window than the documents reported beside it.</li><li style="unicode-bidi: plaintext;">A request that emits no plan at all still translates its query clause, so a malformed query is a 400 again rather than an empty 200.</li></ul><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">4. Testing</h3><ul style="padding-inline-start: 2em; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>584 unit tests, 0 failures.</strong></li><li style="unicode-bidi: plaintext;">The concurrency suites —<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SubPlanParallelismTests</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SubPlanResultCollectorTests</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslQueryPlanExecutorTests</code><span> </span>— also pass under<span> </span><strong><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-Dtests.iters=20</code></strong>, since a fan-out defect is exactly the kind that hides behind a single seed.</li><li style="unicode-bidi: plaintext;">Both launch shapes are covered: the shipped<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">FLAT</code><span> </span>and the<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">STAGED</code><span> </span>alternative, so neither production branch is dead to the suite.</li><li style="unicode-bidi: plaintext;">Unit coverage also includes: the width formula at every term and clamp; result ordering under concurrent completion; the listener firing exactly once including when the engine completes<span> </span><em>and then</em><span> </span>throws; permit accounting (a plan that cannot be dispatched still releases its permit and counts down, so the REST channel cannot hang); the width read degrading to sequential rather than throwing when an input is unavailable; a non-aggregating request staying sequential at any width; and that the plugin registers exactly one setting, with<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dsl.query.fanout_launch</code><span> </span>rejected as unknown — so re-exposing the launch shape as a knob fails the build.</li><li style="unicode-bidi: plaintext;"><strong>Three REST integration tests</strong><span> </span>against real clusters, each on its own gradle task and cluster so a mid-test failure cannot reach a sibling and provisioning cannot race:<ul style="padding-inline-start: 2em;"><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslFanOutIT</code><span> </span>— the fan-out end to end, and that a request with no aggregation plan stays sequential at any width.</li><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslMultiShardSumWideningIT</code><span> </span>— the<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SUM</code>/<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AVG</code><span> </span>widening on more than one shard.</li><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DslDateMathAnchorIT</code><span> </span>— one<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">now</code><span> </span>per request across concurrent sub-plans.</li></ul></li><li style="unicode-bidi: plaintext;">The last two are<span> </span><strong>unreachable by unit tests</strong>: a narrow declared type is only rejected once a PARTIAL/FINAL split crosses an exchange, and a shared date anchor only surfaces with plans running at once.</li></ul><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">5. Benchmarks</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Benchmarked with and without this change to confirm the answers are identical. What was run:</p><ul style="padding-inline-start: 2em; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>Corpus:</strong><span> </span>the OpenSearch Benchmark<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">clickbench</code><span> </span>workload's own data —<span> </span><strong>99,997,497 documents</strong>, ingested with zero failures onto a composite index (parquet primary, Lucene secondary), verified parquet-primary on read-back.</li><li style="unicode-bidi: plaintext;"><strong>Arms:</strong><span> </span>two builds differing by<span> </span><strong>exactly one artifact</strong><span> </span>— the<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dsl-query-executor</code><span> </span>jar, with and without the fan-out. Server, analytics engine, parquet layer and the native library were built once and deployed byte-identically, so no second component can differ between arms.</li><li style="unicode-bidi: plaintext;"><strong>Hardware:</strong><span> </span>four single-node r8g.2xlarge clusters,<span> </span><strong>two machines per arm</strong>, so every figure is measured twice on independent hosts and the spread within a pair is the noise floor.</li><li style="unicode-bidi: plaintext;"><strong>Cells:</strong><span> </span>the legacy aggregation path (interception off) as baseline, the DSL path without the fan-out, and the DSL path at each width<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K=1</code><span> </span>…<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K=5</code>.</li><li style="unicode-bidi: plaintext;"><strong>Queries:</strong><span> </span>a nested<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">terms</code><span> </span>ladder from 1 to 5 levels over increasing-cardinality columns, plus three plain searches (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">match_all</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">term</code>,<span> </span><code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">term</code>+sort) as single-plan controls.</li><li style="unicode-bidi: plaintext;"><strong>Sampling:</strong><span> </span>20 executions per cell per machine, the first excluded and reported separately, in 2 counterbalanced blocks so drift cannot land on one arm — 19 per machine entering every percentile.</li><li style="unicode-bidi: plaintext;"><strong>Route verification:</strong><span> </span>every cell confirmed from the node log to have executed on the path it claims, so a cell cannot be silently served by the wrong engine.</li><li style="unicode-bidi: plaintext;"><strong>Correctness comparison:</strong><span> </span>every response captured and compared bucket-by-bucket — between the two arms, across every width, and against the legacy aggregation path.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(255, 255, 255); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 29, 37); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Outcome relevant to this PR:</strong> aggregation results are <strong>identical with and without the fan-out, and identical at every width</strong> — bucket counts match the legacy path at every level that answers. At the shipped default (<code style="font-family: monospace; color: rgb(147, 143, 155); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">K=1</code>) latency is unchanged, within the measured host-noise band.</p>

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
NA

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
