### PR TITLE
Avoid quadratic identifier scan when removing snapshots

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -152,8 +153,14 @@ public final class IndexMetaDataGenerations {
         final Map<SnapshotId, Map<IndexId, String>> updatedIndexMetaLookup = new HashMap<>(lookup);
         updatedIndexMetaLookup.keySet().removeAll(snapshotIds);
         final Map<String, String> updatedIndexMetaIdentifiers = new HashMap<>(identifiers);
-        updatedIndexMetaIdentifiers.keySet()
-            .removeIf(k -> updatedIndexMetaLookup.values().stream().noneMatch(identifiers -> identifiers.containsValue(k)));
+        // Collect the identifiers referenced by the remaining snapshots once, instead of re-scanning every remaining
+        // snapshot's lookup map for each identifier, which is quadratic in the number of tracked index metadata entries
+        // and dominates snapshot deletion time on repositories with a large number of snapshots and indices.
+        final Set<String> referencedIdentifiers = updatedIndexMetaLookup.values()
+            .stream()
+            .flatMap(m -> m.values().stream())
+            .collect(Collectors.toSet());
+        updatedIndexMetaIdentifiers.keySet().retainAll(referencedIdentifiers);
         return new IndexMetaDataGenerations(updatedIndexMetaLookup, updatedIndexMetaIdentifiers);
     }
 

--- a/server/src/test/java/org/opensearch/repositories/IndexMetadataGenerationsTests.java
+++ b/server/src/test/java/org/opensearch/repositories/IndexMetadataGenerationsTests.java
@@ -84,6 +84,28 @@ public class IndexMetadataGenerationsTests extends OpenSearchTestCase {
         assertEquals(IndexMetaDataGenerations.EMPTY, indexMetaDataGenerations.withRemovedSnapshots(snapshotToRemove));
     }
 
+    public void testWithRemovedSnapshotPreservesSharedIdentifiers() {
+        // Add a second snapshot that shares the identifier "1" with the base snapshot and adds one identifier of its own
+        final SnapshotId newSnapshot = new SnapshotId("newSnapshot", "newSnapshot");
+        final Map<IndexId, String> newLookup = new HashMap<>();
+        newLookup.put(new IndexId(INDEX_PREFIX + 1, INDEX_PREFIX + 1), String.valueOf(1));
+        newLookup.put(new IndexId("newIndex", "newIndex"), "newIdentifier");
+        final IndexMetaDataGenerations added = indexMetaDataGenerations.withAddedSnapshot(
+            newSnapshot,
+            newLookup,
+            Collections.singletonMap("newIdentifier", "newBlob")
+        );
+
+        // Remove the base snapshot: the shared identifier must survive while identifiers only referenced
+        // by the removed snapshot must be pruned
+        final IndexMetaDataGenerations updated = added.withRemovedSnapshots(Collections.singleton(new SnapshotId(SNAPSHOT, SNAPSHOT)));
+
+        assertEquals(BLOB_ID_PREFIX + 1, updated.getIndexMetaBlobId(String.valueOf(1)));
+        assertEquals("newBlob", updated.getIndexMetaBlobId("newIdentifier"));
+        assertNull(updated.getIndexMetaBlobId(String.valueOf(2)));
+        assertEquals(BLOB_ID_PREFIX + 1, updated.indexMetaBlobId(newSnapshot, new IndexId(INDEX_PREFIX + 1, INDEX_PREFIX + 1)));
+    }
+
     private Map<IndexId, String> createIndexMetadataMap(int indexCountLowerBound, int numIndices) {
         final int indexCountUpperBound = indexCountLowerBound + numIndices;
         Map<IndexId, String> map = new HashMap<>();


### PR DESCRIPTION
### Description

`IndexMetaDataGenerations.withRemovedSnapshots` prunes orphaned index metadata identifiers with `removeIf` combined with a stream scan over every remaining snapshot's lookup map for **each** identifier:

```java
updatedIndexMetaIdentifiers.keySet()
    .removeIf(k -> updatedIndexMetaLookup.values().stream().noneMatch(identifiers -> identifiers.containsValue(k)));
```

This costs O(identifiers × total tracked entries). On repositories with a large number of snapshots and indices, this scan is CPU-bound for minutes per snapshot deletion and serializes with other repository operations (snapshot finalizations queue behind it on the repository generation).

This was observed on a production cluster: thread dumps on the elected cluster-manager showed the snapshot-deletion thread on-CPU inside this scan (`Collection.removeIf` → `stream().noneMatch`), with each delete batch holding the repository generation for 8–18 minutes and emitting repeated `Cluster state update timed out while deleting snapshots` warnings while subsequent operations retried.

This change precomputes the set of identifiers referenced by the remaining snapshots once (`flatMap` + `collect(toSet)`), then applies a single `retainAll` — O(total entries). Semantics are unchanged: an identifier is retained iff some remaining snapshot references it (the constructor assertion enforces exactly this consistency on every construction).

### Related Issues

N/A

### Check List
- [x] Functionality includes testing: added `testWithRemovedSnapshotPreservesSharedIdentifiers` covering partial removal — a shared identifier must survive removal of one referencing snapshot while identifiers only referenced by the removed snapshot are pruned (the existing test only covered full removal to `EMPTY`). Verified with `./gradlew server:test --tests "*.IndexMetadataGenerationsTests" -Dtests.iters=5`.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
