### PR TITLE
Fix flat object doc value format serialization

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -25,11 +25,13 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.analysis.NamedAnalyzer;
@@ -52,6 +54,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -504,12 +507,21 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         /**
          * A doc_value formatter for flat_object field.
          */
-        public class FlatObjectDocValueFormat implements DocValueFormat {
-            private static final String NAME = "flat_object";
+        public static class FlatObjectDocValueFormat implements DocValueFormat {
+            public static final String NAME = "flat_object";
             private final String prefix;
 
             public FlatObjectDocValueFormat(String prefix) {
                 this.prefix = prefix;
+            }
+
+            public FlatObjectDocValueFormat(StreamInput input) throws IOException {
+                prefix = input.readString();
+            }
+
+            public static FlatObjectDocValueFormat readFrom(StreamInput input) throws IOException {
+                // Legacy versions wrote only the named-writeable name and omitted the prefix payload.
+                return input.getVersion().before(Version.V_3_9_0) ? new FlatObjectDocValueFormat("") : new FlatObjectDocValueFormat(input);
             }
 
             @Override
@@ -518,7 +530,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             }
 
             @Override
-            public void writeTo(StreamOutput out) {}
+            public void writeTo(StreamOutput out) throws IOException {
+                if (out.getVersion().onOrAfter(Version.V_3_9_0)) {
+                    out.writeString(prefix);
+                }
+            }
 
             @Override
             public Object format(BytesRef value) {
@@ -531,7 +547,20 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
             @Override
             public BytesRef parseBytesRef(String value) {
-                return new BytesRef((String) valueFieldType.rewriteForDocValue(rewriteSearchValue(value)));
+                return new BytesRef(prefix + value);
+            }
+
+            @Override
+            public boolean equals(Object object) {
+                if (this == object) return true;
+                if (object == null || getClass() != object.getClass()) return false;
+                FlatObjectDocValueFormat that = (FlatObjectDocValueFormat) object;
+                return prefix.equals(that.prefix);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(prefix);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -45,6 +45,7 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry.Entry;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.FlatObjectFieldMapper.FlatObjectFieldType.FlatObjectDocValueFormat;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.BoostingQueryBuilder;
 import org.opensearch.index.query.CombinedFieldsQueryBuilder;
@@ -1026,6 +1027,7 @@ public class SearchModule {
         registerValueFormat(DocValueFormat.BINARY.getWriteableName(), in -> DocValueFormat.BINARY);
         registerValueFormat(DocValueFormat.UNSIGNED_LONG_SHIFTED.getWriteableName(), in -> DocValueFormat.UNSIGNED_LONG_SHIFTED);
         registerValueFormat(DocValueFormat.UNSIGNED_LONG.getWriteableName(), in -> DocValueFormat.UNSIGNED_LONG);
+        registerValueFormat(FlatObjectDocValueFormat.NAME, FlatObjectDocValueFormat::readFrom);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
@@ -33,11 +33,13 @@
 package org.opensearch.search;
 
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.Version;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.index.mapper.FlatObjectFieldMapper.FlatObjectFieldType.FlatObjectDocValueFormat;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -94,7 +96,11 @@ public class SearchSortValuesAndFormats implements Writeable {
         out.writeArray(Lucene::writeSortValue, rawSortValues);
         out.writeArray(Lucene::writeSortValue, formattedSortValues);
         for (int i = 0; i < sortValueFormats.length; i++) {
-            out.writeNamedWriteable(sortValueFormats[i]);
+            DocValueFormat format = sortValueFormats[i];
+            if (out.getVersion().before(Version.V_3_9_0) && format instanceof FlatObjectDocValueFormat) {
+                format = DocValueFormat.RAW;
+            }
+            out.writeNamedWriteable(format);
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
@@ -16,21 +16,30 @@ import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.Version;
 import org.opensearch.common.TriFunction;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchModule;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.CONTENT_TYPE;
+import static org.opensearch.index.mapper.FlatObjectFieldMapper.FlatObjectFieldType.FlatObjectDocValueFormat;
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.VALUE_AND_PATH_SUFFIX;
 import static org.opensearch.index.mapper.FlatObjectFieldMapper.VALUE_SUFFIX;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -398,6 +407,42 @@ public class FlatObjectFieldMapperTests extends MapperTestCase {
             MappedFieldType ft = mapperService.fieldType("field");
             Throwable throwable = assertThrows(IllegalArgumentException.class, () -> ft.docValueFormat(null, null));
             assertEquals("Field [field] of type [flat_object] does not support doc_value in root field", throwable.getMessage());
+        }
+    }
+
+    public void testDocValueFormatSerialization() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "flat_object")));
+        MappedFieldType fieldType = mapperService.fieldType("field.name");
+        DocValueFormat format = fieldType.docValueFormat(null, null);
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.writeNamedWriteable(format);
+            NamedWriteableRegistry registry = new NamedWriteableRegistry(
+                new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedWriteables()
+            );
+            try (StreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), registry)) {
+                DocValueFormat copy = input.readNamedWriteable(DocValueFormat.class);
+                assertEquals("1234", copy.format(new BytesRef("field.field.name=1234")));
+                assertEquals(new BytesRef("field.field.name=1234"), copy.parseBytesRef("1234"));
+            }
+        }
+    }
+
+    public void testLegacyDocValueFormatSerialization() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "flat_object")));
+        DocValueFormat format = mapperService.fieldType("field.name").docValueFormat(null, null);
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(Version.V_3_8_0);
+            output.writeNamedWriteable(format);
+            NamedWriteableRegistry registry = new NamedWriteableRegistry(
+                new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedWriteables()
+            );
+            try (StreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), registry)) {
+                input.setVersion(Version.V_3_8_0);
+                assertThat(input.readNamedWriteable(DocValueFormat.class), instanceOf(FlatObjectDocValueFormat.class));
+                assertEquals(0, input.available());
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/search/SearchSortValuesAndFormatsTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchSortValuesAndFormatsTests.java
@@ -33,12 +33,15 @@
 package org.opensearch.search;
 
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.index.mapper.FlatObjectFieldMapper.FlatObjectFieldType.FlatObjectDocValueFormat;
 import org.opensearch.test.AbstractWireSerializingTestCase;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -108,5 +111,15 @@ public class SearchSortValuesAndFormatsTests extends AbstractWireSerializingTest
             sortValueFormats[i] = DocValueFormat.RAW;
         }
         return new SearchSortValuesAndFormats(values, sortValueFormats);
