### PR TITLE
Add administrative REST route metadata

### DIFF
--- a/server/src/main/java/org/opensearch/rest/NamedRoute.java
+++ b/server/src/main/java/org/opensearch/rest/NamedRoute.java
@@ -42,6 +42,7 @@ public class NamedRoute extends RestHandler.Route {
         private String path;
         private String uniqueName;
         private final Set<String> legacyActionNames = new HashSet<>();
+        private final Set<Property> properties = new HashSet<>();
         private Function<RestRequest, RestResponse> handler;
 
         /**
@@ -88,6 +89,17 @@ public class NamedRoute extends RestHandler.Route {
          */
         public Builder legacyActionNames(Set<String> legacyActionNames) {
             this.legacyActionNames.addAll(validateLegacyActionNames(legacyActionNames));
+            return this;
+        }
+
+        /**
+         * Sets properties that describe how the route should be handled.
+         *
+         * @param properties the route properties
+         * @return the builder instance
+         */
+        public Builder properties(Property... properties) {
+            this.properties.addAll(Set.of(properties));
             return this;
         }
 
@@ -140,7 +152,7 @@ public class NamedRoute extends RestHandler.Route {
     }
 
     private NamedRoute(Builder builder) {
-        super(builder.method, builder.path);
+        super(builder.method, builder.path, builder.properties.toArray(Property[]::new));
         if (!isValidRouteName(builder.uniqueName)) {
             throw new OpenSearchException(
                 "Invalid route name specified. The route name may include the following characters"

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -38,8 +38,10 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -214,10 +216,30 @@ public interface RestHandler {
 
         protected final String path;
         protected final Method method;
+        private final Set<Property> properties;
+
+        /**
+         * Properties that describe how a route should be handled.
+         */
+        @PublicApi(since = "3.9.0")
+        public enum Property {
+            /**
+             * Indicates that the route performs an administrative operation. Authorization plugins may apply additional restrictions to
+             * administrative routes beyond ordinary action privileges.
+             */
+            ADMINISTRATIVE
+        }
 
         public Route(Method method, String path) {
+            this(method, path, new Property[0]);
+        }
+
+        public Route(Method method, String path, Property... properties) {
             this.path = path;
             this.method = method;
+            EnumSet<Property> routeProperties = EnumSet.noneOf(Property.class);
+            Collections.addAll(routeProperties, Objects.requireNonNull(properties, "Route properties must not be null"));
+            this.properties = Collections.unmodifiableSet(routeProperties);
         }
 
         public String getPath() {
@@ -230,6 +252,10 @@ public interface RestHandler {
 
         public Method getMethod() {
             return method;
+        }
+
+        public boolean hasProperty(Property property) {
+            return properties.contains(property);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/rest/NamedRouteTests.java
+++ b/server/src/test/java/org/opensearch/rest/NamedRouteTests.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.opensearch.rest.NamedRoute.MAX_LENGTH_OF_ACTION_NAME;
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
 public class NamedRouteTests extends OpenSearchTestCase {
@@ -118,6 +119,12 @@ public class NamedRouteTests extends OpenSearchTestCase {
         } catch (OpenSearchException e) {
             fail("Did not expect NamedRoute to throw exception");
         }
+    }
+
+    public void testNamedRouteWithProperties() {
+        NamedRoute route = new NamedRoute.Builder().method(GET).path("foo/bar").uniqueName("foo:bar").properties(ADMINISTRATIVE).build();
+
+        assertTrue(route.hasProperty(ADMINISTRATIVE));
     }
 
     public void testNamedRouteNullChecks() {

--- a/server/src/test/java/org/opensearch/rest/RestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestHandlerTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.opensearch.rest.RestHandler.Route.Property.ADMINISTRATIVE;
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+public class RestHandlerTests extends OpenSearchTestCase {
+
+    public void testRouteHasNoPropertiesByDefault() {
+        RestHandler.Route route = new RestHandler.Route(GET, "foo/bar");
+
+        assertFalse(route.hasProperty(ADMINISTRATIVE));
+    }
+
+    public void testRouteWithProperty() {
+        RestHandler.Route route = new RestHandler.Route(GET, "foo/bar", ADMINISTRATIVE);
+
+        assertTrue(route.hasProperty(ADMINISTRATIVE));
+    }
+}


### PR DESCRIPTION
### Description
Adds declarative metadata for REST routes that perform administrative operations. Authorization plugins can use this metadata to apply restrictions beyond ordinary action privileges.

The change:
- adds `RestHandler.Route.Property.ADMINISTRATIVE`
- adds a backward-compatible `Route` constructor accepting properties
- allows `NamedRoute.Builder` to set route properties
- adds unit coverage for plain and named routes

This PR only introduces Core metadata; it does not change authorization behavior by itself. Follow-up changes can enforce the property in the Security plugin and mark applicable plugin routes.

### Example usage
- https://github.com/opensearch-project/job-scheduler/pull/993

### Testing
- `./gradlew :server:spotlessJavaCheck :server:test --tests org.opensearch.rest.RestHandlerTests --tests org.opensearch.rest.NamedRouteTests`
- `./gradlew :server:precommit`