### PR TITLE
Add multi-value aggregation and row expansion

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -1613,7 +1613,7 @@ fn derive_schema_from_partial_plan(
     use datafusion::prelude::SessionContext;
     use datafusion_substrait::extensions::Extensions;
     use datafusion_substrait::logical_plan::consumer::{
-        from_substrait_named_struct, from_substrait_plan, DefaultSubstraitConsumer,
+        from_substrait_named_struct, DefaultSubstraitConsumer,
     };
     use prost::Message;
     use substrait::proto::{read_rel::ReadType, Plan};
@@ -1701,7 +1701,9 @@ fn derive_schema_from_partial_plan(
         })
         .unwrap_or_default();
 
-    let logical_plan = futures::executor::block_on(from_substrait_plan(&session_state, &plan))?;
+    let logical_plan = futures::executor::block_on(
+        crate::substrait_consumer::from_substrait_plan(&session_state, &plan),
+    )?;
     let physical_plan =
         futures::executor::block_on(session_state.create_physical_plan(&logical_plan))?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_executor.rs
@@ -38,7 +38,6 @@ use datafusion::{
     physical_plan::stream::RecordBatchStreamAdapter,
     physical_plan::ExecutionPlan,
 };
-use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use native_bridge_common::log_debug;
 use prost::Message;
 use substrait::proto::Plan;
@@ -850,15 +849,17 @@ async unsafe fn execute_indexed_with_context_inner(
         let context_id_early = handle.query_context.context_id();
         // engine-native-merge: borrow the partial-state schema from the prepared plan so the
         // empty stream matches the populated shards' wire shape (e.g. Binary HLL for dc()).
-        let plan_schema: arrow::datatypes::SchemaRef =
-            if let Some(prepared) = handle.prepared_plan.as_ref() {
-                Arc::new(prepared.schema().as_ref().clone())
-            } else {
-                let plan = Plan::decode(substrait_bytes.as_slice())
-                    .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
-                let logical_plan = from_substrait_plan(&handle.ctx.state(), &plan).await?;
-                Arc::new(logical_plan.schema().as_arrow().clone())
-            };
+        let plan_schema: arrow::datatypes::SchemaRef = if let Some(prepared) =
+            handle.prepared_plan.as_ref()
+        {
+            Arc::new(prepared.schema().as_ref().clone())
+        } else {
+            let plan = Plan::decode(substrait_bytes.as_slice())
+                .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
+            let logical_plan =
+                crate::substrait_consumer::from_substrait_plan(&handle.ctx.state(), &plan).await?;
+            Arc::new(logical_plan.schema().as_arrow().clone())
+        };
         let plan_schema = crate::schema_coerce::coerce_inferred_schema(plan_schema);
         let empty_exec = EmptyExec::new(Arc::clone(&plan_schema));
         let df_stream = empty_exec.execute(0, handle.ctx.task_ctx())?;
@@ -963,7 +964,7 @@ async unsafe fn execute_indexed_with_context_inner(
 
     let plan = Plan::decode(substrait_bytes.as_slice())
         .map_err(|e| DataFusionError::Execution(format!("decode substrait: {}", e)))?;
-    let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    let logical_plan = crate::substrait_consumer::from_substrait_plan(&ctx.state(), &plan).await?;
 
     // Sort-aware segment iteration. Mirror of `ContextIndexSearcher.shouldUseTimeSeriesDescSortOptimization`
     // for the indexed-parquet path. When the index has `index.sort.field` and the query's leading
@@ -1415,7 +1416,7 @@ async unsafe fn execute_indexed_with_context_inner(
     }));
     ctx.register_table(&register_name, provider)?;
 
-    let logical_plan = from_substrait_plan(&ctx.state(), &plan).await?;
+    let logical_plan = crate::substrait_consumer::from_substrait_plan(&ctx.state(), &plan).await?;
     log_debug!(
         "DataFusion logical plan:\n{}",
         logical_plan.display_indent()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -51,6 +51,7 @@ pub mod runtime_manager;
 pub mod schema_coerce;
 pub mod session_context;
 pub mod shard_table_provider;
+pub mod substrait_consumer;
 
 pub mod native_node_stats;
 pub mod scoped_index_optimizer;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/local_executor.rs
@@ -38,7 +38,6 @@ use datafusion::execution::{SendableRecordBatchStream, SessionStateBuilder};
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use native_bridge_common::log_debug;
 use prost::Message;
 use substrait::proto::Plan;
@@ -203,7 +202,8 @@ impl LocalSession {
         let plan = Plan::decode(bytes).map_err(|e| {
             DataFusionError::Execution(format!("Failed to decode Substrait plan: {}", e))
         })?;
-        let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        let logical_plan =
+            crate::substrait_consumer::from_substrait_plan(&self.ctx.state(), &plan).await?;
         log_debug!(
             "DataFusion logical plan:\n{}",
             logical_plan.display_indent()
@@ -248,7 +248,8 @@ impl LocalSession {
                 e
             ))
         })?;
