### PR TITLE
Apply index.periodic_flush_interval changes to running shards

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -615,6 +615,65 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
         assertThat(flushStats.getTotal(), greaterThan(flushStats.getPeriodic()));
     }
 
+    public void testPeriodicFlushIntervalDynamicUpdate() throws Exception {
+        final IndexService indexService = createIndex(
+            "test",
+            Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).build()
+        );
+        ensureGreen();
+        final IndexShard shard = indexService.getShard(0);
+        // Periodic flush is disabled by default for a regular index, so no task is running.
+        assertNull(shard.getPeriodicFlushTask());
+
+        // Enable on a live index via the settings API: the task must start without an engine restart.
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder().put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "1m"))
+        );
+        assertBusy(() -> {
+            IndexShard.AsyncShardFlushTask task = shard.getPeriodicFlushTask();
+            assertNotNull(task);
+            assertThat(task.getInterval(), equalTo(TimeValue.timeValueMinutes(1)));
+            assertTrue(task.isScheduled());
+        });
+        final IndexShard.AsyncShardFlushTask task = shard.getPeriodicFlushTask();
+
+        // Shorten the interval: the same task is rescheduled and starts firing flushes at the new cadence.
+        final long periodicBefore = shard.flushStats().getPeriodic();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder().put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "100ms"))
+        );
+        assertBusy(() -> {
+            assertSame(task, shard.getPeriodicFlushTask());
+            assertThat(task.getInterval(), equalTo(TimeValue.timeValueMillis(100)));
+        });
+        client().prepareIndex("test").setId("1").setSource("{}", MediaTypeRegistry.JSON).get();
+        assertBusy(() -> assertThat(shard.flushStats().getPeriodic(), greaterThan(periodicBefore)));
+
+        // Disable: the task is closed and no further periodic flushes happen.
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder().put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "-1"))
+        );
+        assertBusy(() -> {
+            assertNull(shard.getPeriodicFlushTask());
+            assertTrue(task.isClosed());
+            assertFalse(task.isScheduled());
+        });
+        // Allow any in-flight run to finish, then confirm the counter is flat.
+        Thread.sleep(300);
+        final long periodicAfterDisable = shard.flushStats().getPeriodic();
+        Thread.sleep(500);
+        assertThat(shard.flushStats().getPeriodic(), equalTo(periodicAfterDisable));
+    }
+
     public void testShardHasMemoryBufferOnTranslogRecover() throws Throwable {
         createIndex("test");
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -662,15 +662,16 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
                 .prepareUpdateSettings("test")
                 .setSettings(Settings.builder().put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "-1"))
         );
+        // A closed task never reschedules itself; once no periodic run is in flight either, the counter can no longer move.
         assertBusy(() -> {
             assertNull(shard.getPeriodicFlushTask());
             assertTrue(task.isClosed());
             assertFalse(task.isScheduled());
+            assertFalse(shard.isFlushOrRollRunning());
         });
-        // Allow any in-flight run to finish, then confirm the counter is flat.
-        Thread.sleep(300);
         final long periodicAfterDisable = shard.flushStats().getPeriodic();
-        Thread.sleep(500);
+        // Further indexing must not trigger a periodic flush now that the timer is gone.
+        client().prepareIndex("test").setId("2").setSource("{}", MediaTypeRegistry.JSON).setRefreshPolicy(IMMEDIATE).get();
         assertThat(shard.flushStats().getPeriodic(), equalTo(periodicAfterDisable));
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -6758,7 +6758,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 if (engineAvailable == false) {
                     return;
                 }
