### PR TITLE
Defer primary operation policy resolution to engine-build time

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -66,7 +66,7 @@ public class EngineConfigFactory {
     private final TranslogDeletionPolicyFactory translogDeletionPolicyFactory;
     private final List<AdditionalCodecs> additionalCodecs;
     private final CommitterFactory committerFactory;
-    private final PrimaryOperationPolicy primaryOperationPolicy;
+    private final List<EnginePlugin> enginePlugins;
     @Nullable
     private final DocumentLookupProvider documentLookupProvider;
     @Nullable
@@ -117,8 +117,6 @@ public class EngineConfigFactory {
         Optional<TranslogDeletionPolicyFactory> translogDeletionPolicyFactory = Optional.empty();
         String translogDeletionPolicyOverridingPlugin = null;
         List<CommitterFactory> committerFactories = new ArrayList<>();
-        Optional<PrimaryOperationPolicy> primaryOperationPolicy = Optional.empty();
-        String primaryOperationPolicyPlugin = null;
 
         for (EnginePlugin enginePlugin : enginePlugins) {
             // get overriding codec service from EnginePlugin
@@ -161,22 +159,10 @@ public class EngineConfigFactory {
             enginePlugin.getAdditionalCodecs(idxSettings).ifPresent(codecRegistries::add);
 
             enginePlugin.getCommitterFactory(idxSettings).ifPresent(committerFactories::add);
-
-            // get overriding PrimaryOperationPolicy from EnginePlugin
-            final Optional<PrimaryOperationPolicy> pluginPrimaryOperationPolicy = enginePlugin.getPrimaryOperationPolicy(idxSettings);
-            if (pluginPrimaryOperationPolicy.isPresent()) {
-                if (primaryOperationPolicy.isPresent()) {
-                    throw new IllegalStateException(
-                        "existing PrimaryOperationPolicy is already overridden in: "
-                            + primaryOperationPolicyPlugin
-                            + " attempting to override again by: "
-                            + enginePlugin.getClass().getName()
-                    );
-                }
-                primaryOperationPolicy = pluginPrimaryOperationPolicy;
-                primaryOperationPolicyPlugin = enginePlugin.getClass().getName();
-            }
         }
+
+        // Resolution is deferred to engine build time, but do a resolution here to fail fast on conflict
+        resolvePrimaryOperationPolicy(idxSettings, enginePlugins);
 
         if (codecService.isPresent() && codecServiceFactory.isPresent()) {
             throw new IllegalStateException(
@@ -196,7 +182,7 @@ public class EngineConfigFactory {
         this.translogDeletionPolicyFactory = translogDeletionPolicyFactory.orElse((idxs, rtls) -> null);
         this.additionalCodecs = Collections.unmodifiableList(codecRegistries);
         this.committerFactory = committerFactories.isEmpty() ? null : committerFactories.getFirst();
-        this.primaryOperationPolicy = primaryOperationPolicy.orElse(DefaultPrimaryOperationPolicy.INSTANCE);
+        this.enginePlugins = List.copyOf(enginePlugins);
         this.documentLookupProvider = documentLookupProvider;
         this.documentMetadataResolver = documentMetadataResolver;
     }
@@ -281,8 +267,32 @@ public class EngineConfigFactory {
             .checksumStrategies(checksumStrategies)
             .documentLookupProvider(documentLookupProvider)
             .documentMetadataResolver(documentMetadataResolver)
-            .primaryOperationPolicy(primaryOperationPolicy)
+            .primaryOperationPolicy(resolvePrimaryOperationPolicy(indexSettings, enginePlugins))
             .build();
+    }
+
+    private static PrimaryOperationPolicy resolvePrimaryOperationPolicy(
+        IndexSettings indexSettings,
+        Collection<EnginePlugin> enginePlugins
+    ) {
+        PrimaryOperationPolicy primaryOperationPolicy = null;
+        String primaryOperationPolicyPlugin = null;
+        for (EnginePlugin enginePlugin : enginePlugins) {
+            final Optional<PrimaryOperationPolicy> pluginPrimaryOperationPolicy = enginePlugin.getPrimaryOperationPolicy(indexSettings);
+            if (pluginPrimaryOperationPolicy.isPresent()) {
+                if (primaryOperationPolicy != null) {
+                    throw new IllegalStateException(
+                        "existing PrimaryOperationPolicy is already overridden in: "
+                            + primaryOperationPolicyPlugin
+                            + " attempting to override again by: "
+                            + enginePlugin.getClass().getName()
+                    );
+                }
+                primaryOperationPolicy = pluginPrimaryOperationPolicy.get();
+                primaryOperationPolicyPlugin = enginePlugin.getClass().getName();
+            }
+        }
+        return primaryOperationPolicy == null ? DefaultPrimaryOperationPolicy.INSTANCE : primaryOperationPolicy;
     }
 
     public CodecService newDefaultCodecService(IndexSettings indexSettings, @Nullable MapperService mapperService, Logger logger) {

--- a/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
@@ -136,14 +136,14 @@ public interface EnginePlugin {
     }
 
     /**
-     * When an index is created this method is invoked for each engine plugin. Engine plugins can inspect the index settings to determine
+     * Invoked for each engine plugin every time an engine is built for a shard. Engine plugins can inspect the index settings to determine
      * whether the index's writable primary should use a non-default indexing/sequence-number policy, for example a replication follower
      * whose sequence numbers are assigned by an upstream leader rather than generated locally. A plugin that does not override the policy
      * should return {@link Optional#empty()}, in which case {@link DefaultPrimaryOperationPolicy} is used.
      * <p>
      * Only one of the installed engine plugins can override this, otherwise {@link IllegalStateException} will be thrown.
      *
-     * @param indexSettings the settings of the index being created, so a plugin can key off its own marker setting
+     * @param indexSettings the settings of the index whose engine is being built, so a plugin can key off its own marker setting
      * @return an optional PrimaryOperationPolicy
      */
     @ExperimentalApi

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -252,6 +253,53 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
         );
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> new EngineConfigFactory(plugins, indexSettings));
         assertTrue(e.getMessage(), e.getMessage().contains("PrimaryOperationPolicy is already overridden"));
+    }
+
+    public void testMultiplePrimaryOperationPoliciesIllegalStateExceptionOnEngineConfig() {
+        IndexSettings indexSettings = newIndexSettings();
+        AtomicReference<PrimaryOperationPolicy> latePluginPolicy = new AtomicReference<>();
+        List<EnginePlugin> plugins = Arrays.asList(
+            new PrimaryOperationPolicyEnginePlugin(FakePreAssignedSeqNoPrimaryOperationPolicy.INSTANCE),
+            new EnginePlugin() {
+                @Override
+                public Optional<PrimaryOperationPolicy> getPrimaryOperationPolicy(IndexSettings settings) {
+                    return Optional.ofNullable(latePluginPolicy.get());
+                }
+            }
+        );
+        // only one plugin overrides the policy at construction, so the conflict cannot be detected up front
+        EngineConfigFactory factory = new EngineConfigFactory(plugins, indexSettings);
+        assertSame(
+            FakePreAssignedSeqNoPrimaryOperationPolicy.INSTANCE,
+            newEngineConfig(factory, indexSettings).getPrimaryOperationPolicy()
+        );
+
+        // the second plugin starts overriding it too, so the next engine build must reject the conflict
+        latePluginPolicy.set(FakePreAssignedSeqNoPrimaryOperationPolicy.INSTANCE);
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> newEngineConfig(factory, indexSettings));
+        assertTrue(e.getMessage(), e.getMessage().contains("PrimaryOperationPolicy is already overridden"));
+    }
+
+    public void testPrimaryOperationPolicyReconsultedOnEachEngineConfig() {
+        IndexSettings indexSettings = newIndexSettings();
+        AtomicReference<PrimaryOperationPolicy> pluginPolicy = new AtomicReference<>(FakePreAssignedSeqNoPrimaryOperationPolicy.INSTANCE);
+        EnginePlugin plugin = new EnginePlugin() {
+            @Override
+            public Optional<PrimaryOperationPolicy> getPrimaryOperationPolicy(IndexSettings settings) {
+                return Optional.ofNullable(pluginPolicy.get());
+            }
+        };
+        EngineConfigFactory factory = new EngineConfigFactory(Collections.singletonList(plugin), indexSettings);
+
+        assertSame(
+            FakePreAssignedSeqNoPrimaryOperationPolicy.INSTANCE,
+            newEngineConfig(factory, indexSettings).getPrimaryOperationPolicy()
+        );
+
+        // the plugin changes its answer between engine builds (e.g. a replication role flip); the next
+        // config must reflect it without a new factory
+        pluginPolicy.set(null);
+        assertSame(DefaultPrimaryOperationPolicy.INSTANCE, newEngineConfig(factory, indexSettings).getPrimaryOperationPolicy());
     }
 
     private static IndexSettings newIndexSettings() {


### PR DESCRIPTION
This lazy construction is required for a future CCR case where an index may switch replication direction. The previous implementation created a policy at index construction time and never re-consulted when the engine was rebuilt.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
