### PR TITLE
Bound completion suggester determinize work limit

### DIFF
--- a/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
@@ -43,6 +43,7 @@ import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.RegexpQueryBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -120,7 +121,32 @@ public class FuzzyOptions implements ToXContentFragment, Writeable {
         editDistance = in.readVInt();
         fuzzyMinLength = in.readVInt();
         fuzzyPrefixLength = in.readVInt();
-        maxDeterminizedStates = in.readVInt();
+        // Route through validation so the CVE-2026-63136 upper bound is enforced on the transport
+        // deserialization path too, not just REST/XContent. Protects a patched data node from an
+        // unbounded value sent by an unpatched coordinating node in a mixed-version cluster.
+        maxDeterminizedStates = validateMaxDeterminizedStates(in.readVInt());
+    }
+
+    /**
+     * Validates {@code max_determinized_states} against the shared ceiling and returns it. An
+     * unbounded value disables Lucene's determinize safeguard and lets a crafted expansion exhaust
+     * the heap before Lucene throws its own complexity exception. See CVE-2026-63136 and
+     * {@link RegexpQueryBuilder#MAX_DETERMINIZE_WORK_LIMIT}.
+     */
+    private static int validateMaxDeterminizedStates(int maxDeterminizedStates) {
+        if (maxDeterminizedStates < 0) {
+            throw new IllegalArgumentException("maxDeterminizedStates must not be negative");
+        }
+        if (maxDeterminizedStates > RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT) {
+            throw new IllegalArgumentException(
+                "maxDeterminizedStates cannot exceed ["
+                    + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT
+                    + "] but was ["
+                    + maxDeterminizedStates
+                    + "]"
+            );
+        }
+        return maxDeterminizedStates;
     }
 
     @Override