-        let logical_plan = from_substrait_plan(&self.ctx.state(), &plan).await?;
+        let logical_plan =
+            crate::substrait_consumer::from_substrait_plan(&self.ctx.state(), &plan).await?;
         let dataframe = self.ctx.execute_logical_plan(logical_plan).await?;
         let physical_plan = dataframe.create_physical_plan().await?;
         // Strip first so `force_aggregate_mode(Final)` can find the Final/Partial pair

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/query_executor.rs
@@ -17,7 +17,6 @@ use datafusion::{
     execution::runtime_env::RuntimeEnvBuilder, physical_plan::displayable,
     physical_plan::execute_stream,
 };
-use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
 use log::error;
 use native_bridge_common::log_debug;
 use object_store::ObjectMeta;
@@ -148,7 +147,8 @@ async fn build_dataframe(
     // Standard user-search flow: Substrait → logical plan → DataFrame.
     let substrait_plan = Plan::decode(plan_bytes)
         .map_err(|e| DataFusionError::Execution(format!("Failed to decode Substrait: {}", e)))?;
-    let logical_plan = from_substrait_plan(&ctx.state(), &substrait_plan).await?;
+    let logical_plan =
+        crate::substrait_consumer::from_substrait_plan(&ctx.state(), &substrait_plan).await?;
     ctx.execute_logical_plan(logical_plan).await
 }
 
@@ -250,7 +250,9 @@ pub async fn execute_with_context(
         })?;
 
         // Union schema widening was applied at table registration (session_context::widen_to_union_schema).
-        let logical_plan = from_substrait_plan(&handle.ctx.state(), &substrait_plan).await?;
+        let logical_plan =
+            crate::substrait_consumer::from_substrait_plan(&handle.ctx.state(), &substrait_plan)
+                .await?;
         log_debug!(
             "DataFusion logical plan:\n{}",
             logical_plan.display_indent()

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -579,7 +579,6 @@ pub async fn prepare_partial_plan(
     handle: &mut SessionContextHandle,
     substrait_bytes: &[u8],
 ) -> Result<(), datafusion::common::DataFusionError> {
-    use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
     use prost::Message;
     use substrait::proto::Plan;
 
@@ -591,7 +590,8 @@ pub async fn prepare_partial_plan(
             e
         ))
     })?;
