### PR TITLE
Reject unsupported DSL query options

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
@@ -12,13 +12,16 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.query.QueryRegistry;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 
 import java.util.Objects;
 
 /**
  * Converts the DSL {@code query} clause to a {@link LogicalFilter}.
- * Skips match_all since a table scan already returns all rows.
+ * Skips a plain match_all since a table scan already returns all rows; one carrying an
+ * unsupported option still goes through so it can be rejected.
  */
 public class FilterConverter extends AbstractDslConverter {
 
@@ -35,7 +38,17 @@ public class FilterConverter extends AbstractDslConverter {
 
     @Override
     protected boolean isApplicable(ConversionContext ctx) {
-        return ctx.getSearchSource().query() != null && !(ctx.getSearchSource().query() instanceof MatchAllQueryBuilder);
+        QueryBuilder query = ctx.getSearchSource().query();
+        if (query == null) {
+            return false;
+        }
+        if (query instanceof MatchAllQueryBuilder matchAll) {
+            // A plain match_all needs no filter — the table scan already returns all rows. One
+            // carrying boost/_name must still reach its translator so the unsupported option is
+            // rejected rather than silently dropped, matching how it behaves nested in a bool.
+            return matchAll.boost() != AbstractQueryBuilder.DEFAULT_BOOST || matchAll.queryName() != null;
+        }
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -36,6 +36,10 @@ public class ExistsQueryTranslator implements QueryTranslator {
             throw new ConversionException("boost is unsupported for Exists query type");
         }
 
+        if (existsQuery.queryName() != null) {
+            throw new ConversionException("Exists query parameter '_name' is not supported");
+        }
+
         RexNode fieldRef = ctx.makeFieldRef(fieldName);
         return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
@@ -10,13 +10,16 @@ package org.opensearch.dsl.query;
 
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
 /**
  * Converts a {@link MatchAllQueryBuilder} to a boolean TRUE literal.
- * A top-level match_all produces no filter (table scan returns all rows),
- * but match_all can appear nested inside bool queries and needs a translator.
+ * A plain top-level match_all produces no filter (the table scan returns all rows), but it
+ * still reaches this translator when nested in a bool query, or when it carries an option
+ * this path cannot honour.
  */
 public class MatchAllQueryTranslator implements QueryTranslator {
 
@@ -29,7 +32,17 @@ public class MatchAllQueryTranslator implements QueryTranslator {
     }
 
     @Override
-    public RexNode convert(QueryBuilder query, ConversionContext ctx) {
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        MatchAllQueryBuilder matchAllQuery = (MatchAllQueryBuilder) query;
+
+        if (matchAllQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException("Match_all query parameter 'boost' is not supported");
+        }
+        // matched_queries is not surfaced by this path
+        if (matchAllQuery.queryName() != null) {
+            throw new ConversionException("Match_all query parameter '_name' is not supported");
+        }
+
         return ctx.getRexBuilder().makeLiteral(true);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 
@@ -44,6 +45,14 @@ public class TermQueryTranslator implements QueryTranslator {
         TermQueryBuilder termQuery = (TermQueryBuilder) query;
         String fieldName = termQuery.fieldName();
         Object value = termQuery.value();
+
+        if (termQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException("Term query parameter 'boost' is not supported");
+        }
+        // matched_queries is not surfaced by this path
+        if (termQuery.queryName() != null) {
+            throw new ConversionException("Term query parameter '_name' is not supported");
+        }
 
         RelDataTypeField field = ctx.getField(fieldName);
         RelDataType fieldType = field.getType();

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
@@ -40,6 +40,50 @@ public class FilterConverterTests extends OpenSearchTestCase {
         assertSame(scan, result);
     }
 
+    /**
+     * A top-level match_all is skipped before reaching its translator, so options it cannot honour
+     * must still be rejected here — otherwise the same query is rejected inside a bool but accepted
+     * at the top level.
+     */
+    public void testRejectsTopLevelMatchAllWithBoost() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery().boost(1.5f));
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+    }
+
+    public void testRejectsTopLevelMatchAllWithName() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery().queryName("my_match_all"));
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue("Must mention '_name', got: " + ex.getMessage(), ex.getMessage().contains("_name"));
+    }
+
+    /**
+     * The nested path this change aligns the top-level case with — pinned so the two cannot drift.
+     */
+    public void testRejectsMatchAllWithBoostNestedInBool() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery().boost(1.5f))
+        );
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+    }
+
+    public void testRejectsMatchAllWithNameNestedInBool() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery().queryName("my_match_all"))
+        );
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue("Must mention '_name', got: " + ex.getMessage(), ex.getMessage().contains("_name"));
+    }
+
     public void testTermQueryProducesLogicalFilter() throws ConversionException {
         SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.termQuery("name", "laptop"));
         ConversionContext ctx = TestUtils.createContext(source);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
