### PR TITLE
Fix flaky DataformatAwareCatalogSnapshotTests.testDeserializationRejectsInvalidInput

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/exec/coord/DataformatAwareCatalogSnapshotTests.java
@@ -585,22 +585,42 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
         assertEquals(context + ": userData", expected.getUserData(), actual.getUserData());
     }
 
+    /**
+     * The minimum number of bytes {@link DataformatAwareCatalogSnapshot}'s {@code StreamInput}
+     * constructor needs before it can even reach the segment-count check: generation (8) +
+     * version (8) + an empty user-data map's count vint (1) + id (8) + lastWriterGeneration (8)
+     * + a zero segment-count vint (1).
+     */
+    private static final int MIN_SERIALIZED_LENGTH = 34;
+
+    /**
+     * Builds a candidate invalid input that is invalid by construction rather than by chance.
+     *
+     * The wire format has no magic marker or checksum, so a sufficiently long arbitrary byte
+     * sequence can, in principle, happen to decode as a structurally valid (if meaningless)
+     * snapshot -- see https://github.com/opensearch-project/OpenSearch/issues/22315. Each case
+     * here instead targets a specific way {@link DataformatAwareCatalogSnapshot#deserializeFromString}
+     * is guaranteed to fail: a non-Base64 alphabet, a byte count below {@link
+     * #MIN_SERIALIZED_LENGTH} (so the stream always runs out before a segment count can even be
+     * read), or a segment count deliberately built to exceed the bytes remaining.
+     */
     private String generateInvalidInput(int iter) {
         switch (iter % 6) {
             case 0:
-                return randomAlphaOfLengthBetween(1, 200);
+                // Contains a character outside the Base64 alphabet, so decoding always fails
+                // regardless of length.
+                return randomAlphaOfLengthBetween(1, 199) + "!";
             case 1:
-                byte[] randomBytes = new byte[randomIntBetween(1, 100)];
+                // Valid Base64 alphabet, but too few bytes for even an empty snapshot's header
+                // to be read in full.
+                byte[] randomBytes = new byte[randomIntBetween(1, MIN_SERIALIZED_LENGTH - 1)];
                 random().nextBytes(randomBytes);
                 return java.util.Base64.getEncoder().encodeToString(randomBytes);
             case 2:
-                DataformatAwareCatalogSnapshot snap = randomSnapshot();
-                try {
-                    String validBase64 = snap.serializeToString();
-                    return validBase64.substring(0, randomIntBetween(1, Math.max(1, validBase64.length() / 2)));
-                } catch (IOException e) {
-                    return "AAAA";
-                }
+                // A well-formed header (empty user data, arbitrary id/generation/version) whose
+                // segment count is deliberately too large to fit in the remaining bytes, which
+                // DataformatAwareCatalogSnapshot's constructor rejects explicitly.
+                return corruptedSegmentCountInput();
             case 3:
                 return "";
             case 4:
@@ -609,6 +629,20 @@ public class DataformatAwareCatalogSnapshotTests extends OpenSearchTestCase {
                 return randomFrom("null", "undefined", "None", "nil", "NaN");
             default:
                 return randomAlphaOfLength(10);
+        }
+    }
+
+    private String corruptedSegmentCountInput() {
+        try (org.opensearch.common.io.stream.BytesStreamOutput out = new org.opensearch.common.io.stream.BytesStreamOutput()) {
+            out.writeLong(randomLong()); // generation
+            out.writeLong(randomLong()); // version
+            out.writeVInt(0); // empty user data map
+            out.writeLong(randomLong()); // id
+            out.writeLong(randomLong()); // lastWriterGeneration
+            out.writeVInt(Integer.MAX_VALUE); // segment count, always > bytes remaining
+            return java.util.Base64.getEncoder().encodeToString(org.opensearch.core.common.bytes.BytesReference.toBytes(out.bytes()));
+        } catch (IOException e) {
+            throw new AssertionError(e);
         }
     }
 


### PR DESCRIPTION
### Description
`DataformatAwareCatalogSnapshotTests.testDeserializationRejectsInvalidInput` fails intermittently on post-merge and timer runs (#22315). Three of its six "invalid input" generators relied on chance: a random alpha string, up to 100 random bytes, and a truncated valid serialization. The snapshot wire format has no magic marker or checksum, and `DataformatAwareCatalogSnapshot(StreamInput, ...)` reads generation, version, a user-data map, id, last writer generation and a segment count with only `segmentCount < 0 || segmentCount > in.available()` as validation, so a random input of the right shape (an empty map count and a zero segment count at the right offsets, 34 bytes in all) occasionally decodes as a meaningless but well-formed snapshot and the expected `IOException` never comes.

The three cases are rebuilt so each is invalid by construction rather than by probability:

- a random alpha string with a non-Base64 `!` appended, which the strict `Base64.getDecoder()` in `deserializeFromString` always rejects;
- fewer than `MIN_SERIALIZED_LENGTH` (34) random bytes, so the stream ends before the header can be read and `BytesStreamInput` throws `EOFException`;
- a well-formed empty-snapshot header whose segment count is `Integer.MAX_VALUE`, which the constructor's explicit segment-count check rejects.

The other three generators (empty input, non-Base64 alphabets, Base64 of the wrong length or too short to hold a header) were already deterministic and are untouched. The test's assertion and iteration count are unchanged.

Verification: `./gradlew :server:test --tests DataformatAwareCatalogSnapshotTests -Dtests.iters=100` three times, 300 clean iterations, plus one run after `spotlessJavaCheck` was green. The Jenkins report linked from the issue returns 403 without credentials, so the failing seed could not be replayed; the collision shape above is derived from the constructor's reads, and the previous generators could produce it.

The change was prepared with AI assistance under my direction; I am responsible for it.

### Related Issues
Resolves #22315

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