-    let logical_plan = from_substrait_plan(&handle.ctx.state(), &plan).await?;
+    let logical_plan =
+        crate::substrait_consumer::from_substrait_plan(&handle.ctx.state(), &plan).await?;
     let dataframe = handle.ctx.execute_logical_plan(logical_plan).await?;
     let physical_plan = dataframe.create_physical_plan().await?;
 

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/substrait_consumer.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/substrait_consumer.rs
@@ -1,0 +1,381 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::TableProvider;
+use datafusion::common::{not_impl_err, substrait_err, DFSchema, TableReference};
+use datafusion::execution::{FunctionRegistry, SessionState};
+use datafusion::functions_nested::expr_fn::{array_distinct, array_slice};
+use datafusion::logical_expr::{col, lit, Expr, LogicalPlan, LogicalPlanBuilder};
+use datafusion_substrait::extensions::Extensions;
+use datafusion_substrait::logical_plan::consumer::{
+    from_substrait_plan_with_consumer, DefaultSubstraitConsumer, SubstraitConsumer,
+};
+use substrait::proto::{ExtensionSingleRel, Plan};
+
+pub const MULTI_VALUE_EXPAND_TYPE_URL: &str = "opensearch://analytics/multi_value_expand/v1";
+const PAYLOAD_LEN: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExpandSpec {
+    field_index: usize,
+    limit: Option<usize>,
+    append: bool,
+    distinct: bool,
+}
+
+impl ExpandSpec {
+    fn decode(bytes: &[u8]) -> datafusion::common::Result<Self> {
+        if bytes.len() != PAYLOAD_LEN {
+            return substrait_err!(
+                "multi-value expand payload must contain {PAYLOAD_LEN} bytes, got {}",
+                bytes.len()
+            );
+        }
+        let read_i32 = |offset| {
+            i32::from_be_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .expect("four-byte slice"),
+            )
+        };
+        let field_index = read_i32(0);
+        let limit = read_i32(4);
+        let append = read_i32(8);
+        let distinct = read_i32(12);
+        if field_index < 0 || !matches!(append, 0 | 1) || !matches!(distinct, 0 | 1) || limit < -1 {
+            return substrait_err!("invalid multi-value expand payload");
+        }
+        Ok(Self {
+            field_index: field_index as usize,
+            limit: (limit >= 0).then_some(limit as usize),
+            append: append == 1,
+            distinct: distinct == 1,
+        })
+    }
+}
+
+struct OpenSearchSubstraitConsumer<'a> {
+    default: DefaultSubstraitConsumer<'a>,
+}
+
+impl<'a> OpenSearchSubstraitConsumer<'a> {
+    fn new(extensions: &'a Extensions, state: &'a SessionState) -> Self {
+        Self {
+            default: DefaultSubstraitConsumer::new(extensions, state),
+        }
+    }
+}
+
+#[async_trait]
+impl SubstraitConsumer for OpenSearchSubstraitConsumer<'_> {
+    async fn resolve_table_ref(
+        &self,
+        table_ref: &TableReference,
+    ) -> datafusion::common::Result<Option<Arc<dyn TableProvider>>> {
+        self.default.resolve_table_ref(table_ref).await
+    }
+
+    fn get_extensions(&self) -> &Extensions {
+        self.default.get_extensions()
+    }
+
+    fn get_function_registry(&self) -> &impl FunctionRegistry {
+        self.default.get_function_registry()
+    }
+
+    fn push_outer_schema(&self, schema: Arc<DFSchema>) {
+        self.default.push_outer_schema(schema);
+    }
+
+    fn pop_outer_schema(&self) {
+        self.default.pop_outer_schema();
+    }
+
+    fn get_outer_schema(&self, steps_out: usize) -> Option<Arc<DFSchema>> {
+        self.default.get_outer_schema(steps_out)
+    }
+
+    async fn consume_extension_single(
+        &self,
+        rel: &ExtensionSingleRel,
+    ) -> datafusion::common::Result<LogicalPlan> {
+        let detail = rel.detail.as_ref().ok_or_else(|| {
+            datafusion::common::DataFusionError::Plan(
+                "ExtensionSingleRel missing detail".to_string(),
+            )
+        })?;
+        if detail.type_url != MULTI_VALUE_EXPAND_TYPE_URL {
+            return self.default.consume_extension_single(rel).await;
+        }
+        let input = self
+            .consume_rel(rel.input.as_ref().ok_or_else(|| {
+                datafusion::common::DataFusionError::Plan(
+                    "multi-value expand missing input".to_string(),
+                )
+            })?)
+            .await?;
+        expand_multivalue(input, ExpandSpec::decode(&detail.value)?)
+    }
+}
+
+pub async fn from_substrait_plan(
+    state: &SessionState,
+    plan: &Plan,
+) -> datafusion::common::Result<LogicalPlan> {
+    let extensions = Extensions::try_from(&plan.extensions)?;
+    if !extensions.type_variations.is_empty() {
+        return not_impl_err!("Type variation extensions are not supported");
+    }
+    let consumer = OpenSearchSubstraitConsumer::new(&extensions, state);
+    from_substrait_plan_with_consumer(&consumer, plan).await
+}
+
+fn expand_multivalue(
+    input: LogicalPlan,
+    spec: ExpandSpec,
+) -> datafusion::common::Result<LogicalPlan> {
+    let columns = input.schema().columns();
+    let source = columns.get(spec.field_index).cloned().ok_or_else(|| {
+        datafusion::common::DataFusionError::Plan(format!(
+            "multi-value expand field index {} is outside {} columns",
+            spec.field_index,
+            columns.len()
+        ))
+    })?;
+    let mut expanded = Expr::Column(source.clone());
+    if spec.distinct {
+        expanded = array_distinct(expanded);
+    }
+    if let Some(limit) = spec.limit {
+        expanded = array_slice(expanded, lit(1_i64), lit(limit as i64), None);
+    }
+
+    let expand_name = if spec.append {
+        let mut candidate = format!("___mvexpand_{}", spec.field_index);
+        while input
+            .schema()
+            .field_with_unqualified_name(&candidate)
+            .is_ok()
+        {
+            candidate.push('_');
+        }
+        candidate
+    } else {
+        source.name.clone()
+    };
+
+    let mut projection = columns
+        .iter()
+        .cloned()
+        .map(Expr::Column)
+        .collect::<Vec<_>>();
+    if spec.append {
+        projection.push(expanded.alias(&expand_name));
+    } else {
+        projection[spec.field_index] = expanded.alias(&expand_name);
+    }
+
+    LogicalPlanBuilder::from(input)
+        .project(projection)?
+        .unnest_column(expand_name)?
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Array, Int32Array, ListBuilder};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+
+    fn string_lists(rows: &[&[&str]]) -> datafusion::arrow::array::ListArray {
+        let mut builder = ListBuilder::new(datafusion::arrow::array::StringViewBuilder::new());
+        for values in rows {
+            for value in *values {
+                builder.values().append_value(*value);
+            }
+            builder.append(true);
+        }
+        builder.finish()
+    }
+
+    fn input_batch() -> RecordBatch {
+        let tags = string_lists(&[&["b", "a", "a"], &["c", "d"]]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("tags", tags.data_type().clone(), true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(tags)],
+        )
+        .unwrap()
+    }
+
+    async fn run(spec: ExpandSpec) -> Vec<(i32, String)> {
+        let ctx = SessionContext::new();
+        let batch = input_batch();
+        let table = MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+        let input = ctx.table("t").await.unwrap().into_unoptimized_plan();
+        let plan = expand_multivalue(input, spec).unwrap();
+        let batches = ctx
+            .execute_logical_plan(plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+        for batch in batches {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let values = batch
+                .column(if spec.append { 2 } else { 1 })
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                rows.push((ids.value(row), values.value(row).to_string()));
+            }
+        }
+        rows
+    }
+
+    #[tokio::test]
+    async fn explicit_expand_appends_elements_and_honors_per_document_limit() {
+        assert_eq!(
+            run(ExpandSpec {
+                field_index: 1,
+                limit: Some(2),
+                append: true,
+                distinct: false,
+            })
+            .await,
+            vec![
+                (1, "b".into()),
+                (1, "a".into()),
+                (2, "c".into()),
+                (2, "d".into())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn group_expand_replaces_list_and_deduplicates_within_document() {
+        assert_eq!(
+            run(ExpandSpec {
+                field_index: 1,
+                limit: None,
+                append: false,
+                distinct: true,
+            })
+            .await,
+            vec![
+                (1, "b".into()),
+                (1, "a".into()),
+                (2, "c".into()),
+                (2, "d".into())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn sequential_group_expansion_forms_cartesian_product() {
+        let first = string_lists(&[&["a", "a", "b"]]);
+        let second = string_lists(&[&["x", "y"]]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first", first.data_type().clone(), true),
+            Field::new("second", second.data_type().clone(), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(first),
+                Arc::new(second),
+            ],
+        )
+        .unwrap();
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap();
+        ctx.register_table("t", Arc::new(table)).unwrap();
+        let input = ctx.table("t").await.unwrap().into_unoptimized_plan();
+        let first_expanded = expand_multivalue(
+            input,
+            ExpandSpec {
+                field_index: 1,
+                limit: None,
+                append: false,
+                distinct: true,
+            },
+        )
+        .unwrap();
+        let plan = expand_multivalue(
+            first_expanded,
+            ExpandSpec {
+                field_index: 2,
+                limit: None,
+                append: false,
+                distinct: true,
+            },
+        )
+        .unwrap();
+        let batches = ctx
+            .execute_logical_plan(plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut rows = Vec::new();
+        for batch in batches {
+            let first = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+                .unwrap();
+            let second = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                rows.push((first.value(row).to_string(), second.value(row).to_string()));
+            }
+        }
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![
+                ("a".into(), "x".into()),
+                ("a".into(), "y".into()),
+                ("b".into(), "x".into()),
+                ("b".into(), "y".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn payload_validation_rejects_invalid_flags() {
+        let mut payload = Vec::new();
+        for value in [1_i32, -1, 2, 0] {
+            payload.extend_from_slice(&value.to_be_bytes());
+        }
+        assert!(ExpandSpec::decode(&payload).is_err());
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/list_merge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/udaf/list_merge.rs
@@ -34,6 +34,14 @@ use datafusion::logical_expr::{
 pub fn register_all(ctx: &SessionContext) {
     ctx.register_udaf(AggregateUDF::from(ListMergeUdaf::new(false)));
     ctx.register_udaf(AggregateUDF::from(ListMergeUdaf::new(true)));
+    ctx.register_udaf(AggregateUDF::from(ListMergeUdaf::named(
+        "mv_collect",
+        false,
+    )));
+    ctx.register_udaf(AggregateUDF::from(ListMergeUdaf::named(
+        "mv_collect_distinct",
+        true,
+    )));
 }
 
 #[derive(Debug)]
@@ -45,12 +53,19 @@ pub struct ListMergeUdaf {
 
 impl ListMergeUdaf {
     pub fn new(distinct: bool) -> Self {
-        Self {
-            name: if distinct {
+        Self::named(
+            if distinct {
                 "list_merge_distinct"
             } else {
                 "list_merge"
             },
+            distinct,
+        )
+    }
+
+    pub fn named(name: &'static str, distinct: bool) -> Self {
+        Self {
+            name,
             distinct,
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -59,7 +74,7 @@ impl ListMergeUdaf {
 
 impl PartialEq for ListMergeUdaf {
     fn eq(&self, other: &Self) -> bool {
-        self.distinct == other.distinct
+        self.name == other.name && self.distinct == other.distinct
     }
 }
 impl Eq for ListMergeUdaf {}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionFragmentConvertor.java
@@ -9,6 +9,8 @@
 package org.opensearch.be.datafusion;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptSchema;
@@ -21,7 +23,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelReferentialConstraint;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.core.Uncollect;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -55,6 +59,7 @@ import org.opensearch.be.datafusion.planner.adapter.TimeConversionFunctionAdapte
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -79,6 +84,8 @@ import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.proto.PlanRel;
 import io.substrait.proto.ReadRel;
 import io.substrait.relation.Aggregate;
+import io.substrait.relation.Extension;
+import io.substrait.relation.ExtensionSingle;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Project;
@@ -316,6 +323,36 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         return rexBuilder.makeCast(varcharNullable, arg);
     }
 
+    /** PARTIAL-side LIST over a source multi-value field; flattens elements across documents. */
+    static final SqlAggFunction LOCAL_MV_COLLECT_OP = new SqlAggFunction(
+        "mv_collect",
+        null,
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false,
+        false,
+        Optionality.FORBIDDEN
+    ) {
+    };
+
+    /** PARTIAL-side VALUES over a source multi-value field; flattens and de-duplicates elements. */
+    static final SqlAggFunction LOCAL_MV_COLLECT_DISTINCT_OP = new SqlAggFunction(
+        "mv_collect_distinct",
+        null,
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.ARG0,
+        null,
+        OperandTypes.ANY,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false,
+        false,
+        Optionality.FORBIDDEN
+    ) {
+    };
+
     /** FINAL-side merge for LIST; un-nests per-shard list states. */
     static final SqlAggFunction LOCAL_LIST_MERGE_OP = new SqlAggFunction(
         "list_merge",
@@ -438,6 +475,8 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
         FunctionMappings.s(LOCAL_FIRST_OP, "first_value"),
         FunctionMappings.s(LOCAL_LAST_OP, "last_value"),
         FunctionMappings.s(LOCAL_ARRAY_AGG_OP, "array_agg"),
+        FunctionMappings.s(LOCAL_MV_COLLECT_OP, "mv_collect"),
+        FunctionMappings.s(LOCAL_MV_COLLECT_DISTINCT_OP, "mv_collect_distinct"),
         FunctionMappings.s(LOCAL_LIST_MERGE_OP, "list_merge"),
         FunctionMappings.s(LOCAL_LIST_MERGE_DISTINCT_OP, "list_merge_distinct"),
         FunctionMappings.s(LOCAL_PERCENTILE_APPROX_OP, "approx_percentile_cont"),
@@ -557,6 +596,7 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
     private static RelNode preprocessForSubstrait(RelNode rel) {
         RelNode preprocessed = UntypedNullPreprocessor.rewrite(rel);
         preprocessed = PplAggregateCallRewriter.rewrite(preprocessed);
+        preprocessed = MultiValueRelRewriter.rewrite(preprocessed);
         preprocessed = PplWindowCallRewriter.rewrite(preprocessed);
         preprocessed = ItemTypeRebuilder.rewrite(preprocessed);
         preprocessed = CastToVarcharRewriter.rewrite(preprocessed);
@@ -805,7 +845,83 @@ public class DataFusionFragmentConvertor implements FragmentConvertor {
                 Rel rel = super.visit(aggregate);
                 return rel instanceof Aggregate agg ? addNullArgFilters(aggregate, agg) : rel;
             }
+
+            @Override
+            public Rel visit(Correlate correlate) {
+                MultiValueExpandSpec spec = explicitMultiValueExpand(correlate, typeConverter);
+                if (spec == null) {
+                    return super.visit(correlate);
+                }
+                return ExtensionSingle.from(new MultiValueExpandDetail(spec), apply(correlate.getLeft())).build();
+            }
+
+            @Override
+            public Rel visitOther(RelNode other) {
+                if (other instanceof MultiValueExpandRel expand) {
+                    MultiValueExpandSpec spec = new MultiValueExpandSpec(
+                        expand.fieldIndex(),
+                        null,
+                        false,
+                        true,
+                        typeConverter.toNamedStruct(expand.getRowType()).struct()
+                    );
+                    return ExtensionSingle.from(new MultiValueExpandDetail(spec), apply(expand.getInput())).build();
+                }
+                return super.visitOther(other);
+            }
         };
+    }
+
+    private static MultiValueExpandSpec explicitMultiValueExpand(Correlate correlate, TypeConverter typeConverter) {
+        if (correlate.getJoinType() != org.apache.calcite.rel.core.JoinRelType.INNER || correlate.getRequiredColumns().cardinality() != 1) {
+            return null;
+        }
+        RelNode right = correlate.getRight();
+        Integer limit = null;
+        if (right instanceof org.apache.calcite.rel.core.Sort sort) {
+            if (!(sort.fetch instanceof RexLiteral literal)) {
+                return null;
+            }
+            limit = literal.getValueAs(Integer.class);
+            right = sort.getInput();
+        }
+        if (!(right instanceof Uncollect)) {
+            return null;
+        }
+        return new MultiValueExpandSpec(
+            correlate.getRequiredColumns().nextSetBit(0),
+            limit,
+            true,
+            false,
+            typeConverter.toNamedStruct(correlate.getRowType()).struct()
+        );
+    }
+
+    private record MultiValueExpandSpec(int fieldIndex, Integer limit, boolean append, boolean distinct, Type.Struct outputType) {
+    }
+
+    private static final class MultiValueExpandDetail implements Extension.SingleRelDetail {
+        private static final String TYPE_URL = "opensearch://analytics/multi_value_expand/v1";
+        private final MultiValueExpandSpec spec;
+
+        private MultiValueExpandDetail(MultiValueExpandSpec spec) {
+            this.spec = spec;
+        }
+
+        @Override
+        public Type.Struct deriveRecordType(Rel input) {
+            return spec.outputType();
+        }
+
+        @Override
+        public Any toProto(io.substrait.relation.RelProtoConverter converter) {
+            ByteBuffer payload = ByteBuffer.allocate(16);
+            payload.putInt(spec.fieldIndex());
+            payload.putInt(spec.limit() == null ? -1 : spec.limit());
+            payload.putInt(spec.append() ? 1 : 0);
+            payload.putInt(spec.distinct() ? 1 : 0);
+            return Any.newBuilder().setTypeUrl(TYPE_URL).setValue(ByteString.copyFrom(payload.array())).build();
+        }
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueExpandRel.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueExpandRel.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+
+import java.util.List;
+
+/**
+ * Backend-local relation that replaces one LIST column with one row per distinct element.
+ *
+ * <p>The SQL frontend already represents explicit {@code mvexpand} as Correlate+Uncollect.
+ * This relation is used only for implicit multi-value GROUP BY semantics, where each document
+ * contributes at most once to each element bucket.
+ */
+final class MultiValueExpandRel extends SingleRel {
+
+    private final int fieldIndex;
+
+    MultiValueExpandRel(RelNode input, int fieldIndex) {
+        super(input.getCluster(), input.getTraitSet(), input);
+        this.fieldIndex = fieldIndex;
+        if (input.getRowType().getFieldList().get(fieldIndex).getType().getComponentType() == null) {
+            throw new IllegalArgumentException("field " + fieldIndex + " is not a collection");
+        }
+    }
+
+    int fieldIndex() {
+        return fieldIndex;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        RelDataTypeFactory.Builder builder = getCluster().getTypeFactory().builder();
+        List<RelDataTypeField> fields = getInput().getRowType().getFieldList();
+        for (int index = 0; index < fields.size(); index++) {
+            RelDataTypeField field = fields.get(index);
+            RelDataType type = field.getType();
+            if (index == fieldIndex) {
+                type = getCluster().getTypeFactory().createTypeWithNullability(type.getComponentType(), true);
+            }
+            builder.add(field.getName(), type);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new MultiValueExpandRel(sole(inputs), fieldIndex);
+    }
+
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw).item("field", getInput().getRowType().getFieldNames().get(fieldIndex)).item("distinct", true);
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueRelRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/MultiValueRelRewriter.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion;
+
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+
+/** Adds implicit element expansion for LIST-valued GROUP BY keys. */
+final class MultiValueRelRewriter {
+
+    private MultiValueRelRewriter() {}
+
+    static RelNode rewrite(RelNode root) {
+        return root.accept(new RelHomogeneousShuttle() {
+            @Override
+            public RelNode visit(RelNode other) {
+                RelNode visited = super.visit(other);
+                if (!(visited instanceof Aggregate aggregate)) {
+                    return visited;
+                }
+                RelNode input = aggregate.getInput();
+                boolean changed = false;
+                for (int fieldIndex : aggregate.getGroupSet()) {
+                    if (input.getRowType().getFieldList().get(fieldIndex).getType().getComponentType() != null) {
+                        input = new MultiValueExpandRel(input, fieldIndex);
+                        changed = true;
+                    }
+                }
+                return changed
+                    ? aggregate.copy(
+                        aggregate.getTraitSet(),
+                        input,
+                        aggregate.getGroupSet(),
+                        aggregate.getGroupSets(),
+                        aggregate.getAggCallList()
+                    )
+                    : aggregate;
+            }
+        });
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PplAggregateCallRewriter.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/PplAggregateCallRewriter.java
@@ -16,6 +16,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -44,6 +45,8 @@ final class PplAggregateCallRewriter {
         DataFusionFragmentConvertor.LOCAL_FIRST_OP,
         DataFusionFragmentConvertor.LOCAL_LAST_OP,
         DataFusionFragmentConvertor.LOCAL_ARRAY_AGG_OP,
+        DataFusionFragmentConvertor.LOCAL_MV_COLLECT_OP,
+        DataFusionFragmentConvertor.LOCAL_MV_COLLECT_DISTINCT_OP,
         DataFusionFragmentConvertor.LOCAL_LIST_MERGE_OP,
         DataFusionFragmentConvertor.LOCAL_LIST_MERGE_DISTINCT_OP,
         DataFusionFragmentConvertor.LOCAL_PERCENTILE_APPROX_OP,
@@ -164,9 +167,16 @@ final class PplAggregateCallRewriter {
                 RelDataType arg0Type = agg.getInput().getRowType().getFieldList().get(call.getArgList().get(0)).getType();
                 boolean arg0IsList = arg0Type.getComponentType() != null;
                 if (arg0IsList) {
-                    targetOp = isValues
-                        ? DataFusionFragmentConvertor.LOCAL_LIST_MERGE_DISTINCT_OP
-                        : DataFusionFragmentConvertor.LOCAL_LIST_MERGE_OP;
+                    boolean finalState = readsStageInput(agg.getInput());
+                    if (finalState) {
+                        targetOp = isValues
+                            ? DataFusionFragmentConvertor.LOCAL_LIST_MERGE_DISTINCT_OP
+                            : DataFusionFragmentConvertor.LOCAL_LIST_MERGE_OP;
+                    } else {
+                        targetOp = isValues
+                            ? DataFusionFragmentConvertor.LOCAL_MV_COLLECT_DISTINCT_OP
+                            : DataFusionFragmentConvertor.LOCAL_MV_COLLECT_OP;
+                    }
                     targetDistinct = false;
                     explicitReturnType = arg0Type;
                 } else {
@@ -231,6 +241,14 @@ final class PplAggregateCallRewriter {
             explicitReturnType,
             call.getName()
         );
+    }
+
+    private static boolean readsStageInput(RelNode node) {
+        if (node instanceof TableScan scan) {
+            List<String> qualifiedName = scan.getTable().getQualifiedName();
+            return !qualifiedName.isEmpty() && qualifiedName.getLast().startsWith("input-");
+        }
+        return node.getInputs().size() == 1 && readsStageInput(node.getInput(0));
     }
 
     private static RelDataType internalPatternReturnType(RelDataTypeFactory typeFactory) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/resources/opensearch_aggregate_functions.yaml
@@ -90,6 +90,24 @@ aggregate_functions:
           - name: x
             value: any
         return: any
+  - name: mv_collect
+    description: >-
+      PARTIAL-side PPL `list(field)` for a source LIST column. Flattens each document's
+      elements into one aggregate state. Uses the list_merge accumulator implementation.
+    impls:
+      - args:
+          - name: x
+            value: any
+        return: any
+  - name: mv_collect_distinct
+    description: >-
+      PARTIAL-side PPL `values(field)` for a source LIST column. Flattens and
+      de-duplicates elements before the FINAL list_merge_distinct stage.
+    impls:
+      - args:
+          - name: x
+            value: any
+        return: any
   - name: list_merge
     description: >-
       Cross-shard FINAL of LIST. Concatenates per-shard `List<elem>` states.

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionFragmentConvertorTests.java
@@ -16,8 +16,13 @@ import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Uncollect;
 import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
 import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
@@ -708,8 +713,117 @@ public class DataFusionFragmentConvertorTests extends OpenSearchTestCase {
 
     // ── Extension function rename tests ────────────────────────────────────────
 
+    public void testListOverSourceMultiValueRoutesToMvCollect() throws Exception {
+        assertListAggregateUses("test_index", "mv_collect");
+    }
+
+    public void testListOverFinalStateRoutesToListMerge() throws Exception {
+        assertListAggregateUses("input-7", "list_merge");
+    }
+
+    public void testListGroupByAddsDistinctReplaceExpansion() throws Exception {
+        RelNode scan = buildListTableScan("test_index");
+        AggregateCall count = AggregateCall.create(
+            SqlStdOperatorTable.COUNT,
+            false,
+            List.of(),
+            -1,
+            typeFactory.createSqlType(SqlTypeName.BIGINT),
+            "count"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(0), null, List.of(count));
+
+        Rel root = rootRel(decodeSubstrait(newConvertor().convertFragment(aggregate)));
+        assertTrue(root.hasAggregate());
+        Rel expanded = root.getAggregate().getInput();
+        assertTrue("LIST GROUP BY must use an ExtensionSingleRel", expanded.hasExtensionSingle());
+        assertEquals("opensearch://analytics/multi_value_expand/v1", expanded.getExtensionSingle().getDetail().getTypeUrl());
+        java.nio.ByteBuffer payload = expanded.getExtensionSingle().getDetail().getValue().asReadOnlyByteBuffer();
+        assertEquals(0, payload.getInt());
+        assertEquals(-1, payload.getInt());
+        assertEquals("implicit GROUP BY expansion replaces the LIST field", 0, payload.getInt());
+        assertEquals("implicit GROUP BY expansion de-duplicates within each document", 1, payload.getInt());
+    }
+
+    public void testExplicitMvExpandCorrelateEmitsAppendExtensionWithLimit() throws Exception {
+        RelNode left = buildListTableScan("test_index");
+        CorrelationId correlationId = cluster.createCorrel();
+        RexNode correlatedTags = rexBuilder.makeFieldAccess(rexBuilder.makeCorrel(left.getRowType(), correlationId), 0);
+        RelNode values = LogicalValues.createOneRow(cluster);
+        RelNode project = LogicalProject.create(
+            values,
+            List.of(),
+            List.of(correlatedTags),
+            List.of("tags"),
+            java.util.Set.of(correlationId)
+        );
+        RelNode uncollect = Uncollect.create(cluster.traitSet(), project, false, List.of());
+        RexNode fetch = rexBuilder.makeLiteral(2, typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+        RelNode limited = LogicalSort.create(uncollect, RelCollations.EMPTY, null, fetch);
+        RelNode correlate = LogicalCorrelate.create(left, limited, correlationId, ImmutableBitSet.of(0), JoinRelType.INNER);
+
+        Rel root = rootRel(decodeSubstrait(newConvertor().convertFragment(correlate)));
+        assertTrue(root.hasExtensionSingle());
+        java.nio.ByteBuffer payload = root.getExtensionSingle().getDetail().getValue().asReadOnlyByteBuffer();
+        assertEquals(0, payload.getInt());
+        assertEquals(2, payload.getInt());
+        assertEquals("explicit mvexpand appends its element for the frontend projection", 1, payload.getInt());
+        assertEquals("explicit mvexpand preserves duplicate elements", 0, payload.getInt());
+    }
+
+    private void assertListAggregateUses(String tableName, String expectedFunction) throws Exception {
+        RelNode scan = buildListTableScan(tableName);
+        SqlAggFunction list = new SqlAggFunction(
+            "LIST",
+            null,
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.ARG0,
+            null,
+            OperandTypes.ANY,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION,
+            false,
+            false,
+            Optionality.FORBIDDEN
+        ) {
+        };
+        AggregateCall call = AggregateCall.create(
+            list,
+            false,
+            false,
+            false,
+            List.of(),
+            List.of(0),
+            -1,
+            null,
+            RelCollations.EMPTY,
+            0,
+            scan,
+            scan.getRowType().getFieldList().get(0).getType(),
+            "values"
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(scan, List.of(), ImmutableBitSet.of(), null, List.of(call));
+        Plan plan = decodeSubstrait(newConvertor().convertFragment(aggregate));
+        assertTrue(
+            "expected aggregate extension " + expectedFunction,
+            plan.getExtensionsList()
+                .stream()
+                .filter(SimpleExtensionDeclaration::hasExtensionFunction)
+                .map(declaration -> declaration.getExtensionFunction().getName())
+                .map(name -> name.contains(":") ? name.substring(0, name.indexOf(':')) : name)
+                .anyMatch(expectedFunction::equals)
+        );
+    }
+
+    private RelNode buildListTableScan(String tableName) {
+        RelDataType element = typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+        RelDataType list = typeFactory.createTypeWithNullability(typeFactory.createArrayType(element, -1), true);
+        RelDataType type = typeFactory.builder().add("tags", list).build();
+        return new DataFusionFragmentConvertor.StageInputTableScan(cluster, cluster.traitSet(), tableName, type);
+    }
+
     /**
      * APPROX_COUNT_DISTINCT aggregate emits as {@code approx_distinct} in the
+
      * Substrait extension declarations — not the Calcite-native
      * {@code approx_count_distinct} name.
      */


### PR DESCRIPTION
### Description
Adds aggregation and row-expansion semantics for multi-value keyword fields.

This change:
- routes `list(field)` and `values(field)` over source LIST columns to element-flattening `mv_collect` / `mv_collect_distinct` aggregate aliases;
- preserves `list_merge` / `list_merge_distinct` for cross-shard FINAL aggregate states;
- expands LIST-valued GROUP BY keys into one bucket contribution per distinct element per document;
- applies sequential expansion for multiple LIST GROUP BY keys, producing the expected Cartesian product;
- lowers the SQL frontend's `mvexpand` Correlate+Uncollect shape to a versioned OpenSearch `ExtensionSingleRel`;
- supports the `mvexpand ... limit=N` per-document limit through `array_slice` before DataFusion `Unnest`; and
- routes every native Substrait execution path through an extension-aware consumer while delegating ordinary plans unchanged.

This is an independent sibling of query-sorting PR #22905. It is based on #22902, so this PR temporarily includes the #22902 foundation commit and will shrink to incremental commit `9729b657fb9` after #22902 merges. Adaptive LIST indexing is tracked by #22883. It has no dependency on physical merge/sorting PR #22899.

### Validation
- DataFusion Rust suite, serial: 1,329 passed, 1 ignored
- `DataFusionFragmentConvertorTests`: passed
- Explicit mvexpand, per-document limit, LIST GROUP BY deduplication, two-key Cartesian expansion, and source/final aggregate routing tests: passed
- `spotlessJavaCheck`: passed
- `analytics-backend-datafusion:assemble`: passed
- Independent correctness/scope review: approved

### Related Issues
Related to #22902
Related to #22883
Related to #22905

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request is not applicable; no public API is added.
- [x] Public documentation issue/PR is not applicable to this internal execution change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).