@@ -51,6 +51,14 @@ public class ExistsQueryTranslatorTests extends OpenSearchTestCase {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
     }
 
+    public void testThrowsForName() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.existsQuery("name").queryName("my_exists"), ctx)
+        );
+        assertTrue("Must mention '_name', got: " + ex.getMessage(), ex.getMessage().contains("_name"));
+    }
+
     public void testReportsCorrectQueryType() {
         assertEquals(ExistsQueryBuilder.class, translator.getQueryType());
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
@@ -12,13 +12,14 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MatchAllQueryTranslatorTests extends OpenSearchTestCase {
 
-    public void testConvertsMatchAllToTrueLiteral() {
+    public void testConvertsMatchAllToTrueLiteral() throws ConversionException {
         ConversionContext ctx = TestUtils.createContext();
         MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
 
@@ -31,5 +32,27 @@ public class MatchAllQueryTranslatorTests extends OpenSearchTestCase {
     public void testReportsCorrectQueryType() {
         MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
         assertEquals(MatchAllQueryBuilder.class, translator.getQueryType());
+    }
+
+    public void testBoostParameterRejectedWithConversionException() {
+        ConversionContext ctx = TestUtils.createContext();
+        MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
+
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.matchAllQuery().boost(1.5f), ctx)
+        );
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+    }
+
+    public void testNameParameterRejectedWithConversionException() {
+        ConversionContext ctx = TestUtils.createContext();
+        MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
+
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.matchAllQuery().queryName("my_match_all"), ctx)
+        );
+        assertEquals("Match_all query parameter '_name' is not supported", ex.getMessage());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
@@ -206,4 +206,21 @@ public class TermQueryTranslatorTests extends OpenSearchTestCase {
         );
         assertTrue(ex.getMessage().contains("not yet supported"));
     }
+
+    public void testBoostParameterRejectedWithConversionException() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termQuery("name", "laptop").boost(1.5f), ctx)
+        );
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+        assertTrue("Must mention 'not supported', got: " + ex.getMessage(), ex.getMessage().contains("not supported"));
+    }
+
+    public void testNameParameterRejectedWithConversionException() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termQuery("name", "laptop").queryName("my_term"), ctx)
+        );
+        assertEquals("Term query parameter '_name' is not supported", ex.getMessage());
+    }
 }


### PR DESCRIPTION
### Description

Reject non-default `boost` and supplied `_name` in Term and MatchAll
translators, and reject `_name` in Exists. These options were silently
ignored, while Bool, Terms, Range, Prefix, and Wildcard already rejected
them. This execution path does not surface scores or `matched_queries`.

Top-level `match_all` previously bypassed its translator in
`FilterConverter`. Queries carrying non-default `boost` or a supplied
`_name` now reach the translator for validation, matching the handling
of nested clauses that reach translation.

Ordinary `match_all` still skips filter creation. An explicit
`boost: 1.0` remains accepted.

### Testing

- `./gradlew -Dsandbox.enabled=true :sandbox:plugins:dsl-query-executor:test`
  — 552 tests passed.
- `./gradlew -Dsandbox.enabled=true precommit` — passed.
- Reverting only the four production files makes the nine new tests fail,
  each with "Expected exception ConversionException but no exception was
  thrown".
- Regression tests cover the missing translator checks and both
  top-level and `bool.must`-nested `match_all` through the real
  conversion path.
- Existing tests cover ordinary `match_all` filter skipping.

### Scope

Existing bool short-circuit paths, including optional `should` clauses
that never reach translation, remain unchanged.

New rejection messages follow the Prefix/Wildcard convention.
Existing rejection messages are unchanged; message unification is
outside this PR.

### Related Issues

Relates to #22961

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.