### PR TITLE
Ensure run builds native sandbox library

### DIFF
--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -34,15 +34,14 @@ apply plugin: 'opensearch.testclusters'
 
 def numNodes = findProperty('numNodes') as Integer ?: 1
 def numZones = findProperty('numZones') as Integer ?: 1
-def requestedPlugins = findProperty('installedPlugins') ? Eval.me(findProperty('installedPlugins').toString()) : []
 
 testClusters {
   runTask {
     testDistribution = 'archive'
     if (numZones > 1) numberOfZones = numZones
     if (numNodes > 1) numberOfNodes = numNodes
-    if (requestedPlugins.isEmpty() == false) {
-      installedPlugins = requestedPlugins
+    if (findProperty("installedPlugins")) {
+      installedPlugins = Eval.me(installedPlugins)
 
       def resolveMavenPlugin = { coords ->
         // Add default groupId if not fully qualified (less than 2 colons)
@@ -58,7 +57,7 @@ testClusters {
         plugin(project.layout.file(project.provider { config.singleFile }))
       }
 
-      for (String p : requestedPlugins) {
+      for (String p : installedPlugins) {
         // check if its a local plugin first
         if (project.findProject(':plugins:' + p) != null) {
           plugin(':plugins:' + p)
@@ -110,10 +109,6 @@ tasks.register("run", RunTask) {
   useCluster testClusters.runTask;
   description = 'Runs opensearch in the foreground'
   group = 'Verification'
-
-  if (requestedPlugins.any { it == 'analytics-backend-datafusion' || it == 'parquet-data-format' }) {
-    dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
-  }
 
   impliesSubProjects = true
 }

--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -34,14 +34,15 @@ apply plugin: 'opensearch.testclusters'
 
 def numNodes = findProperty('numNodes') as Integer ?: 1
 def numZones = findProperty('numZones') as Integer ?: 1
+def requestedPlugins = findProperty('installedPlugins') ? Eval.me(findProperty('installedPlugins').toString()) : []
 
 testClusters {
   runTask {
     testDistribution = 'archive'
     if (numZones > 1) numberOfZones = numZones
     if (numNodes > 1) numberOfNodes = numNodes
-    if (findProperty("installedPlugins")) {
-      installedPlugins = Eval.me(installedPlugins)
+    if (requestedPlugins.isEmpty() == false) {
+      installedPlugins = requestedPlugins
 
       def resolveMavenPlugin = { coords ->
         // Add default groupId if not fully qualified (less than 2 colons)
@@ -57,7 +58,7 @@ testClusters {
         plugin(project.layout.file(project.provider { config.singleFile }))
       }
 
-      for (String p : installedPlugins) {
+      for (String p : requestedPlugins) {
         // check if its a local plugin first
         if (project.findProject(':plugins:' + p) != null) {
           plugin(':plugins:' + p)
@@ -109,6 +110,10 @@ tasks.register("run", RunTask) {
   useCluster testClusters.runTask;
   description = 'Runs opensearch in the foreground'
   group = 'Verification'
+
+  if (requestedPlugins.any { it == 'analytics-backend-datafusion' || it == 'parquet-data-format' }) {
+    dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
+  }
 
   impliesSubProjects = true
 }

--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -90,15 +90,14 @@ testClusters {
           systemProperty 'io.netty.tryUnsafe', 'true'
           systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
         }
-        if (p.equals("parquet-data-format") || p.equals("analytics-backend-datafusion")) {
-          // Composite engine / DataFusion requires pluggable dataformat feature flag
-          systemProperty 'opensearch.experimental.feature.pluggable.dataformat.enabled', 'true'
-          // Native lib path for DataFusion FFM bridge
-          def nativeLibDir = new File(project(':sandbox:libs:dataformat-native').projectDir, 'rust/target/release').absolutePath
-          systemProperty 'java.library.path', nativeLibDir
-          jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
-          jvmArgs '--enable-native-access=ALL-UNNAMED'
-        }
+      }
+      if (installedPlugins.contains("parquet-data-format") || installedPlugins.contains("analytics-backend-datafusion")) {
+        // Composite engine / DataFusion requires pluggable dataformat feature flag
+        systemProperty 'opensearch.experimental.feature.pluggable.dataformat.enabled', 'true'
+        // Native lib path for DataFusion FFM bridge
+        systemProperty 'java.library.path', { project(':sandbox:libs:dataformat-native').ext.nativeLibPath.parent }
+        jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+        jvmArgs '--enable-native-access=ALL-UNNAMED'
       }
     }
   }

--- a/sandbox/plugins/analytics-backend-datafusion/build.gradle
+++ b/sandbox/plugins/analytics-backend-datafusion/build.gradle
@@ -108,6 +108,10 @@ dependencies {
 
 }
 
+tasks.named('bundlePlugin').configure {
+  dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
+}
+
 test {
   jvmArgs += ["--add-opens", "java.base/java.nio=ALL-UNNAMED"]
   jvmArgs += ["--enable-native-access=ALL-UNNAMED"]

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -53,6 +53,10 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
 }
 
+tasks.named('bundlePlugin').configure {
+  dependsOn ':sandbox:libs:dataformat-native:buildRustLibrary'
+}
+
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /netty-.*/, to: 'netty'


### PR DESCRIPTION
### Description
Ensures `./gradlew run` rebuilds the shared native Rust library when `analytics-backend-datafusion` or `parquet-data-format` is installed.

Each native plugin now makes its `bundlePlugin` task depend on `:sandbox:libs:dataformat-native:buildRustLibrary`. When `run` installs either plugin, the dependency is included transitively. Gradle skips the Rust build when the native artifact is already up to date. The existing `nativeLibOverride` / `OPENSEARCH_NATIVE_LIB` behavior remains unchanged.

The native runtime settings are applied once, and `java.library.path` is resolved lazily from the shared `nativeLibPath`, so `run` follows the selected debug/release build and native-library override directory.

### Testing
- Verified each plugin's `bundlePlugin` dry-run graph includes `buildRustLibrary`.
- Verified runs with either native plugin include `buildRustLibrary` transitively.
- Verified a plain `run --dry-run` does not include `buildRustLibrary`.
- Verified `nativeLibOverride` skips the Cargo task.
- Targeted precommit reached sandbox compilation but could not complete locally because these modules require JDK 25; the available local JDK is 21.

- Verified actual Gradle run configuration for each native plugin with `-PrustDebug`, both plugins together in release mode, both plugins with a debug-mode override directory, the environment override directory, and no installed plugins. These are configuration checks, not an end-to-end OpenSearch run.
- A full `precommit` attempt also failed at `:benchmarks:jarHell` with `zip END header not found`; it was run concurrently with the targeted check, so this is not a clean full-build result.

### Related Issues
Resolves #22917

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request is not applicable.
- [x] Public documentation issue/PR is not applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.