### PR TITLE
Fix directory stream leak in FileCache.restoreFromDirectory

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -214,7 +214,7 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
      * directory within the provided file cache path.
      */
     public void restoreFromDirectory(List<Path> fileCacheDataPaths) {
-        Stream.concat(
+        Stream<Path> directoriesToScan = Stream.concat(
             fileCacheDataPaths.stream()
                 .filter(Files::isDirectory)
                 .map(path -> path.resolve(LOCAL_STORE_LOCATION))
@@ -223,18 +223,24 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
                 .filter(Files::isDirectory)
                 .map(path -> path.resolve(INDICES_FOLDER_IDENTIFIER))
                 .filter(Files::isDirectory)
-        ).flatMap(dir -> {
-            try {
-                return Files.list(dir);
+        );
+        directoriesToScan.forEach(dir -> {
+            // Each Files.list call opens a DirectoryStream that must be closed explicitly,
+            // so this is scoped per directory instead of flatMapping into one long-lived stream.
+            try (Stream<Path> filesInDir = Files.list(dir)) {
+                filesInDir.filter(Files::isRegularFile).forEach(path -> {
+                    try {
+                        put(path.toAbsolutePath(), new RestoredCachedIndexInput(Files.size(path)));
+                        decRef(path.toAbsolutePath());
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(
+                            "Unable to retrieve cache file details. Please clear the file cache for node startup.",
+                            e
+                        );
+                    }
+                });
             } catch (IOException e) {
                 throw new UncheckedIOException("Unable to process file cache directory. Please clear the file cache for node startup.", e);
-            }
-        }).filter(Files::isRegularFile).forEach(path -> {
-            try {
-                put(path.toAbsolutePath(), new RestoredCachedIndexInput(Files.size(path)));
-                decRef(path.toAbsolutePath());
-            } catch (IOException e) {
-                throw new UncheckedIOException("Unable to retrieve cache file details. Please clear the file cache for node startup.", e);
             }
         });
     }


### PR DESCRIPTION
### Description
`FileCache.restoreFromDirectory` rebuilds the file cache from disk at node startup by scanning the local store location and indices folder under each file cache data path. It did this with `Stream.concat(...).flatMap(dir -> Files.list(dir))...forEach(...)`, one long expression with no try with resources anywhere in it. `Files.list()` opens a `DirectoryStream` under the hood that has to be closed explicitly to release its file descriptor, and flatMap does not close the inner streams it consumes, so every directory scanned during startup leaked one.

This restructures the scan to iterate the candidate directories with a plain forEach and open one `Files.list` stream per directory inside a try with resources block, so each directory's handle is released as soon as its contents have been read. Exception messages, put/decRef behavior, and the set of files processed are all unchanged.

Verified against the existing `FileCacheTests` suite (27 tests, all passing).

### Related Issues
Resolves #
No existing issue; found by inspection while reviewing FileCache's startup path.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
