### PR TITLE
Close the Files.walk stream in PluginHelper.verifyIfPluginExists

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/PluginHelper.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/PluginHelper.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A helper class for the plugin-cli tasks.
@@ -31,10 +32,12 @@ public class PluginHelper {
      * @throws IOException if any I/O exception occurs while performing a file operation
      */
     public static Path verifyIfPluginExists(Path pluginPath, String pluginName) throws IOException {
-        List<Path> pluginSubFolders = Files.walk(pluginPath, 1)
-            .filter(Files::isDirectory)
-            .filter(f -> !f.getFileName().toString().equals("lib"))
-            .collect(Collectors.toList());
+        final List<Path> pluginSubFolders;
+        try (Stream<Path> paths = Files.walk(pluginPath, 1)) {
+            pluginSubFolders = paths.filter(Files::isDirectory)
+                .filter(f -> !f.getFileName().toString().equals("lib"))
+                .collect(Collectors.toList());
+        }
         for (Path customPluginFolderPath : pluginSubFolders) {
             if (customPluginFolderPath != pluginPath
                 && !((customPluginFolderPath.getFileName().toString()).contains(".installing"))


### PR DESCRIPTION
### Description
`PluginHelper.verifyIfPluginExists` opens a directory stream with `Files.walk(pluginPath, 1)` and collects it into a list without closing it. `Files.walk` holds an open directory handle internally and must be closed, the same as `Files.list` and `Files.newDirectoryStream`, both of which every other caller in this package already wraps in try-with-resources. This leaks a file descriptor every time a plugin install or remove checks whether a plugin already exists under a different folder name.

Wrapped the stream in try-with-resources, matching the existing pattern used elsewhere in `RemovePluginCommand`, `ListPluginsCommand`, and `InstallPluginCommand`. No behavior change.

### Related Issues
Resolves #

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
