### PR TITLE
[Sandbox] Fix flaky DataFormatAware* ITs under remote store fencing

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReadonlyEngineBaseIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReadonlyEngineBaseIT.java
@@ -34,6 +34,7 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.remotestore.mocks.MockFsMetadataSupportedRepositoryPlugin;
+import org.opensearch.remotestore.multipart.mocks.MockFsRepository;
 import org.opensearch.remotestore.multipart.mocks.MockFsRepositoryPlugin;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.fs.FsRepository;
@@ -109,6 +110,12 @@ public abstract class DataFormatAwareReadonlyEngineBaseIT extends RemoteStoreBas
      * {@link FsNativeObjectStorePlugin} as the native store provider.
      * This covers the {@code "fs_multipart_repository"} path, which is chosen when
      * {@code metadataSupportedType == false} in {@code RemoteStoreBaseIntegTestCase}.
+     *
+     * <p>Keeps {@link MockFsRepository} as the implementation rather than a plain {@link FsRepository}:
+     * the mock's blob container is the only one of the two that reports store-enforced conditional
+     * writes, which remote store fencing requires. Substituting {@code FsRepository} here made every
+     * seed that picked {@code asyncUploadMockFsRepo=true}, {@code metadataSupportedType=false} and
+     * fencing-enabled fail shard recovery outright.
      */
     public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements org.opensearch.plugins.RepositoryPlugin {
 
@@ -123,7 +130,7 @@ public abstract class DataFormatAwareReadonlyEngineBaseIT extends RemoteStoreBas
         ) {
             return Collections.singletonMap(
                 MockFsRepositoryPlugin.TYPE,
-                metadata -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
+                metadata -> new MockFsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
             );
         }
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/DataFormatAwareReplicationBaseIT.java
@@ -33,6 +33,7 @@ import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.remotestore.mocks.MockFsMetadataSupportedRepositoryPlugin;
+import org.opensearch.remotestore.multipart.mocks.MockFsRepository;
 import org.opensearch.remotestore.multipart.mocks.MockFsRepositoryPlugin;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.fs.FsRepository;
@@ -98,7 +99,15 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
         }
     }
 
-    /** Wires FsNativeObjectStorePlugin into "fs_multipart_repository" repos. */
+    /**
+     * Wires FsNativeObjectStorePlugin into "fs_multipart_repository" repos.
+     *
+     * <p>Keeps {@link MockFsRepository} as the implementation rather than a plain {@link FsRepository}:
+     * the mock's blob container is the only one of the two that reports store-enforced conditional
+     * writes, which remote store fencing requires. Substituting {@code FsRepository} here made every
+     * seed that picked {@code asyncUploadMockFsRepo=true}, {@code metadataSupportedType=false} and
+     * fencing-enabled fail shard recovery outright.
+     */
     public static class NativeAwareMockFsRepositoryPlugin extends Plugin implements org.opensearch.plugins.RepositoryPlugin {
 
         private final FsNativeObjectStorePlugin nativeProvider = new FsNativeObjectStorePlugin();
@@ -112,7 +121,7 @@ public abstract class DataFormatAwareReplicationBaseIT extends RemoteStoreBaseIn
         ) {
             return Collections.singletonMap(
                 MockFsRepositoryPlugin.TYPE,
-                metadata -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
+                metadata -> new MockFsRepository(metadata, env, namedXContentRegistry, clusterService, recoverySettings, nativeProvider)
             );
         }
     }

--- a/test/framework/src/main/java/org/opensearch/remotestore/multipart/mocks/MockFsRepository.java
+++ b/test/framework/src/main/java/org/opensearch/remotestore/multipart/mocks/MockFsRepository.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.plugins.NativeRemoteObjectStoreProvider;
 import org.opensearch.repositories.fs.FsRepository;
 
 public class MockFsRepository extends FsRepository {
@@ -34,7 +35,25 @@ public class MockFsRepository extends FsRepository {
         ClusterService clusterService,
         RecoverySettings recoverySettings
     ) {
-        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings);
+        this(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, null);
+    }
+
+    /**
+     * Variant that also wires a native store provider, for tests whose shards need a live
+     * {@code NativeStoreRepository} (e.g. warm Parquet shards in the sandbox composite engine).
+     * Such tests would otherwise have to substitute a plain {@link FsRepository} for this repo type
+     * and would silently lose the mock's behaviour, including the conditional-write support that
+     * remote store fencing requires.
+     */
+    public MockFsRepository(
+        RepositoryMetadata metadata,
+        Environment environment,
+        NamedXContentRegistry namedXContentRegistry,
+        ClusterService clusterService,
+        RecoverySettings recoverySettings,
+        NativeRemoteObjectStoreProvider nativeStoreProvider
+    ) {
+        super(metadata, environment, namedXContentRegistry, clusterService, recoverySettings, nativeStoreProvider);
         triggerDataIntegrityFailure = TRIGGER_DATA_INTEGRITY_FAILURE.get(metadata.settings());
     }
 


### PR DESCRIPTION
### Description
Four `sandbox:plugins:composite-engine` internal cluster tests failed on roughly one seed in
eight with `timed out waiting for green state`:

- `DataFormatAwareWarmEngineIT.testReadOnlyEngineAfterWarmFlip`
- `DataFormatAwareReplicaGetByIdIT.testGetByIdFromReplica`
- `DataFormatAwareReadonlyEngineWriteIT.testWarmEngineFlipAndWriteRejection`
- `DataFormatAwareReadonlyEngineReplicaPromotionIT.testReplicaPromotedAfterPrimaryCancelled`

The primary shard exhausted all five allocation attempts, each rejected because remote store
fencing found the translog repository unable to perform store-enforced conditional writes.

`RemoteStoreBaseIntegTestCase` randomizes `asyncUploadMockFsRepo`, `metadataSupportedType` and
`remoteStoreFencing` independently. The first two select `fs_multipart_repository`, whose
implementation both sandbox base classes replace with a plain `FsRepository` so they can inject a
native store provider. That substitution also dropped the mock's conditional-write support
(`MockFsAsyncBlobContainer` reports `true`, `FsBlobContainer` correctly reports `false`), so the
third choice landing on fencing made shard recovery fail outright.

This gives `MockFsRepository` a constructor that takes a native store provider and uses it in both
substitutions, so the mock behaviour survives and the randomized fencing dimension is exercised
rather than fatal. No production code changes.

Verified with 40 executions at `-Dtests.remote_store.fencing=true` and 60 at random fencing, all
passing. The same forced-fencing run failed 6 of 40 before the change.

### Related Issues
Resolves #22921

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