-                periodicFlushTask = new AsyncShardFlushTask(this, interval);
+                final AsyncShardFlushTask created = new AsyncShardFlushTask(this, interval);
+                periodicFlushTask = created;
+                // close() moves the shard to CLOSED and then closes periodicFlushTask without taking periodicFlushMutex. If it
+                // ran between the state check above and the assignment, it may have observed a null task. Re-checking here
+                // guarantees one of the two paths closes the task, so a scheduled task never outlives a closed shard.
+                if (state == IndexShardState.CLOSED) {
+                    created.close();
+                    periodicFlushTask = null;
+                    return;
+                }
                 logger.info("Started periodic flush task for shard [{}] with interval [{}]", shardId, interval);
             } else if (interval.equals(current.getInterval()) == false) {
                 final TimeValue previous = current.getInterval();
@@ -6771,6 +6780,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     // Visible for testing
     AsyncShardFlushTask getPeriodicFlushTask() {
         return periodicFlushTask;
+    }
+
+    // Visible for testing
+    boolean isFlushOrRollRunning() {
+        return flushOrRollRunning.get();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -412,6 +412,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final Supplier<TimeValue> refreshInterval;
     private final Object refreshMutex;
     private volatile AsyncShardRefreshTask refreshTask;
+    private final Object periodicFlushMutex = new Object();
     private volatile AsyncShardFlushTask periodicFlushTask;
     private final ClusterApplierService clusterApplierService;
     private final MergedSegmentPublisher mergedSegmentPublisher;
@@ -3830,6 +3831,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 indexSettings.getSoftDeleteRetentionOperations()
             );
         }
+        // index.periodic_flush_interval is dynamic: start, reschedule or stop the periodic flush task to match the current value.
+        updatePeriodicFlushTask(engineOrNull != null);
     }
 
     private void turnOffTranslogRetention() {
@@ -6715,12 +6718,53 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return refreshTask;
     }
 
