### PR TITLE
Pair onRequestStart when a search fails before its first phase

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
@@ -39,6 +39,7 @@ import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.action.search.SearchPhaseName;
+import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.routing.GroupShardsIterator;
@@ -46,6 +47,7 @@ import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.search.stats.SearchStats.Stats;
 import org.opensearch.plugins.Plugin;
@@ -248,6 +250,26 @@ public class SearchStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTes
             }
         }
         return nodes;
+    }
+
+    public void testTookCurrentNotLeakedWhenRequestFailsBeforeFirstPhase() throws Exception {
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(SEARCH_REQUEST_STATS_ENABLED_KEY, true).build())
+            .get();
+
+        String coordinator = internalCluster().getNodeNames()[0];
+        SearchRequestStats searchRequestStats = internalCluster().getInstance(SearchRequestStats.class, coordinator);
+        long tookCurrentBefore = searchRequestStats.getTookCurrent();
+
+        // Resolving a missing index fails before the first phase starts, so the request never reaches
+        // AbstractSearchAsyncAction, which is what normally emits the terminal notification. Without the
+        // pre-phase pairing the onRequestStart emitted on arrival is never matched and took.current
+        // stays incremented for the lifetime of the node.
+        expectThrows(IndexNotFoundException.class, () -> client(coordinator).prepareSearch("does_not_exist").get());
+
+        assertEquals(tookCurrentBefore, searchRequestStats.getTookCurrent());
     }
 
     public void testOpenContexts() {

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -500,11 +500,15 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     private void onRequestEnd(SearchRequestContext searchRequestContext) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(this, searchRequestContext);
+        if (searchRequestContext.markRequestCompleted()) {
+            this.searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(this, searchRequestContext);
+        }
     }
 
     private void onRequestFailure(SearchRequestContext searchRequestContext) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(this, searchRequestContext);
