### PR TITLE
[Sandbox] Bound the filter-predicate guard traversal

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
@@ -12,6 +12,10 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
 /**
  * Guards against excessively complex filter predicates by counting leaf predicates
  * in a {@link RexNode} condition tree.
@@ -27,6 +31,18 @@ import org.apache.calcite.sql.SqlKind;
  * rarely survives to this point. Predicate count is the gap that guard doesn't cover —
  * a flat fan-out of many OR-ed conditions passes the SQL plugin's depth check easily.
  *
+ * <p><b>The traversal itself is bounded.</b> A guard that walks the tree recursively is
+ * only as safe as the tree is shallow: a pathologically deep boolean condition (deeper than
+ * the JVM can recurse) would overflow the stack <em>inside the guard</em> and surface as a
+ * {@link StackOverflowError} — an unhandled {@code Error}, not the intended HTTP 400 — before
+ * the guard could reject it. Depth flattening upstream makes this unlikely, but a guard whose
+ * own safety depends on the input already being well-formed is not a guard. So the walk here is
+ * iterative (an explicit stack, never the call stack) and short-circuits the moment the leaf
+ * count exceeds the limit: it never visits more than {@code maxCount + 1} leaves, and never
+ * pushes deeper than the tree it is rejecting. Regardless of how the input is shaped, the guard
+ * either passes it or throws {@link IllegalArgumentException} — it can no longer be made to fail
+ * by the very complexity it exists to reject.
+ *
  * @opensearch.internal
  */
 public final class FilterPredicateGuard {
@@ -37,6 +53,10 @@ public final class FilterPredicateGuard {
      * Validates the filter condition against the configured leaf-predicate count limit.
      * Throws {@link IllegalArgumentException} (HTTP 400) if the limit is exceeded.
      *
+     * <p>The traversal stops as soon as the limit is known to be exceeded, so it is bounded
+     * by {@code maxCount} in both work and stack depth — a deeply nested condition cannot make
+     * the guard itself overflow the stack.
+     *
      * @param condition the filter's RexNode condition tree
      * @param maxCount  maximum leaf predicates allowed (0 = unlimited)
      */
@@ -44,11 +64,13 @@ public final class FilterPredicateGuard {
         if (maxCount <= 0) {
             return; // guard disabled
         }
-        int leafCount = countLeaves(condition);
+        // Count up to maxCount + 1: that is all we need to decide, and it caps the work the
+        // guard does on a hostile condition tree at one leaf beyond the limit.
+        int leafCount = countLeavesUpTo(condition, maxCount + 1);
         if (leafCount > maxCount) {
             throw new IllegalArgumentException(
-                "Filter condition contains "
-                    + leafCount
+                "Filter condition contains more than "
+                    + maxCount
                     + " predicates, exceeding the maximum allowed ["
                     + maxCount
                     + "]. Simplify the query by reducing the number of filter conditions."
@@ -59,23 +81,57 @@ public final class FilterPredicateGuard {
     /**
      * Returns the number of leaf predicates in the given RexNode tree. Boolean connectives
      * ({@code AND}/{@code OR}/{@code NOT}) are not counted themselves — only their operands
-     * contribute, recursively.
+     * contribute.
+     *
+     * <p>Traversal is iterative (explicit stack) rather than recursive, so it is safe against
+     * arbitrarily deep condition trees. This method counts the whole tree; {@link #validate}
+     * uses the bounded {@link #countLeavesUpTo} variant to avoid doing unbounded work on input
+     * it is going to reject anyway.
      */
     static int countLeaves(RexNode node) {
-        if (!(node instanceof RexCall call)) {
-            // Literal or input ref — not a predicate by itself
+        return countLeavesUpTo(node, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Counts leaf predicates in {@code node}, stopping early once the running total reaches
+     * {@code limit}. Returns a value in {@code [0, limit]}: a return value equal to {@code limit}
+     * means "at least {@code limit}" (the walk short-circuited and the true total may be higher).
+     *
+     * <p>Uses an explicit work stack instead of recursion, so traversal depth is independent of
+     * the JVM call-stack depth and cannot overflow it. Combined with the early exit, the guard's
+     * cost is bounded by {@code limit} regardless of the tree's size or nesting.
+     */
+    static int countLeavesUpTo(RexNode node, int limit) {
+        if (limit <= 0) {
             return 0;
         }
-
-        if (call.getKind() == SqlKind.AND || call.getKind() == SqlKind.OR || call.getKind() == SqlKind.NOT) {
-            int total = 0;
-            for (RexNode operand : call.getOperands()) {
-                total += countLeaves(operand);
+        int total = 0;
+        Deque<RexNode> stack = new ArrayDeque<>();
+        stack.push(node);
+        while (!stack.isEmpty()) {
+            RexNode current = stack.pop();
+            if (!(current instanceof RexCall call)) {
+                // Literal or input ref — not a predicate by itself.
+                continue;
             }
-            return total;
+            SqlKind kind = call.getKind();
+            if (kind == SqlKind.AND || kind == SqlKind.OR || kind == SqlKind.NOT) {
+                // Connective: descend into operands. They only contribute leaves, not depth on
+                // the call stack, so a degenerate chain of a million nested ANDs is just a
+                // million iterations of this loop, not a million stack frames.
+                List<RexNode> operands = call.getOperands();
+                for (RexNode operand : operands) {
+                    stack.push(operand);
+                }
+                continue;
+            }
+            // Leaf predicate (comparison, function call, etc.).
+            total++;
+            if (total >= limit) {
+                // Already at or beyond what the caller cares about — no need to keep walking.
+                return limit;
+            }
         }
-
-        // Leaf predicate (comparison, function call, etc.)
-        return 1;
+        return total;
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FilterPredicateGuard.java
@@ -24,24 +24,31 @@ import java.util.List;
  * ({@code AND}, {@code OR}, {@code NOT}). A flat {@code a=1 OR b=2 OR c=3} counts
  * as 3 leaf predicates regardless of the tree's nesting shape.
  *
- * <p>Boolean nesting depth is intentionally not guarded here: the SQL plugin's
- * {@code plugins.query.max_expression_depth} (default 1000) already bounds parse-tree
- * recursion depth before a query reaches the analytics engine, and Calcite flattens
- * associative {@code AND}/{@code OR} chains during optimization, so pathological depth
- * rarely survives to this point. Predicate count is the gap that guard doesn't cover —
- * a flat fan-out of many OR-ed conditions passes the SQL plugin's depth check easily.
+ * <p>Boolean nesting <b>depth</b> is intentionally out of scope here — it is bounded upstream,
+ * before a condition ever reaches this guard:
+ * <ul>
+ *   <li>PPL/SQL text queries: the SQL plugin's {@code plugins.query.max_expression_depth}
+ *       (default 1000) bounds AST-visitor recursion at parse time and rejects deeper expressions
+ *       with HTTP 400.</li>
+ *   <li>DSL {@code _search} queries: the XContent (JSON/CBOR/YAML/SMILE) parser enforces a maximum
+ *       nesting depth (default 1000), so a {@code bool} tree deeper than that is rejected at parse
+ *       time before any query builder — or RexNode — is constructed.</li>
+ * </ul>
+ * A guard here could not defend depth even if it wanted to: Calcite's own {@code RexUtil.isFlat}
+ * recurses the whole AND/OR/NOT subtree while building/normalizing the condition, so a
+ * pathologically deep tree overflows inside Calcite <em>before</em> this guard runs. Depth is the
+ * upstream parsers' job; count is the gap they leave, and count is what this guard covers.
  *
- * <p><b>The traversal itself is bounded.</b> A guard that walks the tree recursively is
- * only as safe as the tree is shallow: a pathologically deep boolean condition (deeper than
- * the JVM can recurse) would overflow the stack <em>inside the guard</em> and surface as a
- * {@link StackOverflowError} — an unhandled {@code Error}, not the intended HTTP 400 — before
- * the guard could reject it. Depth flattening upstream makes this unlikely, but a guard whose
- * own safety depends on the input already being well-formed is not a guard. So the walk here is
- * iterative (an explicit stack, never the call stack) and short-circuits the moment the leaf
- * count exceeds the limit: it never visits more than {@code maxCount + 1} leaves, and never
- * pushes deeper than the tree it is rejecting. Regardless of how the input is shaped, the guard
- * either passes it or throws {@link IllegalArgumentException} — it can no longer be made to fail
- * by the very complexity it exists to reject.
+ * <p>Predicate <b>count</b> is that gap: a flat fan-out of many OR-ed conditions
+ * ({@code a=1 OR b=2 OR ... OR z=26}) is shallow — it sails through the depth bounds above — yet
+ * multiplies per-predicate planning and execution cost. That is the shape this guard rejects.
+ *
+ * <p><b>The count traversal itself is bounded.</b> A guard that walks the tree recursively is only
+ * as safe as the tree is shallow; even though depth is bounded upstream today, this guard does not
+ * rely on that for its own safety. The walk is iterative (an explicit stack, never the call stack)
+ * and short-circuits the moment the leaf count exceeds the limit: it never visits more than
+ * {@code maxCount + 1} leaves and never recurses on the JVM call stack, so it cannot itself be made
+ * to overflow by the complexity it is measuring.
  *
  * @opensearch.internal
  */

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
@@ -42,9 +42,10 @@ public class FilterPredicateGuardTests extends OpenSearchTestCase {
         }
         RexNode bigOr = buildFlatOr(predicates);
 
-        // 30 predicates with limit 10 — should fail
+        // 30 predicates with limit 10 — should fail. The guard short-circuits, so the message
+        // reports "more than [limit]" rather than the exact leaf count (which it never computes).
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FilterPredicateGuard.validate(bigOr, 10));
-        assertTrue(e.getMessage().contains("30 predicates"));
+        assertTrue(e.getMessage().contains("more than 10 predicates"));
         assertTrue(e.getMessage().contains("maximum allowed [10]"));
     }
 
@@ -93,6 +94,71 @@ public class FilterPredicateGuardTests extends OpenSearchTestCase {
         // NOT(a=1) — 1 leaf predicate; NOT itself doesn't count
         RexNode notNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT, makeComparison());
         assertEquals("leaf count", 1, FilterPredicateGuard.countLeaves(notNode));
+    }
+
+    /**
+     * A condition tree deep enough to overflow a recursive walk must be rejected with the
+     * intended {@link IllegalArgumentException} (HTTP 400), NOT escape as a {@link StackOverflowError}.
+     * This is the core regression: the guard's own traversal must be bounded so pathological input
+     * cannot defeat the guard before it runs. A right-leaning AND chain of 200k nodes is far past
+     * the default JVM recursion limit for this walk.
+     */
+    public void testDeeplyNestedConditionRejectedWithoutStackOverflow() {
+        RexNode deep = buildDeepAndChain(200_000);
+        // limit 500 (the production default) — the deep chain has 200k leaves, so it must be rejected.
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FilterPredicateGuard.validate(deep, 500));
+        assertTrue(e.getMessage().contains("more than 500 predicates"));
+        assertTrue(e.getMessage().contains("maximum allowed [500]"));
+    }
+
+    /**
+     * A deep tree that fits under the limit must still be walked without recursing into a
+     * StackOverflowError. Depth here (with only a handful of leaves) exceeds a naive recursive
+     * walk's safe depth, proving traversal depth is decoupled from the JVM call stack.
+     */
+    public void testDeeplyNestedConditionWithinLimitDoesNotOverflow() {
+        // 200k-deep chain of NOT(...) around a single comparison: exactly 1 leaf predicate, but
+        // 200k levels of nesting. A recursive walk would overflow; the iterative walk must not.
+        RexNode deepButOneLeaf = makeComparison();
+        for (int i = 0; i < 200_000; i++) {
+            deepButOneLeaf = rexBuilder.makeCall(SqlStdOperatorTable.NOT, deepButOneLeaf);
+        }
+        // 1 leaf, limit 500 — passes without throwing (and without StackOverflowError).
+        FilterPredicateGuard.validate(deepButOneLeaf, 500);
+        assertEquals("leaf count", 1, FilterPredicateGuard.countLeaves(deepButOneLeaf));
+    }
+
+    /**
+     * The disabled guard (limit 0) must return immediately without walking the tree at all, so an
+     * arbitrarily deep condition can't overflow when the guard is turned off.
+     */
+    public void testDisabledGuardSkipsDeepTreeEntirely() {
+        RexNode deep = buildDeepAndChain(200_000);
+        FilterPredicateGuard.validate(deep, 0); // no throw, no overflow
+    }
+
+    /**
+     * {@code countLeavesUpTo} must stop counting once it reaches the limit, capping the work the
+     * guard does on a hostile tree. A 50-leaf flat OR probed with limit 10 returns exactly 10.
+     */
+    public void testCountLeavesUpToShortCircuitsAtLimit() {
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            predicates.add(makeComparison());
+        }
+        RexNode bigOr = buildFlatOr(predicates);
+        assertEquals("short-circuited count", 10, FilterPredicateGuard.countLeavesUpTo(bigOr, 10));
+        // Full count still reachable via the unbounded entry point.
+        assertEquals("full count", 50, FilterPredicateGuard.countLeaves(bigOr));
+    }
+
+    /** Right-leaning AND chain: AND(a, AND(a, AND(a, ...))) with {@code depth} leaf comparisons. */
+    private RexNode buildDeepAndChain(int depth) {
+        RexNode node = makeComparison();
+        for (int i = 1; i < depth; i++) {
+            node = rexBuilder.makeCall(SqlStdOperatorTable.AND, makeComparison(), node);
+        }
+        return node;
     }
 
     private RexNode makeComparison() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterPredicateGuardTests.java
@@ -97,28 +97,30 @@ public class FilterPredicateGuardTests extends OpenSearchTestCase {
     }
 
     /**
-     * A condition tree deep enough to overflow a recursive walk must be rejected with the
-     * intended {@link IllegalArgumentException} (HTTP 400), NOT escape as a {@link StackOverflowError}.
-     * This is the core regression: the guard's own traversal must be bounded so pathological input
-     * cannot defeat the guard before it runs. A right-leaning AND chain of 200k nodes is far past
-     * the default JVM recursion limit for this walk.
+     * Guard-level stack safety: {@link FilterPredicateGuard} must count a very deep tree without
+     * recursing on the JVM call stack. This asserts the guard's OWN traversal is iterative — it does
+     * NOT claim the system accepts trees this deep. In production, depth is bounded far below this by
+     * the PPL/SQL parser ({@code plugins.query.max_expression_depth}) and the DSL XContent nesting
+     * limit, and Calcite would overflow building such a tree before the guard ever ran. This test
+     * builds the RexNode directly to exercise the guard in isolation.
      */
     public void testDeeplyNestedConditionRejectedWithoutStackOverflow() {
         RexNode deep = buildDeepAndChain(200_000);
-        // limit 500 (the production default) — the deep chain has 200k leaves, so it must be rejected.
+        // limit 500 (the production default) — the deep chain has 200k leaves, so the guard rejects it.
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FilterPredicateGuard.validate(deep, 500));
         assertTrue(e.getMessage().contains("more than 500 predicates"));
         assertTrue(e.getMessage().contains("maximum allowed [500]"));
     }
 
     /**
-     * A deep tree that fits under the limit must still be walked without recursing into a
-     * StackOverflowError. Depth here (with only a handful of leaves) exceeds a naive recursive
-     * walk's safe depth, proving traversal depth is decoupled from the JVM call stack.
+     * Guard-level stack safety for the low-leaf-count case: a tree that is deep but has few leaves
+     * must still be walked iteratively (no StackOverflowError) and pass the count check. Again this
+     * exercises the guard in isolation; it is not a statement that the system accepts 200k-deep
+     * conditions (it does not — see the class Javadoc on upstream depth bounds).
      */
     public void testDeeplyNestedConditionWithinLimitDoesNotOverflow() {
         // 200k-deep chain of NOT(...) around a single comparison: exactly 1 leaf predicate, but
-        // 200k levels of nesting. A recursive walk would overflow; the iterative walk must not.
+        // 200k levels of nesting. A recursive count would overflow; the iterative count must not.
         RexNode deepButOneLeaf = makeComparison();
         for (int i = 0; i < 200_000; i++) {
             deepButOneLeaf = rexBuilder.makeCall(SqlStdOperatorTable.NOT, deepButOneLeaf);
@@ -150,6 +152,41 @@ public class FilterPredicateGuardTests extends OpenSearchTestCase {
         assertEquals("short-circuited count", 10, FilterPredicateGuard.countLeavesUpTo(bigOr, 10));
         // Full count still reachable via the unbounded entry point.
         assertEquals("full count", 50, FilterPredicateGuard.countLeaves(bigOr));
+    }
+
+    /** Boundary: exactly maxCount leaves passes; maxCount + 1 is rejected. */
+    public void testBoundaryExactlyAtLimitPassesOverByOneRejected() {
+        List<RexNode> atLimit = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            atLimit.add(makeComparison());
+        }
+        // Exactly 10 leaves, limit 10 — passes (validate rejects only when count > maxCount).
+        FilterPredicateGuard.validate(buildFlatOr(atLimit), 10);
+
+        List<RexNode> overByOne = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            overByOne.add(makeComparison());
+        }
+        // 11 leaves, limit 10 — rejected.
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FilterPredicateGuard.validate(buildFlatOr(overByOne), 10)
+        );
+        assertTrue(e.getMessage().contains("maximum allowed [10]"));
+    }
+
+    /** A negative limit disables the guard, exactly like 0. */
+    public void testNegativeLimitDisablesGuard() {
+        List<RexNode> predicates = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            predicates.add(makeComparison());
+        }
+        FilterPredicateGuard.validate(buildFlatOr(predicates), -1); // no throw
+    }
+
+    /** A bare leaf predicate at the top level (not wrapped in a connective) counts as one. */
+    public void testBareLeafCountsAsOne() {
+        assertEquals("bare comparison is one leaf", 1, FilterPredicateGuard.countLeaves(makeComparison()));
     }
 
     /** Right-leaning AND chain: AND(a, AND(a, AND(a, ...))) with {@code depth} leaf comparisons. */


### PR DESCRIPTION
## Problem

The filter-predicate count guard (`analytics.query.max_filter_predicate_count`, default 500),
added in #22748, counted leaf predicates by walking the `RexNode` condition tree with
**unbounded recursion** (`total += countLeaves(operand)` per connective operand). Recursion depth
equalled the boolean nesting depth of the condition, so a sufficiently deep tree could overflow the
JVM stack.

## Fix

Make the guard's own traversal self-bounded.