### PR TITLE
Fix 500 on boolean field filters and unify boost/_name rejection

### DIFF
--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/rules/OpenSearchFilterRule.java
@@ -16,6 +16,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -121,6 +122,23 @@ public class OpenSearchFilterRule extends RelOptRule {
      * {@link AnnotatedPredicate} with viable backends resolved from child's field storage.
      */
     private RexNode annotateCondition(RexNode condition, List<FieldStorageInfo> fieldStorageInfos, List<String> childViableBackends) {
+        // Calcite's ReduceExpressionsRule folds `boolCol = TRUE` to a bare boolean reference. Annotate it as an
+        // IS_TRUE leaf so the capability gate runs; an unannotated ref would leave every child-viable backend viable.
+        if (condition instanceof RexInputRef ref && ref.getType().getSqlTypeName() == SqlTypeName.BOOLEAN) {
+            FieldStorageInfo fsi = FieldStorageInfo.resolve(fieldStorageInfos, ref.getIndex());
+            // IS_TRUE is a capability key for routing only: the annotated expression remains the bare ref.
+            Set<String> viable = new HashSet<>(context.getCapabilityRegistry().filterCapableBackends());
+            viable.retainAll(leafFieldViableBackends(ScalarFunction.IS_TRUE, fsi, childViableBackends));
+            // Apply the delegation block-list as the RexCall leaf path does, but never empty the viable set.
+            DelegationBlockList blockList = context.getDelegationBlockList();
+            if (!blockList.isEmpty()) {
+                boolean someBackendSurvives = viable.stream().anyMatch(backend -> !blockList.isBlocked(backend, ScalarFunction.IS_TRUE));
+                if (someBackendSurvives) {
+                    viable.removeIf(backend -> blockList.isBlocked(backend, ScalarFunction.IS_TRUE));
+                }
+            }
+            return new AnnotatedPredicate(ref.getType(), ref, new ArrayList<>(viable), context.nextAnnotationId());
+        }
         if (!(condition instanceof RexCall rexCall)) {
             return condition;
         }
@@ -252,28 +270,7 @@ public class OpenSearchFilterRule extends RelOptRule {
 
         for (int fieldIndex : fieldIndices) {
             FieldStorageInfo storageInfo = FieldStorageInfo.resolve(fieldStorageInfos, fieldIndex);
-
-            Set<String> fieldViable;
-            if (storageInfo.isDerived()) {
-                // Derived columns (post-Aggregate, post-Join, post-Union, post-Project) are
-                // computed in memory by the producer. The filter can only run on a backend
-                // the producer is also viable for (its child's viableBackends), and further
-                // only on backends that support this function on the field's logical type —
-                // delegation isn't applicable because there's no physical storage to delegate
-                // a scan against. Surfaced by testHavingFilterAfterJoin_multiShard etc., where
-                // a HAVING clause filters on a stats-derived column.
-                fieldViable = new HashSet<>(childViableBackends);
-                fieldViable.retainAll(registry.filterBackendsAnyFormat(function, storageInfo.getFieldType()));
-            } else {
-                // Format-aware: backends that can access this field's storage (doc values + index).
-                // A backend is viable only if it has the field in its own storage formats — ensuring
-                // delegation targets are also field-storage-aware (e.g. Lucene is viable for a keyword
-                // field only when the field has indexFormats=[lucene] set in the mapping).
-                // TODO: for FULL_TEXT operators, extract required params from RexCall
-                fieldViable = new HashSet<>(registry.filterBackendsForField(function, storageInfo));
-            }
-
-            viableSet.retainAll(fieldViable);
+            viableSet.retainAll(leafFieldViableBackends(function, storageInfo, childViableBackends));
         }
 
         // Every nested scalar function in the predicate must also be evaluable by a candidate backend
@@ -350,6 +347,32 @@ public class OpenSearchFilterRule extends RelOptRule {
             );
         }
         return new ArrayList<>(viableSet);
+    }
+
+    /**
+     * Resolves the backends able to evaluate a single field reference under {@code function}, per the derived vs
+     * stored-column convention.
+     */
+    private Set<String> leafFieldViableBackends(ScalarFunction function, FieldStorageInfo storageInfo, List<String> childViableBackends) {
+        CapabilityRegistry registry = context.getCapabilityRegistry();
+        if (storageInfo.isDerived()) {
+            // Derived columns (post-Aggregate, post-Join, post-Union, post-Project) are
+            // computed in memory by the producer. The filter can only run on a backend
+            // the producer is also viable for (its child's viableBackends), and further
+            // only on backends that support this function on the field's logical type —
+            // delegation isn't applicable because there's no physical storage to delegate
+            // a scan against. Surfaced by testHavingFilterAfterJoin_multiShard etc., where
+            // a HAVING clause filters on a stats-derived column.
+            Set<String> fieldViable = new HashSet<>(childViableBackends);
+            fieldViable.retainAll(registry.filterBackendsAnyFormat(function, storageInfo.getFieldType()));
+            return fieldViable;
+        }
+        // Format-aware: backends that can access this field's storage (doc values + index).
+        // A backend is viable only if it has the field in its own storage formats — ensuring
+        // delegation targets are also field-storage-aware (e.g. Lucene is viable for a keyword
+        // field only when the field has indexFormats=[lucene] set in the mapping).
+        // TODO: for FULL_TEXT operators, extract required params from RexCall
+        return new HashSet<>(registry.filterBackendsForField(function, storageInfo));
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -15,6 +15,7 @@ import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
@@ -93,6 +94,140 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         // Operator-level: only child backend (no delegation configured)
         assertEquals(1, result.getViableBackends().size());
         assertTrue(result.getViableBackends().contains(MockDataFusionBackend.NAME));
+    }
+
+    /** A bare boolean {@link RexInputRef} as the whole condition: gated on IS_TRUE, so only DataFusion stays viable. */
+    public void testBareBooleanInputRefAnnotatedDataFusionOnly() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("is_active", Map.of("type", "boolean", "index", true)),
+            new String[] { "is_active" },
+            new SqlTypeName[] { SqlTypeName.BOOLEAN },
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BOOLEAN), 0)
+        );
+
+        assertTrue(
+            "bare boolean ref must be annotated as a leaf predicate, got " + result.getCondition().getClass().getSimpleName(),
+            result.getCondition() instanceof AnnotatedPredicate
+        );
+        AnnotatedPredicate annotated = (AnnotatedPredicate) result.getCondition();
+        assertEquals(Set.of(MockDataFusionBackend.NAME), Set.copyOf(annotated.getViableBackends()));
+        assertTrue(
+            "IS_TRUE is a routing key only: the wrapped expression must stay the bare RexInputRef, not be rewritten to an IS_TRUE RexCall, got "
+                + annotated.getOriginal().getClass().getSimpleName(),
+            annotated.getOriginal() instanceof RexInputRef
+        );
+    }
+
+    /** {@code NOT(bare boolean ref)}: the connective is preserved and the inner leaf is gated to DataFusion. */
+    public void testNotBareBooleanInputRefAnnotatedDataFusionOnly() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("is_active", Map.of("type", "boolean", "index", true)),
+            new String[] { "is_active" },
+            new SqlTypeName[] { SqlTypeName.BOOLEAN },
+            rexBuilder.makeCall(SqlStdOperatorTable.NOT, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BOOLEAN), 0))
+        );
+
+        AnnotatedPredicate inner = findBooleanRefAnnotation(result.getCondition());
+        assertNotNull("inner bare boolean ref under NOT must be annotated as a leaf predicate", inner);
+        assertEquals(Set.of(MockDataFusionBackend.NAME), Set.copyOf(inner.getViableBackends()));
+    }
+
+    /**
+     * {@code AND(keyword = 'US', bare boolean ref)}: the keyword leaf alone would keep Lucene viable; gating the
+     * boolean leaf on IS_TRUE drops it.
+     */
+    public void testAndKeywordEqualsAndBareBooleanRefGatesBooleanLeaf() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true), "is_active", Map.of("type", "boolean", "index", true)),
+            new String[] { "country_name", "is_active" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.BOOLEAN },
+            makeAnd(makeEquals(0, SqlTypeName.VARCHAR, "US"), rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BOOLEAN), 1))
+        );
+
+        AnnotatedPredicate boolLeaf = findBooleanRefAnnotation(result.getCondition());
+        assertNotNull("bare boolean ref inside AND must be annotated as a leaf predicate", boolLeaf);
+        assertEquals(Set.of(MockDataFusionBackend.NAME), Set.copyOf(boolLeaf.getViableBackends()));
+
+        // Contrast: the sibling keyword EQUALS leaf on its own would keep Lucene viable.
+        AnnotatedPredicate keywordLeaf = findEqualsAnnotation(result.getCondition());
+        assertNotNull("keyword EQUALS leaf must be annotated", keywordLeaf);
+        assertTrue("keyword EQUALS leaf keeps Lucene viable on its own", keywordLeaf.getViableBackends().contains(MockLuceneBackend.NAME));
+    }
+
+    /** {@code OR(keyword = 'US', bare boolean ref)}: the OR connective is preserved and the boolean leaf is gated as under AND. */
+    public void testOrKeywordEqualsAndBareBooleanRefGatesBooleanLeaf() {
+        OpenSearchFilter result = runFilter(
+            "parquet",
+            Map.of("country_name", Map.of("type", "keyword", "index", true), "is_active", Map.of("type", "boolean", "index", true)),
+            new String[] { "country_name", "is_active" },
+            new SqlTypeName[] { SqlTypeName.VARCHAR, SqlTypeName.BOOLEAN },
+            makeCall(
+                SqlStdOperatorTable.OR,
+                makeEquals(0, SqlTypeName.VARCHAR, "US"),
+                rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BOOLEAN), 1)
+            )
+        );
+
+        AnnotatedPredicate boolLeaf = findBooleanRefAnnotation(result.getCondition());
+        assertNotNull("bare boolean ref inside OR must be annotated as a leaf predicate", boolLeaf);
+        assertEquals(Set.of(MockDataFusionBackend.NAME), Set.copyOf(boolLeaf.getViableBackends()));
+
+        // Contrast: the sibling keyword EQUALS leaf on its own would keep Lucene viable.
+        AnnotatedPredicate keywordLeaf = findEqualsAnnotation(result.getCondition());
+        assertNotNull("keyword EQUALS leaf must be annotated", keywordLeaf);
+        assertTrue("keyword EQUALS leaf keeps Lucene viable on its own", keywordLeaf.getViableBackends().contains(MockLuceneBackend.NAME));
+    }
+
+    /**
+     * A bare boolean {@link RexInputRef} onto a derived column ({@code MIN(is_active)}) in HAVING. A derived column has no
+     * storage format, so the leaf must resolve viability via the derived path and must not throw.
+     */
+    public void testDerivedBooleanColumnBareRefPlansViaDerivedPath() {
+        PlannerContext context = buildContext(
+            "parquet",
+            1,
+            Map.of("status", Map.of("type", "integer"), "is_active", Map.of("type", "boolean"))
+        );
+
+        RelOptTable table = mockTable(
+            "test_index",
+            new String[] { "status", "is_active" },
+            new SqlTypeName[] { SqlTypeName.INTEGER, SqlTypeName.BOOLEAN }
+        );
+        LogicalAggregate aggregate = LogicalAggregate.create(
+            stubScan(table),
+            List.of(),
+            ImmutableBitSet.of(0),
+            null,
+            List.of(
+                AggregateCall.create(
+                    SqlStdOperatorTable.MIN,
+                    false,
+                    List.of(1),
+                    -1,
+                    stubScan(table),
+                    typeFactory.createSqlType(SqlTypeName.BOOLEAN),
+                    "any_active"
+                )
+            )
+        );
+
+        // HAVING on the derived boolean output (index 1) — a column with no storage format to delegate against.
+        RexNode havingCondition = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BOOLEAN), 1);
+        LogicalFilter having = LogicalFilter.create(aggregate, havingCondition);
+
+        RelNode result = runPlanner(having, context);
+        assertNotNull("Planner must produce a plan for HAVING on a derived boolean column", result);
+
+        OpenSearchFilter osFilter = findOpenSearchFilter(result);
+        assertNotNull("plan must contain an OpenSearchFilter over the derived boolean column", osFilter);
+        AnnotatedPredicate boolLeaf = findBooleanRefAnnotation(osFilter.getCondition());
+        assertNotNull("derived boolean HAVING ref must be annotated as a leaf predicate", boolLeaf);
+        // Derived path: childViableBackends intersected with the format-agnostic IS_TRUE capability, so the leaf is non-empty.
+        assertEquals(Set.of(MockDataFusionBackend.NAME), Set.copyOf(boolLeaf.getViableBackends()));
     }
 
     /**
@@ -1087,6 +1222,48 @@ public class FilterRuleTests extends BasePlannerRulesTests {
     private void assertPredicateAnnotation(AnnotatedPredicate predicate, String... expectedBackends) {
         for (String backend : expectedBackends)
             assertTrue("Predicate annotation must contain " + backend, predicate.getViableBackends().contains(backend));
+    }
+
+    private AnnotatedPredicate findBooleanRefAnnotation(RexNode node) {
+        if (node instanceof AnnotatedPredicate annotated
+            && annotated.getOriginal() instanceof RexInputRef ref
+            && ref.getType().getSqlTypeName() == SqlTypeName.BOOLEAN) {
+            return annotated;
+        }
+        if (node instanceof RexCall call) {
+            for (RexNode operand : call.getOperands()) {
+                AnnotatedPredicate found = findBooleanRefAnnotation(operand);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    private AnnotatedPredicate findEqualsAnnotation(RexNode node) {
+        if (node instanceof AnnotatedPredicate annotated
+            && annotated.getOriginal() instanceof RexCall original
+            && original.getKind() == SqlKind.EQUALS) {
+            return annotated;
+        }
+        if (node instanceof RexCall call) {
+            for (RexNode operand : call.getOperands()) {
+                AnnotatedPredicate found = findEqualsAnnotation(operand);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    private OpenSearchFilter findOpenSearchFilter(RelNode node) {
+        RelNode unwrapped = RelNodeUtils.unwrapHep(node);
+        if (unwrapped instanceof OpenSearchFilter filter) {
+            return filter;
+        }
+        for (RelNode input : unwrapped.getInputs()) {
+            OpenSearchFilter found = findOpenSearchFilter(input);
+            if (found != null) return found;
+        }
+        return null;
     }
 
     private List<AnalyticsSearchBackendPlugin> delegationBackends() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/MockDataFusionBackend.java
@@ -64,6 +64,8 @@ public class MockDataFusionBackend extends MockBackend implements SearchBackEndP
         ScalarFunction.LESS_THAN_OR_EQUAL,
         ScalarFunction.IS_NULL,
         ScalarFunction.IS_NOT_NULL,
+        // IS_TRUE mirrors DataFusionAnalyticsBackendPlugin, which declares it for bare boolean predicates.
+        ScalarFunction.IS_TRUE,
         ScalarFunction.IN,
         ScalarFunction.LIKE
     );

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
@@ -12,13 +12,16 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.query.QueryRegistry;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 
 import java.util.Objects;
 
 /**
  * Converts the DSL {@code query} clause to a {@link LogicalFilter}.
- * Skips match_all since a table scan already returns all rows.
+ * Skips a parameter-free match_all since a table scan already returns all rows;
+ * a match_all carrying {@code boost} or {@code _name} still produces a filter so those params are rejected.
  */
 public class FilterConverter extends AbstractDslConverter {
 
@@ -35,7 +38,16 @@ public class FilterConverter extends AbstractDslConverter {
 
     @Override
     protected boolean isApplicable(ConversionContext ctx) {
-        return ctx.getSearchSource().query() != null && !(ctx.getSearchSource().query() instanceof MatchAllQueryBuilder);
+        QueryBuilder query = ctx.getSearchSource().query();
+        if (query == null) {
+            return false;
+        }
+        if (query instanceof MatchAllQueryBuilder matchAll) {
+            // A table scan already returns all rows, so a bare match_all needs no filter; but a match_all
+            // carrying boost or _name must reach its translator to be rejected rather than silently dropped.
+            return matchAll.boost() != AbstractQueryBuilder.DEFAULT_BOOST || matchAll.queryName() != null;
+        }
+        return true;
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
@@ -14,7 +14,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
@@ -51,12 +50,7 @@ public class BoolQueryTranslator implements QueryTranslator {
         BoolQueryBuilder boolQuery = (BoolQueryBuilder) query;
 
         // Citation: AbstractQueryBuilder.toQuery lines 130-139 (boost wrapping + named query registration).
-        if (boolQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Bool query does not support non-default boost");
-        }
-        if (boolQuery.queryName() != null) {
-            throw new ConversionException("Bool query does not support _name");
-        }
+        rejectScoringParams(boolQuery, "Bool");
         // Citation: BoolQueryBuilder.doToQuery:338 only calls fixNegativeQueryIfNeeded when
         // adjustPureNegative is true. Citation: Queries.isNegativeQuery:113-119 requires every
         // clause to be prohibited. Citation: Queries.fixNegativeQueryIfNeeded:121-130 injects

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -12,7 +12,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
@@ -29,12 +28,8 @@ public class ExistsQueryTranslator implements QueryTranslator {
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         ExistsQueryBuilder existsQuery = (ExistsQueryBuilder) query;
+        rejectScoringParams(existsQuery, "Exists");
         String fieldName = existsQuery.fieldName();
-        float boost = existsQuery.boost();
-
-        if (boost != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("boost is unsupported for Exists query type");
-        }
 
         RexNode fieldRef = ctx.makeFieldRef(fieldName);
         return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/MatchAllQueryTranslator.java
@@ -10,6 +10,7 @@ package org.opensearch.dsl.query;
 
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
@@ -29,7 +30,8 @@ public class MatchAllQueryTranslator implements QueryTranslator {
     }
 
     @Override
-    public RexNode convert(QueryBuilder query, ConversionContext ctx) {
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        rejectScoringParams(query, "Match all");
         return ctx.getRexBuilder().makeLiteral(true);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/PrefixQueryTranslator.java
@@ -13,7 +13,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.PrefixQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
@@ -29,13 +28,7 @@ public class PrefixQueryTranslator implements QueryTranslator {
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         PrefixQueryBuilder prefixQuery = (PrefixQueryBuilder) query;
 
-        if (prefixQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Prefix query parameter 'boost' is not supported");
-        }
-        // matched_queries is not surfaced by this path
-        if (prefixQuery.queryName() != null) {
-            throw new ConversionException("Prefix query parameter '_name' is not supported");
-        }
+        rejectScoringParams(prefixQuery, "Prefix");
 
         // MappedFieldType.prefixQuery:291-297 — only keyword and text fields support prefix queries
         RelDataTypeField field = ctx.getField(prefixQuery.fieldName());

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryTranslator.java
@@ -11,6 +11,7 @@ package org.opensearch.dsl.query;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
 /**
@@ -31,4 +32,14 @@ public interface QueryTranslator {
      * @throws ConversionException if conversion fails
      */
     RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException;
+
+    /** Rejects boost and _name: this path is non-scoring and never assembles matched_queries, so neither can be honoured. */
+    default void rejectScoringParams(QueryBuilder query, String queryNoun) throws ConversionException {
+        if (query.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException(queryNoun + " query parameter 'boost' is not supported");
+        }
+        if (query.queryName() != null) {
+            throw new ConversionException(queryNoun + " query parameter '_name' is not supported");
+        }
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
@@ -42,6 +42,7 @@ public class TermQueryTranslator implements QueryTranslator {
     @Override
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         TermQueryBuilder termQuery = (TermQueryBuilder) query;
+        rejectScoringParams(termQuery, "Term");
         String fieldName = termQuery.fieldName();
         Object value = termQuery.value();
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -13,7 +13,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 
@@ -44,12 +43,7 @@ public class TermsQueryTranslator implements QueryTranslator {
         if (termsQuery.termsLookup() != null) {
             throw new ConversionException("Terms query does not support terms lookup");
         }
-        if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Terms query does not support non-default boost");
-        }
-        if (termsQuery.queryName() != null) {
-            throw new ConversionException("Terms query does not support _name");
-        }
+        rejectScoringParams(termsQuery, "Terms");
         if (termsQuery.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
             throw new ConversionException("Terms query does not support non-default value_type");
         }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/WildcardQueryTranslator.java
@@ -13,7 +13,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.WildcardQueryBuilder;
 
@@ -29,13 +28,7 @@ public class WildcardQueryTranslator implements QueryTranslator {
     public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
         WildcardQueryBuilder wildcardQuery = (WildcardQueryBuilder) query;
 
-        if (wildcardQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Wildcard query parameter 'boost' is not supported");
-        }
-        // matched_queries is not surfaced by this path
-        if (wildcardQuery.queryName() != null) {
-            throw new ConversionException("Wildcard query parameter '_name' is not supported");
-        }
+        rejectScoringParams(wildcardQuery, "Wildcard");
 
         // MappedFieldType.wildcardQuery:309-317 — only keyword and text fields support wildcard queries
         RelDataTypeField field = ctx.getField(wildcardQuery.fieldName());

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/range/RangeQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/range/RangeQueryTranslator.java
@@ -18,7 +18,6 @@ import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.dsl.query.QueryTranslator;
 import org.opensearch.dsl.query.TranslatorMapperRegistry;
-import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 
@@ -98,13 +97,7 @@ public class RangeQueryTranslator implements QueryTranslator {
         RangeQueryBuilder rangeQuery = (RangeQueryBuilder) query;
         String fieldName = rangeQuery.fieldName();
 
-        if (rangeQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
-            throw new ConversionException("Range query 'boost' parameter is not supported");
-        }
-
-        if (rangeQuery.queryName() != null) {
-            throw new ConversionException("Range query '_name' parameter is not supported");
-        }
+        rejectScoringParams(rangeQuery, "Range");
 
         // Relation check: per legacy SimpleMappedFieldType.rangeQuery() and DateFieldType.rangeQuery(),
         // DISJOINT is rejected; INTERSECTS/CONTAINS/WITHIN are silently ignored (scalar fields produce

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
@@ -40,6 +40,24 @@ public class FilterConverterTests extends OpenSearchTestCase {
         assertSame(scan, result);
     }
 
+    public void testMatchAllWithBoostIsApplicable() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery().boost(2.0f));
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        // A parameterised match_all is now applicable, so it reaches the translator which rejects boost.
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertEquals("Match all query parameter 'boost' is not supported", e.getMessage());
+    }
+
+    public void testMatchAllWithNameIsApplicable() {
+        SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery().queryName("all"));
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        // A named match_all is now applicable, so it reaches the translator which rejects _name.
+        ConversionException e = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertEquals("Match all query parameter '_name' is not supported", e.getMessage());
+    }
+
     public void testTermQueryProducesLogicalFilter() throws ConversionException {
         SearchSourceBuilder source = new SearchSourceBuilder().query(QueryBuilders.termQuery("name", "laptop"));
         ConversionContext ctx = TestUtils.createContext(source);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
@@ -51,6 +51,14 @@ public class ExistsQueryTranslatorTests extends OpenSearchTestCase {
         expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
     }
 
+    public void testThrowsForName() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.existsQuery("name").queryName("my_exists"), ctx)
+        );
+        assertEquals("Exists query parameter '_name' is not supported", ex.getMessage());
+    }
+
     public void testReportsCorrectQueryType() {
         assertEquals(ExistsQueryBuilder.class, translator.getQueryType());
     }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MatchAllQueryTranslatorTests.java
@@ -12,13 +12,14 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class MatchAllQueryTranslatorTests extends OpenSearchTestCase {
 
-    public void testConvertsMatchAllToTrueLiteral() {
+    public void testConvertsMatchAllToTrueLiteral() throws ConversionException {
         ConversionContext ctx = TestUtils.createContext();
         MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
 
@@ -26,6 +27,28 @@ public class MatchAllQueryTranslatorTests extends OpenSearchTestCase {
 
         assertTrue(result instanceof RexLiteral);
         assertTrue(RexLiteral.booleanValue(result));
+    }
+
+    public void testThrowsForBoost() {
+        ConversionContext ctx = TestUtils.createContext();
+        MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
+
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.matchAllQuery().boost(2.0f), ctx)
+        );
+        assertEquals("Match all query parameter 'boost' is not supported", ex.getMessage());
+    }
+
+    public void testThrowsForName() {
+        ConversionContext ctx = TestUtils.createContext();
+        MatchAllQueryTranslator translator = new MatchAllQueryTranslator();
+
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.matchAllQuery().queryName("my_match_all"), ctx)
+        );
+        assertEquals("Match all query parameter '_name' is not supported", ex.getMessage());
     }
 
     public void testReportsCorrectQueryType() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermQueryTranslatorTests.java
@@ -63,6 +63,22 @@ public class TermQueryTranslatorTests extends OpenSearchTestCase {
         assertEquals(TermQueryBuilder.class, translator.getQueryType());
     }
 
+    public void testThrowsForBoost() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termQuery("name", "laptop").boost(2.0f), ctx)
+        );
+        assertEquals("Term query parameter 'boost' is not supported", ex.getMessage());
+    }
+
+    public void testThrowsForName() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termQuery("name", "laptop").queryName("my_term"), ctx)
+        );
+        assertEquals("Term query parameter '_name' is not supported", ex.getMessage());
+    }
+
     public void testScaledFloatTermQuery() throws ConversionException {
         // term scaled_price = 10.5 with factor 10 -> Math.round(10.5 * 10) = 105
         RexNode result = translator.convert(QueryBuilders.termQuery("scaled_price", 10.5), ctx);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Three related fixes on the analytics engine query path, as three separate commits.

#### 1. Boolean field filters return HTTP 500 (`analytics-engine`)

Calcite's `ReduceExpressionsRule` folds `boolCol = TRUE` to a bare `RexInputRef`. `OpenSearchFilterRule.annotateCondition` only inspected `RexCall` nodes, so no `AnnotatedPredicate` was produced, the capability gate never ran, and Lucene stayed viable — but Lucene cannot index boolean fields under composite-parquet, so conversion threw `IllegalStateException: Unexpected RexNode in Lucene-driver filter condition: $N`.

The fix annotates the bare ref as an `IS_TRUE` leaf so the gate drops Lucene and routes to DataFusion. The executed expression is unchanged — `IS_TRUE` is a routing key, not a rewrite. `EQUALS` would not work: Lucene declares it on `BOOLEAN` but not `IS_TRUE`, so an `EQUALS`-keyed gate leaves Lucene viable.

- Hits both DSL and PPL — the fault is in shared `analytics-engine` code, not a translator.
- Only fired on plans reading no column values (`size:10` bare filter, `stats count()`); value-needing plans route to DataFusion anyway.
- `terms` with exactly one element folds identically and was equally affected; two or more stay a `RexCall` and always worked.
- Also applies the delegation block-list on the new path, matching the `RexCall` leaf path, and extracts a shared `leafFieldViableBackends` helper (behaviour-preserving).

#### 2. Unify `boost` and `_name` rejection across translators (`dsl-query-executor`)

The columnar path is non-scoring and never assembles `matched_queries`, so neither parameter can be honoured. Only some translators said so:

| Translator | `boost` before | `_name` before |
|---|---|---|
| Bool, Prefix, Terms, Wildcard, Range | rejected | rejected |
| Exists | rejected | **silently ignored** |
| Term, MatchAll | **silently accepted** | **silently accepted** |

`{"term": {"status": {"value": "active", "boost": 5}}}` returned `200` with `boost` discarded while the same parameter on `terms` threw. Silently dropping a parameter the user set is the correctness half of this change.

All eight translators now call one `rejectScoringParams(QueryBuilder, String)` default method on `QueryTranslator`; `QueryBuilder` declares `boost()` and `queryName()` directly, so no `AbstractQueryBuilder` cast is needed. The unified message `"<Noun> query parameter 'boost' is not supported"` is byte-identical to what Prefix and Wildcard already emitted, so their exact-string assertions pass unchanged.

#### 3. A top-level `match_all` never reached its translator (`dsl-query-executor`)

Change 2 alone was not sufficient. `FilterConverter.isApplicable` excluded `match_all` by name:

```java
return ctx.getSearchSource().query() != null && !(ctx.getSearchSource().query() instanceof MatchAllQueryBuilder);
```

Returning `false` builds no `LogicalFilter`, so `QueryRegistry` never dispatches and `MatchAllQueryTranslator.rejectScoringParams` never runs — `{"match_all": {"boost": 2}}` still returned `200` with the parameter discarded.

The fix skips `match_all` only when parameter-free, so a plain one still builds no filter and nothing gets slower. The class Javadoc is corrected, having claimed the skip was unconditional. Scope is top-level `match_all` only: every other type always built a filter, and a nested `match_all` already dispatched normally. The bypass is pre-existing (#21047) but contradicts change 2's contract, so it is fixed here.

### Legacy parity

- `BooleanFieldType.termQuery` (`BooleanFieldMapper.java:277-286`) matches only the indexed TRUE term. The DSL path runs `WHERE boolcol`, likewise keeping only TRUE and excluding NULL and FALSE.
- `BoolQueryTranslator` emits `IS_NOT_TRUE`, not `NOT`, and `IS_NOT_TRUE(NULL)` is `TRUE`, so a document with no value survives `must_not` as it does in vanilla.
- Rejection policy matches no vanilla behaviour — vanilla honours both parameters, this path cannot, so it rejects rather than discarding.

### Testing

`analytics-engine` 1063 passed / 0 failed / 2 skipped · `dsl-query-executor` 550 / 0 · `spotlessJavaCheck` clean.

New coverage: the bare boolean ref at top level and under `AND`, `OR`, `NOT` and on a derived column; an assertion that the annotated predicate is still a `RexInputRef`; `boost` and `_name` rejection on Term, MatchAll and Exists, which had none; and `FilterConverter` cases for plain, `boost`-carrying and `_name`-carrying `match_all`.

Each guard was verified by mutation: removing the bare-ref interception turns 5 `FilterRuleTests` red, neutering `rejectScoringParams` turns 18 translator tests red across all eight families with none vacuous, and reverting the `FilterConverter` condition turns both new tests red while the plain-`match_all` guard holds.

### End-to-end validation

Live single-node cluster, `index.pluggable.dataformat: composite` with a parquet primary format, five documents with a boolean field set true, false and absent. Queries used `size: 0` plus a `terms` aggregation on a unique id and a `sum` over distinct powers of two, so count and sum identify the matched set uniquely; every row was paired with a partner differing by one element, and every pair differed.

- Every boolean-filter shape that returned 500 now returns 200 with correct counts, including the `size:10` and count-only plans that read no column values.
- All eight translators reject both parameters with the exact expected messages.
- `match_all` with `boost` or `_name` returns 400; plain `match_all` still returns all rows and builds no filter.

The live run is what caught change 3 — `MatchAllQueryTranslatorTests` passed throughout and is provably falsifiable, but exercised a method the request path never invoked.

### Related Issues

- Closes #22961
- Meta issue: #20914

### Check List

- [x] Functionality includes testing.
- [x] Public documentation issue/PR created, if applicable.
- [x] Commits are signed per the DCO using `--signoff`.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
