### PR TITLE
Enforce complete wire deserialization in tests

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
@@ -44,7 +44,9 @@ public class ListViewNamesAction extends ActionType<ListViewNamesAction.Response
     public static class Request extends ActionRequest {
         public Request() {}
 
-        public Request(final StreamInput in) {}
+        public Request(final StreamInput in) throws IOException {
+            super(in);
+        }
 
         @Override
         public boolean equals(Object o) {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -1611,7 +1611,13 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
             writer.write(output, original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
                 in.setVersion(version);
-                return reader.read(in);
+                final T copy = reader.read(in);
+                assertEquals(
+                    "wire reader for [" + original.getClass().getName() + "] left unread bytes at version [" + version + "]",
+                    0,
+                    in.available()
+                );
+                return copy;
             }
         }
     }

--- a/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
@@ -32,9 +32,12 @@
 
 package org.opensearch.test.test;
 
+import org.opensearch.Version;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.OpenSearchTestCase;
@@ -54,6 +57,7 @@ import java.util.function.Supplier;
 
 import junit.framework.AssertionFailedError;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -84,6 +88,27 @@ public class OpenSearchTestCaseTests extends OpenSearchTestCase {
             assertNull(assertFailed.getCause());
             assertEquals("Expected exception IllegalArgumentException but no exception was thrown", assertFailed.getMessage());
         }
+    }
+
+    public void testCopyWriteableRejectsUnreadBytes() {
+        final Writeable writeable = out -> {
+            out.writeInt(1);
+            out.writeInt(2);
+        };
+        final AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> copyWriteable(writeable, new NamedWriteableRegistry(Collections.emptyList()), in -> {
+                in.readInt();
+                return writeable;
+            })
+        );
+
+        assertThat(
+            error.getMessage(),
+            containsString(
+                "wire reader for [" + writeable.getClass().getName() + "] left unread bytes at version [" + Version.CURRENT + "]"
+            )
+        );
     }
 
     public void testShuffleMap() throws IOException {


### PR DESCRIPTION
## Summary
- assert that wire readers consume every byte emitted by the corresponding writer
- fix `ListViewNamesAction.Request` to deserialize its inherited parent task ID
- add focused coverage for unread trailing bytes

## Why
A same-version round trip can still pass equality checks when a reader silently leaves trailing bytes. In an enclosing transport message, those bytes can corrupt the next field.

## Testing
- `./gradlew :test:framework:test --tests org.opensearch.test.test.OpenSearchTestCaseTests`
- `./gradlew :server:test --tests "*.testSerialization"`
- `./gradlew :test:framework:precommit :server:precommit`