@@ -293,10 +319,7 @@ public class FuzzyOptions implements ToXContentFragment, Writeable {
          * Sets the maximum automaton states allowed for the fuzzy expansion
          */
         public Builder setMaxDeterminizedStates(int maxDeterminizedStates) {
-            if (maxDeterminizedStates < 0) {
-                throw new IllegalArgumentException("maxDeterminizedStates must not be negative");
-            }
-            this.maxDeterminizedStates = maxDeterminizedStates;
+            this.maxDeterminizedStates = validateMaxDeterminizedStates(maxDeterminizedStates);
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
@@ -44,6 +44,7 @@ import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.RegexpFlag;
+import org.opensearch.index.query.RegexpQueryBuilder;
 
 import java.io.IOException;
 
@@ -101,7 +102,32 @@ public class RegexOptions implements ToXContentFragment, Writeable {
      */
     RegexOptions(StreamInput in) throws IOException {
         this.flagsValue = in.readVInt();
-        this.maxDeterminizedStates = in.readVInt();
+        // Route through validation so the CVE-2026-63136 upper bound is enforced on the transport
+        // deserialization path too, not just REST/XContent. Protects a patched data node from an
+        // unbounded value sent by an unpatched coordinating node in a mixed-version cluster.
+        this.maxDeterminizedStates = validateMaxDeterminizedStates(in.readVInt());
+    }
+
+    /**
+     * Validates {@code max_determinized_states} against the shared ceiling and returns it. An
+     * unbounded value disables Lucene's determinize safeguard and lets a crafted regex exhaust the
+     * heap before Lucene throws its own complexity exception. See CVE-2026-63136 and
+     * {@link RegexpQueryBuilder#MAX_DETERMINIZE_WORK_LIMIT}.
+     */
+    private static int validateMaxDeterminizedStates(int maxDeterminizedStates) {
+        if (maxDeterminizedStates < 0) {
+            throw new IllegalArgumentException("maxDeterminizedStates must not be negative");
+        }
+        if (maxDeterminizedStates > RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT) {
+            throw new IllegalArgumentException(
+                "maxDeterminizedStates cannot exceed ["
+                    + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT
+                    + "] but was ["
+                    + maxDeterminizedStates
+                    + "]"
+            );
+        }
+        return maxDeterminizedStates;
     }
 
     @Override
@@ -182,10 +208,7 @@ public class RegexOptions implements ToXContentFragment, Writeable {
          * Sets the maximum automaton states allowed for the regular expression expansion
          */
         public Builder setMaxDeterminizedStates(int maxDeterminizedStates) {
-            if (maxDeterminizedStates < 0) {
-                throw new IllegalArgumentException("maxDeterminizedStates must not be negative");
-            }
-            this.maxDeterminizedStates = maxDeterminizedStates;
+            this.maxDeterminizedStates = validateMaxDeterminizedStates(maxDeterminizedStates);
             return this;
         }
 

--- a/server/src/test/java/org/opensearch/search/suggest/completion/FuzzyOptionsTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/FuzzyOptionsTests.java
@@ -32,8 +32,11 @@
 
 package org.opensearch.search.suggest.completion;
 
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.RegexpQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -153,6 +156,54 @@ public class FuzzyOptionsTests extends OpenSearchTestCase {
             fail("max determinized state must be >= 0");
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "maxDeterminizedStates must not be negative");
+        }
+    }
+
+    public void testMaxDeterminizedStatesIsBounded() {
+        final FuzzyOptions.Builder builder = FuzzyOptions.builder();
+
+        // the ceiling and typical values are accepted
+        assertEquals(
+            RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT,
+            builder.setMaxDeterminizedStates(RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT).build().getMaxDeterminizedStates()
+        );
+        assertEquals(500, builder.setMaxDeterminizedStates(500).build().getMaxDeterminizedStates());
+
+        // anything above the ceiling is rejected
+        int aboveLimit = RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + 1;
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.setMaxDeterminizedStates(aboveLimit));
+        assertEquals(
+            "maxDeterminizedStates cannot exceed [" + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + "] but was [" + aboveLimit + "]",
+            e.getMessage()
+        );
+        expectThrows(IllegalArgumentException.class, () -> builder.setMaxDeterminizedStates(Integer.MAX_VALUE));
+    }
+
+    /**
+     * A legitimately-built FuzzyOptions cannot carry an out-of-bounds value, so hand-craft the wire
+     * bytes to prove the transport deserialization path enforces the bound too (mixed-version cluster).
+     */
+    public void testMaxDeterminizedStatesFromStreamIsBounded() throws IOException {
+        int aboveLimit = RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + 1;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            // matches FuzzyOptions#writeTo ordering
+            out.writeBoolean(false); // transpositions
+            out.writeBoolean(false); // unicodeAware
+            out.writeVInt(1); // editDistance
+            out.writeVInt(0); // fuzzyMinLength
+            out.writeVInt(0); // fuzzyPrefixLength
+            out.writeVInt(aboveLimit); // maxDeterminizedStates
+            try (StreamInput in = out.bytes().streamInput()) {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new FuzzyOptions(in));
+                assertEquals(
+                    "maxDeterminizedStates cannot exceed ["
+                        + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT
+                        + "] but was ["
+                        + aboveLimit
+                        + "]",
+                    e.getMessage()
+                );
+            }
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/suggest/completion/RegexOptionsTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/RegexOptionsTests.java
@@ -32,8 +32,11 @@
 
 package org.opensearch.search.suggest.completion;
 
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.query.RegexpFlag;
+import org.opensearch.index.query.RegexpQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -89,6 +92,49 @@ public class RegexOptionsTests extends OpenSearchTestCase {
             fail("max determinized state must be positive");
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "maxDeterminizedStates must not be negative");
+        }
+    }
+
+    public void testMaxDeterminizedStatesIsBounded() {
+        final RegexOptions.Builder builder = RegexOptions.builder();
+
+        // the ceiling and typical values are accepted
+        assertEquals(
+            RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT,
+            builder.setMaxDeterminizedStates(RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT).build().getMaxDeterminizedStates()
+        );
+        assertEquals(500, builder.setMaxDeterminizedStates(500).build().getMaxDeterminizedStates());
+
+        // anything above the ceiling is rejected
+        int aboveLimit = RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + 1;
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.setMaxDeterminizedStates(aboveLimit));
+        assertEquals(
+            "maxDeterminizedStates cannot exceed [" + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + "] but was [" + aboveLimit + "]",
+            e.getMessage()
+        );
+        expectThrows(IllegalArgumentException.class, () -> builder.setMaxDeterminizedStates(Integer.MAX_VALUE));
+    }
+
+    /**
+     * A legitimately-built RegexOptions cannot carry an out-of-bounds value, so hand-craft the wire
+     * bytes to prove the transport deserialization path enforces the bound too (mixed-version cluster).
+     */
+    public void testMaxDeterminizedStatesFromStreamIsBounded() throws IOException {
+        int aboveLimit = RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT + 1;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0); // flagsValue
+            out.writeVInt(aboveLimit); // maxDeterminizedStates
+            try (StreamInput in = out.bytes().streamInput()) {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RegexOptions(in));
+                assertEquals(
+                    "maxDeterminizedStates cannot exceed ["
+                        + RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT
+                        + "] but was ["
+                        + aboveLimit
+                        + "]",
+                    e.getMessage()
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

The completion suggester's regex and fuzzy options accepted an unbounded `max_determinized_states`. An arbitrarily large value (e.g. `Integer.MAX_VALUE`) disables Lucene's determinize safeguard, letting a crafted pattern exhaust the heap before Lucene throws its own complexity exception.

This is the same gap PR 22557 closed for the `regexp`/`query_string` queries, which never reached the completion path — `CompletionSuggestionContext` feeds these values straight into `regexpQuery(...)` / `FuzzyCompletionQuery`.

This change:
- Caps `max_determinized_states` at the shared `RegexpQueryBuilder.MAX_DETERMINIZE_WORK_LIMIT` ceiling in both `RegexOptions` and `FuzzyOptions` (reusing the existing constant, no new magic value).
- Routes the transport deserialization path through the same validation, so a patched data node rejects an unbounded value sent by an unpatched coordinating node in a mixed-version cluster.

The existing negative-value check and its message are unchanged.

### Related Issues

CVE-2026-63136. Follow-up to PR 22557, which bounded the same value for the `regexp`/`query_string` query builders.

### Testing

- `./gradlew :server:spotlessJavaCheck` passes.
- `RegexOptionsTests` and `FuzzyOptionsTests` pass, including new `testMaxDeterminizedStatesIsBounded` (setter accepts the ceiling and typical values, rejects above-limit and `Integer.MAX_VALUE`) and `testMaxDeterminizedStatesFromStreamIsBounded` (transport path rejects hand-crafted oversized wire bytes).

### Check List
- [x] Functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).