+    /**
+     * Starts the periodic flush task if {@code index.periodic_flush_interval} is enabled and the task is not already running.
+     * Invoked when a new engine is created. Subsequent changes to the setting are applied by {@link #updatePeriodicFlushTask(boolean)}.
+     */
     public void startPeriodicFlushTask() {
-        TimeValue interval = indexSettings.getPeriodicFlushInterval();
-        // Only start the async flush task if interval is >0 and task is not already running
-        if (interval.millis() > 0 && periodicFlushTask == null) {
-            periodicFlushTask = new AsyncShardFlushTask(this, interval);
-            logger.info("Started periodic flush task for shard [{}] with interval [{}]", shardId, interval);
+        // Called from onNewEngine, before the engine reference is published, so the engine is known to be available.
+        updatePeriodicFlushTask(true);
+    }
+
+    /**
+     * Reconciles the periodic flush task with the current value of {@code index.periodic_flush_interval}:
+     * <ul>
+     *   <li>interval &gt; 0 and no task: a new task is started (only if an engine is available to flush)</li>
+     *   <li>interval &gt; 0 and a task exists with a different interval: the task is rescheduled with the new interval</li>
+     *   <li>interval &lt;= 0 and a task exists: the task is closed</li>
+     * </ul>
+     * The setting is dynamic, so this is called both on engine creation and on every settings change.
+     *
+     * @param engineAvailable whether an engine exists (or is about to be published) for this shard
+     */
+    void updatePeriodicFlushTask(boolean engineAvailable) {
+        synchronized (periodicFlushMutex) {
+            if (state == IndexShardState.CLOSED) {
+                return;
+            }
+            final TimeValue interval = indexSettings.getPeriodicFlushInterval();
+            final AsyncShardFlushTask current = periodicFlushTask;
+            if (interval.millis() <= 0) {
+                if (current != null) {
+                    current.close();
+                    periodicFlushTask = null;
+                    logger.info("Stopped periodic flush task for shard [{}]", shardId);
+                }
+                return;
+            }
+            if (current == null) {
+                // Without an engine there is nothing to flush; onNewEngine will start the task once one is created.
+                if (engineAvailable == false) {
+                    return;
+                }
+                periodicFlushTask = new AsyncShardFlushTask(this, interval);
+                logger.info("Started periodic flush task for shard [{}] with interval [{}]", shardId, interval);
+            } else if (interval.equals(current.getInterval()) == false) {
+                final TimeValue previous = current.getInterval();
+                current.setInterval(interval);
+                logger.info("Updated periodic flush interval for shard [{}] from [{}] to [{}]", shardId, previous, interval);
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -5520,6 +5520,110 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(primary);
     }
 
+    public void testPeriodicFlushTaskStartedOnDynamicEnable() throws Exception {
+        // Regular index: periodic flush disabled by default, so no task is started with the engine.
+        IndexShard primary = newStartedShard(true);
+        assertNull(primary.getPeriodicFlushTask());
+
+        updatePeriodicFlushInterval(primary, "1m");
+
+        IndexShard.AsyncShardFlushTask flushTask = primary.getPeriodicFlushTask();
+        assertNotNull("enabling index.periodic_flush_interval on a live shard should start the task", flushTask);
+        assertEquals(TimeValue.timeValueMinutes(1), flushTask.getInterval());
+        assertFalse(flushTask.isClosed());
+        assertTrue(flushTask.isScheduled());
+
+        closeShards(primary);
+        assertTrue(flushTask.isClosed());
+    }
+
+    public void testPeriodicFlushTaskRescheduledOnIntervalChange() throws Exception {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "1m")
+            .build();
+        IndexMetadata metadata = IndexMetadata.builder("test")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\"}}}")
+            .settings(settings)
+            .primaryTerm(0, 1)
+            .build();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+        recoverShardFromStore(primary);
+
+        IndexShard.AsyncShardFlushTask flushTask = primary.getPeriodicFlushTask();
+        assertNotNull(flushTask);
+        assertEquals(TimeValue.timeValueMinutes(1), flushTask.getInterval());
+
+        updatePeriodicFlushInterval(primary, "30s");
+
+        // The same task is kept and rescheduled with the new interval.
+        assertSame(flushTask, primary.getPeriodicFlushTask());
+        assertEquals(TimeValue.timeValueSeconds(30), flushTask.getInterval());
+        assertFalse(flushTask.isClosed());
+        assertTrue(flushTask.isScheduled());
+
+        // An unchanged value is a no-op.
+        updatePeriodicFlushInterval(primary, "30s");
+        assertSame(flushTask, primary.getPeriodicFlushTask());
+        assertEquals(TimeValue.timeValueSeconds(30), flushTask.getInterval());
+
+        closeShards(primary);
+    }
+
+    public void testPeriodicFlushTaskStoppedOnDynamicDisable() throws Exception {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "1m")
+            .build();
+        IndexMetadata metadata = IndexMetadata.builder("test")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\"}}}")
+            .settings(settings)
+            .primaryTerm(0, 1)
+            .build();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+        recoverShardFromStore(primary);
+
+        IndexShard.AsyncShardFlushTask flushTask = primary.getPeriodicFlushTask();
+        assertNotNull(flushTask);
+
+        updatePeriodicFlushInterval(primary, "-1");
+
+        assertTrue("disabling index.periodic_flush_interval should close the running task", flushTask.isClosed());
+        assertFalse(flushTask.isScheduled());
+        assertNull(primary.getPeriodicFlushTask());
+
+        // Re-enabling starts a fresh task.
+        updatePeriodicFlushInterval(primary, "2m");
+        IndexShard.AsyncShardFlushTask restarted = primary.getPeriodicFlushTask();
+        assertNotNull(restarted);
+        assertNotSame(flushTask, restarted);
+        assertEquals(TimeValue.timeValueMinutes(2), restarted.getInterval());
+
+        closeShards(primary);
+    }
+
+    /**
+     * Applies a dynamic update of {@code index.periodic_flush_interval} to the shard the same way
+     * {@code IndexService#updateMetadata} does: update the index settings, then notify the shard.
+     */
+    private static void updatePeriodicFlushInterval(IndexShard shard, String interval) {
+        IndexMetadata current = shard.indexSettings().getIndexMetadata();
+        Settings newSettings = Settings.builder()
+            .put(current.getSettings())
+            .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), interval)
+            .build();
+        IndexMetadata updated = IndexMetadata.builder(current)
+            .settings(newSettings)
+            .settingsVersion(current.getSettingsVersion() + 1)
+            .build();
+        shard.indexSettings().updateIndexMetadata(updated);
+        shard.onSettingsChanged();
+    }
+
     /**
      * Verifies that {@code isRemoteSegmentStoreInSync} uses {@code getCatalogSnapshot()} (the unified
      * catalog API) rather than the legacy {@code getSegmentInfosSnapshot()}. After indexing and refreshing,

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -5606,6 +5606,36 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(primary);
     }
 
+    public void testPeriodicFlushTaskDeferredUntilEngineExists() throws Exception {
+        // Setting is enabled at creation, but the shard has no engine yet. A settings change in this
+        // state must defer the task (there is nothing to flush) rather than start it.
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING.getKey(), "1m")
+            .build();
+        IndexMetadata metadata = IndexMetadata.builder("test")
+            .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\"}}}")
+            .settings(settings)
+            .primaryTerm(0, 1)
+            .build();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+
+        // No engine yet: onSettingsChanged must not start the task.
+        primary.onSettingsChanged();
+        assertNull("periodic flush task must not start before an engine exists", primary.getPeriodicFlushTask());
+
+        // Once the engine is created during recovery, the task starts with the configured interval.
+        recoverShardFromStore(primary);
+        IndexShard.AsyncShardFlushTask flushTask = primary.getPeriodicFlushTask();
+        assertNotNull("task should start once an engine is available", flushTask);
+        assertEquals(TimeValue.timeValueMinutes(1), flushTask.getInterval());
+        assertTrue(flushTask.isScheduled());
+
+        closeShards(primary);
+    }
+
     /**
      * Applies a dynamic update of {@code index.periodic_flush_interval} to the shard the same way
      * {@code IndexService#updateMetadata} does: update the index settings, then notify the shard.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

`index.periodic_flush_interval` (added in #19878) is declared `Dynamic`, and `IndexSettings` registers an update consumer that tracks the new value. However, the shard-level `AsyncShardFlushTask` is created exactly once in `IndexShard#onNewEngine` with the interval captured at construction time, and nothing re-reads the setting afterwards. Changing the setting on a live index therefore has no effect until the shard's engine is recreated (recovery, relocation, close/open, node restart):

- `-1 -> Xm`: no task starts
- `Xm -> Ym`: the task keeps firing at `X`
- `Xm -> -1`: the task keeps flushing at `X`; `mustReschedule()` checks the task's stored interval rather than the live setting, so it never self-cancels

This change makes `IndexShard#onSettingsChanged`, which `IndexService#updateMetadata` already invokes for every shard on each index settings change, reconcile the task with the current value:

- enabled and no task exists: start it (only if an engine exists to flush)
- enabled with a different interval: call `setInterval()` on the existing task, which cancels and reschedules it (an in-flight run picks up the new interval on its reschedule)
- disabled with a task running: close it and clear the reference

`onNewEngine` continues to start the task on engine creation exactly as before and now delegates to the same reconciliation method. The task lifecycle is guarded by a dedicated `periodicFlushMutex`. Unrelated settings changes are a no-op because the interval is unchanged.

### Related Issues

Follow-up to #19878.

### Testing

- `IndexShardTests`: three new unit tests covering enable (`-1 -> 1m`), reschedule (`1m -> 30s` keeps the same task instance; an unchanged value is a no-op) and disable (`1m -> -1` closes the task; re-enabling creates a fresh one). The existing periodic-flush tests are unchanged.
- `IndexShardIT#testPeriodicFlushIntervalDynamicUpdate`: drives the transitions through the index settings API on a live single-shard index and asserts the task starts, is rescheduled to `100ms` and observably increments `flush.periodic`, then is closed and the counter stays flat.
- `IndexShardTests` (116), `IndexServiceTests` (19) and `IndexShardIT` (17) all pass.

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).