### PR TITLE
Decouple shard snapshots from Lucene IndexCommit

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoryFilterUserMetadataIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoryFilterUserMetadataIT.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.snapshots;
 
-import org.apache.lucene.index.IndexCommit;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -42,6 +41,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.store.Store;
@@ -142,7 +142,7 @@ public class RepositoryFilterUserMetadataIT extends OpenSearchIntegTestCase {
                         MapperService mapperService,
                         SnapshotId snapshotId,
                         IndexId indexId,
-                        IndexCommit snapshotIndexCommit,
+                        CatalogSnapshot catalogSnapshot,
                         String shardStateIdentifier,
                         IndexShardSnapshotStatus snapshotStatus,
                         Version repositoryMetaVersion,
@@ -156,7 +156,7 @@ public class RepositoryFilterUserMetadataIT extends OpenSearchIntegTestCase {
                             mapperService,
                             snapshotId,
                             indexId,
-                            snapshotIndexCommit,
+                            catalogSnapshot,
                             shardStateIdentifier,
                             snapshotStatus,
                             repositoryMetaVersion,

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1948,6 +1948,39 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Creates a new {@link CatalogSnapshot} pinned to the most recent commit of the currently running indexer.
+     * All files referenced by this snapshot won't be freed until the returned handle is closed.
+     * <p>
+     * This is the format-neutral replacement for {@link #acquireLastIndexCommit(boolean)}: it goes through the
+     * {@link Indexer} contract rather than {@link #applyOnEngine}, so it works for multi-format
+     * (catalog-based) indexers as well as Lucene-backed ones.
+     *
+     * @param flushFirst {@code true} if the shard should be flushed before the snapshot is taken
+     */
+    @ExperimentalApi
+    public GatedCloseable<CatalogSnapshot> acquireLastCommittedSnapshot(boolean flushFirst) throws EngineException, IOException {
+        final IndexShardState state = this.state; // one time volatile read
+        // we allow snapshot on closed index shard, since we want to do one after we close the shard and before we close the engine
+        if (state == IndexShardState.STARTED || state == IndexShardState.CLOSED) {
+            return getIndexer().acquireLastCommittedSnapshot(flushFirst);
+        } else {
+            throw new IllegalIndexShardStateException(shardId, state, "snapshot is not allowed");
+        }
+    }
+
+    /**
+     * Same as {@link #acquireLastCommittedSnapshot(boolean)} but additionally triggers a refresh so that the
+     * remote store upload of the pinned commit is kicked off. Format-neutral replacement for
+     * {@link #acquireLastIndexCommitAndRefresh(boolean)}.
+     */
+    @ExperimentalApi
+    public GatedCloseable<CatalogSnapshot> acquireLastCommittedSnapshotAndRefresh(boolean flushFirst) throws EngineException, IOException {
+        GatedCloseable<CatalogSnapshot> catalogSnapshot = acquireLastCommittedSnapshot(flushFirst);
+        getIndexer().refresh("Snapshot for Remote Store based Shard");
+        return catalogSnapshot;
+    }
+
+    /**
      *
      * @param snapshotId Snapshot UUID.
      * @param primaryTerm current primary term.

--- a/server/src/main/java/org/opensearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/FilterRepository.java
@@ -44,6 +44,7 @@ import org.opensearch.common.lifecycle.Lifecycle;
 import org.opensearch.common.lifecycle.LifecycleListener;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.snapshots.blobstore.RemoteStoreShardShallowCopySnapshot;
@@ -236,6 +237,35 @@ public class FilterRepository implements Repository {
     }
 
     @Override
+    public void snapshotShard(
+        Store store,
+        MapperService mapperService,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        CatalogSnapshot catalogSnapshot,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        Version repositoryMetaVersion,
+        Map<String, Object> userMetadata,
+        ActionListener<String> listener,
+        IndexMetadata indexMetadata
+    ) {
+        in.snapshotShard(
+            store,
+            mapperService,
+            snapshotId,
+            indexId,
+            catalogSnapshot,
+            shardStateIdentifier,
+            snapshotStatus,
+            repositoryMetaVersion,
+            userMetadata,
+            listener,
+            indexMetadata
+        );
+    }
+
+    @Override
     public void snapshotRemoteStoreIndexShard(
         Store store,
         SnapshotId snapshotId,
@@ -256,6 +286,64 @@ public class FilterRepository implements Repository {
             snapshotStatus,
             primaryTerm,
             startTime,
+            listener
+        );
+    }
+
+    @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        IndexCommit snapshotIndexCommit,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        Map<String, Long> indexFilesToFileLengthMap,
+        ActionListener<String> listener
+    ) {
+        in.snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            snapshotIndexCommit,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            indexFilesToFileLengthMap,
+            listener
+        );
+    }
+
+    @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        CatalogSnapshot catalogSnapshot,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        Map<String, Long> indexFilesToFileLengthMap,
+        ActionListener<String> listener
+    ) {
+        in.snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            catalogSnapshot,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            indexFilesToFileLengthMap,
             listener
         );
     }

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -42,11 +42,15 @@ import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Priority;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lifecycle.LifecycleComponent;
+import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.index.engine.exec.coord.SegmentInfosCatalogSnapshot;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.snapshots.blobstore.RemoteStoreShardShallowCopySnapshot;
@@ -440,6 +444,71 @@ public interface Repository extends LifecycleComponent {
     );
 
     /**
+     * Creates a snapshot of the shard based on a {@link CatalogSnapshot} commit point.
+     * <p>
+     * This is the format-neutral entry point used by {@code SnapshotShardsService}. A {@link CatalogSnapshot}
+     * describes the committed files of a shard regardless of the data format that produced them, so this
+     * overload works for both Lucene-backed and multi-format (catalog-based) engines. The commit point can be
+     * obtained via {@link org.opensearch.index.shard.IndexShard#acquireLastCommittedSnapshot(boolean)}.
+     * Repository implementations shouldn't release the snapshot; it is done by the method caller.
+     * <p>
+     * The default implementation adapts Lucene-backed catalog snapshots down to
+     * {@link #snapshotShard(Store, MapperService, SnapshotId, IndexId, IndexCommit, String, IndexShardSnapshotStatus,
+     * Version, Map, ActionListener, IndexMetadata)} so that repository implementations which only understand
+     * {@link IndexCommit} keep working unchanged. Multi-format catalog snapshots have no {@link IndexCommit}
+     * representation, so implementations that want to support them must override this method.
+     *
+     * @param store                 store to be snapshotted
+     * @param mapperService         the shards mapper service
+     * @param snapshotId            snapshot id
+     * @param indexId               id for the index being snapshotted
+     * @param catalogSnapshot       commit point
+     * @param shardStateIdentifier  a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                              to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
+     *                              snapshotting will be done by inspecting the physical files referenced by {@code catalogSnapshot}
+     * @param snapshotStatus        snapshot status
+     * @param repositoryMetaVersion version of the updated repository metadata to write
+     * @param userMetadata          user metadata of the snapshot found in {@link SnapshotsInProgress.Entry#userMetadata()}
+     * @param listener              listener invoked on completion
+     * @param indexMetadata         index metadata for the shard being snapshotted
+     */
+    @ExperimentalApi
+    default void snapshotShard(
+        Store store,
+        MapperService mapperService,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        CatalogSnapshot catalogSnapshot,
+        @Nullable String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        Version repositoryMetaVersion,
+        Map<String, Object> userMetadata,
+        ActionListener<String> listener,
+        @Nullable IndexMetadata indexMetadata
+    ) {
+        final IndexCommit snapshotIndexCommit;
+        try {
+            snapshotIndexCommit = asIndexCommit(catalogSnapshot, store);
+        } catch (IOException e) {
+            listener.onFailure(e);
+            return;
+        }
+        snapshotShard(
+            store,
+            mapperService,
+            snapshotId,
+            indexId,
+            snapshotIndexCommit,
+            shardStateIdentifier,
+            snapshotStatus,
+            repositoryMetaVersion,
+            userMetadata,
+            listener,
+            indexMetadata
+        );
+    }
+
+    /**
      * Adds a reference of remote store data for a index commit point.
      * <p>
      * The index commit point can be obtained by using {@link org.opensearch.index.engine.Engine#acquireLastIndexCommit} method.
@@ -510,6 +579,87 @@ public interface Repository extends LifecycleComponent {
         ActionListener<String> listener
     ) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a reference of remote store data for a {@link CatalogSnapshot} commit point.
+     * <p>
+     * Format-neutral counterpart of
+     * {@link #snapshotRemoteStoreIndexShard(Store, SnapshotId, IndexId, IndexCommit, String, IndexShardSnapshotStatus,
+     * long, long, long, Map, ActionListener)}. The commit point can be obtained via
+     * {@link org.opensearch.index.shard.IndexShard#acquireLastCommittedSnapshot(boolean)}, or — for a closed index —
+     * by reading the last remote uploaded metadata via
+     * {@link org.opensearch.index.shard.IndexShard#fetchLastRemoteUploadedSegmentMetadata()}, in which case
+     * {@code catalogSnapshot} is {@code null} and {@code indexFilesToFileLengthMap} carries the file listing.
+     * Repository implementations shouldn't release the snapshot; it is done by the method caller.
+     * <p>
+     * The default implementation adapts Lucene-backed catalog snapshots down to the {@link IndexCommit} overload.
+     *
+     * @param store                     store to be snapshotted
+     * @param snapshotId                snapshot id
+     * @param indexId                   id for the index being snapshotted
+     * @param catalogSnapshot           commit point, or {@code null} for a closed index
+     * @param shardStateIdentifier      a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                                  to detect if the shard has changed between snapshots
+     * @param snapshotStatus            snapshot status
+     * @param primaryTerm               current primary term
+     * @param commitGeneration          current commit generation
+     * @param startTime                 start time of the snapshot commit, this will be used as the start time for snapshot
+     * @param indexFilesToFileLengthMap map of index files to file length
+     * @param listener                  listener invoked on completion
+     */
+    @ExperimentalApi
+    default void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        @Nullable CatalogSnapshot catalogSnapshot,
+        @Nullable String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        @Nullable Map<String, Long> indexFilesToFileLengthMap,
+        ActionListener<String> listener
+    ) {
+        final IndexCommit snapshotIndexCommit;
+        try {
+            snapshotIndexCommit = catalogSnapshot == null ? null : asIndexCommit(catalogSnapshot, store);
+        } catch (IOException e) {
+            listener.onFailure(e);
+            return;
+        }
+        snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            snapshotIndexCommit,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            indexFilesToFileLengthMap,
+            listener
+        );
+    }
+
+    /**
+     * Materializes a Lucene {@link IndexCommit} view of the given {@link CatalogSnapshot} so that repository
+     * implementations which have not been converted to the catalog-based API keep working.
+     *
+     * @throws IOException if the commit view cannot be built, or if the snapshot is not Lucene-backed
+     */
+    private static IndexCommit asIndexCommit(CatalogSnapshot catalogSnapshot, Store store) throws IOException {
+        if (catalogSnapshot instanceof SegmentInfosCatalogSnapshot == false) {
+            throw new IOException(
+                "repository does not support snapshotting multi-format shards: cannot represent ["
+                    + catalogSnapshot.getClass().getSimpleName()
+                    + "] as an IndexCommit. The repository implementation must override the CatalogSnapshot-based "
+                    + "snapshotShard overload."
+            );
+        }
+        return Lucene.getIndexCommit(((SegmentInfosCatalogSnapshot) catalogSnapshot).getSegmentInfos(), store.directory());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -109,6 +109,7 @@ import org.opensearch.core.util.BytesRefUtils;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
@@ -3858,12 +3859,51 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         );
     }
 
+    /**
+     * Adapts the deprecated {@link IndexCommit}-based entry point onto the catalog-based implementation.
+     */
     @Override
     public void snapshotRemoteStoreIndexShard(
         Store store,
         SnapshotId snapshotId,
         IndexId indexId,
         IndexCommit snapshotIndexCommit,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        Map<String, Long> indexFilesToFileLengthMap,
+        ActionListener<String> listener
+    ) {
+        final CatalogSnapshot catalogSnapshot;
+        try {
+            catalogSnapshot = snapshotIndexCommit == null ? null : toCatalogSnapshot(snapshotIndexCommit, store);
+        } catch (IOException e) {
+            listener.onFailure(new IndexShardSnapshotFailedException(store.shardId(), "Failed to read commit point", e));
+            return;
+        }
+        snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            catalogSnapshot,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            indexFilesToFileLengthMap,
+            listener
+        );
+    }
+
+    @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        CatalogSnapshot catalogSnapshot,
         String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         long primaryTerm,
