### PR TITLE
Fix flaky SnapshotCleanupRetryIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotCleanupRetryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotCleanupRetryIT.java
@@ -64,17 +64,18 @@ public class SnapshotCleanupRetryIT extends AbstractSnapshotIntegTestCase {
             assertTrue("Snapshot marker should be cleaned up", snapshotsInProgress.entries().isEmpty());
         }, 60, TimeUnit.SECONDS);
 
-        logger.info("--> verify snapshot state after failover");
-        GetSnapshotsResponse snapshotResponse = client().admin()
-            .cluster()
-            .prepareGetSnapshots("test-repo")
-            .setSnapshots("test-snap")
-            .setIgnoreUnavailable(true)
-            .get();
-        if (snapshotResponse.getSnapshots().isEmpty() == false) {
-            SnapshotState state = snapshotResponse.getSnapshots().get(0).state();
-            assertTrue("Snapshot should be completed but was " + state, state.completed());
-        }
+        assertBusy(() -> {
+            GetSnapshotsResponse snapshotResponse = client().admin()
+                .cluster()
+                .prepareGetSnapshots("test-repo")
+                .setSnapshots("test-snap")
+                .setIgnoreUnavailable(true)
+                .get();
+            if (snapshotResponse.getSnapshots().isEmpty() == false) {
+                SnapshotState state = snapshotResponse.getSnapshots().get(0).state();
+                assertTrue("Snapshot should be completed but was " + state, state.completed());
+            }
+        });
 
         logger.info("--> verify index deletion is unblocked");
         assertAcked(client().admin().indices().prepareDelete("test-idx").get());


### PR DESCRIPTION
Cluster state updates are applied asynchronously. It is possible for the snapshot marker request to hit one node with the newest state and see no snapshots in the cluster state, then the next snapshot state request hits a node that hasn't applied the latest cluster state version and sees the snapshot in progress. The fix is to poll for the state to resolve.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
