### PR TITLE
Support _explain/<id> on composite indexes via the Lucene secondary

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.engine.exec.LuceneReaderAccess;
 
 import java.util.Map;
 import java.util.Objects;
@@ -25,7 +26,7 @@ import java.util.Objects;
  * same as the current reader's top-reader" assertion — fatal across the FFM boundary.
  */
 @ExperimentalApi
-public final class LuceneReader {
+public final class LuceneReader implements LuceneReaderAccess {
 
     private final DirectoryReader directoryReader;
     private final Map<Long, String> generationToSegmentName;
@@ -38,6 +39,7 @@ public final class LuceneReader {
         this.generationToSegmentName = Map.copyOf(generationToSegmentName);
     }
 
+    @Override
     public DirectoryReader directoryReader() {
         return directoryReader;
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeExplainIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeExplainIT.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.explain.ExplainResponse;
+import org.opensearch.index.query.QueryBuilders;
+
+import java.util.List;
+
+/**
+ * Integration tests for the Explain API ({@code _explain/<id>}) on a composite
+ * (parquet primary + lucene secondary) index.
+ *
+ * <p>A composite shard's {@code DataFormatAwareEngine} cannot serve the classic Lucene search
+ * context, so vanilla explain used to fail with {@code IllegalStateException} ("Cannot apply
+ * function on indexer ... DataFormatAwareEngine directly on IndexShard"). Explain now runs against
+ * the Lucene secondary copy — answering "did this document match, and why" — which these tests
+ * verify end to end.
+ */
+public class CompositeExplainIT extends AbstractCompositeEngineIT {
+
+    public void testExplainMatchOnCompositeIndex() {
+        String index = "explain_match";
+        createCompositeIndex(index);
+        List<String> ids = indexDocs(index, 1, 1); // one doc: name="doc_1", value=1
+        flushIndex(index);
+        String id = ids.get(0);
+
+        ExplainResponse response = client().prepareExplain(index, id).setQuery(QueryBuilders.termQuery("name", "doc_1")).get();
+
+        assertTrue("document must exist", response.isExists());
+        assertTrue("matching query must report matched=true", response.isMatch());
+        assertNotNull("a Lucene explanation must be returned", response.getExplanation());
+        assertTrue("matched explanation must have a positive score", response.getExplanation().getValue().doubleValue() > 0.0);
+    }
+
+    public void testExplainNoMatchOnCompositeIndex() {
+        String index = "explain_nomatch";
+        createCompositeIndex(index);
+        List<String> ids = indexDocs(index, 1, 1);
+        flushIndex(index);
+        String id = ids.get(0);
+
+        // query targets a value the document does not have
+        ExplainResponse response = client().prepareExplain(index, id).setQuery(QueryBuilders.termQuery("name", "doc_999")).get();
+
+        assertTrue("document must exist", response.isExists());
+        assertFalse("non-matching query must report matched=false", response.isMatch());
+        assertNotNull("a Lucene explanation must be returned even for a non-match", response.getExplanation());
+        assertEquals("non-match must have zero score", 0.0, response.getExplanation().getValue().doubleValue(), 0.0);
+    }
+
+    public void testExplainNonExistentDocumentOnCompositeIndex() {
+        String index = "explain_missing";
+        createCompositeIndex(index);
+        indexDocs(index, 1, 1);
+        flushIndex(index);
+
+        ExplainResponse response = client().prepareExplain(index, "does-not-exist")
+            .setQuery(QueryBuilders.termQuery("name", "doc_1"))
+            .get();
+
+        assertFalse("a non-existent document must report exists=false", response.isExists());
+        assertFalse("a non-existent document cannot match", response.isMatch());
+    }
+}

--- a/server/src/main/java/org/opensearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/opensearch/action/explain/TransportExplainAction.java
@@ -34,6 +34,9 @@ package org.opensearch.action.explain;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.RoutingMissingException;
 import org.opensearch.action.support.ActionFilters;
@@ -53,6 +56,7 @@ import org.opensearch.index.get.GetResult;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.Uid;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.Rewriteable;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.search.SearchService;
@@ -147,6 +151,18 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
 
     @Override
     protected ExplainResponse shardOperation(ExplainRequest request, ShardId shardId) throws IOException {
+        IndexService indexService = searchService.getIndicesService().indexServiceSafe(shardId.getIndex());
+        IndexShard indexShard = indexService.getShard(shardId.id());
+
+        // Composite (data-format) indexes can't serve the classic Lucene search context — their engine
+        // is not an EngineBackedIndexer. When such a shard exposes a Lucene secondary copy, explain
+        // against that copy: "did this document match, and why", per the Lucene secondary. Classic
+        // shards return null here and fall through to the standard path below.
+        Engine.Searcher dataFormatSearcher = indexShard.acquireDataFormatLuceneSearcher("explain");
+        if (dataFormatSearcher != null) {
+            return explainAgainstLuceneSecondary(request, shardId, indexService, dataFormatSearcher);
+        }
+
         ShardSearchRequest shardSearchLocalRequest = new ShardSearchRequest(shardId, request.nowInMillis, request.filteringAlias());
         SearchContext context = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT);
         Engine.GetResult result = null;
@@ -186,6 +202,43 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
     @Override
     protected Writeable.Reader<ExplainResponse> getResponseReader() {
         return ExplainResponse::new;
+    }
+
+    /**
+     * Explains a query against a data-format shard's Lucene secondary copy (e.g. a composite
+     * parquet+lucene index), whose engine cannot serve the classic Lucene search context.
+     *
+     * <p>Resolves the document by its {@code _id} within the Lucene secondary, parses the query
+     * with a {@link QueryShardContext} bound to that reader, and returns the Lucene
+     * {@link Explanation}. This reflects how the Lucene copy matches/scores the document, not the
+     * engine's primary-format execution. {@code _source} / stored-field return is not yet supported
+     * on this path.
+     */
+    private ExplainResponse explainAgainstLuceneSecondary(
+        ExplainRequest request,
+        ShardId shardId,
+        IndexService indexService,
+        Engine.Searcher searcher
+    ) throws IOException {
+        try (searcher) {
+            // Composite indexes are append-only, so an _id resolves to exactly one live document —
+            // a top-1 term lookup on _id is therefore exact.
+            Term uidTerm = new Term(IdFieldMapper.NAME, Uid.encodeId(request.id()));
+            TopDocs topDocs = searcher.search(new TermQuery(uidTerm), 1);
+            if (topDocs.totalHits.value() == 0) {
+                return new ExplainResponse(shardId.getIndexName(), request.id(), false);
+            }
+            int docId = topDocs.scoreDocs[0].doc;
+            QueryShardContext queryShardContext = indexService.newQueryShardContext(
+                shardId.id(),
+                searcher,
+                () -> request.nowInMillis,
+                null
+            );
+            Query query = queryShardContext.toQuery(request.query()).query();
+            Explanation explanation = searcher.explain(query, docId);
+            return new ExplainResponse(shardId.getIndexName(), request.id(), true, explanation);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -65,6 +65,7 @@ import org.opensearch.index.engine.exec.FileDeleter;
 import org.opensearch.index.engine.exec.FilesListener;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.Indexer;
+import org.opensearch.index.engine.exec.LuceneReaderAccess;
 import org.opensearch.index.engine.exec.PrimaryTermFieldType;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
@@ -2535,6 +2536,16 @@ public class DataFormatAwareEngine implements Indexer {
         @Override
         public CatalogSnapshot catalogSnapshot() {
             return snapshotRef.get();
+        }
+
+        @Override
+        public LuceneReaderAccess luceneReader() {
+            for (Object reader : readers.values()) {
+                if (reader instanceof LuceneReaderAccess luceneReaderAccess) {
+                    return luceneReaderAccess;
+                }
+            }
+            return null;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/engine/exec/IndexReaderProvider.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/IndexReaderProvider.java
@@ -63,5 +63,17 @@ public interface IndexReaderProvider {
         Object reader(DataFormat format);
 
         <R> R getReader(DataFormat format, Class<R> readerType);
+
+        /**
+         * Returns {@link LuceneReaderAccess} for this reader when a Lucene-backed format is present
+         * (for example, a composite index's Lucene secondary), or {@code null} when no Lucene-backed
+         * format reader exists. Lets core run Lucene operations — such as the Explain API — against
+         * the Lucene copy without knowing which {@link DataFormat} provides it.
+         *
+         * @return Lucene reader access, or {@code null} if no Lucene-backed format reader is present
+         */
+        default LuceneReaderAccess luceneReader() {
+            return null;
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/LuceneReaderAccess.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/LuceneReaderAccess.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.exec;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Bridge that lets core obtain a Lucene {@link DirectoryReader} from a data-format-specific reader
+ * (for example, the Lucene secondary of a composite index) without depending on the format plugin
+ * that produces it. Format readers that are backed by Lucene implement this interface so that
+ * shard-level Lucene operations — such as the Explain API — can run against the Lucene copy while
+ * the primary data lives in another format (e.g. Parquet).
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface LuceneReaderAccess {
+
+    /**
+     * Returns the underlying Lucene {@link DirectoryReader} backing this format reader.
+     *
+     * @return the directory reader, or {@code null} if none is available
+     */
+    DirectoryReader directoryReader();
+}

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -151,6 +151,7 @@ import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.Indexer;
 import org.opensearch.index.engine.exec.IndexerFactory;
+import org.opensearch.index.engine.exec.LuceneReaderAccess;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.SegmentInfosCatalogSnapshot;
 import org.opensearch.index.fielddata.FieldDataStats;
@@ -2684,6 +2685,54 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         markSearcherAccessed();
         final Indexer indexer = getIndexer();
         return applyOnEngine(indexer, engine -> engine.acquireSearcher(source, scope, this::wrapSearcher));
+    }
+
+    /**
+     * Acquires a Lucene {@link Engine.Searcher} over a data-format engine's Lucene secondary copy
+     * (for example, a composite parquet+lucene index), for shard-level Lucene operations such as the
+     * Explain API. The returned searcher reads the Lucene secondary, not the primary format, so it
+     * answers "did this document match, and why" against the Lucene copy rather than reflecting the
+     * engine's actual (e.g. Parquet/DataFusion) execution.
+     *
+     * <p>Returns {@code null} for classic (Lucene-engine) shards — callers must use the normal
+     * {@link #acquireSearcher(String)} path there — and for data-format shards that expose no
+     * Lucene-backed secondary. The caller owns the returned searcher and must close it.
+     *
+     * @param source the source that caused this searcher to be acquired
+     * @return a searcher over the Lucene secondary, or {@code null} if not applicable
+     * @throws IOException if acquiring the underlying reader fails
+     */
+    @Nullable
+    public Engine.Searcher acquireDataFormatLuceneSearcher(String source) throws IOException {
+        final Indexer indexer = getIndexerOrNull();
+        if (indexer == null || indexer instanceof EngineBackedIndexer) {
+            return null;
+        }
+        readAllowed();
+        markSearcherAccessed();
+        final GatedCloseable<IndexReaderProvider.Reader> readerRef = indexer.acquireReader();
+        boolean success = false;
+        try {
+            final LuceneReaderAccess luceneReader = readerRef.get().luceneReader();
+            if (luceneReader == null || luceneReader.directoryReader() == null) {
+                return null;
+            }
+            final EngineConfig config = indexer.config();
+            final Engine.Searcher searcher = new Engine.Searcher(
+                source,
+                luceneReader.directoryReader(),
+                config.getSimilarity(),
+                config.getQueryCache(),
+                config.getQueryCachingPolicy(),
+                readerRef
+            );
+            success = true;
+            return searcher;
+        } finally {
+            if (success == false) {
+                readerRef.close();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
`_explain/<id>` currently fails on composite (parquet primary + lucene secondary) indexes with `IllegalStateException` — *"Cannot apply function on indexer ... DataFormatAwareEngine directly on IndexShard"* — because a composite shard's `DataFormatAwareEngine` is not an `EngineBackedIndexer` and can't serve the classic Lucene search context.

This routes explain to the index's **Lucene secondary copy**, so it answers *"did this document match, and why"* — the same output shape as a plain index.

## Approach
- **`LuceneReaderAccess`** (new, `org.opensearch.index.engine.exec`): a server-side bridge that exposes a Lucene `DirectoryReader` from a data-format reader **without** core depending on the format plugin. `analytics-backend-lucene`'s `LuceneReader` implements it (one line).
- **`IndexReaderProvider.Reader#luceneReader()`**: returns the Lucene-backed format reader when present (composite's lucene secondary).
- **`IndexShard#acquireDataFormatLuceneSearcher(...)`**: builds an `Engine.Searcher` over the Lucene secondary for data-format shards; returns `null` for classic shards (which keep the existing path).
- **`TransportExplainAction`**: for such shards, resolves the doc by `_id` and runs the Lucene `explain(query, docId)` against the secondary.

## Semantics / scope
- The explanation reflects how the **Lucene secondary** matches/scores the doc, not the primary-format (Parquet/DataFusion) execution — appropriate for a *"did it match and why"* answer. Requires a Lucene secondary to be configured.
- `_source` / stored-field return is **not** yet supported on this path.

## Testing
- New `CompositeExplainIT` (composite-engine `internalClusterTest`): match, no-match, and non-existent-doc — 3/3 pass against the real composite engine.
- Verified end-to-end on a live composite cluster: matching → `ConstantScore 1.0`, non-matching → `0.0`, missing id → `exists:false` (previously a 500).
- spotless + affected-module precommit green.

```
 Matching (term name=laptop):
{"_index":"products","_id":"pcWvZqABJBJNpUqAWTCt","matched":true,"explanation": {"value":1.0,"description":"ConstantScore(name:laptop)","details":[]}}
  
Non-matching (term name=phone):
{"_index":"products","_id":"pcWvZqABJBJNpUqAWTCt","matched":false,"explanation":{"value":0.0,"description":"ConstantScore(name:phone) doesn't match id 0","details":[]}}
  
Missing id:
{"_index":"products","_id":"nope123","matched":false}
```