### PR TITLE
Add report-only empty wire serialization audit

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/view/ListViewNamesAction.java
@@ -44,7 +44,9 @@ public class ListViewNamesAction extends ActionType<ListViewNamesAction.Response
     public static class Request extends ActionRequest {
         public Request() {}
 
-        public Request(final StreamInput in) {}
+        public Request(final StreamInput in) throws IOException {
+            super(in);
+        }
 
         @Override
         public boolean equals(Object o) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -116,6 +116,7 @@ List projects = [
   'test:fixtures:minio-fixture',
   'test:fixtures:s3-fixture',
   'test:logger-usage',
+  'test:wire-serialization-audit',
   'test:telemetry'
 ]
 

--- a/test/framework/src/main/java/org/opensearch/test/AbstractWireSerializingTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractWireSerializingTestCase.java
@@ -32,7 +32,10 @@
 package org.opensearch.test;
 
 import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.NamedWriteable;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -55,5 +58,32 @@ public abstract class AbstractWireSerializingTestCase<T extends Writeable> exten
     @Override
     protected final T copyInstance(T instance, Version version) throws IOException {
         return copyWriteable(instance, getNamedWriteableRegistry(), instanceReader(), version);
+    }
+
+    /**
+     * Verifies that an instance retains an exact wire representation captured from an older release.
+     * This catches compatible reader and writer changes that ordinary same-version round trips cannot detect.
+     */
+    protected final void assertWireFixture(T expectedInstance, Version version, BytesReference fixture) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(version);
+            expectedInstance.writeTo(output);
+            assertArrayEquals(
+                "wire bytes changed for [" + expectedInstance.getClass().getName() + "] at version [" + version + "]",
+                BytesReference.toBytes(fixture),
+                BytesReference.toBytes(output.bytes())
+            );
+        }
+
+        try (StreamInput input = new NamedWriteableAwareStreamInput(fixture.streamInput(), getNamedWriteableRegistry())) {
+            input.setVersion(version);
+            final T fixtureInstance = instanceReader().read(input);
+            assertEquals(
+                "wire reader for [" + expectedInstance.getClass().getName() + "] left unread fixture bytes at version [" + version + "]",
+                0,
+                input.available()
+            );
+            assertEqualInstances(expectedInstance, fixtureInstance);
+        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -1611,7 +1611,13 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
             writer.write(output, original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
                 in.setVersion(version);
-                return reader.read(in);
+                final T copy = reader.read(in);
+                assertEquals(
+                    "wire reader for [" + original.getClass().getName() + "] left unread bytes at version [" + version + "]",
+                    0,
+                    in.available()
+                );
+                return copy;
             }
         }
     }