+        if (searchRequestContext.markRequestCompleted()) {
+            this.searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(this, searchRequestContext);
+        }
     }
 
     private void executePhase(SearchPhase phase) {

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 /**
@@ -44,6 +45,7 @@ public class SearchRequestContext {
     private final LinkedBlockingQueue<TaskResourceInfo> phaseResourceUsage;
     private final Supplier<TaskResourceInfo> taskResourceUsageSupplier;
     private boolean streamingRequest;
+    private final AtomicBoolean requestCompleted = new AtomicBoolean(false);
 
     SearchRequestContext(
         final SearchRequestOperationsListener searchRequestOperationsListener,
@@ -61,6 +63,16 @@ public class SearchRequestContext {
 
     SearchRequestOperationsListener getSearchRequestOperationsListener() {
         return searchRequestOperationsListener;
+    }
+
+    /**
+     * Claims the single terminal notification for this request, so that the {@code onRequestStart}
+     * emitted when the request arrived is paired exactly once. Returns {@code true} only for the
+     * first caller, whether that is a phase completing, a phase failing, or the request failing
+     * before any phase started.
+     */
+    boolean markRequestCompleted() {
+        return requestCompleted.compareAndSet(false, true);
     }
 
     void updatePhaseTookMap(String phaseName, Long tookTime) {

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -47,10 +47,23 @@ public abstract class SearchRequestOperationsListener {
 
     protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {};
 
+    /**
+     * Invoked when a search request arrives. Exactly one of
+     * {@link #onRequestEnd(SearchPhaseContext, SearchRequestContext)} or
+     * {@link #onRequestFailure(SearchPhaseContext, SearchRequestContext)} follows it, so listeners can
+     * safely pair state started here.
+     */
     protected void onRequestStart(SearchRequestContext searchRequestContext) {}
 
     protected void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
+    /**
+     * Invoked when a search request fails.
+     *
+     * @param context the phase the request failed in, or {@code null} when it failed before its first
+     *                phase started, for instance while resolving indices or the search pipeline.
+     *                Implementations must tolerate a null context.
+     */
     protected void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     protected boolean isEnabled(SearchRequest searchRequest) {

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -485,6 +485,17 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             );
             searchRequestContext.getSearchRequestOperationsListener().onRequestStart(searchRequestContext);
 
+            // A request that fails before its first phase starts never reaches AbstractSearchAsyncAction, which is
+            // what normally emits the terminal notification, so the onRequestStart above would otherwise go unpaired
+            // and leak search.request.took.current. There is no SearchPhaseContext to report on these paths; no
+            // onRequestFailure implementation reads it, and CompositeListener isolates each listener anyway.
+            final ActionListener<SearchResponse> accountedListener = ActionListener.wrap(updatedListener::onResponse, e -> {
+                if (searchRequestContext.markRequestCompleted()) {
+                    searchRequestContext.getSearchRequestOperationsListener().onRequestFailure(null, searchRequestContext);
+                }
+                updatedListener.onFailure(e);
+            });
+
             // At this point either the QUERY_GROUP_ID header will be present in ThreadContext either via ActionFilter
             // or HTTP header (HTTP header will be deprecated once ActionFilter is implemented)
             if (task instanceof WorkloadGroupTask) {
@@ -496,9 +507,9 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             try {
                 final Task parentTask = extractParentTask(originalSearchRequest);
                 searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest, parentTask, indexNameExpressionResolver);
-                listener = searchRequest.transformResponseListener(updatedListener);
+                listener = searchRequest.transformResponseListener(accountedListener);
             } catch (Exception e) {
-                updatedListener.onFailure(e);
+                accountedListener.onFailure(e);
                 return;
             }
 


### PR DESCRIPTION
### Description

`TransportSearchAction.executeRequest` emits `onRequestStart` for every search, which increments `search.request.took.current`. The only thing that emits the terminal notification is `AbstractSearchAsyncAction`, and it is not constructed until a phase starts. A request that fails earlier, during index resolution, pipeline resolution or request transformation, is routed straight to the listener by `buildRewriteListener`, so the increment is never matched.

The result is `took.current` rising forever while `took.total` stays flat and every per-phase `current` stays at 0. Searching a missing index is enough to reproduce it:

```
curl -s 'localhost:9200/does_not_exist/_search'
curl -s 'localhost:9200/_nodes/stats/indices/search?filter_path=nodes.*.indices.search.request.took'
```

The fix claims the single terminal notification with a compare-and-set on `SearchRequestContext`, and fires `onRequestFailure` from the listener when a request ends before any phase started.

The guard is load bearing rather than defensive. `AbstractSearchAsyncAction` calls `onRequestFailure(...)` and then `listener.onFailure(...)`, so without it the listener wrapper would decrement a second time on phase failures and drive the counter negative, which is the failure mode #19340 had to correct. Guarding both terminal callbacks keeps the pairing exactly one-to-one in either direction.

Two things worth a reviewer's attention:

- The pre-phase call passes a null `SearchPhaseContext`, because there is no phase to report. No `onRequestFailure` implementation reads that parameter today (`SearchRequestStats` only decrements, `SearchTaskRequestOperationsListener` clears thread-local usage, `WorkloadGroupRequestOperationListener` reads a thread-context header, and `TraceableSearchRequestOperationsListener` overrides only `onRequestEnd`), and `CompositeListener` isolates each listener in a try/catch. If you would rather widen the signature or add a separate callback for the pre-phase case, I am happy to rework it.
- Firing the chain on these paths also reaches `SearchTaskRequestOperationsListener.removeTaskResourceUsage()` and `WorkloadGroupRequestOperationListener.incrementFailuresFor()`, so a request failing before its first phase now releases its task resource usage and counts against its workload group. Both read as more correct than the status quo, but they are behaviour changes beyond the metric and should be a deliberate call, not a side effect.

### Testing

Added `SearchStatsIT.testTookCurrentNotLeakedWhenRequestFailsBeforeFirstPhase`, which enables `search.request_stats_enabled`, records `took.current` on the coordinator, searches a missing index, and asserts the counter returns to its previous value.

Verified it is a real regression test rather than one asserting an incidental zero, by reverting the three source files and leaving the test in place:

```
# without the fix
Tests with failures:
 - SearchStatsIT.testTookCurrentNotLeakedWhenRequestFailsBeforeFirstPhase {p0={"search.concurrent_segment_search.enabled":"false"}}
 - SearchStatsIT.testTookCurrentNotLeakedWhenRequestFailsBeforeFirstPhase {p0={"search.concurrent_segment_search.enabled":"true"}}
2 tests completed, 2 failed

# with the fix
BUILD SUCCESSFUL
```

Also green locally on JDK 21:

- `./gradlew :server:test --tests "org.opensearch.action.search.*"`
- `./gradlew :server:internalClusterTest --tests "*SearchStatsIT*"`

### Related Issues

Resolves #22745

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
