### PR TITLE
Fix opensearch-heap-prof reset crashing on a non numeric sample arg

### DIFF
--- a/distribution/tools/heap-prof-cli/src/main/java/org/opensearch/tools/cli/heapprof/ResetCommand.java
+++ b/distribution/tools/heap-prof-cli/src/main/java/org/opensearch/tools/cli/heapprof/ResetCommand.java
@@ -6,6 +6,7 @@ package org.opensearch.tools.cli.heapprof;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.opensearch.cli.Terminal;
+import org.opensearch.cli.UserException;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -26,7 +27,11 @@ class ResetCommand extends HeapProfCommand {
         var args = lgSampleArg.values(options);
         int lgSample = 17; // default
         if (!args.isEmpty()) {
-            lgSample = Integer.parseInt(args.get(0));
+            try {
+                lgSample = Integer.parseInt(args.get(0));
+            } catch (NumberFormatException e) {
+                throw new UserException(1, "lg_prof_sample must be an integer, got: " + args.get(0));
+            }
         }
         mbs.invoke(mbean, "reset", new Object[] { lgSample }, new String[] { "int" });
         terminal.println("Profiling reset with lg_prof_sample=" + lgSample + " (sample every ~" + ((1L << lgSample) / 1024) + "KB)");


### PR DESCRIPTION
### Description
`opensearch-heap-prof reset`'s `lg_prof_sample` argument was parsed with a bare `Integer.parseInt`, so passing a non numeric value crashed with a raw `NumberFormatException` stack trace instead of a clean usage message. Its sibling commands in the same tool already handle bad usage this way: `DumpCommand` throws `UserException(1, "Usage: ...")` and `JmxCommand` does the same for a missing process, so `ResetCommand` was the one command in the tool not following that pattern.

This wraps the parse in a try/catch and throws `UserException(1, "lg_prof_sample must be an integer, got: " + args.get(0))`, matching the exact exception type and exit code the tool's other commands already use.

### Related Issues
Resolves #
No existing issue; found by inspection while reviewing the heap-prof-cli tool, see description above.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
