### PR TITLE
Fix WLM auto-tagging failure on rule-matching nested searches

### DIFF
--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/AutoTaggingActionFilter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/AutoTaggingActionFilter.java
@@ -15,6 +15,7 @@ import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.plugin.wlm.rule.attribute_extractor.IndicesExtractor;
@@ -124,7 +125,10 @@ public class AutoTaggingActionFilter implements ActionFilter {
         }
 
         Optional<String> label = ruleProcessingService.evaluateLabel(attributeExtractors);
-        label.ifPresent(s -> threadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, s));
+        ThreadContext threadContext = threadPool.getThreadContext();
+        if (threadContext.getHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER) == null) {
+            label.ifPresent(s -> threadContext.putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, s));
+        }
         chain.proceed(task, action, request, listener);
     }
 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/AutoTaggingActionFilterTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/AutoTaggingActionFilterTests.java
@@ -92,6 +92,21 @@ public class AutoTaggingActionFilterTests extends OpenSearchTestCase {
         }
     }
 
+    public void testApplyDoesNotOverwriteExistingHeader() {
+        SearchRequest request = mock(SearchRequest.class);
+        ActionFilterChain<ActionRequest, ActionResponse> mockFilterChain = mock(TestActionFilterChain.class);
+        when(request.indices()).thenReturn(new String[] { "lookupidx" });
+        try (ThreadContext.StoredContext context = threadPool.getThreadContext().stashContext()) {
+            threadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, "OuterQG_ID");
+            when(ruleProcessingService.evaluateLabel(anyList())).thenReturn(Optional.of("NestedQG_ID"));
+
+            // Must not throw "value for key [workloadGroupId] already present"
+            autoTaggingActionFilter.apply(mock(Task.class), "Test", request, ActionRequestMetadata.empty(), null, mockFilterChain);
+
+            assertEquals("OuterQG_ID", threadPool.getThreadContext().getHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER));
+        }
+    }
+
     public void testApplyForInValidRequest() {
         ActionFilterChain<ActionRequest, ActionResponse> mockFilterChain = mock(TestActionFilterChain.class);
         CancelTasksRequest request = new CancelTasksRequest();


### PR DESCRIPTION
### Description
`AutoTaggingActionFilter` writes the resolved workload group id header with `ThreadContext#putHeader`, which
throws `IllegalArgumentException` if the key is already present. A rewrite phase can issue a nested coordinator
search on the same, un-stashed thread context (e.g. a `terms` lookup with a `query`). If the nested search's own
index also matches an auto-tagging rule, the filter re-enters and tries to write the header a second time, and
the whole outer search fails with a `400` that mentions neither WLM nor auto-tagging.

This makes the header write conditional on the header not already being present, so a re-entrant nested search
on the same thread context simply keeps the outer request's already-resolved workload group instead of throwing.
This matches the behavior already exercised when the nested search's index matches no rule (silent inheritance
of the outer group), so both paths are now consistent.

### Related Issues
Resolves #22927

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).