### PR TITLE
Add exact wire serialization fixture assertions

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
@@ -44,7 +44,9 @@ public class ListViewNamesAction extends ActionType<ListViewNamesAction.Response
     public static class Request extends ActionRequest {
         public Request() {}
 
-        public Request(final StreamInput in) {}
+        public Request(final StreamInput in) throws IOException {
+            super(in);
+        }
 
         @Override
         public boolean equals(Object o) {

--- a/test/framework/src/main/java/org/opensearch/test/AbstractWireSerializingTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractWireSerializingTestCase.java
@@ -32,7 +32,10 @@
 package org.opensearch.test;
 
 import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.NamedWriteable;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -55,5 +58,32 @@ public abstract class AbstractWireSerializingTestCase<T extends Writeable> exten
     @Override
     protected final T copyInstance(T instance, Version version) throws IOException {
         return copyWriteable(instance, getNamedWriteableRegistry(), instanceReader(), version);
+    }
+
+    /**
+     * Verifies that an instance retains an exact wire representation captured from an older release.
+     * This catches compatible reader and writer changes that ordinary same-version round trips cannot detect.
+     */
+    protected final void assertWireFixture(T expectedInstance, Version version, BytesReference fixture) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(version);
+            expectedInstance.writeTo(output);
+            assertArrayEquals(
+                "wire bytes changed for [" + expectedInstance.getClass().getName() + "] at version [" + version + "]",
+                BytesReference.toBytes(fixture),
+                BytesReference.toBytes(output.bytes())
+            );
+        }
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(fixture.streamInput(), getNamedWriteableRegistry())) {
+            input.setVersion(version);
+            final T fixtureInstance = instanceReader().read(input);
+            assertEquals(
+                "wire reader for [" + expectedInstance.getClass().getName() + "] left unread fixture bytes at version [" + version + "]",
+                0,
+                input.available()
+            );
+            assertEqualInstances(expectedInstance, fixtureInstance);
+        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -1611,7 +1611,13 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
             writer.write(output, original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
                 in.setVersion(version);
-                return reader.read(in);
+                final T copy = reader.read(in);
+                assertEquals(
+                    "wire reader for [" + original.getClass().getName() + "] left unread bytes at version [" + version + "]",
+                    0,
+                    in.available()
+                );
+                return copy;
             }
         }
     }

--- a/test/framework/src/test/java/org/opensearch/test/AbstractWireSerializingTestCaseTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/AbstractWireSerializingTestCaseTests.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.opensearch.Version;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class AbstractWireSerializingTestCaseTests extends AbstractWireSerializingTestCase<AbstractWireSerializingTestCaseTests.Value> {
+    public void testWireFixture() throws IOException {
+        assertWireFixture(new Value(42), Version.CURRENT, new BytesArray(new byte[] { 0, 0, 0, 42 }));
+    }
+
+    public void testWireFixtureRejectsChangedBytes() {
+        final AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> assertWireFixture(new Value(42), Version.CURRENT, new BytesArray(new byte[] { 0, 0, 0, 41 }))
+        );
+        assertTrue(error.getMessage(), error.getMessage().contains("wire bytes changed"));
+    }
+
+    @Override
+    protected Writeable.Reader<Value> instanceReader() {
+        return Value::new;
+    }
+
+    @Override
+    protected Value createTestInstance() {
+        return new Value(randomInt());
+    }
+
+    static class Value implements Writeable {
+        private final int value;
+
+        Value(int value) {
+            this.value = value;
+        }
+
+        Value(StreamInput input) throws IOException {
+            value = input.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput output) throws IOException {
+            output.writeInt(value);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            Value value1 = (Value) object;
+            return value == value1.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+}

--- a/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
@@ -32,9 +32,12 @@
 
 package org.opensearch.test.test;
 
+import org.opensearch.Version;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.OpenSearchTestCase;
@@ -54,6 +57,7 @@ import java.util.function.Supplier;
 
 import junit.framework.AssertionFailedError;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -84,6 +88,27 @@ public class OpenSearchTestCaseTests extends OpenSearchTestCase {
             assertNull(assertFailed.getCause());
             assertEquals("Expected exception IllegalArgumentException but no exception was thrown", assertFailed.getMessage());
         }
+    }
+
+    public void testCopyWriteableRejectsUnreadBytes() {
+        final Writeable writeable = out -> {
+            out.writeInt(1);
+            out.writeInt(2);
+        };
+        final AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> copyWriteable(writeable, new NamedWriteableRegistry(Collections.emptyList()), in -> {
+                in.readInt();
+                return writeable;
+            })
+        );
+
+        assertThat(
+            error.getMessage(),
+            containsString(
+                "wire reader for [" + writeable.getClass().getName() + "] left unread bytes at version [" + Version.CURRENT + "]"
+            )
+        );
     }
 
     public void testShuffleMap() throws IOException {


### PR DESCRIPTION
## Stack
- Depends on #22963
- Review commit `41685025738` for this layer only.

Because the head branches live in a fork, GitHub cannot use the preceding fork branch as an upstream base. This PR therefore temporarily includes #22963 and will shrink automatically after that PR merges.

## Summary
- add an opt-in `assertWireFixture` helper to `AbstractWireSerializingTestCase`
- verify both current writes against historical bytes and current reads from those bytes
- reject unread fixture bytes

## Why
Same-code round trips cannot detect symmetric reader/writer changes. Historical byte fixtures catch field reordering, type changes, and incorrectly moved version guards.

## Testing
- `./gradlew :test:framework:test --tests org.opensearch.test.AbstractWireSerializingTestCaseTests`
- `./gradlew :test:framework:precommit`