+    }
+
+    public void testFlatObjectFormatFallsBackForLegacyNodes() throws IOException {
+        SearchSortValuesAndFormats instance = new SearchSortValuesAndFormats(
+            new Object[] { new BytesRef("field.field.name=1234") },
+            new DocValueFormat[] { new FlatObjectDocValueFormat("field.field.name=") }
+        );
+
+        SearchSortValuesAndFormats copy = copyWriteable(instance, getNamedWriteableRegistry(), instanceReader(), Version.V_3_8_0);
+        assertSame(DocValueFormat.RAW, copy.getSortValueFormats()[0]);
     }
 }


### PR DESCRIPTION
## Summary
- register the `flat_object` `DocValueFormat` as a named writeable
- serialize its stateful prefix on 3.9+ wire streams
- preserve the legacy zero-payload representation when reading older streams
- downgrade transported sort formats to `RAW` for pre-3.9 recipients
- add current and legacy serialization coverage

## Bug
`FlatObjectDocValueFormat` carried a prefix used to format values, but `writeTo` emitted no payload and `SearchModule` registered no reader. Round-tripping it failed with:

```
Unknown NamedWriteable [org.opensearch.search.DocValueFormat][flat_object]
```

`SearchSortValuesAndFormats` transports these formats as part of bottom-sort optimization, so this can affect distributed search rather than being merely unused serialization code.

## BWC
Older nodes do not recognize a stateful `flat_object` format. For older recipient versions, `SearchSortValuesAndFormats` writes `RAW`; when reading a legacy name-only payload, current nodes use a same-name empty placeholder to preserve stream framing.

## Testing
- `./gradlew :server:test --tests org.opensearch.index.mapper.FlatObjectFieldMapperTests`
- `./gradlew :server:test --tests org.opensearch.search.SearchSortValuesAndFormatsTests`
- `./gradlew :server:test --tests "*.testSerialization"`
- `./gradlew :server:precommit`