### PR TITLE
Support target_partitions in analytics PPL queries

### DIFF
--- a/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
+++ b/sandbox/libs/analytics-api/src/main/java/org/opensearch/analytics/QueryRequestContext.java
@@ -28,13 +28,18 @@ import org.opensearch.tasks.Task;
  *
  * @opensearch.internal
  */
-public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask) {
+public record QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask,
+    Integer targetPartitions) {
+
+    public QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource, Task parentTask) {
+        this(clusterState, schema, querySource, parentTask, null);
+    }
 
     public QueryRequestContext(ClusterState clusterState, SchemaPlus schema, String querySource) {
-        this(clusterState, schema, querySource, null);
+        this(clusterState, schema, querySource, null, null);
     }
 
     public QueryRequestContext(ClusterState clusterState, SchemaPlus schema) {
-        this(clusterState, schema, null, null);
+        this(clusterState, schema, null, null, null);
     }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FragmentInstructionHandlerFactory.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/FragmentInstructionHandlerFactory.java
@@ -36,6 +36,13 @@ public interface FragmentInstructionHandlerFactory {
      */
     Optional<InstructionNode> createShardScanNode(boolean requestsRowIds, String logicalTableName);
 
+    /**
+     * Creates a shard scan instruction node with optional targetPartitions override.
+     */
+    default Optional<InstructionNode> createShardScanNode(boolean requestsRowIds, String logicalTableName, Integer targetPartitions) {
+        return createShardScanNode(requestsRowIds, logicalTableName);
+    }
+
     /** Creates a filter delegation instruction node with the given delegation metadata. */
     Optional<InstructionNode> createFilterDelegationNode(
         FilterTreeShape treeShape,
@@ -62,6 +69,19 @@ public interface FragmentInstructionHandlerFactory {
         boolean requestsRowIds,
         String logicalTableName
     );
+
+    /**
+     * Creates a shard scan with delegation instruction node with optional targetPartitions override.
+     */
+    default Optional<InstructionNode> createShardScanWithDelegationNode(
+        FilterTreeShape treeShape,
+        int delegatedPredicateCount,
+        boolean requestsRowIds,
+        String logicalTableName,
+        Integer targetPartitions
+    ) {
+        return createShardScanWithDelegationNode(treeShape, delegatedPredicateCount, requestsRowIds, logicalTableName);
+    }
 
     /** Creates a partial aggregate instruction node. */
     Optional<InstructionNode> createPartialAggregateNode();

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShardScanInstructionNode.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShardScanInstructionNode.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.spi;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -34,24 +35,35 @@ public class ShardScanInstructionNode implements InstructionNode, Writeable {
 
     private final String logicalTableName;
     private final boolean requestsRowIds;
+    private final Integer targetPartitions;
 
     public ShardScanInstructionNode() {
-        this(false, null);
+        this(false, null, null);
     }
 
     public ShardScanInstructionNode(boolean requestsRowIds) {
-        this(requestsRowIds, null);
+        this(requestsRowIds, null, null);
     }
 
     // requestsRowIds is upstream's param; logicalTableName is our feature-branch addition, appended last.
     public ShardScanInstructionNode(boolean requestsRowIds, String logicalTableName) {
+        this(requestsRowIds, logicalTableName, null);
+    }
+
+    public ShardScanInstructionNode(boolean requestsRowIds, String logicalTableName, Integer targetPartitions) {
         this.logicalTableName = logicalTableName;
         this.requestsRowIds = requestsRowIds;
+        this.targetPartitions = targetPartitions;
     }
 
     public ShardScanInstructionNode(StreamInput in) throws IOException {
         this.logicalTableName = in.readOptionalString();
         this.requestsRowIds = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_9_0)) {
+            this.targetPartitions = in.readOptionalVInt();
+        } else {
+            this.targetPartitions = null;
+        }
     }
 
     /**
@@ -67,6 +79,10 @@ public class ShardScanInstructionNode implements InstructionNode, Writeable {
         return requestsRowIds;
     }
 
+    public Integer getTargetPartitions() {
+        return targetPartitions;
+    }
+
     @Override
     public InstructionType type() {
         return InstructionType.SETUP_SHARD_SCAN;
@@ -76,5 +92,8 @@ public class ShardScanInstructionNode implements InstructionNode, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(logicalTableName);
         out.writeBoolean(requestsRowIds);
+        if (out.getVersion().onOrAfter(Version.V_3_9_0)) {
+            out.writeOptionalVInt(targetPartitions);
+        }
     }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShardScanWithDelegationInstructionNode.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShardScanWithDelegationInstructionNode.java
@@ -27,7 +27,7 @@ public class ShardScanWithDelegationInstructionNode extends ShardScanInstruction
     private final int delegatedPredicateCount;
 
     public ShardScanWithDelegationInstructionNode(FilterTreeShape treeShape, int delegatedPredicateCount) {
-        this(treeShape, delegatedPredicateCount, false, null);
+        this(treeShape, delegatedPredicateCount, false, null, null);
     }
 
     // treeShape/delegatedPredicateCount/requestsRowIds are upstream's params; logicalTableName is our
@@ -38,7 +38,17 @@ public class ShardScanWithDelegationInstructionNode extends ShardScanInstruction
         boolean requestsRowIds,
         String logicalTableName
     ) {
-        super(requestsRowIds, logicalTableName);
+        this(treeShape, delegatedPredicateCount, requestsRowIds, logicalTableName, null);
+    }
+
+    public ShardScanWithDelegationInstructionNode(
+        FilterTreeShape treeShape,
+        int delegatedPredicateCount,
+        boolean requestsRowIds,
+        String logicalTableName,
+        Integer targetPartitions
+    ) {
+        super(requestsRowIds, logicalTableName, targetPartitions);
         this.treeShape = treeShape;
         this.delegatedPredicateCount = delegatedPredicateCount;
     }

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShardScanInstructionNodeTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShardScanInstructionNodeTests.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class ShardScanInstructionNodeTests extends OpenSearchTestCase {
+
+    public void testShardScanInstructionNodeWireRoundtripWithTargetPartitions() throws IOException {
+        ShardScanInstructionNode original = new ShardScanInstructionNode(true, "test_table", 8);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                ShardScanInstructionNode decoded = new ShardScanInstructionNode(in);
+                assertEquals("test_table", decoded.getLogicalTableName());
+                assertTrue(decoded.requestsRowIds());
+                assertEquals(Integer.valueOf(8), decoded.getTargetPartitions());
+                assertEquals(InstructionType.SETUP_SHARD_SCAN, decoded.type());
+            }
+        }
+    }
+
+    public void testShardScanInstructionNodeWireRoundtripWithNullTargetPartitions() throws IOException {
+        ShardScanInstructionNode original = new ShardScanInstructionNode(false, "test_table");
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                ShardScanInstructionNode decoded = new ShardScanInstructionNode(in);
+                assertEquals("test_table", decoded.getLogicalTableName());
+                assertFalse(decoded.requestsRowIds());
+                assertNull(decoded.getTargetPartitions());
+                assertEquals(InstructionType.SETUP_SHARD_SCAN, decoded.type());
+            }
+        }
+    }
+
+    public void testShardScanWithDelegationInstructionNodeWireRoundtrip() throws IOException {
+        ShardScanWithDelegationInstructionNode original = new ShardScanWithDelegationInstructionNode(
+            FilterTreeShape.CONJUNCTIVE,
+            3,
+            true,
+            "delegated_table",
+            12
+        );
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                ShardScanWithDelegationInstructionNode decoded = new ShardScanWithDelegationInstructionNode(in);
+                assertEquals("delegated_table", decoded.getLogicalTableName());
+                assertTrue(decoded.requestsRowIds());
+                assertEquals(Integer.valueOf(12), decoded.getTargetPartitions());
+                assertEquals(FilterTreeShape.CONJUNCTIVE, decoded.getTreeShape());
+                assertEquals(3, decoded.getDelegatedPredicateCount());
+                assertEquals(InstructionType.SETUP_SHARD_SCAN_WITH_DELEGATION, decoded.type());
+            }
+        }
+    }
+
+    public void testShardScanInstructionNodeWireRoundtripLegacyVersion() throws IOException {
+        ShardScanInstructionNode original = new ShardScanInstructionNode(true, "test_table", 8);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(org.opensearch.Version.V_3_8_0);
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(org.opensearch.Version.V_3_8_0);
+                ShardScanInstructionNode decoded = new ShardScanInstructionNode(in);
+                assertEquals("test_table", decoded.getLogicalTableName());
+                assertTrue(decoded.requestsRowIds());
+                assertNull(decoded.getTargetPartitions());
+                assertEquals(InstructionType.SETUP_SHARD_SCAN, decoded.type());
+            }
+        }
+    }
+
+    public void testShardScanWithDelegationInstructionNodeWireRoundtripLegacyVersion() throws IOException {
+        ShardScanWithDelegationInstructionNode original = new ShardScanWithDelegationInstructionNode(
+            FilterTreeShape.CONJUNCTIVE,
+            3,
+            true,
+            "delegated_table",
+            12
+        );
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(org.opensearch.Version.V_3_8_0);
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(org.opensearch.Version.V_3_8_0);
+                ShardScanWithDelegationInstructionNode decoded = new ShardScanWithDelegationInstructionNode(in);
+                assertEquals("delegated_table", decoded.getLogicalTableName());
+                assertTrue(decoded.requestsRowIds());
+                assertNull(decoded.getTargetPartitions());
+                assertEquals(FilterTreeShape.CONJUNCTIVE, decoded.getTreeShape());
+                assertEquals(3, decoded.getDelegatedPredicateCount());
+                assertEquals(InstructionType.SETUP_SHARD_SCAN_WITH_DELEGATION, decoded.type());
+            }
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionInstructionHandlerFactory.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionInstructionHandlerFactory.java
@@ -44,7 +44,12 @@ public class DataFusionInstructionHandlerFactory implements FragmentInstructionH
 
     @Override
     public Optional<InstructionNode> createShardScanNode(boolean requestsRowIds, String logicalTableName) {
-        return Optional.of(new ShardScanInstructionNode(requestsRowIds, logicalTableName));
+        return createShardScanNode(requestsRowIds, logicalTableName, null);
+    }
+
+    @Override
+    public Optional<InstructionNode> createShardScanNode(boolean requestsRowIds, String logicalTableName, Integer targetPartitions) {
+        return Optional.of(new ShardScanInstructionNode(requestsRowIds, logicalTableName, targetPartitions));
     }
 
     @Override
@@ -63,8 +68,25 @@ public class DataFusionInstructionHandlerFactory implements FragmentInstructionH
         boolean requestsRowIds,
         String logicalTableName
     ) {
+        return createShardScanWithDelegationNode(treeShape, delegatedPredicateCount, requestsRowIds, logicalTableName, null);
+    }
+
+    @Override
+    public Optional<InstructionNode> createShardScanWithDelegationNode(
+        FilterTreeShape treeShape,
+        int delegatedPredicateCount,
+        boolean requestsRowIds,
+        String logicalTableName,
+        Integer targetPartitions
+    ) {
         return Optional.of(
-            new ShardScanWithDelegationInstructionNode(treeShape, delegatedPredicateCount, requestsRowIds, logicalTableName)
+            new ShardScanWithDelegationInstructionNode(
+                treeShape,
+                delegatedPredicateCount,
+                requestsRowIds,
+                logicalTableName,
+                targetPartitions
+            )
         );
     }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
@@ -61,6 +61,9 @@ public class ShardScanInstructionHandler implements FragmentInstructionHandler<S
         String tableName = node.getLogicalTableName() != null ? node.getLogicalTableName() : context.getTableName();
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
+        if (node.getTargetPartitions() != null) {
+            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(node.getTargetPartitions()).build();
+        }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
             snapshot.writeTo(segment);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.ShardScanExecutionContext;
 import org.opensearch.analytics.spi.BackendExecutionContext;
 import org.opensearch.analytics.spi.CommonExecutionContext;
@@ -26,6 +28,8 @@ import java.lang.foreign.MemorySegment;
  * the default ListingTable provider for parquet scans.
  */
 public class ShardScanInstructionHandler implements FragmentInstructionHandler<ShardScanInstructionNode> {
+
+    private static final Logger logger = LogManager.getLogger(ShardScanInstructionHandler.class);
 
     private final DataFusionPlugin plugin;
 
@@ -62,7 +66,17 @@ public class ShardScanInstructionHandler implements FragmentInstructionHandler<S
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
         if (node.getTargetPartitions() != null) {
-            int effectivePartitions = Math.min(node.getTargetPartitions(), Runtime.getRuntime().availableProcessors());
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            int effectivePartitions = Math.min(node.getTargetPartitions(), availableProcessors);
+            if (node.getTargetPartitions() > availableProcessors) {
+                logger.debug(
+                    "Requested target_partitions [{}] exceeds available processors [{}]; clamping to [{}] for table [{}]",
+                    node.getTargetPartitions(),
+                    availableProcessors,
+                    effectivePartitions,
+                    tableName
+                );
+            }
             snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
         }
         try (Arena arena = Arena.ofConfined()) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanInstructionHandler.java
@@ -62,7 +62,8 @@ public class ShardScanInstructionHandler implements FragmentInstructionHandler<S
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
         if (node.getTargetPartitions() != null) {
-            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(node.getTargetPartitions()).build();
+            int effectivePartitions = Math.min(node.getTargetPartitions(), Runtime.getRuntime().availableProcessors());
+            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
         }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
@@ -65,6 +65,9 @@ public class ShardScanWithDelegationHandler implements FragmentInstructionHandle
         int delegatedPredicateCount = node.getDelegatedPredicateCount();
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
+        if (node.getTargetPartitions() != null) {
+            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(node.getTargetPartitions()).build();
+        }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);
             snapshot.writeTo(segment);

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.be.datafusion;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.backend.ShardScanExecutionContext;
 import org.opensearch.analytics.spi.BackendExecutionContext;
 import org.opensearch.analytics.spi.CommonExecutionContext;
@@ -28,6 +30,8 @@ import java.lang.foreign.MemorySegment;
  * and delegatedPredicateCount.
  */
 public class ShardScanWithDelegationHandler implements FragmentInstructionHandler<ShardScanWithDelegationInstructionNode> {
+
+    private static final Logger logger = LogManager.getLogger(ShardScanWithDelegationHandler.class);
 
     private final DataFusionPlugin plugin;
 
@@ -66,7 +70,17 @@ public class ShardScanWithDelegationHandler implements FragmentInstructionHandle
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
         if (node.getTargetPartitions() != null) {
-            int effectivePartitions = Math.min(node.getTargetPartitions(), Runtime.getRuntime().availableProcessors());
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            int effectivePartitions = Math.min(node.getTargetPartitions(), availableProcessors);
+            if (node.getTargetPartitions() > availableProcessors) {
+                logger.debug(
+                    "Requested target_partitions [{}] exceeds available processors [{}]; clamping to [{}] for table [{}]",
+                    node.getTargetPartitions(),
+                    availableProcessors,
+                    effectivePartitions,
+                    tableName
+                );
+            }
             snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
         }
         try (Arena arena = Arena.ofConfined()) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShardScanWithDelegationHandler.java
@@ -66,7 +66,8 @@ public class ShardScanWithDelegationHandler implements FragmentInstructionHandle
 
         WireConfigSnapshot snapshot = plugin.getDatafusionSettings().getSnapshot();
         if (node.getTargetPartitions() != null) {
-            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(node.getTargetPartitions()).build();
+            int effectivePartitions = Math.min(node.getTargetPartitions(), Runtime.getRuntime().availableProcessors());
+            snapshot = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
         }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(WireConfigSnapshot.BYTE_SIZE);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/WireConfigSnapshotTests.java
@@ -126,4 +126,30 @@ public class WireConfigSnapshotTests extends OpenSearchTestCase {
         assertEquals(original.indexedPushdownFilters(), copy.indexedPushdownFilters());
         assertEquals(original.forceStrategy(), copy.forceStrategy());
     }
+
+    public void testTargetPartitionsOverrideCappedAtAvailableProcessors() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().build();
+
+        int excessivePartitions = processors + 100;
+        int effectivePartitions = Math.min(excessivePartitions, processors);
+
+        WireConfigSnapshot updated = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
+
+        assertEquals(processors, updated.targetPartitions());
+    }
+
+    public void testTargetPartitionsOverrideLowerThanAvailableProcessors() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        WireConfigSnapshot snapshot = WireConfigSnapshot.builder().build();
+
+        int lowerPartitions = 1;
+        int effectivePartitions = Math.min(lowerPartitions, processors);
+        WireConfigSnapshot updatedLower = WireConfigSnapshot.builder(snapshot).targetPartitions(effectivePartitions).build();
+        assertEquals(1, updatedLower.targetPartitions());
+
+        int exactPartitions = Math.min(processors, processors);
+        WireConfigSnapshot updatedExact = WireConfigSnapshot.builder(snapshot).targetPartitions(exactPartitions).build();
+        assertEquals(processors, updatedExact.targetPartitions());
+    }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -436,7 +436,8 @@ public class DefaultPlanExecutor extends HandledTransportAction<AnalyticsQueryRe
             );
         }
         final String fullPlan = profile ? RelOptUtil.toString(plan) : null;