@@ -3886,11 +3926,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             long indexTotalFileSize = 0;
             List<String> fileNames;
 
-            if (snapshotIndexCommit != null) {
+            if (catalogSnapshot != null) {
                 // local store is being used here to fetch the files metadata instead of remote store as currently
                 // remote store is mirroring the local store.
-                fileNames = new ArrayList<>(snapshotIndexCommit.getFileNames());
-                Store.MetadataSnapshot commitSnapshotMetadata = store.getMetadata(snapshotIndexCommit);
+                fileNames = new ArrayList<>(catalogSnapshot.getFiles(true));
+                Store.MetadataSnapshot commitSnapshotMetadata = store.getMetadata(catalogSnapshot);
                 for (String fileName : fileNames) {
                     indexTotalFileSize += commitSnapshotMetadata.get(fileName).length();
                 }
@@ -3951,6 +3991,20 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
+    /**
+     * Builds the {@link CatalogSnapshot} view of a Lucene {@link IndexCommit}, mirroring what
+     * {@link Store#getMetadata(IndexCommit)} does internally: a multi-format snapshot is recovered from commit
+     * user data when present, otherwise the {@link org.apache.lucene.index.SegmentInfos} is wrapped as-is.
+     */
+    private static CatalogSnapshot toCatalogSnapshot(IndexCommit snapshotIndexCommit, Store store) throws IOException {
+        return Store.fromSegmentInfos(Lucene.readSegmentInfos(snapshotIndexCommit), store.shardFormatDirectoryResolver());
+    }
+
+    /**
+     * Adapts the deprecated {@link IndexCommit}-based entry point onto the catalog-based implementation.
+     * Retained for repository callers that have not been converted to
+     * {@link org.opensearch.index.engine.exec.coord.CatalogSnapshot}.
+     */
     @Override
     public void snapshotShard(
         Store store,
@@ -3958,6 +4012,42 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         SnapshotId snapshotId,
         IndexId indexId,
         IndexCommit snapshotIndexCommit,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        Version repositoryMetaVersion,
+        Map<String, Object> userMetadata,
+        ActionListener<String> listener,
+        IndexMetadata indexMetadata
+    ) {
+        final CatalogSnapshot catalogSnapshot;
+        try {
+            catalogSnapshot = toCatalogSnapshot(snapshotIndexCommit, store);
+        } catch (IOException e) {
+            listener.onFailure(new IndexShardSnapshotFailedException(store.shardId(), "Failed to read commit point", e));
+            return;
+        }
+        snapshotShard(
+            store,
+            mapperService,
+            snapshotId,
+            indexId,
+            catalogSnapshot,
+            shardStateIdentifier,
+            snapshotStatus,
+            repositoryMetaVersion,
+            userMetadata,
+            listener,
+            indexMetadata
+        );
+    }
+
+    @Override
+    public void snapshotShard(
+        Store store,
+        MapperService mapperService,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        CatalogSnapshot catalogSnapshot,
         String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         Version repositoryMetaVersion,
@@ -4024,9 +4114,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 try (Releasable ignored = incrementStoreRef(store, snapshotStatus, shardId)) {
                     // TODO apparently we don't use the MetadataSnapshot#.recoveryDiff(...) here but we should
                     try {
-                        logger.trace("[{}] [{}] Loading store metadata using index commit [{}]", shardId, snapshotId, snapshotIndexCommit);
-                        metadataFromStore = store.getMetadata(snapshotIndexCommit);
-                        fileNames = snapshotIndexCommit.getFileNames();
+                        logger.trace(
+                            "[{}] [{}] Loading store metadata using catalog snapshot generation [{}]",
+                            shardId,
+                            snapshotId,
+                            catalogSnapshot.getGeneration()
+                        );
+                        metadataFromStore = store.getMetadata(catalogSnapshot);
+                        fileNames = catalogSnapshot.getFiles(true);
                     } catch (IOException e) {
                         throw new IndexShardSnapshotFailedException(shardId, "Failed to get store file metadata", e);
                     }
@@ -4119,7 +4214,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
             final StepListener<Collection<Void>> allFilesUploadedListener = new StepListener<>();
             allFilesUploadedListener.whenComplete(v -> {
-                final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.moveToFinalize(snapshotIndexCommit.getGeneration());
+                final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.moveToFinalize(catalogSnapshot.getGeneration());
 
                 // now create and write the commit point
                 logger.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -35,7 +35,6 @@ package org.opensearch.snapshots;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.lucene.index.IndexCommit;
 import org.opensearch.Version;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.cluster.ClusterChangedEvent;
@@ -57,7 +56,9 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.index.snapshots.IndexShardSnapshotFailedException;
 import org.opensearch.index.IndexService;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.Engine;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
@@ -384,15 +385,27 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 throw new IndexShardSnapshotFailedException(shardId, "shard didn't fully recover yet");
             }
 
+            // The catalog-based shard snapshot path is not validated for multi-format (pluggable data format) shards
+            // yet: checksum comparison, format-qualified blob naming and the restore path are still outstanding.
+            // Fail at the API boundary with an actionable message rather than deeper in the engine.
+            if (indexShard.indexSettings().isPluggableDataFormatEnabled()) {
+                throw new IndexShardSnapshotFailedException(
+                    shardId,
+                    "snapshots are not yet supported for indices using a pluggable data format ["
+                        + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
+                        + "=true]"
+                );
+            }
+
             final Repository repository = repositoriesService.repository(snapshot.getRepository());
-            GatedCloseable<IndexCommit> wrappedSnapshot = null;
+            GatedCloseable<CatalogSnapshot> wrappedSnapshot = null;
             try {
                 if (remoteStoreIndexShallowCopy && indexShard.indexSettings().isRemoteStoreEnabled()) {
                     long startTime = threadPool.relativeTimeInMillis();
                     long primaryTerm = indexShard.getOperationPrimaryTerm();
                     long commitGeneration = 0L;
                     Map<String, Long> indexFilesToFileLengthMap = null;
-                    IndexCommit snapshotIndexCommit = null;
+                    CatalogSnapshot catalogSnapshot = null;
 
                     try {
                         if (closedIndex) {
@@ -404,9 +417,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             primaryTerm = lastRemoteUploadedIndexCommit.getPrimaryTerm();
                             commitGeneration = lastRemoteUploadedIndexCommit.getGeneration();
                         } else {
-                            wrappedSnapshot = indexShard.acquireLastIndexCommitAndRefresh(true);
-                            snapshotIndexCommit = wrappedSnapshot.get();
-                            commitGeneration = snapshotIndexCommit.getGeneration();
+                            wrappedSnapshot = indexShard.acquireLastCommittedSnapshotAndRefresh(true);
+                            catalogSnapshot = wrappedSnapshot.get();
+                            commitGeneration = catalogSnapshot.getGeneration();
                         }
                         indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
                     } catch (IOException e) {
@@ -421,9 +434,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                 commitGeneration
                             );
                             indexShard.flush(new FlushRequest(shardId.getIndexName()).force(true));
-                            wrappedSnapshot = indexShard.acquireLastIndexCommit(false);
-                            snapshotIndexCommit = wrappedSnapshot.get();
-                            commitGeneration = snapshotIndexCommit.getGeneration();
+                            wrappedSnapshot = indexShard.acquireLastCommittedSnapshot(false);
+                            catalogSnapshot = wrappedSnapshot.get();
+                            commitGeneration = catalogSnapshot.getGeneration();
                             indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
                         }
                     }
@@ -432,7 +445,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             indexShard.store(),
                             snapshot.getSnapshotId(),
                             indexId,
-                            snapshotIndexCommit,
+                            catalogSnapshot,
                             null,
                             snapshotStatus,
                             primaryTerm,
@@ -468,8 +481,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     );
                 } else {
                     // we flush first to make sure we get the latest writes snapshotted
-                    wrappedSnapshot = indexShard.acquireLastIndexCommit(true);
-                    final IndexCommit snapshotIndexCommit = wrappedSnapshot.get();
+                    wrappedSnapshot = indexShard.acquireLastCommittedSnapshot(true);
+                    final CatalogSnapshot catalogSnapshot = wrappedSnapshot.get();
 
                     IndexMetadata indexMetadata = clusterService.state().metadata().index(indexId.getName());
 
@@ -478,8 +491,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         indexShard.mapperService(),
                         snapshot.getSnapshotId(),
                         indexId,
-                        wrappedSnapshot.get(),
-                        getShardStateId(indexShard, snapshotIndexCommit),
+                        catalogSnapshot,
+                        getShardStateId(indexShard, catalogSnapshot),
                         snapshotStatus,
                         version,
                         userMetadata,
@@ -505,13 +518,13 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * shard state id can be used in this case because of the possibility of a primary failover leading to different
      * shard content for the same sequence number on a subsequent snapshot.
      *
-     * @param indexShard          Shard
-     * @param snapshotIndexCommit IndexCommit for shard
+     * @param indexShard      Shard
+     * @param catalogSnapshot commit point for shard
      * @return shard state id or {@code null} if none can be used
      */
     @Nullable
-    private static String getShardStateId(IndexShard indexShard, IndexCommit snapshotIndexCommit) throws IOException {
-        final Map<String, String> userCommitData = snapshotIndexCommit.getUserData();
+    private static String getShardStateId(IndexShard indexShard, CatalogSnapshot catalogSnapshot) throws IOException {
+        final Map<String, String> userCommitData = catalogSnapshot.getUserData();
         final SequenceNumbers.CommitInfo seqNumInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userCommitData.entrySet());
         final long maxSeqNo = seqNumInfo.maxSeqNo;
         if (maxSeqNo != seqNumInfo.localCheckpoint || maxSeqNo != indexShard.getLastSyncedGlobalCheckpoint()) {

--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -23,6 +23,7 @@ import org.opensearch.index.engine.DocIdSeqNoAndSource;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.InternalEngine;
 import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -66,6 +67,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -585,7 +587,19 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
                 listener.onResponse(snapshotStatus.generation());
                 return null;
             }).when(repository)
-                .snapshotRemoteStoreIndexShard(any(), any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any(), any());
+                .snapshotRemoteStoreIndexShard(
+                    any(),
+                    any(),
+                    any(),
+                    nullable(CatalogSnapshot.class),
+                    any(),
+                    any(),
+                    anyLong(),
+                    anyLong(),
+                    anyLong(),
+                    any(),
+                    any()
+                );
 
             final SnapshotShardsService shardsService = getSnapshotShardsService(
                 primaryShard,

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -32,7 +32,6 @@
 package org.opensearch.index.shard;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
@@ -104,6 +103,7 @@ import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.engine.exec.EngineBackedIndexerFactory;
 import org.opensearch.index.engine.exec.Indexer;
 import org.opensearch.index.engine.exec.IndexerFactory;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
@@ -1534,13 +1534,13 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         );
         final PlainActionFuture<String> future = PlainActionFuture.newFuture();
         final String shardGen;
-        try (GatedCloseable<IndexCommit> wrappedIndexCommit = shard.acquireLastIndexCommit(true)) {
+        try (GatedCloseable<CatalogSnapshot> wrappedSnapshot = shard.acquireLastCommittedSnapshot(true)) {
             repository.snapshotShard(
                 shard.store(),
                 shard.mapperService(),
                 snapshot.getSnapshotId(),
                 indexId,
-                wrappedIndexCommit.get(),
+                wrappedSnapshot.get(),
                 null,
                 snapshotStatus,
                 Version.CURRENT,


### PR DESCRIPTION
### Description

Replaces the Lucene `IndexCommit` with the format-neutral `CatalogSnapshot` as the commit point of the shard snapshot flow, so snapshotting no longer depends on the shard's engine being Lucene-backed.

**The problem.** `IndexShard.acquireLastIndexCommit(...)` dispatches through `applyOnEngine(...)`, which requires the shard's indexer to be an `EngineBackedIndexer`. Multi-format engines implement `Indexer` directly, so every shard snapshot path — full copy and shallow copy alike — fails with an opaque `IllegalStateException` from the engine layer before it ever reaches the repository. `CatalogSnapshot` is already the commit-point currency for peer recovery (`IndexShard.snapshotStoreMetadata`) and remote store upload (`RemoteStoreRefreshListener`); shard snapshots were the last `IndexCommit`-only consumer.

**What changed.**

- `IndexShard` gains `acquireLastCommittedSnapshot(boolean)` and `acquireLastCommittedSnapshotAndRefresh(boolean)`, returning `GatedCloseable<CatalogSnapshot>` and mirroring the deprecated `IndexCommit` pair. These call `getIndexer()` directly rather than `applyOnEngine(...)` — that is the change that removes the constraint.
- `SnapshotShardsService.snapshot()` uses the new methods at all three acquisition sites (shallow-copy branch, lock-failure retry, full-copy branch) and derives `commitGeneration` from `CatalogSnapshot.getGeneration()`. `getShardStateId(...)` now takes a `CatalogSnapshot` and reads `getUserData()`.
- `Repository` gains `CatalogSnapshot` overloads of `snapshotShard` and the 11-arg `snapshotRemoteStoreIndexShard`, as `default` methods that adapt Lucene-backed catalog snapshots down to the existing `IndexCommit` methods. `BlobStoreRepository` implements the catalog forms and keeps the `IndexCommit` forms as thin adapters.
- `FilterRepository` gains the corresponding delegating overrides, including the 11-arg `IndexCommit` remote-store variant that was previously missing and fell through to the interface's `UnsupportedOperationException`.

**Side benefit.** The repository now calls `Store.getMetadata(CatalogSnapshot)` instead of `Store.getMetadata(IndexCommit)`, which drops a redundant `segments_N` read per shard snapshot.

**Compatibility.** The Lucene path is behaviour-identical: `Engine.acquireLastCommittedSnapshot` already defaults to wrapping `acquireLastIndexCommit`, and `SegmentInfosCatalogSnapshot` surfaces the same commit user data, so the shard state identifier that drives the incremental-snapshot skip stays stable across upgrade. `Repository` gains only `default` methods, so existing repository plugins compile and behave unchanged (`japicmp` clean). No user-facing API or wire format changes.

**Transitional guardrail.** Multi-format shards now reach the repository layer, but the remaining work for them — checksum comparison against `FormatChecksumStrategy`-based `StoreFileMetadata`, format-qualified blob naming, and restore file materialization — is not in this PR. Until that lands, `snapshot()` fails such shards up front with `IndexShardSnapshotFailedException` naming `index.pluggable.dataformat.enabled`, replacing the previous opaque `IllegalStateException`. This guard is removed by the follow-up that adds the full-copy create and restore paths.

**Testing.** `:server:precommit`, `:test:framework:precommit` and `:server:japicmp` pass. Green suites: `SnapshotResiliencyTests`, `org.opensearch.snapshots.*`, `RemoteIndexShardTests`, `FsRepositoryTests`, `BlobStoreRepositoryRestoreTests`, `RepositoriesServiceTests`, `IndexShardTests`, `StoreTests`.

### Related Issues
<!-- TODO: link tracking issue -->
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
