### PR TITLE
Expose auxiliary transport bound ports in the test cluster framework

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
@@ -513,6 +513,13 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
 
     @Override
     @Internal
+    public String getAuxTransportPortURI(String auxTransportType) {
+        waitForAllConditions();
+        return getFirstNode().getAuxTransportPortURI(auxTransportType);
+    }
+
+    @Override
+    @Internal
     public List<String> getAllHttpSocketURI() {
         waitForAllConditions();
         return nodes.stream().flatMap(each -> each.getAllHttpSocketURI().stream()).collect(Collectors.toList());

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -884,6 +884,12 @@ public class OpenSearchNode implements TestClusterConfiguration {
 
     @Override
     @Internal
+    public String getAuxTransportPortURI(String auxTransportType) {
+        return getAuxTransportPortInternal(auxTransportType).get(0);
+    }
+
+    @Override
+    @Internal
     public List<String> getAllHttpSocketURI() {
         waitForAllConditions();
         return getHttpPortInternal();
@@ -1311,6 +1317,14 @@ public class OpenSearchNode implements TestClusterConfiguration {
             return readPortsFile(httpPortsFile);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read http ports file: " + httpPortsFile + " for " + this, e);
+        }
+    }
+
+    private List<String> getAuxTransportPortInternal(String auxTransportType) {
+        try {
+            return readPortsFile(confPathLogs.resolve(auxTransportType + ".ports"));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read " + auxTransportType + " ports file for " + this, e);
         }
     }
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
@@ -128,6 +128,8 @@ public interface TestClusterConfiguration {
 
     String getTransportPortURI();
 
+    String getAuxTransportPortURI(String auxTransportType);
+
     List<String> getAllHttpSocketURI();
 
     List<String> getAllTransportPortURI();

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -2202,6 +2202,10 @@ public class Node implements Closeable {
             writePortsFile("transport", transport.boundAddress());
             HttpServerTransport http = injector.getInstance(HttpServerTransport.class);
             writePortsFile("http", http.boundAddress());
+            pluginLifecycleComponents.stream()
+                .filter(AuxTransport.class::isInstance)
+                .map(AuxTransport.class::cast)
+                .forEach(aux -> writePortsFile(aux.settingKey(), aux.getBoundAddress()));
         }
 
         logger.info("started");


### PR DESCRIPTION
### Description
The test cluster framework already writes an `http.ports` and `transport.ports` file to a node's logs directory after it starts, and exposes them through `getHttpSocketURI()` and `getTransportPortURI()` on `TestClusterConfiguration`. Auxiliary transports, such as the gRPC transport, had no equivalent, so a plugin's integ test had no reliable way to discover the actual bound port for an auxiliary transport, which can differ from the configured default under a port conflict or dual stack binding. The only workaround was parsing the cluster log text for a publish_address line, which is fragile.

This adds a ports file for every configured auxiliary transport, named after its setting key (for example transport-grpc.ports), written the same way and at the same point as the existing http and transport ports files. It also adds `getAuxTransportPortURI(String auxTransportType)` to `TestClusterConfiguration`, `OpenSearchNode`, and `OpenSearchCluster` so a build script can read it back, mirroring the existing `getHttpSocketURI()` and `getTransportPortURI()` getters.

Verified that `:server:compileJava` and `:buildSrc:compileJava` build cleanly with this change, and that `:server:spotlessJavaCheck` passes. There are no existing unit tests for these Gradle wiring classes to extend, and exercising the new getter end to end needs a real integ test against a plugin with an auxiliary transport enabled, such as transport-grpc, which is outside what this change touches.

### Related Issues
Resolves #21027

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