--- a/test/framework/src/test/java/org/opensearch/test/AbstractWireSerializingTestCaseTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/AbstractWireSerializingTestCaseTests.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.opensearch.Version;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class AbstractWireSerializingTestCaseTests extends AbstractWireSerializingTestCase<AbstractWireSerializingTestCaseTests.Value> {
+    public void testWireFixture() throws IOException {
+        assertWireFixture(new Value(42), Version.CURRENT, new BytesArray(new byte[] { 0, 0, 0, 42 }));
+    }
+
+    public void testWireFixtureRejectsChangedBytes() {
+        final AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> assertWireFixture(new Value(42), Version.CURRENT, new BytesArray(new byte[] { 0, 0, 0, 41 }))
+        );
+        assertTrue(error.getMessage(), error.getMessage().contains("wire bytes changed"));
+    }
+
+    @Override
+    protected Writeable.Reader<Value> instanceReader() {
+        return Value::new;
+    }
+
+    @Override
+    protected Value createTestInstance() {
+        return new Value(randomInt());
+    }
+
+    static class Value implements Writeable {
+        private final int value;
+
+        Value(int value) {
+            this.value = value;
+        }
+
+        Value(StreamInput input) throws IOException {
+            value = input.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput output) throws IOException {
+            output.writeInt(value);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            Value value1 = (Value) object;
+            return value == value1.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+}

--- a/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/OpenSearchTestCaseTests.java
@@ -32,9 +32,12 @@
 
 package org.opensearch.test.test;
 
+import org.opensearch.Version;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.OpenSearchTestCase;
@@ -54,6 +57,7 @@ import java.util.function.Supplier;
 
 import junit.framework.AssertionFailedError;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -84,6 +88,27 @@ public class OpenSearchTestCaseTests extends OpenSearchTestCase {
             assertNull(assertFailed.getCause());
             assertEquals("Expected exception IllegalArgumentException but no exception was thrown", assertFailed.getMessage());
         }
+    }
+
+    public void testCopyWriteableRejectsUnreadBytes() {
+        final Writeable writeable = out -> {
+            out.writeInt(1);
+            out.writeInt(2);
+        };
+        final AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> copyWriteable(writeable, new NamedWriteableRegistry(Collections.emptyList()), in -> {
+                in.readInt();
+                return writeable;
+            })
+        );
+
+        assertThat(
+            error.getMessage(),
+            containsString(
+                "wire reader for [" + writeable.getClass().getName() + "] left unread bytes at version [" + Version.CURRENT + "]"
+            )
+        );
     }
 
     public void testShuffleMap() throws IOException {

--- a/test/wire-serialization-audit/build.gradle
+++ b/test/wire-serialization-audit/build.gradle
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+apply plugin: 'opensearch.java'
+
+dependencies {
+  implementation "org.ow2.asm:asm:${versions.asm}"
+  implementation "org.ow2.asm:asm-tree:${versions.asm}"
+  testImplementation project(":test:framework")
+}
+
+tasks.register('auditServerWireSerialization', JavaExec) {
+  dependsOn ':server:classes', ':libs:opensearch-core:classes'
+  classpath = sourceSets.main.runtimeClasspath
+  mainClass = 'org.opensearch.test.wire.WireSerializationAudit'
+  args project(':server').sourceSets.main.output.classesDirs
+  args project(':libs:opensearch-core').sourceSets.main.output.classesDirs
+}

--- a/test/wire-serialization-audit/src/main/java/org/opensearch/test/wire/WireSerializationAudit.java
+++ b/test/wire-serialization-audit/src/main/java/org/opensearch/test/wire/WireSerializationAudit.java
@@ -1,0 +1,248 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test.wire;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Reports wire serializers that emit no bytes. */
+public class WireSerializationAudit {
+    static final String STREAM_INPUT = "org/opensearch/core/common/io/stream/StreamInput";
+    static final String STREAM_OUTPUT = "org/opensearch/core/common/io/stream/StreamOutput";
+    static final String WRITE_TO_DESCRIPTOR = "(L" + STREAM_OUTPUT + ";)V";
+    static final String STREAM_CONSTRUCTOR_DESCRIPTOR = "(L" + STREAM_INPUT + ";)V";
+
+    public static void main(String[] args) throws Exception {
+        final List<Path> roots = new ArrayList<>();
+        for (String arg : args) {
+            roots.add(Paths.get(arg));
+        }
+
+        System.out.println("class\tline\tinstance_fields\tstream_constructor\tclassification");
+        for (Finding finding : scan(roots)) {
+            System.out.println(
+                finding.className
+                    + "\t"
+                    + finding.line
+                    + "\t"
+                    + finding.instanceFields
+                    + "\t"
+                    + finding.streamConstructor
+                    + "\t"
+                    + finding.classification()
+            );
+        }
+    }
+
+    static List<Finding> scan(Collection<Path> roots) throws IOException {
+        final Map<String, ClassNode> classes = new HashMap<>();
+        for (Path root : roots) {
+            if (Files.isDirectory(root) == false) {
+                continue;
+            }
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (file.getFileName().toString().endsWith(".class")) {
+                        try (InputStream input = Files.newInputStream(file)) {
+                            final ClassNode classNode = new ClassNode(Opcodes.ASM9);
+                            new ClassReader(input).accept(classNode, 0);
+                            classes.put(classNode.name, classNode);
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return scan(classes);
+    }
+
+    static List<Finding> scan(Map<String, ClassNode> classes) {
+        final List<Finding> findings = new ArrayList<>();
+        for (ClassNode classNode : classes.values()) {
+            if ((classNode.access & (Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE)) != 0) {
+                continue;
+            }
+            final MethodNode writeTo = findMethod(classNode, "writeTo", WRITE_TO_DESCRIPTOR);
+            if (writeTo != null
+                && (writeTo.access & (Opcodes.ACC_ABSTRACT | Opcodes.ACC_NATIVE)) == 0
+                && writesNoBytes(classNode.name, classes, new HashSet<>())) {
+                findings.add(
+                    new Finding(
+                        Type.getObjectType(classNode.name).getClassName(),
+                        firstLine(writeTo),
+                        countInstanceFields(classNode),
+                        streamConstructorStatus(classNode, classes)
+                    )
+                );
+            }
+        }
+        findings.sort(Comparator.comparing(finding -> finding.className));
+        return findings;
+    }
+
+    private static boolean writesNoBytes(String className, Map<String, ClassNode> classes, Set<String> visiting) {
+        if (visiting.add(className) == false) {
+            return false;
+        }
+        final ClassNode classNode = classes.get(className);
+        if (classNode == null) {
+            return false;
+        }
+        final MethodNode method = findMethod(classNode, "writeTo", WRITE_TO_DESCRIPTOR);
+        if (method == null) {
+            return writesNoBytes(classNode.superName, classes, visiting);
+        }
+
+        boolean callsSuper = false;
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction.getType() == AbstractInsnNode.LABEL
+                || instruction.getType() == AbstractInsnNode.LINE
+                || instruction.getType() == AbstractInsnNode.FRAME) {
+                continue;
+            }
+            if (instruction.getOpcode() == Opcodes.RETURN) {
+                continue;
+            }
+            if (instruction instanceof VarInsnNode variable
+                && variable.getOpcode() == Opcodes.ALOAD
+                && (variable.var == 0 || variable.var == 1)) {
+                continue;
+            }
+            if (instruction instanceof MethodInsnNode invocation
+                && invocation.getOpcode() == Opcodes.INVOKESPECIAL
+                && invocation.owner.equals(classNode.superName)
+                && invocation.name.equals("writeTo")
+                && invocation.desc.equals(WRITE_TO_DESCRIPTOR)) {
+                callsSuper = true;
+                continue;
+            }
+            return false;
+        }
+        return callsSuper == false || writesNoBytes(classNode.superName, classes, visiting);
+    }
+
+    private static String streamConstructorStatus(ClassNode classNode, Map<String, ClassNode> classes) {
+        final MethodNode constructor = findMethod(classNode, "<init>", STREAM_CONSTRUCTOR_DESCRIPTOR);
+        if (constructor == null) {
+            return "absent";
+        }
+        return consumesStreamInput(classNode, constructor, classes, new HashSet<>()) ? "consumes" : "empty";
+    }
+
+    private static boolean consumesStreamInput(
+        ClassNode classNode,
+        MethodNode constructor,
+        Map<String, ClassNode> classes,
+        Set<String> visiting
+    ) {
+        if (visiting.add(classNode.name) == false) {
+            return true;
+        }
+        for (AbstractInsnNode instruction : constructor.instructions) {
+            if (instruction instanceof MethodInsnNode invocation) {
+                if (invocation.getOpcode() == Opcodes.INVOKESPECIAL
+                    && invocation.owner.equals(classNode.superName)
+                    && invocation.name.equals("<init>")
+                    && invocation.desc.equals(STREAM_CONSTRUCTOR_DESCRIPTOR)) {
+                    final ClassNode parent = classes.get(classNode.superName);
+                    final MethodNode parentConstructor = parent == null
+                        ? null
+                        : findMethod(parent, "<init>", STREAM_CONSTRUCTOR_DESCRIPTOR);
+                    if (parentConstructor == null || consumesStreamInput(parent, parentConstructor, classes, visiting)) {
+                        return true;
+                    }
+                } else if (invocation.owner.equals(STREAM_INPUT) || invocation.desc.contains("L" + STREAM_INPUT + ";")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static MethodNode findMethod(ClassNode classNode, String name, String descriptor) {
+        for (MethodNode method : classNode.methods) {
+            if (method.name.equals(name) && method.desc.equals(descriptor)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private static int firstLine(MethodNode method) {
+        for (AbstractInsnNode instruction : method.instructions) {
+            if (instruction instanceof LineNumberNode lineNumber) {
+                return lineNumber.line;
+            }
+        }
+        return -1;
+    }
+
+    private static int countInstanceFields(ClassNode classNode) {
+        int count = 0;
+        for (FieldNode field : classNode.fields) {
+            if ((field.access & (Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC)) == 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    static class Finding {
+        final String className;
+        final int line;
+        final int instanceFields;
+        final String streamConstructor;
+
+        Finding(String className, int line, int instanceFields, String streamConstructor) {
+            this.className = className;
+            this.line = line;
+            this.instanceFields = instanceFields;
+            this.streamConstructor = streamConstructor;
+        }
+
+        String classification() {
+            if (instanceFields > 0 && streamConstructor.equals("empty")) {
+                return "stateful-empty-reader";
+            }
+            if (instanceFields > 0) {
+                return "stateful-no-reader";
+            }
+            if (streamConstructor.equals("empty")) {
+                return "empty-message";
+            }
+            return "stateless-singleton";
+        }
+    }
+}

--- a/test/wire-serialization-audit/src/test/java/org/opensearch/test/wire/WireSerializationAuditTests.java
+++ b/test/wire-serialization-audit/src/test/java/org/opensearch/test/wire/WireSerializationAuditTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test.wire;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class WireSerializationAuditTests extends OpenSearchTestCase {
+    public void testFindsDirectAndInheritedEmptyWriters() throws IOException {
+        final List<WireSerializationAudit.Finding> findings = scan(EmptyWriteable.class, EmptyChild.class, EmptyParent.class);
+
+        assertThat(
+            findings.stream().map(finding -> finding.className).toList(),
+            containsInAnyOrder(EmptyWriteable.class.getName(), EmptyParent.class.getName(), EmptyChild.class.getName())
+        );
+        final WireSerializationAudit.Finding stateful = findings.stream()
+            .filter(finding -> finding.className.equals(EmptyWriteable.class.getName()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(stateful.instanceFields, equalTo(1));
+        assertThat(stateful.streamConstructor, equalTo("empty"));
+        assertThat(stateful.classification(), equalTo("stateful-empty-reader"));
+    }
+
+    public void testIgnoresInheritedWriterThatEmitsBytes() throws IOException {
+        assertThat(scan(WritingParent.class, WritingChild.class), empty());
+    }
+
+    private static List<WireSerializationAudit.Finding> scan(Class<?>... classes) throws IOException {
+        final Map<String, ClassNode> classNodes = new HashMap<>();
+        for (Class<?> clazz : classes) {
+            try (InputStream input = clazz.getResourceAsStream("/" + clazz.getName().replace('.', '/') + ".class")) {
+                final ClassNode classNode = new ClassNode(Opcodes.ASM9);
+                new ClassReader(input).accept(classNode, 0);
+                classNodes.put(classNode.name, classNode);
+            }
+        }
+        return WireSerializationAudit.scan(classNodes);
+    }
+
+    static class EmptyWriteable implements Writeable {
+        private int value;
+
+        EmptyWriteable(StreamInput in) {}
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {}
+    }
+
+    static class EmptyParent implements Writeable {
+        EmptyParent(StreamInput in) {}
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {}
+    }
+
+    static class EmptyChild extends EmptyParent {
+        EmptyChild(StreamInput in) {
+            super(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+
+    static class WritingParent implements Writeable {
+        WritingParent(StreamInput in) throws IOException {
+            in.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeInt(1);
+        }
+    }
+
+    static class WritingChild extends WritingParent {
+        WritingChild(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+}


### PR DESCRIPTION
## Stack
- Depends on #22964, which depends on #22963.
- Review commit `6bbe949e09d` for this layer only.

Because these branches live in a fork, this PR temporarily includes the lower stack layers. Its diff will shrink as they merge.

## Summary
- add an ASM-based report for concrete `writeTo(StreamOutput)` implementations that emit no bytes
- follow simple superclass delegation so inherited payloads are not misclassified
- classify stateless singletons, empty messages, and stateful candidates
- keep the audit informational rather than failing precommit

## Example finding
The audit highlighted the stateful `flat_object` doc-value formatter, which led to a separate reproducible wire-format fix.

## Testing
- `./gradlew :test:wire-serialization-audit:test`
- `./gradlew :test:wire-serialization-audit:auditServerWireSerialization`