### PR TITLE
Replace deprecated AccessController in plugins

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightServer.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/apache/arrow/flight/OSFlightServer.java
@@ -25,8 +25,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,13 +45,13 @@ import org.apache.arrow.flight.grpc.ServerInterceptorAdapter;
 import org.apache.arrow.flight.grpc.ServerInterceptorAdapter.KeyFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.opensearch.secure_sm.AccessController;
 
 /**
  * Clone of {@link org.apache.arrow.flight.FlightServer} to support setting SslContext. It can be discarded once FlightServer.Builder supports setting SslContext directly.
  * <p>
  * It changes {@link org.apache.arrow.flight.FlightServer.Builder} to allow hook to configure the NettyServerBuilder.
  */
-@SuppressWarnings("removal")
 public class OSFlightServer {
     /** The maximum size of an individual gRPC message. This effectively disables the limit. */
     static final int MAX_GRPC_MESSAGE_SIZE = Integer.MAX_VALUE;
@@ -65,7 +63,7 @@ public class OSFlightServer {
     private static final MethodHandle FLIGHT_SERVER_CTOR_MH;
 
     static {
-            FLIGHT_SERVER_CTOR_MH = AccessController.doPrivileged((PrivilegedAction<MethodHandle>) () -> {
+            FLIGHT_SERVER_CTOR_MH = AccessController.doPrivileged(() -> {
                     try {
                 return MethodHandles
                 .privateLookupIn(FlightServer.class, MethodHandles.lookup())

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
@@ -16,10 +16,9 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -268,15 +267,13 @@ public class ServerConfig {
      * @param settings The OpenSearch settings to initialize the server with
      */
     @SuppressForbidden(reason = "required for arrow allocator")
-    @SuppressWarnings("removal")
     public static void init(Settings settings) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        AccessController.doPrivileged(() -> {
             System.setProperty("arrow.allocation.manager.type", ARROW_ALLOCATION_MANAGER_TYPE.get(settings));
             System.setProperty("arrow.enable_null_check_for_get", Boolean.toString(ARROW_ENABLE_NULL_CHECK_FOR_GET.get(settings)));
             System.setProperty("arrow.enable_unsafe_memory_access", Boolean.toString(ARROW_ENABLE_UNSAFE_MEMORY_ACCESS.get(settings)));
             System.setProperty("arrow.memory.debug.allocator", Boolean.toString(ARROW_ENABLE_DEBUG_ALLOCATOR.get(settings)));
             Netty4Configs.init(settings);
-            return null;
         });
         enableSsl = ARROW_SSL_ENABLE.get(settings);
         threadPoolMin = FLIGHT_THREAD_POOL_MIN_SIZE.get(settings);

--- a/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
+++ b/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
@@ -34,6 +34,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,8 +42,6 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -191,7 +190,7 @@ public class EhcacheDiskCache<K, V> implements ICache<K, V> {
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "removal" })
+    @SuppressWarnings("rawtypes")
     private Cache<ICacheKey, ByteArrayWrapper> buildCache(Duration expireAfterAccess, Builder<K, V> builder) {
         // Creating the cache requires permissions specified in plugin-security.policy
         int segmentCount = (Integer) EhcacheDiskCacheSettings.getSettingListForCacheType(cacheType).get(DISK_SEGMENT_KEY).get(settings);
@@ -262,12 +261,11 @@ public class EhcacheDiskCache<K, V> implements ICache<K, V> {
         return completableFutureMap;
     }
 
-    @SuppressWarnings("removal")
     @SuppressForbidden(reason = "Ehcache uses File.io")
     PersistentCacheManager buildCacheManager() {
         // In case we use multiple ehCaches, we can define this cache manager at a global level.
         // Creating the cache manager also requires permissions specified in plugin-security.policy
-        return AccessController.doPrivileged((PrivilegedAction<PersistentCacheManager>) () -> {
+        return AccessController.doPrivileged(() -> {
             return CacheManagerBuilder.newCacheManagerBuilder()
                 .with(CacheManagerBuilder.persistence(new File(storagePath)))
 

--- a/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCacheManager.java
+++ b/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCacheManager.java
@@ -17,14 +17,13 @@ import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -111,7 +110,6 @@ public class EhcacheDiskCacheManager {
      * @param <K> key type
      * @param <V> value type
      */
-    @SuppressWarnings({ "removal" })
     public static <K, V> Cache<K, V> createCache(
         CacheType cacheType,
         String diskCacheAlias,
@@ -133,7 +131,7 @@ public class EhcacheDiskCacheManager {
             throw new IllegalArgumentException(CACHE_MANAGER_DOES_NOT_EXIST_EXCEPTION_MSG + cacheType);
         }
         // Creating the cache requires permissions specified in plugin-security.policy
-        return AccessController.doPrivileged((PrivilegedAction<Cache<K, V>>) () -> {
+        return AccessController.doPrivileged(() -> {
             try {
                 lock.lock();
                 // Check again for null cache manager, in case it got removed by another thread in below closeCache()
@@ -219,7 +217,6 @@ public class EhcacheDiskCacheManager {
         }
     }
 
-    @SuppressWarnings("removal")
     @SuppressForbidden(reason = "Ehcache uses File.io")
     private static PersistentCacheManager createCacheManager(
         CacheType cacheType,
@@ -229,7 +226,7 @@ public class EhcacheDiskCacheManager {
     ) {
 
         return AccessController.doPrivileged(
-            (PrivilegedAction<PersistentCacheManager>) () -> CacheManagerBuilder.newCacheManagerBuilder()
+            () -> CacheManagerBuilder.newCacheManagerBuilder()
                 .with(CacheManagerBuilder.persistence(new File(storagePath)))
 
                 .using(

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -22,9 +22,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
+import org.opensearch.secure_sm.AccessController;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeoutException;
 /**
  * Kafka consumer to read messages from a Kafka partition
  */
-@SuppressWarnings("removal")
 public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffset, KafkaMessage> {
     private static final Logger logger = LogManager.getLogger(KafkaPartitionConsumer.class);
 
@@ -78,10 +76,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     void initialize() throws Exception {
         String topic = config.getTopic();
         List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
-            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(
-                topic,
-                Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs())
-            )
+            () -> consumer.partitionsFor(topic, Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs()))
         );
         if (partitionInfos == null) {
             throw new IllegalArgumentException("Topic " + topic + " does not exist");
@@ -131,11 +126,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         try {
             Thread.currentThread().setContextClassLoader(KafkaPlugin.class.getClassLoader());
             return AccessController.doPrivileged(
-                (PrivilegedAction<Consumer<byte[], byte[]>>) () -> new KafkaConsumer<>(
-                    consumerProp,
-                    new ByteArrayDeserializer(),
-                    new ByteArrayDeserializer()
-                )
+                () -> new KafkaConsumer<>(consumerProp, new ByteArrayDeserializer(), new ByteArrayDeserializer())
             );
         } finally {
             Thread.currentThread().setContextClassLoader(restore);
@@ -159,7 +150,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         int timeoutMillis
     ) throws TimeoutException {
         List<ReadResult<KafkaOffset, KafkaMessage>> records = AccessController.doPrivileged(
-            (PrivilegedAction<List<ReadResult<KafkaOffset, KafkaMessage>>>) () -> fetch(offset.getOffset(), includeStart, timeoutMillis)
+            () -> fetch(offset.getOffset(), includeStart, timeoutMillis)
         );
         return records;
     }
@@ -174,7 +165,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     @Override
     public synchronized List<ReadResult<KafkaOffset, KafkaMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
         List<ReadResult<KafkaOffset, KafkaMessage>> records = AccessController.doPrivileged(
-            (PrivilegedAction<List<ReadResult<KafkaOffset, KafkaMessage>>>) () -> fetch(lastFetchedOffset, false, timeoutMillis)
+            () -> fetch(lastFetchedOffset, false, timeoutMillis)
         );
         return records;
     }
@@ -182,8 +173,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     @Override
     public synchronized IngestionShardPointer earliestPointer() {
         long startOffset = AccessController.doPrivileged(
-            (PrivilegedAction<Long>) () -> consumer.beginningOffsets(Collections.singletonList(topicPartition))
-                .getOrDefault(topicPartition, 0L)
+            () -> consumer.beginningOffsets(Collections.singletonList(topicPartition)).getOrDefault(topicPartition, 0L)
         );
         return new KafkaOffset(startOffset);
     }
@@ -191,14 +181,14 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     @Override
     public synchronized IngestionShardPointer latestPointer() {
         long endOffset = AccessController.doPrivileged(
-            (PrivilegedAction<Long>) () -> consumer.endOffsets(Collections.singletonList(topicPartition)).getOrDefault(topicPartition, 0L)
+            () -> consumer.endOffsets(Collections.singletonList(topicPartition)).getOrDefault(topicPartition, 0L)
         );
         return new KafkaOffset(endOffset);
     }
 
     @Override
     public synchronized IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
-        long offset = AccessController.doPrivileged((PrivilegedAction<Long>) () -> {
+        long offset = AccessController.doPrivileged(() -> {
             Map<TopicPartition, OffsetAndTimestamp> position = consumer.offsetsForTimes(
                 Collections.singletonMap(topicPartition, timestampMillis)
             );

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/OTelTelemetrySettings.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/OTelTelemetrySettings.java
@@ -11,15 +11,13 @@ package org.opensearch.telemetry;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.metrics.exporter.OTelMetricsExporterFactory;
 import org.opensearch.telemetry.tracing.exporter.OTelSpanExporterFactory;
 import org.opensearch.telemetry.tracing.sampler.OTelSamplerFactory;
 import org.opensearch.telemetry.tracing.sampler.ProbabilisticSampler;
 import org.opensearch.telemetry.tracing.sampler.ProbabilisticTransportActionSampler;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.List;
 
@@ -72,7 +70,7 @@ public final class OTelTelemetrySettings {
     /**
      * Span Exporter type setting.
      */
-    @SuppressWarnings({ "unchecked", "removal" })
+    @SuppressWarnings("unchecked")
     public static final Setting<Class<SpanExporter>> OTEL_TRACER_SPAN_EXPORTER_CLASS_SETTING = new Setting<>(
         "telemetry.otel.tracer.span.exporter.class",
         LoggingSpanExporter.class.getName(),
@@ -81,12 +79,12 @@ public final class OTelTelemetrySettings {
             SpecialPermission.check();
 
             try {
-                return AccessController.doPrivileged((PrivilegedExceptionAction<Class<SpanExporter>>) () -> {
+                return AccessController.doPrivilegedChecked(() -> {
                     final ClassLoader loader = OTelSpanExporterFactory.class.getClassLoader();
                     return (Class<SpanExporter>) loader.loadClass(className);
                 });
-            } catch (PrivilegedActionException ex) {
-                throw new IllegalStateException("Unable to load span exporter class:" + className, ex.getCause());
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalStateException("Unable to load span exporter class:" + className, ex);
             }
         },
         Setting.Property.NodeScope,
@@ -96,7 +94,7 @@ public final class OTelTelemetrySettings {
     /**
      * Metrics Exporter type setting.
      */
-    @SuppressWarnings({ "unchecked", "removal" })
+    @SuppressWarnings("unchecked")
     public static final Setting<Class<MetricExporter>> OTEL_METRICS_EXPORTER_CLASS_SETTING = new Setting<>(
         "telemetry.otel.metrics.exporter.class",
         LoggingMetricExporter.class.getName(),
@@ -105,12 +103,12 @@ public final class OTelTelemetrySettings {
             SpecialPermission.check();
 
             try {
-                return AccessController.doPrivileged((PrivilegedExceptionAction<Class<MetricExporter>>) () -> {
+                return AccessController.doPrivilegedChecked(() -> {
                     final ClassLoader loader = OTelMetricsExporterFactory.class.getClassLoader();
                     return (Class<MetricExporter>) loader.loadClass(className);
                 });
-            } catch (PrivilegedActionException ex) {
-                throw new IllegalStateException("Unable to load span exporter class:" + className, ex.getCause());
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalStateException("Unable to load span exporter class:" + className, ex);
             }
         },
         Setting.Property.NodeScope,
@@ -120,7 +118,7 @@ public final class OTelTelemetrySettings {
     /**
      * Samplers orders setting.
      */
-    @SuppressWarnings({ "unchecked", "removal" })
+    @SuppressWarnings("unchecked")
     public static final Setting<List<Class<Sampler>>> OTEL_TRACER_SPAN_SAMPLER_CLASS_SETTINGS = Setting.listSetting(
         "telemetry.otel.tracer.span.sampler.classes",
         Arrays.asList(ProbabilisticTransportActionSampler.class.getName(), ProbabilisticSampler.class.getName()),
@@ -128,12 +126,12 @@ public final class OTelTelemetrySettings {
             // Check we ourselves are not being called by unprivileged code.
             SpecialPermission.check();
             try {
-                return AccessController.doPrivileged((PrivilegedExceptionAction<Class<Sampler>>) () -> {
+                return AccessController.doPrivilegedChecked(() -> {
                     final ClassLoader loader = OTelSamplerFactory.class.getClassLoader();
                     return (Class<Sampler>) loader.loadClass(sampler);
                 });
-            } catch (PrivilegedActionException ex) {
-                throw new IllegalStateException("Unable to load sampler class: " + sampler, ex.getCause());
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalStateException("Unable to load sampler class: " + sampler, ex);
             }
         },
         Setting.Property.NodeScope,

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetry.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetry.java
@@ -9,14 +9,13 @@
 package org.opensearch.telemetry.metrics;
 
 import org.opensearch.common.concurrent.RefCountedReleasable;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.OTelAttributesConverter;
 import org.opensearch.telemetry.OTelTelemetryPlugin;
 import org.opensearch.telemetry.metrics.tags.Tags;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.function.Supplier;
 
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -47,28 +46,18 @@ public class OTelMetricsTelemetry<T extends MeterProvider & Closeable> implement
         this.otelMeter = meterProvider.get(OTelTelemetryPlugin.INSTRUMENTATION_SCOPE_NAME);
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Counter createCounter(String name, String description, String unit) {
         DoubleCounter doubleCounter = AccessController.doPrivileged(
-            (PrivilegedAction<DoubleCounter>) () -> otelMeter.counterBuilder(name)
-                .setUnit(unit)
-                .setDescription(description)
-                .ofDoubles()
-                .build()
+            () -> otelMeter.counterBuilder(name).setUnit(unit).setDescription(description).ofDoubles().build()
         );
         return new OTelCounter(doubleCounter);
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Counter createUpDownCounter(String name, String description, String unit) {
         DoubleUpDownCounter doubleUpDownCounter = AccessController.doPrivileged(
-            (PrivilegedAction<DoubleUpDownCounter>) () -> otelMeter.upDownCounterBuilder(name)
-                .setUnit(unit)
-                .setDescription(description)
-                .ofDoubles()
-                .build()
+            () -> otelMeter.upDownCounterBuilder(name).setUnit(unit).setDescription(description).ofDoubles().build()
         );
         return new OTelUpDownCounter(doubleUpDownCounter);
     }
@@ -82,20 +71,18 @@ public class OTelMetricsTelemetry<T extends MeterProvider & Closeable> implement
      * @param unit        unit of the metric.
      * @return histogram
      */
-    @SuppressWarnings("removal")
     @Override
     public Histogram createHistogram(String name, String description, String unit) {
         DoubleHistogram doubleHistogram = AccessController.doPrivileged(
-            (PrivilegedAction<DoubleHistogram>) () -> otelMeter.histogramBuilder(name).setUnit(unit).setDescription(description).build()
+            () -> otelMeter.histogramBuilder(name).setUnit(unit).setDescription(description).build()
         );
         return new OTelHistogram(doubleHistogram);
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags) {
         ObservableDoubleGauge doubleObservableGauge = AccessController.doPrivileged(
-            (PrivilegedAction<ObservableDoubleGauge>) () -> otelMeter.gaugeBuilder(name)
+            () -> otelMeter.gaugeBuilder(name)
                 .setUnit(unit)
                 .setDescription(description)
                 .buildWithCallback(record -> record.record(valueProvider.get(), OTelAttributesConverter.convert(tags)))
@@ -103,11 +90,10 @@ public class OTelMetricsTelemetry<T extends MeterProvider & Closeable> implement
         return () -> doubleObservableGauge.close();
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Closeable createGauge(String name, String description, String unit, Supplier<TaggedMeasurement> value) {
         ObservableDoubleGauge doubleObservableGauge = AccessController.doPrivileged(
-            (PrivilegedAction<ObservableDoubleGauge>) () -> otelMeter.gaugeBuilder(name)
+            () -> otelMeter.gaugeBuilder(name)
                 .setUnit(unit)
                 .setDescription(description)
                 .buildWithCallback(record -> record.record(value.get().getValue(), OTelAttributesConverter.convert(value.get().getTags())))

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/exporter/OTelMetricsExporterFactory.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/exporter/OTelMetricsExporterFactory.java
@@ -12,14 +12,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.OTelTelemetrySettings;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
@@ -51,41 +49,33 @@ public class OTelMetricsExporterFactory {
         return metricExporter;
     }
 
-    @SuppressWarnings("removal")
     private static MetricExporter instantiateExporter(Class<MetricExporter> exporterProviderClass) {
-        try {
-            // Check we ourselves are not being called by unprivileged code.
-            SpecialPermission.check();
-            return AccessController.doPrivileged((PrivilegedExceptionAction<MetricExporter>) () -> {
-                String methodName = "create";
-                String getDefaultMethod = "getDefault";
-                for (Method m : exporterProviderClass.getMethods()) {
-                    if (m.getName().equals(getDefaultMethod)) {
-                        methodName = getDefaultMethod;
-                        break;
-                    }
+        // Check we ourselves are not being called by unprivileged code.
+        SpecialPermission.check();
+        return AccessController.doPrivileged(() -> {
+            String methodName = "create";
+            String getDefaultMethod = "getDefault";
+            for (Method m : exporterProviderClass.getMethods()) {
+                if (m.getName().equals(getDefaultMethod)) {
+                    methodName = getDefaultMethod;
+                    break;
                 }
-                try {
-                    return (MetricExporter) MethodHandles.publicLookup()
-                        .findStatic(exporterProviderClass, methodName, MethodType.methodType(exporterProviderClass))
-                        .asType(MethodType.methodType(MetricExporter.class))
-                        .invokeExact();
-                } catch (Throwable e) {
-                    if (e.getCause() instanceof NoSuchMethodException) {
-                        throw new IllegalStateException("No create factory method exist in [" + exporterProviderClass.getName() + "]");
-                    } else {
-                        throw new IllegalStateException(
-                            "MetricExporter instantiation failed for class [" + exporterProviderClass.getName() + "]",
-                            e.getCause()
-                        );
-                    }
+            }
+            try {
+                return (MetricExporter) MethodHandles.publicLookup()
+                    .findStatic(exporterProviderClass, methodName, MethodType.methodType(exporterProviderClass))
+                    .asType(MethodType.methodType(MetricExporter.class))
+                    .invokeExact();
+            } catch (Throwable e) {
+                if (e.getCause() instanceof NoSuchMethodException) {
+                    throw new IllegalStateException("No create factory method exist in [" + exporterProviderClass.getName() + "]");
+                } else {
+                    throw new IllegalStateException(
+                        "MetricExporter instantiation failed for class [" + exporterProviderClass.getName() + "]",
+                        e.getCause()
+                    );
                 }
-            });
-        } catch (PrivilegedActionException ex) {
-            throw new IllegalStateException(
-                "MetricExporter instantiation failed for class [" + exporterProviderClass.getName() + "]",
-                ex.getCause()
-            );
-        }
+            }
+        });
     }
 }

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelResourceProvider.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelResourceProvider.java
@@ -9,14 +9,13 @@
 package org.opensearch.telemetry.tracing;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.telemetry.metrics.exporter.OTelMetricsExporterFactory;
 import org.opensearch.telemetry.tracing.exporter.OTelSpanExporterFactory;
 import org.opensearch.telemetry.tracing.sampler.OTelSamplerFactory;
 import org.opensearch.telemetry.tracing.sampler.RequestSampler;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.api.common.Attributes;
@@ -53,10 +52,9 @@ public final class OTelResourceProvider {
      * @param settings cluster settings
      * @return OpenTelemetrySdk instance
      */
-    @SuppressWarnings("removal")
     public static OpenTelemetrySdk get(TelemetrySettings telemetrySettings, Settings settings) {
         return AccessController.doPrivileged(
-            (PrivilegedAction<OpenTelemetrySdk>) () -> get(
+            () -> get(
                 settings,
                 OTelSpanExporterFactory.create(settings),
                 ContextPropagators.create(W3CTraceContextPropagator.getInstance()),

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/exporter/OTelSpanExporterFactory.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/exporter/OTelSpanExporterFactory.java
@@ -12,14 +12,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.OTelTelemetrySettings;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
@@ -51,41 +49,33 @@ public class OTelSpanExporterFactory {
         return spanExporter;
     }
 
-    @SuppressWarnings("removal")
     private static SpanExporter instantiateSpanExporter(Class<SpanExporter> spanExporterProviderClass) {
-        try {
-            // Check we ourselves are not being called by unprivileged code.
-            SpecialPermission.check();
-            return AccessController.doPrivileged((PrivilegedExceptionAction<SpanExporter>) () -> {
-                String methodName = "create";
-                String getDefaultMethod = "getDefault";
-                for (Method m : spanExporterProviderClass.getMethods()) {
-                    if (m.getName().equals(getDefaultMethod)) {
-                        methodName = getDefaultMethod;
-                        break;
-                    }
+        // Check we ourselves are not being called by unprivileged code.
+        SpecialPermission.check();
+        return AccessController.doPrivileged(() -> {
+            String methodName = "create";
+            String getDefaultMethod = "getDefault";
+            for (Method m : spanExporterProviderClass.getMethods()) {
+                if (m.getName().equals(getDefaultMethod)) {
+                    methodName = getDefaultMethod;
+                    break;
                 }
-                try {
-                    return (SpanExporter) MethodHandles.publicLookup()
-                        .findStatic(spanExporterProviderClass, methodName, MethodType.methodType(spanExporterProviderClass))
-                        .asType(MethodType.methodType(SpanExporter.class))
-                        .invokeExact();
-                } catch (Throwable e) {
-                    if (e.getCause() instanceof NoSuchMethodException) {
-                        throw new IllegalStateException("No create factory method exist in [" + spanExporterProviderClass.getName() + "]");
-                    } else {
-                        throw new IllegalStateException(
-                            "SpanExporter instantiation failed for class [" + spanExporterProviderClass.getName() + "]",
-                            e.getCause()
-                        );
-                    }
+            }
+            try {
+                return (SpanExporter) MethodHandles.publicLookup()
+                    .findStatic(spanExporterProviderClass, methodName, MethodType.methodType(spanExporterProviderClass))
+                    .asType(MethodType.methodType(SpanExporter.class))
+                    .invokeExact();
+            } catch (Throwable e) {
+                if (e.getCause() instanceof NoSuchMethodException) {
+                    throw new IllegalStateException("No create factory method exist in [" + spanExporterProviderClass.getName() + "]");
+                } else {
+                    throw new IllegalStateException(
+                        "SpanExporter instantiation failed for class [" + spanExporterProviderClass.getName() + "]",
+                        e.getCause()
+                    );
                 }
-            });
-        } catch (PrivilegedActionException ex) {
-            throw new IllegalStateException(
-                "SpanExporter instantiation failed for class [" + spanExporterProviderClass.getName() + "]",
-                ex.getCause()
-            );
-        }
+            }
+        });
     }
 }

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/sampler/OTelSamplerFactory.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/sampler/OTelSamplerFactory.java
@@ -12,13 +12,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.OTelTelemetrySettings;
 import org.opensearch.telemetry.TelemetrySettings;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -63,7 +62,6 @@ public class OTelSamplerFactory {
         return fallbackSampler;
     }
 
-    @SuppressWarnings("removal")
     private static Sampler instantiateSampler(
         Class<Sampler> samplerClassName,
         TelemetrySettings telemetrySettings,
@@ -74,7 +72,7 @@ public class OTelSamplerFactory {
             // Check we ourselves are not being called by unprivileged code.
             SpecialPermission.check();
 
-            return AccessController.doPrivileged((PrivilegedExceptionAction<Sampler>) () -> {
+            return AccessController.doPrivileged(() -> {
                 try {
                     // Define the method type which receives TelemetrySettings & Sampler as arguments
                     MethodType methodType = MethodType.methodType(Sampler.class, TelemetrySettings.class, Settings.class, Sampler.class);


### PR DESCRIPTION
### Description
Migrates remaining straightforward plugin usages of the deprecated JDK `AccessController` to `org.opensearch.secure_sm.AccessController` in:

- `cache-ehcache`
- `ingestion-kafka`
- `telemetry-otel`
- `arrow-flight-rpc`

The OpenTelemetry class-loading paths use `doPrivilegedChecked` so checked exceptions remain explicit. This also removes obsolete privileged action casts and `removal` suppressions.

More specialized usages involving explicit `AccessControlContext` or permission arguments are intentionally left for separate changes.

### Testing
- `./gradlew :plugins:cache-ehcache:precommit :plugins:cache-ehcache:test :plugins:ingestion-kafka:precommit :plugins:ingestion-kafka:test :plugins:telemetry-otel:precommit :plugins:telemetry-otel:test :plugins:arrow-flight-rpc:precommit :plugins:arrow-flight-rpc:test --console=plain`