### PR TITLE
Correct adaptive replica service-time ranking

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -39,6 +39,7 @@ import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.ExponentiallyWeightedMovingAverage;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.annotation.PublicApi;
@@ -517,7 +518,12 @@ public class IndexShardRoutingTable extends AbstractDiffable<IndexShardRoutingTa
                     final ResponseCollectorService.ComputedNodeStats stats = maybeStats.get();
                     final int updatedQueue = (minStats.queueSize + stats.queueSize) / 2;
                     final long updatedResponse = (long) (minStats.responseTime + stats.responseTime) / 2;
-                    final long updatedService = (long) (minStats.serviceTime + stats.serviceTime) / 2;
+                    final ExponentiallyWeightedMovingAverage serviceTimeEWMA = new ExponentiallyWeightedMovingAverage(
+                        ResponseCollectorService.ALPHA,
+                        stats.serviceTime
+                    );
+                    serviceTimeEWMA.addValue((minStats.serviceTime + stats.serviceTime) / 2.0);
+                    final long updatedService = (long) serviceTimeEWMA.getAverage();
                     collector.addNodeStatistics(nodeId, updatedQueue, updatedResponse, updatedService);
                 }
             }

--- a/server/src/main/java/org/opensearch/node/ResponseCollectorService.java
+++ b/server/src/main/java/org/opensearch/node/ResponseCollectorService.java
@@ -60,7 +60,10 @@ import java.util.concurrent.ConcurrentMap;
 @PublicApi(since = "1.0.0")
 public final class ResponseCollectorService implements ClusterStateListener {
 
-    private static final double ALPHA = 0.3;
+    /**
+     * The weight parameter used for moving averages of node statistics.
+     */
+    public static final double ALPHA = 0.3;
 
     private final ConcurrentMap<String, NodeStatistics> nodeIdToStats = ConcurrentCollections.newConcurrentMap();
 
@@ -197,12 +200,12 @@ public final class ResponseCollectorService implements ClusterStateListener {
 
             // EWMA of response time
             double rS = responseTime / FACTOR;
-            // EWMA of service time
-            double muBarS = serviceTime / FACTOR;
+            // EWMA of service time. The paper uses muBarS for the service rate,
+            // so its inverse is the service time measured here.
+            double serviceTimeMillis = serviceTime / FACTOR;
 
             // The final formula
-            double rank = rS - (1.0 / muBarS) + (Math.pow(qHatS, queueAdjustmentFactor) / muBarS);
-            return rank;
+            return rS - serviceTimeMillis + Math.pow(qHatS, queueAdjustmentFactor) * serviceTimeMillis;
         }
 
         public double rank(long outstandingRequests) {

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -595,84 +595,93 @@ public class OperationRoutingTests extends OpenSearchTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
         opRouting.setUseAdaptiveReplicaSelection(true);
-        List<ShardRouting> searchedShards = new ArrayList<>(numShards);
-        Set<String> selectedNodes = new HashSet<>(numShards);
         TestThreadPool threadPool = new TestThreadPool("testThatOnlyNodesSupportNodeIds");
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        ResponseCollectorService collector = new ResponseCollectorService(clusterService);
-        Map<String, Long> outstandingRequests = new HashMap<>();
-        GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(
-            state,
-            indexNames,
-            null,
-            null,
-            collector,
-            outstandingRequests,
-            null
+        try {
+            ResponseCollectorService collector = new ResponseCollectorService(clusterService);
+            Map<String, Long> outstandingRequests = new HashMap<>();
+            Set<String> selectedNodes = new HashSet<>();
+
+            // Test that the shards use a round-robin pattern when there are no stats.
+            for (int i = 0; i < numReplicas + 1; i++) {
+                GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(
+                    state,
+                    indexNames,
+                    null,
+                    null,
+                    collector,
+                    outstandingRequests,
+                    null
+                );
+                assertThat("One group per index shard", groupIterator.size(), equalTo(numIndices * numShards));
+                assertThat(groupIterator.get(0).size(), equalTo(numReplicas + 1));
+                ShardRouting shardChoice = groupIterator.get(0).nextOrNull();
+                assertNotNull(shardChoice);
+                selectedNodes.add(shardChoice.currentNodeId());
+            }
+            assertThat(selectedNodes.size(), equalTo(numReplicas + 1));
+
+            // With equal queue and response time, the node with the shortest service time must win.
+            collector.addNodeStatistics("node_0", 1, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(150).nanos());
+            collector.addNodeStatistics("node_1", 1, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(50).nanos());
+            collector.addNodeStatistics("node_2", 1, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(200).nanos());
+            outstandingRequests.put("node_0", 1L);
+            outstandingRequests.put("node_1", 1L);
+            outstandingRequests.put("node_2", 1L);
+
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(
+                state,
+                indexNames,
+                null,
+                null,
+                collector,
+                outstandingRequests,
+                null
+            );
+            ShardRouting shardChoice = groupIterator.get(0).nextOrNull();
+            assertNotNull(shardChoice);
+            assertThat(shardChoice.currentNodeId(), equalTo("node_1"));
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
+    }
+
+    public void testAdaptiveReplicaSelectionStatsAdjustment() throws Exception {
+        final String[] indexNames = new String[] { "test" };
+        ClusterState state = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(indexNames, 1, 1);
+        OperationRouting opRouting = new OperationRouting(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
+        opRouting.setUseAdaptiveReplicaSelection(true);
+        TestThreadPool threadPool = new TestThreadPool("testAdaptiveReplicaSelectionStatsAdjustment");
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        try {
+            ResponseCollectorService collector = new ResponseCollectorService(clusterService);
+            collector.addNodeStatistics("node_0", 1, TimeValue.timeValueMillis(50).nanos(), TimeValue.timeValueMillis(40).nanos());
+            collector.addNodeStatistics("node_1", 1, TimeValue.timeValueMillis(50).nanos(), TimeValue.timeValueMillis(60).nanos());
 
-        assertThat("One group per index shard", groupIterator.size(), equalTo(numIndices * numShards));
+            GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(
+                state,
+                indexNames,
+                null,
+                null,
+                collector,
+                new HashMap<>(),
+                null
+            );
+            ShardRouting shardChoice = groupIterator.get(0).nextOrNull();
+            assertNotNull(shardChoice);
+            assertThat(shardChoice.currentNodeId(), equalTo("node_0"));
 
-        // Test that the shards use a round-robin pattern when there are no stats
-        assertThat(groupIterator.get(0).size(), equalTo(numReplicas + 1));
-        ShardRouting firstChoice = groupIterator.get(0).nextOrNull();
-        assertNotNull(firstChoice);
-        searchedShards.add(firstChoice);
-        selectedNodes.add(firstChoice.currentNodeId());
-
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-
-        assertThat(groupIterator.size(), equalTo(numIndices * numShards));
-        ShardRouting secondChoice = groupIterator.get(0).nextOrNull();
-        assertNotNull(secondChoice);
-        searchedShards.add(secondChoice);
-        selectedNodes.add(secondChoice.currentNodeId());
-
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-
-        assertThat(groupIterator.size(), equalTo(numIndices * numShards));
-        ShardRouting thirdChoice = groupIterator.get(0).nextOrNull();
-        assertNotNull(thirdChoice);
-        searchedShards.add(thirdChoice);
-        selectedNodes.add(thirdChoice.currentNodeId());
-
-        // All three shards should have been separate, because there are no stats yet so they're all ranked equally.
-        assertThat(searchedShards.size(), equalTo(3));
-
-        // Now let's start adding node metrics, since that will affect which node is chosen
-        collector.addNodeStatistics("node_0", 2, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(150).nanos());
-        collector.addNodeStatistics("node_1", 1, TimeValue.timeValueMillis(100).nanos(), TimeValue.timeValueMillis(50).nanos());
-        collector.addNodeStatistics("node_2", 1, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(200).nanos());
-        outstandingRequests.put("node_0", 1L);
-        outstandingRequests.put("node_1", 1L);
-        outstandingRequests.put("node_2", 1L);
-
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-        ShardRouting shardChoice = groupIterator.get(0).nextOrNull();
-        // node 1 should be the lowest ranked node to start
-        assertThat(shardChoice.currentNodeId(), equalTo("node_1"));
-
-        // node 1 starts getting more loaded...
-        collector.addNodeStatistics("node_1", 2, TimeValue.timeValueMillis(200).nanos(), TimeValue.timeValueMillis(150).nanos());
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-        shardChoice = groupIterator.get(0).nextOrNull();
-        assertThat(shardChoice.currentNodeId(), equalTo("node_1"));
-
-        // and more loaded...
-        collector.addNodeStatistics("node_1", 3, TimeValue.timeValueMillis(250).nanos(), TimeValue.timeValueMillis(200).nanos());
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-        shardChoice = groupIterator.get(0).nextOrNull();
-        assertThat(shardChoice.currentNodeId(), equalTo("node_1"));
-
-        // and even more
-        collector.addNodeStatistics("node_1", 4, TimeValue.timeValueMillis(300).nanos(), TimeValue.timeValueMillis(250).nanos());
-        groupIterator = opRouting.searchShards(state, indexNames, null, null, collector, outstandingRequests, null);
-        shardChoice = groupIterator.get(0).nextOrNull();
-        // finally, node 2 is chosen instead
-        assertThat(shardChoice.currentNodeId(), equalTo("node_2"));
-
-        IOUtils.close(clusterService);
-        terminate(threadPool);
+            // The synthetic 50ms sample decays node_1's 60ms service time with alpha=0.3.
+            ResponseCollectorService.ComputedNodeStats adjustedStats = collector.getNodeStatistics("node_1").orElseThrow();
+            assertEquals(TimeValue.timeValueMillis(57).nanos(), (long) adjustedStats.serviceTime);
+        } finally {
+            IOUtils.close(clusterService);
+            terminate(threadPool);
+        }
     }
 
     // Regression test to ignore awareness attributes. This test creates shards in different zones and simulates stress

--- a/server/src/test/java/org/opensearch/node/ResponseCollectorServiceTests.java
+++ b/server/src/test/java/org/opensearch/node/ResponseCollectorServiceTests.java
@@ -162,4 +162,42 @@ public class ResponseCollectorServiceTests extends OpenSearchTestCase {
         assertTrue(nodeStats.containsKey("node1"));
         assertFalse(nodeStats.containsKey("node2"));
     }
+
+    public void testNodeRankFormulaInvariants() {
+        // With no queue or outstanding requests, rank is response time.
+        ResponseCollectorService.ComputedNodeStats stats = createStats(0, 150, 100);
+        assertThat(stats.rank(0), equalTo(150.0));
+
+        stats = createStats(0, 20, 19);
+        assertThat(stats.rank(0), equalTo(20.0));
+
+        // Slower service time must increase rank when there is work waiting.
+        ResponseCollectorService.ComputedNodeStats first = createStats(0, 150, 100);
+        ResponseCollectorService.ComputedNodeStats second = createStats(0, 150, 120);
+        assertTrue(first.rank(1) < second.rank(1));
+
+        // Slower response time must increase rank.
+        first = createStats(2, 150, 100);
+        second = createStats(2, 200, 100);
+        assertTrue(first.rank(1) < second.rank(1));
+
+        // More queued or outstanding requests must increase rank.
+        first = createStats(2, 150, 100);
+        second = createStats(3, 150, 100);
+        assertTrue(first.rank(1) < second.rank(1));
+
+        first = createStats(2, 150, 100);
+        second = createStats(2, 150, 100);
+        assertTrue(first.rank(0) < second.rank(1));
+    }
+
+    private ResponseCollectorService.ComputedNodeStats createStats(int queueSize, int responseTimeMillis, int serviceTimeMillis) {
+        return new ResponseCollectorService.ComputedNodeStats(
+            "node0",
+            5,
+            queueSize,
+            1_000_000.0 * responseTimeMillis,
+            1_000_000.0 * serviceTimeMillis
+        );
+    }
 }


### PR DESCRIPTION
### Description
Adaptive replica selection currently substitutes service time for the service-rate term in the C3 ranking formula. Under queue or outstanding-request pressure, that inversion can make a larger service time produce a better rank.

This change:
- uses measured service time as the inverse of the service-rate term from the C3 paper, restoring monotonic ranking
- applies EWMA smoothing when synthetic statistics decay unselected nodes, instead of replacing the collected service-time average
- adds deterministic formula invariants, routing regression coverage, and failure-safe test cleanup

OpenSearch issue #19891 also describes coordinator-local and stale-state effects. This change corrects a concrete ranking defect but does not change coordinator-local ARS state or claim to eliminate all reported traffic skew.

Primary references:
- https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-suresh.pdf
- https://github.com/elastic/elasticsearch/issues/65838
- https://github.com/elastic/elasticsearch/commit/ca43dd1e5bc708eb730ccd36b9afd1bb213ebd79

### Related Issues
Related to #19891

### Validation
- focused `ResponseCollectorService` and `OperationRouting` tests
- complete `OperationRoutingTests` suite
- modified tests repeated for 50 iterations
- `:server:precommit`
- `:server:japicmp`

The repository-wide precommit progressed through 626 tasks before an unrelated example-plugin dependency download returned HTTP 403. The complete server precommit passed.

### Check List
- [x] Functionality includes testing.
- [x] API specification companion pull request, if applicable. No REST API change.
- [x] Public documentation issue or pull request, if applicable. No documentation change is required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.