### PR TITLE
Ignore excluded nodes in zone awareness count

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -38,6 +38,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeFilters;
 import org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.common.Nullable;
@@ -104,6 +105,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<String, Set<String>> nodesPerAttributeNames;
     private final Map<String, Set<String>> searchNodesPerAttributeNames;
+    // Dedicated to AwarenessAllocationDecider: distinct awareness attribute values after applying the cluster
+    // allocation exclude filters, partitioned by node type (data vs search) and keyed by attribute name.
+    private final Map<String, Set<String>> awarenessAttributeValues;
+    private final Map<String, Set<String>> searchAwarenessAttributeValues;
     private final Map<String, Recoveries> recoveriesPerNode = new HashMap<>();
     private final Map<String, Recoveries> initialReplicaRecoveries = new HashMap<>();
     private final Map<String, Recoveries> initialPrimaryRecoveries = new HashMap<>();
@@ -118,6 +123,8 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         final RoutingTable routingTable = clusterState.routingTable();
         this.nodesPerAttributeNames = Collections.synchronizedMap(new HashMap<>());
         this.searchNodesPerAttributeNames = Collections.synchronizedMap(new HashMap<>());
+        this.awarenessAttributeValues = Collections.synchronizedMap(new HashMap<>());
+        this.searchAwarenessAttributeValues = Collections.synchronizedMap(new HashMap<>());
 
         // fill in the nodeToShards with the "live" nodes
         for (final DiscoveryNode cursor : clusterState.nodes().getDataNodes().values()) {
@@ -340,6 +347,40 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         return nodesPerAttributeNames.computeIfAbsent(
             attributeName,
             ignored -> stream().filter(routingNodeFilter).map(r -> r.node().getAttributes().get(attributeName)).collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     * Retrieves the distinct values of an awareness attribute across the nodes eligible to hold the shard,
+     * dropping any node matched by the cluster-level allocation exclude filters. Nodes are partitioned by type:
+     * search-only shards look at search nodes, every other shard looks at data nodes. A value therefore leaves
+     * the awareness balance only when every node carrying it is excluded, letting a fully drained value (for
+     * example a zone being replaced) release its shards onto the remaining values.
+     * <p>
+     * The result is memoized per attribute name for the lifetime of this {@link RoutingNodes} instance. That is
+     * safe because both the node attributes and the exclude filters are constant over that lifetime: any change
+     * produces a new cluster state and therefore a new {@link RoutingNodes} with a fresh cache. This cache is
+     * dedicated to {@code AwarenessAllocationDecider} and is intentionally kept separate from
+     * {@link #nodesPerAttributesCounts(String)} so the weighted-routing path is left untouched.
+     *
+     * @param attributeName the awareness attribute to collect values for
+     * @param searchOnly whether the shard is search-only (selects search nodes rather than data nodes)
+     * @param excludeFilters the cluster-level allocation exclude filters, or {@code null} if none are configured
+     * @return the distinct, non-excluded values for the attribute
+     */
+    public Set<String> getAwarenessAttributeValues(
+        String attributeName,
+        boolean searchOnly,
+        @Nullable DiscoveryNodeFilters excludeFilters
+    ) {
+        final Map<String, Set<String>> cache = searchOnly ? searchAwarenessAttributeValues : awarenessAttributeValues;
+        return cache.computeIfAbsent(
+            attributeName,
+            attr -> stream().filter(routingNode -> routingNode.node().isSearchNode() == searchOnly)
+                .filter(routingNode -> excludeFilters == null || excludeFilters.match(routingNode.node()) == false)
+                .map(routingNode -> routingNode.node().getAttributes().get(attr))
+                .filter(value -> value != null)
+                .collect(Collectors.toSet())
         );
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -33,6 +33,7 @@
 package org.opensearch.cluster.routing.allocation.decider;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.node.DiscoveryNodeFilters;
 import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
@@ -52,6 +53,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING;
+import static org.opensearch.cluster.node.DiscoveryNodeFilters.OpType.OR;
 
 /**
  * This {@link AllocationDecider} controls shard allocation based on
@@ -114,6 +116,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
     private volatile List<String> awarenessAttributes;
     private volatile Map<String, List<String>> forcedAwarenessAttributes;
+    private volatile DiscoveryNodeFilters clusterExcludeFilters;
 
     public AwarenessAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
         this.awarenessAttributes = CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
@@ -122,6 +125,21 @@ public class AwarenessAllocationDecider extends AllocationDecider {
         clusterSettings.addSettingsUpdateConsumer(
             CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING,
             this::setForcedAwarenessAttributes
+        );
+        // Track the cluster-level allocation exclude filters so awareness can drop fully-excluded attribute
+        // values from its balance. Maintained on settings changes (like FilterAllocationDecider) instead of
+        // being rebuilt on every allocation decision.
+        setExcludeFilters(FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP_SETTING.getAsMap(settings));
+        clusterSettings.addAffixMapUpdateConsumer(
+            FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP_SETTING,
+            this::setExcludeFilters,
+            (a, b) -> {}
+        );
+    }
+
+    private void setExcludeFilters(Map<String, String> filters) {
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterExcludeFilters, OR, filters)
         );
     }
 
@@ -194,6 +212,10 @@ public class AwarenessAllocationDecider extends AllocationDecider {
                 numberOfAttributes = attributesSet.size();
             }
 
+            if (numberOfAttributes == 0) {
+                continue;
+            }
+
             // TODO should we remove ones that are not part of full list?
             final int maximumNodeCount = (shardCount + numberOfAttributes - 1) / numberOfAttributes; // ceil(shardCount/numberOfAttributes)
             if (currentNodeCount > maximumNodeCount) {
@@ -216,8 +238,12 @@ public class AwarenessAllocationDecider extends AllocationDecider {
     }
 
     private Set<String> getAttributeValues(ShardRouting shardRouting, RoutingAllocation allocation, String awarenessAttribute) {
+        // The distinct attribute values are stable for the whole allocation round, so RoutingNodes memoizes them
+        // (keyed by attribute name, partitioned by node type). Nodes matched by the cluster-level allocation exclude
+        // filters are dropped: a value leaves the awareness balance only when every node carrying it is excluded,
+        // letting a fully-drained value (e.g. a zone being replaced) release its shards onto the remaining values.
         return allocation.routingNodes()
-            .nodesPerAttributesCounts(awarenessAttribute, routingNode -> routingNode.node().isSearchNode() == shardRouting.isSearchOnly());
+            .getAwarenessAttributeValues(awarenessAttribute, shardRouting.isSearchOnly(), clusterExcludeFilters);
     }
 
     private int getCurrentNodeCountForAttribute(

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -1154,4 +1154,129 @@ public class AwarenessAllocationTests extends OpenSearchAllocationTestCase {
 
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
     }
+
+    public void testExcludedZoneIsIgnoredInAwarenessCount() {
+        // zone awareness is enabled and zone "b" is fully excluded from allocation via the cluster exclude filter
+        final Settings settings = Settings.builder()
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone")
+            .put("cluster.routing.allocation.exclude.zone", "b")
+            .build();
+
+        final AllocationService strategy = createAllocationService(settings);
+
+        // 1 primary + 2 replicas = 3 copies of the shard
+        final Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(2))
+            .build();
+
+        // zone a has two nodes, zone c has one, and the excluded zone b has one
+        final DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(newNode("a1", singletonMap("zone", "a")))
+            .add(newNode("a2", singletonMap("zone", "a")))
+            .add(newNode("c1", singletonMap("zone", "c")))
+            .add(newNode("b1", singletonMap("zone", "b")))
+            .build();
+
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+                .nodes(nodes)
+                .build(),
+            strategy
+        );
+
+        // Because every node in zone b is excluded, awareness counts only zones {a, c}, so the per-zone cap is
+        // ceil(3/2) = 2. All three copies allocate onto the two remaining zones and nothing is left unassigned.
+        // Previously all three zones were counted (ceil(3/3) = 1) and the third copy would stay UNASSIGNED.
+        final RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.shardsWithState(STARTED).size(), equalTo(3));
+        assertThat(routingNodes.shardsWithState(UNASSIGNED).size(), equalTo(0));
+        assertThat(routingNodes.node("b1").size(), equalTo(0));
+        assertThat(routingNodes.node("a1").size(), equalTo(1));
+        assertThat(routingNodes.node("a2").size(), equalTo(1));
+        assertThat(routingNodes.node("c1").size(), equalTo(1));
+    }
+
+    public void testAllZonesCountedWhenNothingExcluded() {
+        // same topology as the excluded-zone test but with no exclude filter: all three zones must still count
+        final Settings settings = Settings.builder()
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone")
+            .build();
+
+        final AllocationService strategy = createAllocationService(settings);
+
+        final Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(2))
+            .build();
+
+        final DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(newNode("a1", singletonMap("zone", "a")))
+            .add(newNode("a2", singletonMap("zone", "a")))
+            .add(newNode("c1", singletonMap("zone", "c")))
+            .add(newNode("b1", singletonMap("zone", "b")))
+            .build();
+
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+                .nodes(nodes)
+                .build(),
+            strategy
+        );
+
+        // With nothing excluded, awareness counts all three zones {a, b, c}, so the per-zone cap is ceil(3/3) = 1.
+        // The three copies spread one per zone: zone a receives a single copy (not two), and zone b is used.
+        final RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.shardsWithState(STARTED).size(), equalTo(3));
+        assertThat(routingNodes.shardsWithState(UNASSIGNED).size(), equalTo(0));
+        assertThat(routingNodes.node("a1").size() + routingNodes.node("a2").size(), equalTo(1));
+        assertThat(routingNodes.node("b1").size(), equalTo(1));
+        assertThat(routingNodes.node("c1").size(), equalTo(1));
+    }
+
+    public void testZoneStillCountedWhenOnlySomeOfItsNodesExcluded() {
+        // exclude a single node in zone a by id; zone a still has a non-excluded node, so zone a must keep counting
+        final Settings settings = Settings.builder()
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone")
+            .put("cluster.routing.allocation.exclude._id", "a1")
+            .build();
+
+        final AllocationService strategy = createAllocationService(settings);
+
+        // 1 primary + 3 replicas = 4 copies of the shard
+        final Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(3))
+            .build();
+
+        // zone a: a1 (excluded) and a2 (usable); zone b: three usable nodes
+        final DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(newNode("a1", singletonMap("zone", "a")))
+            .add(newNode("a2", singletonMap("zone", "a")))
+            .add(newNode("b1", singletonMap("zone", "b")))
+            .add(newNode("b2", singletonMap("zone", "b")))
+            .add(newNode("b3", singletonMap("zone", "b")))
+            .build();
+
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+                .nodes(nodes)
+                .build(),
+            strategy
+        );
+
+        // Zone a keeps counting because a2 is not excluded, so awareness sees zones {a, b} and the per-zone cap is
+        // ceil(4/2) = 2. Only a2 is usable in zone a (1 copy) and zone b is capped at 2, so a fourth copy cannot be
+        // placed and stays UNASSIGNED. If zone a had been wrongly dropped, the cap would be ceil(4/1) = 4 and all
+        // four copies would fit, so this asserts we drop a value only when every one of its nodes is excluded.
+        final RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.shardsWithState(STARTED).size(), equalTo(3));
+        assertThat(routingNodes.shardsWithState(UNASSIGNED).size(), equalTo(1));
+        assertThat(routingNodes.node("a1").size(), equalTo(0));
+        assertThat(routingNodes.node("a2").size(), equalTo(1));
+        assertThat(routingNodes.node("b1").size() + routingNodes.node("b2").size() + routingNodes.node("b3").size(), equalTo(2));
+    }
 }


### PR DESCRIPTION
Zone awareness now drops an attribute value (such as a zone) from the awareness balance when every node carrying it is excluded by the cluster allocation exclude filters. This lets shards drain off a fully excluded zone and consolidate onto the remaining zones instead of getting stuck relocating or unassigned, for example when replacing all nodes in an availability zone.

The exclude filters are tracked on settings changes (like FilterAllocationDecider) rather than rebuilt on every decision, and the distinct attribute values are memoized per RoutingNodes instance (keyed by attribute name, partitioned by data/search nodes) so they are computed once per reroute. The weighted-routing path (nodesPerAttributesCounts) is left untouched.


### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
