### PR TITLE
propagate min competitive score for field collapse

### DIFF
--- a/benchmarks/src/main/java/org/opensearch/benchmark/search/collapse/CollapsingTopDocsCollectorBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/search/collapse/CollapsingTopDocsCollectorBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.benchmark.search.collapse;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.grouping.CollapsingTopDocsCollector;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Microbenchmark for score-sorted field collapse. Compare {@code totalHitsThreshold=0}
+ * (min competitive score enabled once the group heap is full) against
+ * {@code Integer.MAX_VALUE} (always exhaustive, the previous collector behavior).
+ *
+ * <pre>
+ * gradlew -p benchmarks run --args ' CollapsingTopDocsCollectorBenchmark'
+ * </pre>
+ */
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class CollapsingTopDocsCollectorBenchmark {
+
+    @Param({ "100000" })
+    public int numDocs;
+
+    @Param({ "100" })
+    public int numGroups;
+
+    @Param({ "10" })
+    public int topN;
+
+    /**
+     * 0 enables min-competitive-score pruning as soon as the group heap is full.
+     * {@link Integer#MAX_VALUE} forces an accurate hit count and disables pruning.
+     */
+    @Param({ "0", "2147483647" })
+    public int totalHitsThreshold;
+
+    private Directory directory;
+    private DirectoryReader reader;
+    private IndexSearcher searcher;
+    private Query query;
+    private MappedFieldType fieldType;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        directory = new ByteBuffersDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig();
+        try (IndexWriter writer = new IndexWriter(directory, iwc)) {
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new NumericDocValuesField("group", i % numGroups));
+                int tf = (i % 32) + 1;
+                for (int j = 0; j < tf; j++) {
+                    doc.add(new TextField("text", "term", Field.Store.NO));
+                }
+                writer.addDocument(doc);
+            }
+            writer.commit();
+        }
+        reader = DirectoryReader.open(directory);
+        searcher = new IndexSearcher(reader);
+        query = new TermQuery(new Term("text", "term"));
+        fieldType = new NumberFieldMapper.NumberFieldType("group", NumberFieldMapper.NumberType.LONG);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws IOException {
+        reader.close();
+        directory.close();
+    }
+
+    @Benchmark
+    public void collapseByScore(Blackhole bh) throws IOException {
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric(
+            "group",
+            fieldType,
+            Sort.RELEVANCE,
+            topN,
+            totalHitsThreshold
+        );
+        searcher.search(query, collector);
+        bh.consume(collector.getTopDocs());
+    }
+}

--- a/server/src/main/java/org/apache/lucene/search/grouping/CollapsingTopDocsCollector.java
+++ b/server/src/main/java/org/apache/lucene/search/grouping/CollapsingTopDocsCollector.java
@@ -45,8 +45,11 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import static org.apache.lucene.search.SortField.Type.SCORE;
 