-        QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver);
+        Integer targetPartitions = queryCtx != null ? queryCtx.targetPartitions() : null;
+        QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService, indexNameExpressionResolver, targetPartitions);
 
         // Dispatch resolution under the GENERAL post-CBO scheduler. The enforcement pass placed every
         // exchange (shuffle/broadcast) + pre-split any distributed aggregate; DAGBuilder cut at those and

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/UnifiedDispatch.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/UnifiedDispatch.java
@@ -312,7 +312,7 @@ public final class UnifiedDispatch {
         ActionListener<Iterable<VectorSchemaRoot>> terminal
     ) {
         Stage strippedRoot = stripBuildChildren(dag.rootStage(), capturedByBuildId);
-        QueryDAG strippedDag = new QueryDAG(dag.queryId(), strippedRoot);
+        QueryDAG strippedDag = new QueryDAG(dag.queryId(), strippedRoot, dag.targetPartitions());
         LOGGER.debug(
             "[UnifiedDispatch] stripped {} captured build(s); dispatching broadcast-free DAG with deferred injection",
             capturedByBuildId.size()

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/DAGBuilder.java
@@ -61,6 +61,16 @@ public class DAGBuilder {
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver
     ) {
+        return build(cboOutput, registry, clusterService, indexNameExpressionResolver, null);
+    }
+
+    public static QueryDAG build(
+        RelNode cboOutput,
+        CapabilityRegistry registry,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Integer targetPartitions
+    ) {
         int[] counter = { 0 };
         List<Stage> childStages = new ArrayList<>();
 
@@ -76,7 +86,7 @@ public class DAGBuilder {
             // wrap a bare StageInputScan placeholder.
             cutAtLateMaterialization(lm, counter, childStages, registry, clusterService, indexNameExpressionResolver);
             assert childStages.size() == 1 : "cutAtLateMaterialization must add exactly one child (the LM stage)";
-            return new QueryDAG(newQueryId(), childStages.getFirst());
+            return new QueryDAG(newQueryId(), childStages.getFirst(), targetPartitions);
         } else {
             rootFragment = sever(cboOutput, counter, childStages, registry, clusterService, indexNameExpressionResolver);
         }
@@ -105,7 +115,7 @@ public class DAGBuilder {
             : null;
 
         Stage rootStage = new Stage(counter[0]++, rootFragment, childStages, null, sinkProvider, rootTargetResolver);
-        return new QueryDAG(newQueryId(), rootStage);
+        return new QueryDAG(newQueryId(), rootStage, targetPartitions);
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/FragmentConversionDriver.java
@@ -84,7 +84,7 @@ public class FragmentConversionDriver {
      * {@link StagePlan#convertedBytes()} on each plan.
      */
     public static void convertAll(QueryDAG dag, CapabilityRegistry registry) {
-        convertStage(dag.rootStage(), registry);
+        convertStage(dag.rootStage(), registry, dag.targetPartitions());
         // Root stage executes locally at coordinator — store factory for instruction dispatch.
         Stage root = dag.rootStage();
         if (root.getExchangeSinkProvider() != null && !root.getPlanAlternatives().isEmpty()) {
@@ -93,9 +93,9 @@ public class FragmentConversionDriver {
         }
     }
 
-    private static void convertStage(Stage stage, CapabilityRegistry registry) {
+    private static void convertStage(Stage stage, CapabilityRegistry registry, Integer targetPartitions) {
         for (Stage child : stage.getChildStages()) {
-            convertStage(child, registry);
+            convertStage(child, registry, targetPartitions);
         }
         // After children are converted, surface any decorator-induced schema delta as
         // postDecorationSchemaBytes on the child plans. The reduce sink consults this when
@@ -130,7 +130,7 @@ public class FragmentConversionDriver {
 
             // Assemble instruction list
             List<DelegatedExpression> delegated = delegationBytes.getResult();
-            List<InstructionNode> instructions = assembleInstructions(backend, plan, treeShape, delegationBytes);
+            List<InstructionNode> instructions = assembleInstructions(backend, plan, treeShape, delegationBytes, targetPartitions);
 
             converted.add(plan.withConvertedBytes(bytes, delegated).withInstructions(instructions));
             LOGGER.debug(
@@ -239,7 +239,8 @@ public class FragmentConversionDriver {
         AnalyticsSearchBackendPlugin backend,
         StagePlan plan,
         FilterTreeShape treeShape,
-        IntraOperatorDelegationBytes delegationBytes
+        IntraOperatorDelegationBytes delegationBytes,
+        Integer targetPartitions
     ) {
         FragmentInstructionHandlerFactory factory = backend.getInstructionHandlerFactory();
         LinkedList<InstructionNode> instructions = new LinkedList<>();
@@ -257,10 +258,10 @@ public class FragmentConversionDriver {
             boolean requestsRowIds = tableScan.getRowType().getFieldNames().contains(OpenSearchLateMaterialization.ROW_ID_FIELD);
             List<DelegatedExpression> delegated = delegationBytes.getResult();
             if (!delegated.isEmpty()) {
-                factory.createShardScanWithDelegationNode(treeShape, delegated.size(), requestsRowIds, logicalTableName)
+                factory.createShardScanWithDelegationNode(treeShape, delegated.size(), requestsRowIds, logicalTableName, targetPartitions)
                     .ifPresent(instructions::add);
             } else {
-                factory.createShardScanNode(requestsRowIds, logicalTableName).ifPresent(instructions::add);
+                factory.createShardScanNode(requestsRowIds, logicalTableName, targetPartitions).ifPresent(instructions::add);
             }
             if (containsPartialAggregate(resolvedFragment)) {
                 factory.createPartialAggregateNode().ifPresent(instructions::add);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/GeneralShuffleDAGRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/GeneralShuffleDAGRewriter.java
@@ -157,7 +157,7 @@ public final class GeneralShuffleDAGRewriter {
 
         Set<Integer> workerIds = descriptors.keySet();
         Stage newRoot = rebuild(root, workerIds, nodesByStageId, backend);
-        QueryDAG rewrittenDag = new QueryDAG(dag.queryId(), newRoot);
+        QueryDAG rewrittenDag = new QueryDAG(dag.queryId(), newRoot, dag.targetPartitions());
 
         // Deferred level builder — run after the convert pipeline re-creates non-worker stages. Producers
         // are looked up from the rewritten DAG by stage id; an intermediate-worker producer keeps its

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/QueryDAG.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/QueryDAG.java
@@ -12,12 +12,16 @@ import org.apache.calcite.plan.RelOptUtil;
 
 /**
  * Root of the query execution DAG. Recursive tree of {@link Stage}s.
- *
- * @param queryId   unique identifier for this query
- * @param rootStage the coordinator root stage
+ * @param queryId          unique identifier for this query
+ * @param rootStage        the coordinator root stage
+ * @param targetPartitions optional per-query target partitions override
  * @opensearch.internal
  */
-public record QueryDAG(String queryId, Stage rootStage) {
+public record QueryDAG(String queryId, Stage rootStage, Integer targetPartitions) {
+
+    public QueryDAG(String queryId, Stage rootStage) {
+        this(queryId, rootStage, null);
+    }
 
     @Override
     public String toString() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/dag/DAGBuilderTests.java
@@ -415,4 +415,22 @@ public class DAGBuilderTests extends BasePlannerRulesTests {
             dag.rootStage().getExecutionType()
         );
     }
+
+    public void testDAGBuilderPreservesTargetPartitions() {
+        var context = buildContext("parquet", 2, intFields());
+        RelNode logical = stubScan(mockTable("test_index", "status", "size"));
+        RelNode cbo = runPlanner(logical, context);
+
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER, 8);
+        assertEquals(Integer.valueOf(8), dag.targetPartitions());
+    }
+
+    public void testDAGBuilderDefaultTargetPartitionsIsNull() {
+        var context = buildContext("parquet", 2, intFields());
+        RelNode logical = stubScan(mockTable("test_index", "status", "size"));
+        RelNode cbo = runPlanner(logical, context);
+
+        QueryDAG dag = DAGBuilder.build(cbo, context.getCapabilityRegistry(), mockClusterService(), TEST_RESOLVER);
+        assertNull(dag.targetPartitions());
+    }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLRequest.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/PPLRequest.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.ppl.action;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -24,20 +25,31 @@ public class PPLRequest extends ActionRequest {
 
     private final String pplText;
     private final boolean explain;
+    private final Integer targetPartitions;
 
     public PPLRequest(String pplText) {
-        this(pplText, false);
+        this(pplText, false, null);
     }
 
     public PPLRequest(String pplText, boolean explain) {
+        this(pplText, explain, null);
+    }
+
+    public PPLRequest(String pplText, boolean explain, Integer targetPartitions) {
         this.pplText = pplText;
         this.explain = explain;
+        this.targetPartitions = targetPartitions;
     }
 
     public PPLRequest(StreamInput in) throws IOException {
         super(in);
         this.pplText = in.readString();
         this.explain = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_9_0)) {
+            this.targetPartitions = in.readOptionalVInt();
+        } else {
+            this.targetPartitions = null;
+        }
     }
 
     @Override
@@ -45,6 +57,9 @@ public class PPLRequest extends ActionRequest {
         super.writeTo(out);
         out.writeString(pplText);
         out.writeBoolean(explain);
+        if (out.getVersion().onOrAfter(Version.V_3_9_0)) {
+            out.writeOptionalVInt(targetPartitions);
+        }
     }
 
     @Override
@@ -52,6 +67,9 @@ public class PPLRequest extends ActionRequest {
         ActionRequestValidationException validationException = null;
         if (pplText == null || pplText.isEmpty()) {
             validationException = addValidationError("pplText is missing or empty", validationException);
+        }
+        if (targetPartitions != null && targetPartitions < 1) {
+            validationException = addValidationError("targetPartitions must be >= 1", validationException);
         }
         return validationException;
     }
@@ -62,5 +80,9 @@ public class PPLRequest extends ActionRequest {
 
     public boolean isExplain() {
         return explain;
+    }
+
+    public Integer getTargetPartitions() {
+        return targetPartitions;
     }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
@@ -46,6 +46,7 @@ public class RestPPLQueryAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String queryText = null;
         boolean profile = false;
+        Integer targetPartitions = null;
         try (XContentParser parser = request.contentParser()) {
             parser.nextToken();
             while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -55,6 +56,17 @@ public class RestPPLQueryAction extends BaseRestHandler {
                     queryText = parser.text();
                 } else if ("profile".equals(fieldName)) {
                     profile = parser.booleanValue();
+                } else if ("target_partitions".equals(fieldName)) {
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                        targetPartitions = parser.intValue();
+                    } else if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        targetPartitions = null;
+                    } else {
+                        throw new IllegalArgumentException("target_partitions must be a positive integer");
+                    }
+                    if (targetPartitions != null && targetPartitions < 1) {
+                        throw new IllegalArgumentException("target_partitions must be greater than or equal to 1");
+                    }
                 } else {
                     parser.skipChildren();
                 }
@@ -64,7 +76,7 @@ public class RestPPLQueryAction extends BaseRestHandler {
             throw new IllegalArgumentException("Request body must contain a 'query' field");
         }
         boolean enableProfile = profile || request.path().endsWith("/_explain");
-        PPLRequest pplRequest = new PPLRequest(queryText, enableProfile);
+        PPLRequest pplRequest = new PPLRequest(queryText, enableProfile, targetPartitions);
         return channel -> client.execute(UnifiedPPLExecuteAction.INSTANCE, pplRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/RestPPLQueryAction.java
@@ -62,7 +62,7 @@ public class RestPPLQueryAction extends BaseRestHandler {
                     } else if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         targetPartitions = null;
                     } else {
-                        throw new IllegalArgumentException("target_partitions must be a positive integer");
+                        throw new IllegalArgumentException("target_partitions must be an integer");
                     }
                     if (targetPartitions != null && targetPartitions < 1) {
                         throw new IllegalArgumentException("target_partitions must be greater than or equal to 1");

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/TestPPLTransportAction.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/TestPPLTransportAction.java
@@ -69,9 +69,16 @@ public class TestPPLTransportAction extends HandledTransportAction<PPLRequest, P
         // TODO: update UnifiedQueryService to consume a listener that DefaultPlanExecutor does to avoid threadpool fork
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
             try {
-                PPLResponse response = request.isExplain()
-                    ? unifiedQueryService.executeWithProfile(request.getPplText())
-                    : unifiedQueryService.execute(request.getPplText());
+                PPLResponse response;
+                if (request.isExplain()) {
+                    response = request.getTargetPartitions() != null
+                        ? unifiedQueryService.executeWithProfile(request.getPplText(), request.getTargetPartitions())
+                        : unifiedQueryService.executeWithProfile(request.getPplText());
+                } else {
+                    response = request.getTargetPartitions() != null
+                        ? unifiedQueryService.execute(request.getPplText(), request.getTargetPartitions())
+                        : unifiedQueryService.execute(request.getPplText());
+                }
                 listener.onResponse(response);
             } catch (Exception e) {
                 logger.error("[UNIFIED_PPL] execution failed", e);

--- a/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
+++ b/sandbox/plugins/test-ppl-frontend/src/main/java/org/opensearch/ppl/action/UnifiedQueryService.java
@@ -54,7 +54,11 @@ public class UnifiedQueryService {
      * PPL text → RelNode → planExecutor.execute() → PPLResponse.
      */
     public PPLResponse execute(String pplText) {
-        return execute(pplText, false);
+        return execute(pplText, false, null);
+    }
+
+    public PPLResponse execute(String pplText, Integer targetPartitions) {
+        return execute(pplText, false, targetPartitions);
     }
 
     /**
@@ -62,10 +66,14 @@ public class UnifiedQueryService {
      * planExecutor.executeWithProfile() → PPLResponse with profile.
      */
     public PPLResponse executeWithProfile(String pplText) {
-        return execute(pplText, true);
+        return execute(pplText, true, null);
     }
 
-    private PPLResponse execute(String pplText, boolean profile) {
+    public PPLResponse executeWithProfile(String pplText, Integer targetPartitions) {
+        return execute(pplText, true, targetPartitions);
+    }
+
+    private PPLResponse execute(String pplText, boolean profile, Integer targetPartitions) {
         // Wrap the SchemaPlus in a delegating AbstractSchema that preserves lazy table resolution.
         // The underlying OpenSearchSchemaBuilder resolves wildcard/comma/exclusion expressions
         // lazily via getTable(name) — a static copy would lose that.
@@ -126,7 +134,13 @@ public class UnifiedQueryService {
             }
 
             QueryRequestContext baseCtx = contextProvider.getContext();
-            QueryRequestContext queryCtx = new QueryRequestContext(baseCtx.clusterState(), baseCtx.schema(), pplText);
+            QueryRequestContext queryCtx = new QueryRequestContext(
+                baseCtx.clusterState(),
+                baseCtx.schema(),
+                pplText,
+                baseCtx.parentTask(),
+                targetPartitions
+            );
 
             if (profile) {
                 PlainActionFuture<ProfiledResult> future = new PlainActionFuture<>();

--- a/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/PPLRequestTests.java
+++ b/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/PPLRequestTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ppl.action;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class PPLRequestTests extends OpenSearchTestCase {
+
+    public void testDefaultConstructor() {
+        PPLRequest request = new PPLRequest("source=test");
+        assertEquals("source=test", request.getPplText());
+        assertFalse(request.isExplain());
+        assertNull(request.getTargetPartitions());
+        assertNull(request.validate());
+    }
+
+    public void testExplainConstructor() {
+        PPLRequest request = new PPLRequest("source=test", true);
+        assertEquals("source=test", request.getPplText());
+        assertTrue(request.isExplain());
+        assertNull(request.getTargetPartitions());
+        assertNull(request.validate());
+    }
+
+    public void testTargetPartitionsConstructor() {
+        PPLRequest request = new PPLRequest("source=test", false, 8);
+        assertEquals("source=test", request.getPplText());
+        assertFalse(request.isExplain());
+        assertEquals(Integer.valueOf(8), request.getTargetPartitions());
+        assertNull(request.validate());
+    }
+
+    public void testValidationInvalidTargetPartitions() {
+        PPLRequest request = new PPLRequest("source=test", false, 0);
+        ActionRequestValidationException ex = request.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("targetPartitions must be >= 1"));
+
+        PPLRequest requestNegative = new PPLRequest("source=test", false, -3);
+        ActionRequestValidationException exNegative = requestNegative.validate();
+        assertNotNull(exNegative);
+        assertTrue(exNegative.getMessage().contains("targetPartitions must be >= 1"));
+    }
+
+    public void testValidationMissingQuery() {
+        PPLRequest request = new PPLRequest((String) null);
+        ActionRequestValidationException ex = request.validate();
+        assertNotNull(ex);
+        assertTrue(ex.getMessage().contains("pplText is missing or empty"));
+    }
+
+    public void testStreamSerializationRoundTripWithTargetPartitions() throws IOException {
+        PPLRequest original = new PPLRequest("source=index | where a > 1", true, 16);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                PPLRequest decoded = new PPLRequest(in);
+                assertEquals(original.getPplText(), decoded.getPplText());
+                assertEquals(original.isExplain(), decoded.isExplain());
+                assertEquals(original.getTargetPartitions(), decoded.getTargetPartitions());
+            }
+        }
+    }
+
+    public void testStreamSerializationRoundTripWithNullTargetPartitions() throws IOException {
+        PPLRequest original = new PPLRequest("source=index", false, null);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                PPLRequest decoded = new PPLRequest(in);
+                assertEquals(original.getPplText(), decoded.getPplText());
+                assertEquals(original.isExplain(), decoded.isExplain());
+                assertNull(decoded.getTargetPartitions());
+            }
+        }
+    }
+
+    public void testStreamSerializationWithLegacyVersion() throws IOException {
+        PPLRequest original = new PPLRequest("source=index", true, 8);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(org.opensearch.Version.V_3_8_0);
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(org.opensearch.Version.V_3_8_0);
+                PPLRequest decoded = new PPLRequest(in);
+                assertEquals(original.getPplText(), decoded.getPplText());
+                assertEquals(original.isExplain(), decoded.isExplain());
+                assertNull(decoded.getTargetPartitions());
+            }
+        }
+    }
+}

--- a/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
+++ b/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
@@ -39,4 +39,42 @@ public class RestPPLQueryActionTests extends OpenSearchTestCase {
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
         assertTrue(ex.getMessage().contains("query"));
     }
+
+    public void testPrepareRequestWithTargetPartitions() throws Exception {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("/_analytics/ppl")
+            .withContent(new BytesArray("{\"query\":\"source=test\",\"target_partitions\":4}"), XContentType.JSON)
+            .build();
+
+        action.prepareRequest(request, null);
+    }
+
+    public void testPrepareRequestWithInvalidTargetPartitions() {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("/_analytics/ppl")
+            .withContent(new BytesArray("{\"query\":\"source=test\",\"target_partitions\":0}"), XContentType.JSON)
+            .build();
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
+        assertTrue(ex.getMessage().contains("target_partitions must be greater than or equal to 1"));
+    }
+
+    public void testPrepareRequestWithNullTargetPartitions() throws Exception {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("/_analytics/ppl")
+            .withContent(new BytesArray("{\"query\":\"source=test\",\"target_partitions\":null}"), XContentType.JSON)
+            .build();
+
+        action.prepareRequest(request, null);
+    }
+
+    public void testPrepareRequestWithNonNumberTargetPartitions() {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("/_analytics/ppl")
+            .withContent(new BytesArray("{\"query\":\"source=test\",\"target_partitions\":\"invalid\"}"), XContentType.JSON)
+            .build();
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
+        assertTrue(ex.getMessage().contains("target_partitions must be a positive integer"));
+    }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
+++ b/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/RestPPLQueryActionTests.java
@@ -75,6 +75,6 @@ public class RestPPLQueryActionTests extends OpenSearchTestCase {
             .build();
 
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, null));
-        assertTrue(ex.getMessage().contains("target_partitions must be a positive integer"));
+        assertTrue(ex.getMessage().contains("target_partitions must be an integer"));
     }
 }

--- a/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/TestPPLTransportActionTests.java
+++ b/sandbox/plugins/test-ppl-frontend/src/test/java/org/opensearch/ppl/action/TestPPLTransportActionTests.java
@@ -200,4 +200,27 @@ public class TestPPLTransportActionTests extends OpenSearchTestCase {
         verify(mockUnifiedQueryService).execute("source=metrics | where status=500");
         verifyNoMoreInteractions(mockUnifiedQueryService);
     }
+
+    public void testTargetPartitionsForwardedToUnifiedQueryService() throws Exception {
+        PPLResponse response = new PPLResponse(Collections.emptyList(), Collections.emptyList());
+        when(mockUnifiedQueryService.execute("source=logs", 4)).thenReturn(response);
+
+        AtomicReference<PPLResponse> captured = new AtomicReference<>();
+        ActionListener<PPLResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(PPLResponse r) {
+                captured.set(r);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail");
+            }
+        };
+        action.execute(null, new PPLRequest("source=logs", false, 4), listener);
+
+        assertBusy(() -> assertNotNull(captured.get()));
+        verify(mockUnifiedQueryService).execute("source=logs", 4);
+        verifyNoMoreInteractions(mockUnifiedQueryService);
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds support for an optional `target_partitions` parameter in analytics PPL request payloads (`POST /_analytics/ppl`) to control DataFusion intra-shard execution concurrency dynamically per query without changing cluster-level defaults.

- **Propagation Pipeline**: REST (`RestPPLQueryAction`) -> Transport (`PPLRequest`, `TestPPLTransportAction`) -> Context (`QueryRequestContext`) -> Planner (`DAGBuilder`, `QueryDAG`) -> SPI Nodes (`ShardScanInstructionNode`, `ShardScanWithDelegationInstructionNode`) -> Backend (`DataFusionInstructionHandlerFactory`, `WireConfigSnapshot`).
- **Validation & Compatibility**: Enforces `target_partitions >= 1` (rejects  <= 0 with 400 Bad Request); defaults to existing node configurations when omitted (`null`).
- **Testing**: Added unit test coverage for REST JSON parsing, transport/SPI wire serialization round-trips, validation failure modes, and DAG stage propagation (`PPLRequestTests`, `RestPPLQueryActionTests`, `TestPPLTransportActionTests`, `ShardScanInstructionNodeTests`, `DAGBuilderTests`).

### Related Issues
Resolves #22919

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).