### PR TITLE
[Remote Store] Limit full translog reads to ILE

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/CryptoMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/CryptoMetadata.java
@@ -36,6 +36,8 @@ public class CryptoMetadata implements Writeable {
     static final public String SETTINGS_KEY = "settings";
     static final private String KMS_KEY_ARN_SETTING = "kms.key_arn";
     static final private String KMS_ENCRYPTION_CONTEXT_SETTING = "kms.encryption_context";
+    static final private String INDEX_STORE_TYPE_SETTING = "index.store.type";
+    static final private String CRYPTO_STORE_TYPE = "cryptofs";
     private final String keyProviderName;
     private final String keyProviderType;
     private final Settings settings;
@@ -112,6 +114,10 @@ public class CryptoMetadata implements Writeable {
     }
 
     public static CryptoMetadata fromIndexSettings(Settings indexSettings) {
+        if (CRYPTO_STORE_TYPE.equals(indexSettings.get(INDEX_STORE_TYPE_SETTING)) == false) {
+            return null;
+        }
+
         String keyProviderName = indexSettings.get("index.store.crypto.key_provider");
         if (keyProviderName == null) {
             return null;

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -23,6 +23,7 @@ import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.InputStreamWithMetadata;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.transfer.RemoteTransferContainer;
+import org.opensearch.common.blobstore.transfer.stream.OffsetRangeFileInputStream;
 import org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.core.action.ActionListener;
@@ -33,6 +34,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -187,13 +189,6 @@ public class BlobStoreTransferService implements TransferService {
                 metadata = buildTransferFileMetadata(fileSnapshot.getMetadataFileInputStream());
             }
 
-            // Read content once using inputStream() to invoke any overrides (e.g., decryption)
-            byte[] fileContent;
-            try (InputStream inputStream = fileSnapshot.inputStream()) {
-                fileContent = inputStream.readAllBytes();
-            }
-            long contentLength = fileContent.length;
-
             ActionListener<Void> completionListener = ActionListener.wrap(resp -> listener.onResponse(fileSnapshot), ex -> {
                 logger.error(() -> new ParameterizedMessage("Failed to upload blob {}", fileSnapshot.getName()), ex);
                 listener.onFailure(new FileTransferException(fileSnapshot, ex));
@@ -202,19 +197,45 @@ public class BlobStoreTransferService implements TransferService {
             // Only the first generation doesn't have checksum
             assert (fileSnapshot.getChecksum() != null || fileSnapshot.getName().contains("-1."));
 
-            // Use ByteArrayIndexInput for async upload with the content from inputStream()
-            String resourceDesc = "FileSnapshot[" + fileSnapshot.getName() + "]";
+            if (cryptoMetadata != null) {
+                // ILE snapshots override inputStream() to decrypt the local cryptofs file before remote upload.
+                final byte[] fileContent;
+                try (InputStream inputStream = fileSnapshot.inputStream()) {
+                    fileContent = inputStream.readAllBytes();
+                }
+                String resourceDescription = "FileSnapshot[" + fileSnapshot.getName() + "]";
+                uploadBlobAsyncInternal(
+                    fileSnapshot.getName(),
+                    fileSnapshot.getName(),
+                    fileContent.length,
+                    blobPath,
+                    writePriority,
+                    (size, position) -> new OffsetRangeIndexInputStream(
+                        new ByteArrayIndexInput(resourceDescription, fileContent),
+                        size,
+                        position
+                    ),
+                    fileSnapshot.getChecksum(),
+                    completionListener,
+                    metadata,
+                    cryptoMetadata
+                );
+                return;
+            }
+
+            // Ordinary translogs can be uploaded directly from independent file ranges without buffering the full file.
+            final long contentLength = Files.size(fileSnapshot.getPath());
             uploadBlobAsyncInternal(
                 fileSnapshot.getName(),
                 fileSnapshot.getName(),
                 contentLength,
                 blobPath,
                 writePriority,
-                (size, position) -> new OffsetRangeIndexInputStream(new ByteArrayIndexInput(resourceDesc, fileContent), size, position),
+                (size, position) -> new OffsetRangeFileInputStream(fileSnapshot.getPath(), size, position),
                 fileSnapshot.getChecksum(),
                 completionListener,
                 metadata,
-                cryptoMetadata
+                null
             );
 
         } catch (Exception e) {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/BlobStoreTransferServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/BlobStoreTransferServiceTests.java
@@ -10,6 +10,7 @@ package org.opensearch.index.translog.transfer;
 
 import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.metadata.CryptoMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.service.ClusterService;
@@ -54,6 +55,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,6 +102,77 @@ public class BlobStoreTransferServiceTests extends OpenSearchTestCase {
         );
         TransferService transferService = new BlobStoreTransferService(repository.blobStore(), threadPool);
         transferService.uploadBlob(transferFileSnapshot, repository.basePath(), WritePriority.NORMAL, null);
+    }
+
+    public void testAsyncUploadWithoutCryptoMetadataStreamsFromFile() throws Exception {
+        byte[] fileContent = randomByteArrayOfLength(128);
+        Path testFile = createTempFile();
+        Files.write(testFile, fileContent);
+        long primaryTerm = randomNonNegativeLong();
+        FileSnapshot.TransferFileSnapshot transferFileSnapshot = Mockito.spy(
+            new FileSnapshot.TransferFileSnapshot(testFile, primaryTerm, randomLong())
+        );
+
+        BlobStore blobStore = createTestBlobStore();
+        MockAsyncFsContainer mockAsyncFsContainer = new MockAsyncFsContainer((FsBlobStore) blobStore, BlobPath.cleanPath(), null);
+        FsBlobStore fsBlobStore = mock(FsBlobStore.class);
+        when(fsBlobStore.blobContainer(any())).thenReturn(mockAsyncFsContainer);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean succeeded = new AtomicBoolean(false);
+        new BlobStoreTransferService(fsBlobStore, threadPool).uploadBlobs(
+            Set.of(transferFileSnapshot),
+            Map.of(primaryTerm, BlobPath.cleanPath()),
+            new LatchedActionListener<>(ActionListener.wrap(response -> succeeded.set(true), failure -> {
+                throw new AssertionError("Upload failed", failure);
+            }), latch),
+            WritePriority.NORMAL,
+            null
+        );
+
+        assertTrue(latch.await(1, TimeUnit.SECONDS));
+        assertTrue(succeeded.get());
+        verify(transferFileSnapshot, Mockito.never()).inputStream();
+        try (InputStream uploaded = mockAsyncFsContainer.getDelegate().readBlob(transferFileSnapshot.getName())) {
+            assertArrayEquals(fileContent, uploaded.readAllBytes());
+        }
+    }
+
+    public void testAsyncUploadWithCryptoMetadataReadsSnapshotInputStream() throws Exception {
+        byte[] encryptedFileContent = randomByteArrayOfLength(128);
+        byte[] decryptedFileContent = randomByteArrayOfLength(96);
+        Path testFile = createTempFile();
+        Files.write(testFile, encryptedFileContent);
+        long primaryTerm = randomNonNegativeLong();
+        FileSnapshot.TransferFileSnapshot transferFileSnapshot = Mockito.spy(
+            new FileSnapshot.TransferFileSnapshot(testFile, primaryTerm, randomLong())
+        );
+        Mockito.doReturn(new ByteArrayInputStream(decryptedFileContent)).when(transferFileSnapshot).inputStream();
+
+        BlobStore blobStore = createTestBlobStore();
+        MockAsyncFsContainer mockAsyncFsContainer = new MockAsyncFsContainer((FsBlobStore) blobStore, BlobPath.cleanPath(), null);
+        FsBlobStore fsBlobStore = mock(FsBlobStore.class);
+        when(fsBlobStore.blobContainer(any())).thenReturn(mockAsyncFsContainer);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean succeeded = new AtomicBoolean(false);
+        CryptoMetadata cryptoMetadata = new CryptoMetadata("test-provider", "aws-kms", Settings.EMPTY);
+        new BlobStoreTransferService(fsBlobStore, threadPool).uploadBlobs(
+            Set.of(transferFileSnapshot),
+            Map.of(primaryTerm, BlobPath.cleanPath()),
+            new LatchedActionListener<>(ActionListener.wrap(response -> succeeded.set(true), failure -> {
+                throw new AssertionError("Upload failed", failure);
+            }), latch),
+            WritePriority.NORMAL,
+            cryptoMetadata
+        );
+
+        assertTrue(latch.await(1, TimeUnit.SECONDS));
+        assertTrue(succeeded.get());
+        verify(transferFileSnapshot).inputStream();
+        try (InputStream uploaded = mockAsyncFsContainer.getDelegate().readBlob(transferFileSnapshot.getName())) {
+            assertArrayEquals(decryptedFileContent, uploaded.readAllBytes());
+        }
     }
 
     public void testUploadBlobAsync() throws IOException, InterruptedException {

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryEncryptionTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryEncryptionTests.java
@@ -25,6 +25,7 @@ public class BlobStoreRepositoryEncryptionTests extends OpenSearchTestCase {
         // Create index settings with KMS encryption configuration
         Settings indexSettings = Settings.builder()
             .put("index.version.created", Version.CURRENT)
+            .put("index.store.type", "cryptofs")
             .put("index.store.crypto.key_provider", "aws-kms-provider")
             .put("index.store.crypto.kms.key_arn", "arn:aws:kms:us-east-1:123456789:key/test-key")
             .put("index.store.crypto.kms.encryption_context", "tenant=test,env=prod")
@@ -57,10 +58,21 @@ public class BlobStoreRepositoryEncryptionTests extends OpenSearchTestCase {
         assertNull(cryptoMetadata);
     }
 
+    public void testResolveCryptoMetadataReturnsNullWithoutCryptofsStoreType() {
+        Settings indexSettings = Settings.builder()
+            .put("index.version.created", Version.CURRENT)
+            .put("index.store.crypto.key_provider", "aws-kms-provider")
+            .put("index.store.crypto.kms.key_arn", "arn:aws:kms:us-east-1:123456789:key/test-key")
+            .build();
+
+        assertNull(CryptoMetadata.fromIndexSettings(indexSettings));
+    }
+
     public void testResolveCryptoMetadataReturnsNullForMissingKeyProvider() {
         // Create index settings with some crypto-related settings but missing key provider
         Settings indexSettings = Settings.builder()
             .put("index.version.created", Version.CURRENT)
+            .put("index.store.type", "cryptofs")
             .put("index.store.crypto.kms.key_arn", "arn:aws:kms:us-east-1:123456789:key/test-key")
             .build();
 
@@ -104,6 +116,7 @@ public class BlobStoreRepositoryEncryptionTests extends OpenSearchTestCase {
         // Index A with one KMS key
         Settings indexASettings = Settings.builder()
             .put("index.version.created", Version.CURRENT)
+            .put("index.store.type", "cryptofs")
             .put("index.store.crypto.key_provider", "provider-a")
             .put("index.store.crypto.kms.key_arn", "arn:aws:kms:us-east-1:111:key/key-a")
             .put("index.store.crypto.kms.encryption_context", "tenant=acme")
@@ -112,6 +125,7 @@ public class BlobStoreRepositoryEncryptionTests extends OpenSearchTestCase {
         // Index B with different KMS key
         Settings indexBSettings = Settings.builder()
             .put("index.version.created", Version.CURRENT)
+            .put("index.store.type", "cryptofs")
             .put("index.store.crypto.key_provider", "provider-b")
             .put("index.store.crypto.kms.key_arn", "arn:aws:kms:us-west-2:222:key/key-b")
             .put("index.store.crypto.kms.encryption_context", "tenant=globex")


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
PR #20095 changed asynchronous translog uploads to read the full `TransferFileSnapshot` stream before multipart upload. The ILE plugin needs that path because `CryptoRemoteFsTranslog` supplies a snapshot whose `inputStream()` decrypts the local cryptofs file. Ordinary remote translogs do not need it, and buffering a large translog generation can exhaust heap.

ILE is enabled at the node with `plugins.crypto.enabled=true` and selected per index with `index.store.type=cryptofs`. This change makes `CryptoMetadata.fromIndexSettings(...)` honor that per-index activation boundary.

When `CryptoMetadata` is present, `BlobStoreTransferService` takes the decrypt/full-read path and returns. Otherwise, it falls through to the original `OffsetRangeFileInputStream` multipart path, which streams independent file ranges without holding the whole translog in memory.

### Related Issues
Related to #20095

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request is not applicable; no REST API changes.
- [x] Public documentation issue/PR is not applicable; this restores the existing upload behavior outside ILE.

#### Validation
- `./gradlew :server:test --tests 'org.opensearch.index.translog.transfer.BlobStoreTransferServiceTests' --tests 'org.opensearch.repositories.blobstore.BlobStoreRepositoryEncryptionTests'`
- `./gradlew :server:spotlessJavaCheck`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