@@ -55,8 +58,9 @@ import static org.apache.lucene.search.SortField.Type.SCORE;
  * output. The collapsing is done in a single pass by selecting only the top sorted document per collapse key.
  * The value used for the collapse key of each group can be found in {@link CollapseTopFieldDocs#collapseValues}.
  * <p>
- * TODO: If the sort is based on score we should propagate the mininum competitive score when <code>orderedGroups</code> is full.
- * This is safe for collapsing since the group <code>sort</code> is the same as the query sort.
+ * When the sort is descending relevance, the collector propagates the minimum competitive score once
+ * {@code orderedGroups} is full and the total-hits threshold is exceeded. This is safe for collapsing
+ * since the group {@code sort} is the same as the query sort.
  */
 public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollector<T> {
     protected final String collapseField;
@@ -70,19 +74,39 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
     private LeafFieldComparator leafComparator;
     private final int reverseMul;
 
+    private final boolean canSetMinScore;
+    private final int totalHitsThreshold;
+    private final Map<T, Float> groupBestScores;
+    private final float[] groupScores;
+    private float minCompetitiveScore;
+    private TotalHits.Relation totalHitsRelation;
+    private int docBase;
+
     CollapsingTopDocsCollector(GroupSelector<T> groupSelector, String collapseField, Sort sort, int topN) {
-        super(groupSelector, sort, topN);
-        this.collapseField = collapseField;
-        this.sort = sort;
-        this.after = null;
-        this.reverseMul = 1;
+        this(groupSelector, collapseField, sort, topN, null, Integer.MAX_VALUE);
+    }
+
+    CollapsingTopDocsCollector(GroupSelector<T> groupSelector, String collapseField, Sort sort, int topN, int totalHitsThreshold) {
+        this(groupSelector, collapseField, sort, topN, null, totalHitsThreshold);
     }
 
     CollapsingTopDocsCollector(GroupSelector<T> groupSelector, String collapseField, Sort sort, int topN, FieldDoc after) {
+        this(groupSelector, collapseField, sort, topN, after, Integer.MAX_VALUE);
+    }
+
+    CollapsingTopDocsCollector(
+        GroupSelector<T> groupSelector,
+        String collapseField,
+        Sort sort,
+        int topN,
+        FieldDoc after,
+        int totalHitsThreshold
+    ) {
         super(groupSelector, sort, topN);
         this.collapseField = collapseField;
         this.sort = sort;
         this.after = after;
+        this.totalHitsThreshold = Math.max(0, totalHitsThreshold);
 
         if (after != null) {
             // we should have only one sort field which is the collapse field
@@ -100,6 +124,17 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         } else {
             reverseMul = 1;
         }
+
+        // Match Lucene TopFieldCollector: min-score pruning is only enabled for descending
+        // relevance when the hit count is allowed to be a lower bound.
+        this.canSetMinScore = canSetMinScore(sort) && this.totalHitsThreshold != Integer.MAX_VALUE;
+        this.groupBestScores = this.canSetMinScore ? new HashMap<>() : null;
+        this.groupScores = this.canSetMinScore ? new float[topN + 1] : null;
+        if (this.groupScores != null) {
+            Arrays.fill(this.groupScores, Float.NaN);
+        }
+        this.minCompetitiveScore = 0f;
+        this.totalHitsRelation = TotalHits.Relation.EQUAL_TO;
     }
 
     /**
@@ -112,7 +147,7 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         if (groups == null) {
             // For search_after, use totalHitCount to preserve hit information
             // For non-search_after, totalHitCount equals 0 when no matches, so behavior unchanged
-            TotalHits totalHits = new TotalHits(totalHitCount, TotalHits.Relation.EQUAL_TO);
+            TotalHits totalHits = new TotalHits(totalHitCount, totalHitsRelation);
             return new CollapseTopFieldDocs(collapseField, totalHits, new ScoreDoc[0], sort.getSort(), new Object[0]);
         }
         FieldDoc[] docs = new FieldDoc[groups.size()];
@@ -138,23 +173,28 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
             collapseValues[pos] = group.groupValue;
             pos++;
         }
-        TotalHits totalHits = new TotalHits(totalHitCount, TotalHits.Relation.EQUAL_TO);
+        TotalHits totalHits = new TotalHits(totalHitCount, totalHitsRelation);
         return new CollapseTopFieldDocs(collapseField, totalHits, docs, sort.getSort(), collapseValues);
     }
 
     @Override
     public ScoreMode scoreMode() {
+        if (canSetMinScore) {
+            return ScoreMode.TOP_SCORES;
+        }
         if (super.scoreMode().needsScores()) {
             return ScoreMode.COMPLETE;
-        } else {
-            return ScoreMode.COMPLETE_NO_SCORES;
         }
+        return ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
         super.setScorer(scorer);
         this.scorer = scorer;
+        this.minCompetitiveScore = 0f;
+        // Re-apply the threshold for this leaf, matching Lucene's TopFieldCollector.
+        maybeUpdateMinCompetitiveScore();
     }
 
     @Override
@@ -164,8 +204,76 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
             return;
         }
 
+        final boolean heapWasEmpty = orderedGroups == null;
         super.collect(doc);
         totalHitCount++;
+
+        if (canSetMinScore == false) {
+            return;
+        }
+
+        if (heapWasEmpty) {
+            recordGroupBestScore();
+            if (orderedGroups != null) {
+                seedGroupScores();
+                maybeUpdateMinCompetitiveScore();
+            }
+        } else if (updateGroupScore(doc)) {
+            maybeUpdateMinCompetitiveScore();
+        }
+    }
+
+    private void recordGroupBestScore() throws IOException {
+        final T groupValue = getGroupSelector().copyValue();
+        final float score = scorer.score();
+        final Float current = groupBestScores.get(groupValue);
+        if (current == null || score > current) {
+            groupBestScores.put(groupValue, score);
+        }
+    }
+
+    private void seedGroupScores() {
+        for (CollectedSearchGroup<T> group : orderedGroups) {
+            final Float score = groupBestScores.get(group.groupValue);
+            if (score != null) {
+                groupScores[group.comparatorSlot] = score;
+            }
+        }
+        groupBestScores.clear();
+    }
+
+    private boolean updateGroupScore(int doc) throws IOException {
+        final int globalDoc = docBase + doc;
+        for (CollectedSearchGroup<T> group : orderedGroups) {
+            if (group.topDoc == globalDoc) {
+                groupScores[group.comparatorSlot] = scorer.score();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void maybeUpdateMinCompetitiveScore() throws IOException {
+        if (canSetMinScore && orderedGroups != null && totalHitCount > totalHitsThreshold) {
+            updateMinCompetitiveScore();
+        }
+    }
+
+    private void updateMinCompetitiveScore() throws IOException {
+        final CollectedSearchGroup<T> bottomGroup = orderedGroups.last();
+        final float minScore = groupScores[bottomGroup.comparatorSlot];
+        // Skip if the bottom group's score has not been observed yet: a stale or missing value
+        // could be higher than the true bottom and would prune competitive hits.
+        if (Float.isNaN(minScore) == false && minScore > minCompetitiveScore) {
+            scorer.setMinCompetitiveScore(minScore);
+            minCompetitiveScore = minScore;
+            totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
+        }
+    }
+
+    private static boolean canSetMinScore(Sort sort) {
+        final SortField[] fields = sort.getSort();
+        return fields.length > 0 && fields[0].getType() == SCORE && fields[0].getReverse() == false;
     }
 
     private boolean isAfterDoc(int doc) throws IOException {
@@ -182,6 +290,7 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
     @Override
     protected void doSetNextReader(LeafReaderContext readerContext) throws IOException {
         super.doSetNextReader(readerContext);
+        this.docBase = readerContext.docBase;
         if (after != null) {
             leafComparator = afterComparator.getLeafComparator(readerContext);
         }
@@ -207,7 +316,39 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         Sort sort,
         int topN
     ) {
-        return new CollapsingTopDocsCollector<>(new CollapsingDocValuesSource.Numeric(collapseFieldType), collapseField, sort, topN);
+        return createNumeric(collapseField, collapseFieldType, sort, topN, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a collapsing top docs collector on a {@link org.apache.lucene.index.NumericDocValues} field.
+     * It accepts also {@link org.apache.lucene.index.SortedNumericDocValues} field but
+     * the collect will fail with an {@link IllegalStateException} if a document contains more than one value for the
+     * field.
+     *
+     * @param collapseField      The sort field used to group documents.
+     * @param collapseFieldType  The {@link MappedFieldType} for this sort field.
+     * @param sort               The {@link Sort} used to sort the collapsed hits.
+     *                           The collapsing keeps only the top sorted document per collapsed key.
+     *                           This must be non-null, ie, if you want to groupSort by relevance
+     *                           use Sort.RELEVANCE.
+     * @param topN               How many top groups to keep.
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     */
+    public static CollapsingTopDocsCollector<?> createNumeric(
+        String collapseField,
+        MappedFieldType collapseFieldType,
+        Sort sort,
+        int topN,
+        int totalHitsThreshold
+    ) {
+        return new CollapsingTopDocsCollector<>(
+            new CollapsingDocValuesSource.Numeric(collapseFieldType),
+            collapseField,
+            sort,
+            topN,
+            totalHitsThreshold
+        );
     }
 
     /**
@@ -232,7 +373,42 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         int topN,
         FieldDoc after
     ) {
-        return new CollapsingTopDocsCollector<>(new CollapsingDocValuesSource.Numeric(collapseFieldType), collapseField, sort, topN, after);
+        return createNumeric(collapseField, collapseFieldType, sort, topN, after, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a collapsing top docs collector on a {@link org.apache.lucene.index.NumericDocValues} field.
+     * It accepts also {@link org.apache.lucene.index.SortedNumericDocValues} field but
+     * the collect will fail with an {@link IllegalStateException} if a document contains more than one value for the
+     * field.
+     *
+     * @param collapseField      The sort field used to group documents.
+     * @param collapseFieldType  The {@link MappedFieldType} for this sort field.
+     * @param sort               The {@link Sort} used to sort the collapsed hits.
+     *                           The collapsing keeps only the top sorted document per collapsed key.
+     *                           This must be non-null, ie, if you want to groupSort by relevance
+     *                           use Sort.RELEVANCE.
+     * @param topN               How many top groups to keep.
+     * @param after              The last sort value of the previous page. Pass null if this is the first page.
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     */
+    public static CollapsingTopDocsCollector<?> createNumeric(
+        String collapseField,
+        MappedFieldType collapseFieldType,
+        Sort sort,
+        int topN,
+        FieldDoc after,
+        int totalHitsThreshold
+    ) {
+        return new CollapsingTopDocsCollector<>(
+            new CollapsingDocValuesSource.Numeric(collapseFieldType),
+            collapseField,
+            sort,
+            topN,
+            after,
+            totalHitsThreshold
+        );
     }
 
     /**
@@ -254,7 +430,38 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         Sort sort,
         int topN
     ) {
-        return new CollapsingTopDocsCollector<>(new CollapsingDocValuesSource.Keyword(collapseFieldType), collapseField, sort, topN);
+        return createKeyword(collapseField, collapseFieldType, sort, topN, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a collapsing top docs collector on a {@link org.apache.lucene.index.SortedDocValues} field.
+     * It accepts also {@link org.apache.lucene.index.SortedSetDocValues} field but
+     * the collect will fail with an {@link IllegalStateException} if a document contains more than one value for the
+     * field.
+     *
+     * @param collapseField      The sort field used to group documents.
+     * @param collapseFieldType  The {@link MappedFieldType} for this sort field.
+     * @param sort               The {@link Sort} used to sort the collapsed hits. The collapsing keeps only the top sorted
+     *                           document per collapsed key.
+     *                           This must be non-null, ie, if you want to groupSort by relevance use Sort.RELEVANCE.
+     * @param topN               How many top groups to keep.
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     */
+    public static CollapsingTopDocsCollector<?> createKeyword(
+        String collapseField,
+        MappedFieldType collapseFieldType,
+        Sort sort,
+        int topN,
+        int totalHitsThreshold
+    ) {
+        return new CollapsingTopDocsCollector<>(
+            new CollapsingDocValuesSource.Keyword(collapseFieldType),
+            collapseField,
+            sort,
+            topN,
+            totalHitsThreshold
+        );
     }
 
     /**
@@ -278,6 +485,40 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
         int topN,
         FieldDoc after
     ) {
-        return new CollapsingTopDocsCollector<>(new CollapsingDocValuesSource.Keyword(collapseFieldType), collapseField, sort, topN, after);
+        return createKeyword(collapseField, collapseFieldType, sort, topN, after, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a collapsing top docs collector on a {@link org.apache.lucene.index.SortedDocValues} field.
+     * It accepts also {@link org.apache.lucene.index.SortedSetDocValues} field but
+     * the collect will fail with an {@link IllegalStateException} if a document contains more than one value for the
+     * field.
+     *
+     * @param collapseField      The sort field used to group documents.
+     * @param collapseFieldType  The {@link MappedFieldType} for this sort field.
+     * @param sort               The {@link Sort} used to sort the collapsed hits. The collapsing keeps only the top sorted
+     *                           document per collapsed key.
+     *                           This must be non-null, ie, if you want to groupSort by relevance use Sort.RELEVANCE.
+     * @param topN               How many top groups to keep.
+     * @param after              The last sort value of the previous page. Pass null if this is the first page.
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     */
+    public static CollapsingTopDocsCollector<?> createKeyword(
+        String collapseField,
+        MappedFieldType collapseFieldType,
+        Sort sort,
+        int topN,
+        FieldDoc after,
+        int totalHitsThreshold
+    ) {
+        return new CollapsingTopDocsCollector<>(
+            new CollapsingDocValuesSource.Keyword(collapseFieldType),
+            collapseField,
+            sort,
+            topN,
+            after,
+            totalHitsThreshold
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/search/collapse/CollapseContext.java
+++ b/server/src/main/java/org/opensearch/search/collapse/CollapseContext.java
@@ -85,10 +85,24 @@ public class CollapseContext {
      * @throws IllegalStateException if field type is not keyword or numeric
      */
     public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN) {
+        return createTopDocs(sort, topN, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a CollapsingTopDocsCollector for field collapsing without search_after support.
+     *
+     * @param sort               The sort order for collapsed groups
+     * @param topN               Maximum number of collapsed groups to collect
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     * @return CollapsingTopDocsCollector instance based on field type
+     * @throws IllegalStateException if field type is not keyword or numeric
+     */
+    public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN, int totalHitsThreshold) {
         if (fieldType != null && fieldType.unwrap() instanceof KeywordFieldMapper.KeywordFieldType) {
-            return CollapsingTopDocsCollector.createKeyword(fieldName, fieldType, sort, topN);
+            return CollapsingTopDocsCollector.createKeyword(fieldName, fieldType, sort, topN, totalHitsThreshold);
         } else if (fieldType != null && fieldType.unwrap() instanceof NumberFieldMapper.NumberFieldType) {
-            return CollapsingTopDocsCollector.createNumeric(fieldName, fieldType, sort, topN);
+            return CollapsingTopDocsCollector.createNumeric(fieldName, fieldType, sort, topN, totalHitsThreshold);
         } else {
             throw new IllegalStateException("unknown type for collapse field " + fieldName + ", only keywords and numbers are accepted");
         }
@@ -104,10 +118,25 @@ public class CollapseContext {
      * @throws IllegalStateException if field type is not keyword or numeric
      */
     public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN, FieldDoc searchAfter) {
+        return createTopDocs(sort, topN, searchAfter, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a CollapsingTopDocsCollector for field collapsing with search_after support.
+     *
+     * @param sort               The sort order for collapsed groups (must match collapse field for search_after)
+     * @param topN               Maximum number of collapsed groups to collect
+     * @param searchAfter        The last sort value from previous page for pagination
+     * @param totalHitsThreshold The total hit count up to which an accurate count is required.
+     *                           Once exceeded the collector may set a minimum competitive score.
+     * @return CollapsingTopDocsCollector instance based on field type
+     * @throws IllegalStateException if field type is not keyword or numeric
+     */
+    public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN, FieldDoc searchAfter, int totalHitsThreshold) {
         if (fieldType != null && fieldType.unwrap() instanceof KeywordFieldMapper.KeywordFieldType) {
-            return CollapsingTopDocsCollector.createKeyword(fieldName, fieldType, sort, topN, searchAfter);
+            return CollapsingTopDocsCollector.createKeyword(fieldName, fieldType, sort, topN, searchAfter, totalHitsThreshold);
         } else if (fieldType != null && fieldType.unwrap() instanceof NumberFieldMapper.NumberFieldType) {
-            return CollapsingTopDocsCollector.createNumeric(fieldName, fieldType, sort, topN, searchAfter);
+            return CollapsingTopDocsCollector.createNumeric(fieldName, fieldType, sort, topN, searchAfter, totalHitsThreshold);
         } else {
             throw new IllegalStateException(
                 "unsupported type for collapse field " + fieldName + ", only keywords and numbers are accepted"

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -236,6 +236,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
         private final Sort sort;
         private final boolean sortByScore;
         private final FieldDoc searchAfter;
+        private final int totalHitsThreshold;
 
         /**
          * Ctr
@@ -250,7 +251,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             int numHits,
             boolean trackMaxScore
         ) {
-            this(collapseContext, sortAndFormats, numHits, trackMaxScore, null);
+            this(collapseContext, sortAndFormats, numHits, trackMaxScore, null, SearchContext.TRACK_TOTAL_HITS_ACCURATE);
         }
 
         /**
@@ -260,13 +261,15 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
          * @param numHits The number of collapsed top hits to retrieve.
          * @param trackMaxScore True if max score should be tracked
          * @param searchAfter The search after value
+         * @param trackTotalHitsUpTo The total hit count up to which an accurate count is required
          */
         private CollapsingTopDocsCollectorContext(
             CollapseContext collapseContext,
             @Nullable SortAndFormats sortAndFormats,
             int numHits,
             boolean trackMaxScore,
-            FieldDoc searchAfter
+            FieldDoc searchAfter,
+            int trackTotalHitsUpTo
         ) {
             super(REASON_SEARCH_TOP_HITS, numHits);
             assert numHits > 0;
@@ -275,7 +278,8 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             this.sortFmt = sortAndFormats == null ? new DocValueFormat[] { DocValueFormat.RAW } : sortAndFormats.formats;
             this.collapseContext = collapseContext;
             this.searchAfter = searchAfter;
-            this.topDocsCollector = collapseContext.createTopDocs(sort, numHits, searchAfter);
+            this.totalHitsThreshold = trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED ? 0 : trackTotalHitsUpTo;
+            this.topDocsCollector = collapseContext.createTopDocs(sort, numHits, searchAfter, totalHitsThreshold);
             this.trackMaxScore = trackMaxScore;
             this.sortByScore = sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0]);
 
@@ -323,7 +327,10 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                         maxScoreCollector = new MaxScoreCollector();
                     }
 
-                    return MultiCollector.wrap(collapseContext.createTopDocs(sort, numHits, searchAfter), maxScoreCollector);
+                    return MultiCollector.wrap(
+                        collapseContext.createTopDocs(sort, numHits, searchAfter, totalHitsThreshold),
+                        maxScoreCollector
+                    );
                 }
 
                 @Override
@@ -862,7 +869,8 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                 searchContext.sort(),
                 numDocs,
                 searchContext.trackScores(),
-                searchContext.searchAfter()
+                searchContext.searchAfter(),
+                searchContext.trackTotalHitsUpTo()
             );
         } else {
             int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);

--- a/server/src/test/java/org/opensearch/lucene/grouping/CollapsingTopDocsCollectorTests.java
+++ b/server/src/test/java/org/opensearch/lucene/grouping/CollapsingTopDocsCollectorTests.java
@@ -32,25 +32,31 @@
 package org.opensearch.lucene.grouping;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.CompositeReaderContext;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.search.TopFieldCollectorManager;
 import org.apache.lucene.search.TopFieldDocs;
@@ -633,6 +639,279 @@ public class CollapsingTopDocsCollectorTests extends OpenSearchTestCase {
         w.close();
         reader.close();
         dir.close();
+    }
+
+    public void testScoreModeForRelevanceSort() {
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        // Accurate hit counts keep COMPLETE so Lucene uses the exhaustive bulk scorer.
+        CollapsingTopDocsCollector<?> accurate = CollapsingTopDocsCollector.createNumeric("group", fieldType, Sort.RELEVANCE, 10);
+        assertEquals(ScoreMode.COMPLETE, accurate.scoreMode());
+        CollapsingTopDocsCollector<?> pruning = CollapsingTopDocsCollector.createNumeric("group", fieldType, Sort.RELEVANCE, 10, 0);
+        assertEquals(ScoreMode.TOP_SCORES, pruning.scoreMode());
+    }
+
+    public void testScoreModeForNonRelevanceSort() {
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        Sort sort = new Sort(new SortField("group", SortField.Type.LONG));
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric("group", fieldType, sort, 10);
+        assertEquals(ScoreMode.COMPLETE_NO_SCORES, collector.scoreMode());
+    }
+
+    public void testScoreModeForAscendingScoreSort() {
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        Sort sort = new Sort(new SortField(null, SortField.Type.SCORE, true));
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric("group", fieldType, sort, 10);
+        // Ascending score sort cannot use min competitive score because lower scores are more competitive.
+        assertEquals(ScoreMode.COMPLETE, collector.scoreMode());
+    }
+
+    public void testMinCompetitiveScoreIsPropagatedAfterHeapFills() throws IOException {
+        final int numDocs = 200;
+        final int numGroups = 50;
+        final int topN = 10;
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("group", i % numGroups));
+            w.addDocument(doc);
+        }
+
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric("group", fieldType, Sort.RELEVANCE, topN, 0);
+        MinScoreTrackingCollector wrapper = new MinScoreTrackingCollector(collector);
+
+        searcher.search(new MatchAllDocsQuery(), wrapper);
+        CollapseTopFieldDocs topDocs = collector.getTopDocs();
+
+        assertEquals(topN, topDocs.scoreDocs.length);
+        assertTrue("min competitive score should be propagated after the group heap fills", wrapper.minCompetitiveScoreSet);
+        assertTrue("min competitive score should be > 0", wrapper.minCompetitiveScore > 0f);
+        assertTrue("min competitive score should be set after at least topN groups are collected", wrapper.firstSetAtCollect >= topN);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation());
+
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinCompetitiveScoreNotPropagatedWhenHeapNotFull() throws IOException {
+        final int numDocs = 50;
+        final int numGroups = 10;
+        final int topN = 100;
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("group", i % numGroups));
+            w.addDocument(doc);
+        }
+
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric("group", fieldType, Sort.RELEVANCE, topN, 0);
+        MinScoreTrackingCollector wrapper = new MinScoreTrackingCollector(collector);
+
+        searcher.search(new MatchAllDocsQuery(), wrapper);
+        CollapseTopFieldDocs topDocs = collector.getTopDocs();
+
+        assertEquals(numGroups, topDocs.scoreDocs.length);
+        assertFalse("min competitive score must not be set before the group heap is full", wrapper.minCompetitiveScoreSet);
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation());
+        assertEquals(numDocs, topDocs.totalHits.value());
+
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinCompetitiveScoreNotPropagatedWhenAccurate() throws IOException {
+        final int numDocs = 100;
+        final int maxGroup = 10;
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("group", i % maxGroup));
+            w.addDocument(doc);
+        }
+
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric(
+            "group",
+            fieldType,
+            Sort.RELEVANCE,
+            maxGroup,
+            Integer.MAX_VALUE
+        );
+        MinScoreTrackingCollector wrapper = new MinScoreTrackingCollector(collector);
+
+        searcher.search(new MatchAllDocsQuery(), wrapper);
+        CollapseTopFieldDocs topDocs = collector.getTopDocs();
+
+        assertEquals(maxGroup, topDocs.scoreDocs.length);
+        assertFalse("min competitive score should not be propagated when total hits must be accurate", wrapper.minCompetitiveScoreSet);
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation());
+        assertEquals(numDocs, topDocs.totalHits.value());
+
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinCompetitiveScoreMatchesUnoptimizedPath() throws IOException {
+        final int numDocs = 200;
+        final int numGroups = 40;
+        final int topN = 10;
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("group", i % numGroups));
+            for (int j = 0; j < (i % 20) + 1; j++) {
+                doc.add(new TextField("text", "term", Field.Store.NO));
+            }
+            w.addDocument(doc);
+        }
+
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        Query query = new TermQuery(new Term("text", "term"));
+
+        CollapsingTopDocsCollector<?> baselineCollector = CollapsingTopDocsCollector.createNumeric(
+            "group",
+            fieldType,
+            Sort.RELEVANCE,
+            topN,
+            Integer.MAX_VALUE
+        );
+        searcher.search(query, baselineCollector);
+        CollapseTopFieldDocs baselineTopDocs = baselineCollector.getTopDocs();
+
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createNumeric("group", fieldType, Sort.RELEVANCE, topN, 0);
+        MinScoreTrackingCollector wrapper = new MinScoreTrackingCollector(collector);
+        searcher.search(query, wrapper);
+        CollapseTopFieldDocs topDocs = collector.getTopDocs();
+
+        assertTrue("min competitive score should be propagated", wrapper.minCompetitiveScoreSet);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation());
+        assertEquals(baselineTopDocs.scoreDocs.length, topDocs.scoreDocs.length);
+        assertTopDocsEquals(query, baselineTopDocs, topDocs);
+
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinCompetitiveScoreMatchesUnoptimizedPathKeyword() throws IOException {
+        final int numDocs = 200;
+        final int numGroups = 40;
+        final int topN = 10;
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField("group", new BytesRef("g" + (i % numGroups))));
+            for (int j = 0; j < (i % 20) + 1; j++) {
+                doc.add(new TextField("text", "term", Field.Store.NO));
+            }
+            w.addDocument(doc);
+        }
+
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+        MappedFieldType fieldType = new MockFieldMapper.FakeFieldType("group");
+        Query query = new TermQuery(new Term("text", "term"));
+
+        CollapsingTopDocsCollector<?> baselineCollector = CollapsingTopDocsCollector.createKeyword(
+            "group",
+            fieldType,
+            Sort.RELEVANCE,
+            topN,
+            Integer.MAX_VALUE
+        );
+        searcher.search(query, baselineCollector);
+        CollapseTopFieldDocs baselineTopDocs = baselineCollector.getTopDocs();
+
+        CollapsingTopDocsCollector<?> collector = CollapsingTopDocsCollector.createKeyword("group", fieldType, Sort.RELEVANCE, topN, 0);
+        MinScoreTrackingCollector wrapper = new MinScoreTrackingCollector(collector);
+        searcher.search(query, wrapper);
+        CollapseTopFieldDocs topDocs = collector.getTopDocs();
+
+        assertTrue("min competitive score should be propagated", wrapper.minCompetitiveScoreSet);
+        assertEquals(baselineTopDocs.scoreDocs.length, topDocs.scoreDocs.length);
+        assertTopDocsEquals(query, baselineTopDocs, topDocs);
+
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+    /**
+     * Wraps a collapsing collector so tests can observe {@link Scorable#setMinCompetitiveScore(float)}
+     * after the group heap fills.
+     */
+    private static class MinScoreTrackingCollector implements Collector {
+        private final CollapsingTopDocsCollector<?> inner;
+        private boolean minCompetitiveScoreSet;
+        private float minCompetitiveScore;
+        private int collectCount;
+        private int firstSetAtCollect = -1;
+
+        MinScoreTrackingCollector(CollapsingTopDocsCollector<?> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public ScoreMode scoreMode() {
+            return inner.scoreMode();
+        }
+
+        @Override
+        public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+            LeafCollector innerLeaf = inner.getLeafCollector(context);
+            return new LeafCollector() {
+                @Override
+                public void setScorer(Scorable scorer) throws IOException {
+                    innerLeaf.setScorer(new Scorable() {
+                        @Override
+                        public float score() throws IOException {
+                            return scorer.score();
+                        }
+
+                        @Override
+                        public void setMinCompetitiveScore(float minScore) throws IOException {
+                            minCompetitiveScoreSet = true;
+                            minCompetitiveScore = minScore;
+                            if (firstSetAtCollect < 0) {
+                                firstSetAtCollect = collectCount;
+                            }
+                            scorer.setMinCompetitiveScore(minScore);
+                        }
+                    });
+                }
+
+                @Override
+                public void collect(int doc) throws IOException {
+                    collectCount++;
+                    innerLeaf.collect(doc);
+                }
+            };
+        }
     }
 
     // Helper classes for test data


### PR DESCRIPTION
when collapse is sorted by `_score`, we currently collect every matching hit. `scoreMode()` is always `COMPLETE`, so Lucene never gets a chance to skip low-scoring docs.

that's the in-tree TODO on `CollapsingTopDocsCollector`, and it matches what #18861 asked for on the collector side. #19181 already stopped wrapping this collector in `MaxScoreCollector` for score sort, which was the blocker, `MultiCollector` would have swallowed `setMinCompetitiveScore`.

this change only kicks in for descending relevance sort, and only after the group heap is full. we also honor `track_total_hits`, so accurate counts stay accurate. keyword global-ordinals and field-sort pruning are left for a follow-up.

resolves the score-sort half of #18861 (and the leftover part of #19180).