### PR TITLE
[Analytics-Engine][MPP] Stream the hash-shuffle consumer and pick pipelined or materialized per worker stage

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
@@ -9,11 +9,13 @@
 package org.opensearch.analytics.spi;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Read-only handle to a node-local shuffle buffer slice — what a hash-shuffle worker handler
- * uses to drain accumulated bytes for one (queryId, stageId, partitionIndex) on one side.
+ * uses to drain accumulated bytes for one (queryId, stageId, partitionIndex) on one slot.
  *
  * <p>The implementing class lives in analytics-engine ({@code ShuffleBufferManager.ShuffleBuffer});
  * the SPI exposes only the consumer-side surface so backend handlers don't need a hard
@@ -26,49 +28,82 @@ import java.util.List;
 public interface ShuffleBufferAccess {
 
     /**
-     * Sets the number of senders this buffer will receive on each side. The consumer-side
-     * handler calls this on the worker node before {@link #awaitReady} so the buffer's
-     * completion latches know when to fire. {@code expectedLeft} / {@code expectedRight} should
-     * each equal the number of producer tasks (one per source shard) that will ship into this
-     * partition. Calling this multiple times with the same values is idempotent (CountDownLatch
-     * only fires once); calling with different values from concurrent threads is unsupported.
+     * Sets the number of senders this buffer will receive on each slot, keyed by slot label (see
+     * {@link ShuffleSlots}). The consumer-side handler calls this on the worker node before
+     * {@link #awaitReady} so the buffer's per-slot completion latches know when to fire. Each value
+     * should equal the number of producer tasks (one per source shard) that will ship into this
+     * partition on that slot.
+     *
+     * <p>ALL of the consumer's slots must be declared in ONE call: {@link #awaitReady} waits for
+     * every declared slot, and a slot first named by a later call would not be waited on by an
+     * already-blocked consumer. Calling this repeatedly with the same values is idempotent (a
+     * CountDownLatch only fires once); calling with different values from concurrent threads is
+     * unsupported.
      */
-    void setExpectedSenders(int expectedLeftSenders, int expectedRightSenders);
+    void setExpectedSenders(Map<String, Integer> expectedSendersBySlot);
 
     /**
-     * Blocks until both sides' senders have all reported {@code isLast}, or {@code timeoutMillis}
-     * elapses. Returns {@code true} on success, {@code false} on timeout. Throws
-     * {@link InterruptedException} if the calling thread is interrupted (e.g. task cancellation).
+     * Binary convenience form of {@link #setExpectedSenders(Map)} for a two-slot (hash-join)
+     * consumer. A negative count means "leave this slot unchanged", which is how the single-slot
+     * aggregate-shuffle path declares an unused right side.
+     */
+    default void setExpectedSenders(int expectedLeftSenders, int expectedRightSenders) {
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        if (expectedLeftSenders >= 0) {
+            bySlot.put(ShuffleSlots.LEFT, expectedLeftSenders);
+        }
+        if (expectedRightSenders >= 0) {
+            bySlot.put(ShuffleSlots.RIGHT, expectedRightSenders);
+        }
+        setExpectedSenders(bySlot);
+    }
+
+    /**
+     * Blocks until every declared slot's senders have all reported {@code isLast}, or
+     * {@code timeoutMillis} elapses. Returns {@code true} on success, {@code false} on timeout.
+     * Throws {@link InterruptedException} if the calling thread is interrupted (e.g. task
+     * cancellation).
      */
     boolean awaitReady(long timeoutMillis) throws InterruptedException;
 
-    /** Returns the accumulated Arrow IPC chunks for the {@code "left"} side. Caller must not mutate.
+    /** Returns the accumulated Arrow IPC chunks for {@code slot}. Caller must not mutate.
      *  <p>EAGER: with spill enabled this reads the whole partition (spilled file + in-memory tail)
-     *  back into heap at once. Prefer {@link #drainLeft()} on the consumer hot path so a spilled
+     *  back into heap at once. Prefer {@link #drain(String)} on the consumer hot path so a spilled
      *  partition never fully materializes. Retained for tests / small non-spill callers. */
-    List<byte[]> getLeftData();
-
-    /** Returns the accumulated Arrow IPC chunks for the {@code "right"} side. Caller must not mutate.
-     *  <p>EAGER — see {@link #getLeftData()}. Prefer {@link #drainRight()} on the hot path. */
-    List<byte[]> getRightData();
+    List<byte[]> getData(String slot);
 
     /**
-     * LAZILY drains the {@code "left"} side's chunks in arrival order: spilled chunks are streamed
+     * LAZILY drains {@code slot}'s chunks in arrival order: spilled chunks are streamed
      * one-at-a-time from disk, then the in-memory tail. The consumer feeds each chunk to the native
      * sender and discards it before pulling the next, so a spilled partition is never fully resident
      * in heap (this is what lets an over-budget shuffle RUN rather than OOM during drain).
      *
-     * <p>Call once per side after {@link #awaitReady}. MUST be closed (try-with-resources) so the
-     * spill-file handle is released even on partial iteration. The default wraps {@link #getLeftData()}
-     * for implementations that hold everything in memory anyway.
+     * <p>Call once per slot after {@link #awaitReady}. MUST be closed (try-with-resources) so the
+     * spill-file handle is released even on partial iteration. The default wraps
+     * {@link #getData(String)} for implementations that hold everything in memory anyway.
      */
-    default CloseableIterator<byte[]> drainLeft() {
-        return wrap(getLeftData().iterator());
+    default CloseableIterator<byte[]> drain(String slot) {
+        return wrap(getData(slot).iterator());
     }
 
-    /** LAZILY drains the {@code "right"} side — see {@link #drainLeft()}. */
+    /** {@link #getData(String)} for the {@link ShuffleSlots#LEFT} slot. */
+    default List<byte[]> getLeftData() {
+        return getData(ShuffleSlots.LEFT);
+    }
+
+    /** {@link #getData(String)} for the {@link ShuffleSlots#RIGHT} slot. */
+    default List<byte[]> getRightData() {
+        return getData(ShuffleSlots.RIGHT);
+    }
+
+    /** {@link #drain(String)} for the {@link ShuffleSlots#LEFT} slot. */
+    default CloseableIterator<byte[]> drainLeft() {
+        return drain(ShuffleSlots.LEFT);
+    }
+
+    /** {@link #drain(String)} for the {@link ShuffleSlots#RIGHT} slot. */
     default CloseableIterator<byte[]> drainRight() {
-        return wrap(getRightData().iterator());
+        return drain(ShuffleSlots.RIGHT);
     }
 
     /** Adapts a plain {@link Iterator} to a no-op-close {@link CloseableIterator} (in-memory case). */

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
@@ -86,6 +86,19 @@ public interface ShuffleBufferAccess {
         return wrap(getData(slot).iterator());
     }
 
+    /**
+     * {@link #drain(String)} with an explicit per-chunk liveness timeout.
+     *
+     * <p>Under pipelined shuffle the returned iterator is CONCURRENT with the producers: it blocks for
+     * the next chunk rather than being created after the partition is complete, and terminates at the
+     * stream's end-of-stream marker. {@code timeoutMillis} therefore bounds the wait for ONE chunk, not
+     * for the whole partition, and a timeout means the producers have stalled — implementations must
+     * fail rather than report a clean end-of-stream, or the consumer would silently under-deliver.
+     */
+    default CloseableIterator<byte[]> drain(String slot, long timeoutMillis) {
+        return drain(slot);
+    }
+
     /** {@link #getData(String)} for the {@link ShuffleSlots#LEFT} slot. */
     default List<byte[]> getLeftData() {
         return getData(ShuffleSlots.LEFT);

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleBufferAccess.java
@@ -59,6 +59,20 @@ public interface ShuffleBufferAccess {
     }
 
     /**
+     * Switches this buffer to the MATERIALIZED shape: {@link #drain(String, long)} waits for every
+     * declared sender before yielding a chunk, and the accumulating buffer spills so residency stays
+     * bounded while nothing is draining.
+     *
+     * <p>One-way on purpose. The coordinator decides the mode per worker stage (from the same estimate
+     * that picks a spillable join), and the node-level {@code analytics.mpp.shuffle.pipelined.enabled}
+     * switch is an operator kill switch; letting an instruction turn pipelining back ON would let a plan
+     * override that switch. So a stage can only narrow to materialized, never broaden.
+     *
+     * <p>Default no-op: an implementation that holds everything in memory has one mode.
+     */
+    default void useMaterializedMode() {}
+
+    /**
      * Blocks until every declared slot's senders have all reported {@code isLast}, or
      * {@code timeoutMillis} elapses. Returns {@code true} on success, {@code false} on timeout.
      * Throws {@link InterruptedException} if the calling thread is interrupted (e.g. task

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleSlots.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleSlots.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+/**
+ * Slot labels for the hash-shuffle transport. A <em>slot</em> identifies one of a shuffle
+ * consumer's independent input streams: producers stamp their outgoing payloads with it and the
+ * consumer's buffer keeps one accumulation + completion latch per slot.
+ *
+ * <p>The transport is N-ary — a consumer may have any number of slots — but a two-input consumer
+ * (the binary hash join, by far the common case) uses the historical {@link #LEFT} / {@link #RIGHT}
+ * labels so its wire payloads, buffer keys and spill file names are unchanged. Only a consumer with
+ * three or more inputs uses the positional {@code "in<index>"} form.
+ *
+ * @opensearch.internal
+ */
+public final class ShuffleSlots {
+
+    /** Slot label for a binary consumer's first (probe) input. Also the single slot of a
+     *  one-input consumer such as the FINAL-aggregate shuffle worker. */
+    public static final String LEFT = "left";
+
+    /** Slot label for a binary consumer's second (build) input. */
+    public static final String RIGHT = "right";
+
+    private ShuffleSlots() {}
+
+    /**
+     * The slot label for input {@code index} of an {@code arity}-input consumer. Arity 1 and 2 map
+     * to {@link #LEFT} / {@link #RIGHT} so the binary path keeps its historical labels; higher
+     * arities use {@code "in<index>"}.
+     *
+     * @throws IllegalArgumentException if {@code index} is outside {@code [0, arity)}
+     */
+    public static String forInput(int index, int arity) {
+        if (index < 0 || index >= arity) {
+            throw new IllegalArgumentException("Shuffle slot index " + index + " is outside [0," + arity + ")");
+        }
+        if (arity <= 2) {
+            return index == 0 ? LEFT : RIGHT;
+        }
+        return "in" + index;
+    }
+
+    /**
+     * Validates a slot label. Labels are engine-generated, but they key the consumer buffer's
+     * per-slot state AND name its on-disk spill file, so a label containing a path separator or
+     * {@code ..} would let a future caller escape the spill directory. Reject anything that is not
+     * a simple alphanumeric/dash/underscore token.
+     *
+     * @return {@code slot}, for use in a fluent assignment
+     * @throws IllegalArgumentException if {@code slot} is null, empty, or not a safe token
+     */
+    public static String validate(String slot) {
+        if (slot == null || slot.isEmpty()) {
+            throw new IllegalArgumentException("Shuffle slot label must be non-empty");
+        }
+        for (int i = 0; i < slot.length(); i++) {
+            char c = slot.charAt(i);
+            boolean ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+            if (!ok) {
+                throw new IllegalArgumentException("Shuffle slot label '" + slot + "' must contain only [A-Za-z0-9_-]");
+            }
+        }
+        return slot;
+    }
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleWorkerSetupInstructionNode.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleWorkerSetupInstructionNode.java
@@ -12,6 +12,9 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Instruction prepended to every hash-shuffle worker fragment's plan alternatives. The
@@ -32,17 +35,38 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
     private final String queryId;
     private final int targetStageId;
     private final int partitionIndex;
-    private final int leftExpectedSenders;
-    private final int rightExpectedSenders;
+    private final Map<String, Integer> expectedSendersBySlot;
     private final boolean preferHashJoin;
 
     /**
-     * @param queryId             worker buffer triple key
-     * @param targetStageId       worker buffer triple key
-     * @param partitionIndex      worker buffer triple key
-     * @param leftExpectedSenders expected isLast count from left producers for this partition
-     * @param rightExpectedSenders expected isLast count from right producers for this partition
-     * @param preferHashJoin      false → the backend builds a spillable sort-merge join for this worker
+     * @param queryId               worker buffer triple key
+     * @param targetStageId         worker buffer triple key
+     * @param partitionIndex        worker buffer triple key
+     * @param expectedSendersBySlot expected isLast count per slot label (see {@link ShuffleSlots}) for
+     *                              this partition. Must name EVERY slot the consumer will read — the
+     *                              handler declares them all in one call so the buffer's
+     *                              {@code awaitReady} waits on the complete set.
+     * @param preferHashJoin        false → the backend builds a spillable sort-merge join for this worker
+     */
+    public ShuffleWorkerSetupInstructionNode(
+        String queryId,
+        int targetStageId,
+        int partitionIndex,
+        Map<String, Integer> expectedSendersBySlot,
+        boolean preferHashJoin
+    ) {
+        this.queryId = queryId;
+        this.targetStageId = targetStageId;
+        this.partitionIndex = partitionIndex;
+        // LinkedHashMap: slot order is the consumer's input order, which keeps log output and the
+        // handler's declaration order deterministic (the buffer itself is order-insensitive).
+        this.expectedSendersBySlot = Collections.unmodifiableMap(new LinkedHashMap<>(expectedSendersBySlot));
+        this.preferHashJoin = preferHashJoin;
+    }
+
+    /**
+     * Binary convenience form for a two-slot (hash-join) consumer. A negative count omits that slot,
+     * which is how the single-slot aggregate-shuffle path declares an unused right side.
      */
     public ShuffleWorkerSetupInstructionNode(
         String queryId,
@@ -52,20 +76,30 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         int rightExpectedSenders,
         boolean preferHashJoin
     ) {
-        this.queryId = queryId;
-        this.targetStageId = targetStageId;
-        this.partitionIndex = partitionIndex;
-        this.leftExpectedSenders = leftExpectedSenders;
-        this.rightExpectedSenders = rightExpectedSenders;
-        this.preferHashJoin = preferHashJoin;
+        this(queryId, targetStageId, partitionIndex, binarySlots(leftExpectedSenders, rightExpectedSenders), preferHashJoin);
+    }
+
+    private static Map<String, Integer> binarySlots(int leftExpectedSenders, int rightExpectedSenders) {
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        if (leftExpectedSenders >= 0) {
+            bySlot.put(ShuffleSlots.LEFT, leftExpectedSenders);
+        }
+        if (rightExpectedSenders >= 0) {
+            bySlot.put(ShuffleSlots.RIGHT, rightExpectedSenders);
+        }
+        return bySlot;
     }
 
     public ShuffleWorkerSetupInstructionNode(StreamInput in) throws IOException {
         this.queryId = in.readString();
         this.targetStageId = in.readVInt();
         this.partitionIndex = in.readVInt();
-        this.leftExpectedSenders = in.readVInt();
-        this.rightExpectedSenders = in.readVInt();
+        int slotCount = in.readVInt();
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        for (int i = 0; i < slotCount; i++) {
+            bySlot.put(in.readString(), in.readVInt());
+        }
+        this.expectedSendersBySlot = Collections.unmodifiableMap(bySlot);
         this.preferHashJoin = in.readBoolean();
     }
 
@@ -81,12 +115,22 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         return partitionIndex;
     }
 
+    /** Expected isLast count per slot label; never null, possibly empty. */
+    public Map<String, Integer> getExpectedSendersBySlot() {
+        return expectedSendersBySlot;
+    }
+
+    /** Expected isLast count for {@code slot}, or -1 when this node does not declare that slot. */
+    public int getExpectedSenders(String slot) {
+        return expectedSendersBySlot.getOrDefault(slot, -1);
+    }
+
     public int getLeftExpectedSenders() {
-        return leftExpectedSenders;
+        return getExpectedSenders(ShuffleSlots.LEFT);
     }
 
     public int getRightExpectedSenders() {
-        return rightExpectedSenders;
+        return getExpectedSenders(ShuffleSlots.RIGHT);
     }
 
     public boolean getPreferHashJoin() {
@@ -103,8 +147,11 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         out.writeString(queryId);
         out.writeVInt(targetStageId);
         out.writeVInt(partitionIndex);
-        out.writeVInt(leftExpectedSenders);
-        out.writeVInt(rightExpectedSenders);
+        out.writeVInt(expectedSendersBySlot.size());
+        for (Map.Entry<String, Integer> e : expectedSendersBySlot.entrySet()) {
+            out.writeString(e.getKey());
+            out.writeVInt(e.getValue());
+        }
         out.writeBoolean(preferHashJoin);
     }
 }

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleWorkerSetupInstructionNode.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/ShuffleWorkerSetupInstructionNode.java
@@ -22,11 +22,19 @@ import java.util.Map;
  * table) and returns it as the {@link BackendExecutionContext}, so subsequent
  * {@link ShuffleScanInstructionNode} handlers can register named-input streams against it.
  *
- * <p>Beyond the buffer-triple key + expected-sender counts, the node carries the per-worker-stage
- * {@code preferHashJoin} decision: the coordinator sets it {@code false} when it estimates this
- * worker join's build side is too large for an in-memory hash table, so the backend builds a
- * spillable sort-merge join instead of the non-spillable hash-join build. Defaults {@code true}
- * (hash-join, the historical behavior).
+ * <p>Beyond the buffer-triple key + expected-sender counts, the node carries two per-worker-stage
+ * decisions the coordinator makes because that is where the stats live:
+ * <ul>
+ *   <li>{@code preferHashJoin} — {@code false} when this worker join's build side is estimated too
+ *       large for an in-memory hash table, so the backend builds a spillable sort-merge join instead
+ *       of the non-spillable hash-join build. Defaults {@code true} (hash-join, the historical
+ *       behavior).</li>
+ *   <li>{@code pipelined} — {@code true} to drain CONCURRENTLY with the producers (low latency,
+ *       residency bounded by arrival rate), {@code false} for the MATERIALIZED shape: the producers
+ *       all finish first and the consumer's buffer spills, so residency is bounded by a shallow
+ *       window and backpressure cannot fail the query. Per stage rather than per node because the
+ *       right answer is a property of the shuffle's size, not of the cluster.</li>
+ * </ul>
  *
  * @opensearch.internal
  */
@@ -37,6 +45,7 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
     private final int partitionIndex;
     private final Map<String, Integer> expectedSendersBySlot;
     private final boolean preferHashJoin;
+    private final boolean pipelined;
 
     /**
      * @param queryId               worker buffer triple key
@@ -47,13 +56,16 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
      *                              handler declares them all in one call so the buffer's
      *                              {@code awaitReady} waits on the complete set.
      * @param preferHashJoin        false → the backend builds a spillable sort-merge join for this worker
+     * @param pipelined             false → this worker uses the materialized shape (producers finish
+     *                              first, consumer buffer spills) instead of draining concurrently
      */
     public ShuffleWorkerSetupInstructionNode(
         String queryId,
         int targetStageId,
         int partitionIndex,
         Map<String, Integer> expectedSendersBySlot,
-        boolean preferHashJoin
+        boolean preferHashJoin,
+        boolean pipelined
     ) {
         this.queryId = queryId;
         this.targetStageId = targetStageId;
@@ -62,6 +74,7 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         // handler's declaration order deterministic (the buffer itself is order-insensitive).
         this.expectedSendersBySlot = Collections.unmodifiableMap(new LinkedHashMap<>(expectedSendersBySlot));
         this.preferHashJoin = preferHashJoin;
+        this.pipelined = pipelined;
     }
 
     /**
@@ -74,9 +87,10 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         int partitionIndex,
         int leftExpectedSenders,
         int rightExpectedSenders,
-        boolean preferHashJoin
+        boolean preferHashJoin,
+        boolean pipelined
     ) {
-        this(queryId, targetStageId, partitionIndex, binarySlots(leftExpectedSenders, rightExpectedSenders), preferHashJoin);
+        this(queryId, targetStageId, partitionIndex, binarySlots(leftExpectedSenders, rightExpectedSenders), preferHashJoin, pipelined);
     }
 
     private static Map<String, Integer> binarySlots(int leftExpectedSenders, int rightExpectedSenders) {
@@ -101,6 +115,7 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         }
         this.expectedSendersBySlot = Collections.unmodifiableMap(bySlot);
         this.preferHashJoin = in.readBoolean();
+        this.pipelined = in.readBoolean();
     }
 
     public String getQueryId() {
@@ -137,6 +152,11 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
         return preferHashJoin;
     }
 
+    /** True when this worker drains concurrently with its producers; false for the materialized shape. */
+    public boolean isPipelined() {
+        return pipelined;
+    }
+
     @Override
     public InstructionType type() {
         return InstructionType.SETUP_SHUFFLE_WORKER;
@@ -153,5 +173,6 @@ public class ShuffleWorkerSetupInstructionNode implements InstructionNode {
             out.writeVInt(e.getValue());
         }
         out.writeBoolean(preferHashJoin);
+        out.writeBoolean(pipelined);
     }
 }

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShuffleSlotsTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShuffleSlotsTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.spi;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ShuffleSlots} + the N-ary {@link ShuffleWorkerSetupInstructionNode} wire shape.
+ *
+ * <p>The load-bearing property is BINARY WIRE COMPATIBILITY: a two-input hash join must keep the
+ * historical {@code left}/{@code right} labels so its spill-file names, buffer keys and producer payload
+ * tags are unchanged. Only a 3+-input consumer uses the positional form.
+ */
+public class ShuffleSlotsTests extends OpenSearchTestCase {
+
+    public void testBinaryArityKeepsHistoricalLabels() {
+        // Arity 1 (the FINAL-aggregate shuffle worker) and arity 2 (hash join) must map to left/right —
+        // any other choice would rename spill files and break the producer/consumer rendezvous.
+        assertEquals("left", ShuffleSlots.forInput(0, 1));
+        assertEquals("left", ShuffleSlots.forInput(0, 2));
+        assertEquals("right", ShuffleSlots.forInput(1, 2));
+    }
+
+    public void testHigherArityUsesPositionalLabels() {
+        assertEquals("in0", ShuffleSlots.forInput(0, 3));
+        assertEquals("in1", ShuffleSlots.forInput(1, 3));
+        assertEquals("in2", ShuffleSlots.forInput(2, 3));
+        // Distinctness across the whole range is what keeps one slot's rows out of another's buffer.
+        assertEquals(4, java.util.stream.IntStream.range(0, 4).mapToObj(i -> ShuffleSlots.forInput(i, 4)).distinct().count());
+    }
+
+    public void testForInputRejectsOutOfRange() {
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.forInput(2, 2));
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.forInput(-1, 2));
+    }
+
+    public void testValidateRejectsPathTraversal() {
+        // Slot labels name on-disk spill files, so a separator or ".." must never reach the filesystem.
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.validate("../escape"));
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.validate("a/b"));
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.validate(".."));
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.validate(""));
+        expectThrows(IllegalArgumentException.class, () -> ShuffleSlots.validate(null));
+        assertEquals("left", ShuffleSlots.validate("left"));
+        assertEquals("in7", ShuffleSlots.validate("in7"));
+    }
+
+    public void testWorkerSetupNaryWireRoundtrip() throws Exception {
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        bySlot.put("in0", 5);
+        bySlot.put("in1", 3);
+        bySlot.put("in2", 7);
+        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-1", 9, 2, bySlot, false);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                ShuffleWorkerSetupInstructionNode decoded = new ShuffleWorkerSetupInstructionNode(in);
+                assertEquals(bySlot, decoded.getExpectedSendersBySlot());
+                assertEquals(5, decoded.getExpectedSenders("in0"));
+                assertEquals(7, decoded.getExpectedSenders("in2"));
+                assertEquals("an undeclared slot reads as -1 (leave unchanged)", -1, decoded.getExpectedSenders("in9"));
+                assertEquals("q-1", decoded.getQueryId());
+                assertEquals(9, decoded.getTargetStageId());
+                assertEquals(2, decoded.getPartitionIndex());
+                assertFalse(decoded.getPreferHashJoin());
+            }
+        }
+    }
+
+    public void testWorkerSetupBinaryCtorRoundtripsThroughSlots() throws Exception {
+        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-2", 4, -1, 7, 3, true);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                ShuffleWorkerSetupInstructionNode decoded = new ShuffleWorkerSetupInstructionNode(in);
+                assertEquals(7, decoded.getLeftExpectedSenders());
+                assertEquals(3, decoded.getRightExpectedSenders());
+                assertEquals(
+                    "binary ctor declares exactly the two historical slots",
+                    Map.of("left", 7, "right", 3),
+                    decoded.getExpectedSendersBySlot()
+                );
+            }
+        }
+    }
+
+    public void testWorkerSetupBinaryCtorOmitsNegativeSide() {
+        // The single-slot agg-shuffle path passes rightExpectedSenders=-1 meaning "no right slot at all";
+        // declaring it as -1 would leave a slot the buffer's awaitReady could never satisfy.
+        ShuffleWorkerSetupInstructionNode node = new ShuffleWorkerSetupInstructionNode("q-3", 4, 0, 2, -1, true);
+        assertEquals(Map.of("left", 2), node.getExpectedSendersBySlot());
+        assertEquals(-1, node.getRightExpectedSenders());
+    }
+}

--- a/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShuffleSlotsTests.java
+++ b/sandbox/libs/analytics-framework/src/test/java/org/opensearch/analytics/spi/ShuffleSlotsTests.java
@@ -61,7 +61,7 @@ public class ShuffleSlotsTests extends OpenSearchTestCase {
         bySlot.put("in0", 5);
         bySlot.put("in1", 3);
         bySlot.put("in2", 7);
-        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-1", 9, 2, bySlot, false);
+        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-1", 9, 2, bySlot, false, /* pipelined */ false);
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             original.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
@@ -74,12 +74,13 @@ public class ShuffleSlotsTests extends OpenSearchTestCase {
                 assertEquals(9, decoded.getTargetStageId());
                 assertEquals(2, decoded.getPartitionIndex());
                 assertFalse(decoded.getPreferHashJoin());
+                assertFalse("the shuffle shape must survive the wire too", decoded.isPipelined());
             }
         }
     }
 
     public void testWorkerSetupBinaryCtorRoundtripsThroughSlots() throws Exception {
-        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-2", 4, -1, 7, 3, true);
+        ShuffleWorkerSetupInstructionNode original = new ShuffleWorkerSetupInstructionNode("q-2", 4, -1, 7, 3, true, /* pipelined */ true);
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             original.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
@@ -98,7 +99,15 @@ public class ShuffleSlotsTests extends OpenSearchTestCase {
     public void testWorkerSetupBinaryCtorOmitsNegativeSide() {
         // The single-slot agg-shuffle path passes rightExpectedSenders=-1 meaning "no right slot at all";
         // declaring it as -1 would leave a slot the buffer's awaitReady could never satisfy.
-        ShuffleWorkerSetupInstructionNode node = new ShuffleWorkerSetupInstructionNode("q-3", 4, 0, 2, -1, true);
+        ShuffleWorkerSetupInstructionNode node = new ShuffleWorkerSetupInstructionNode(
+            "q-3",
+            4,
+            0,
+            2,
+            -1,
+            /* preferHashJoin */ true,
+            /* pipelined */ true
+        );
         assertEquals(Map.of("left", 2), node.getExpectedSendersBySlot());
         assertEquals(-1, node.getRightExpectedSenders());
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionedSink.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionPartitionedSink.java
@@ -27,6 +27,7 @@ import org.opensearch.core.action.ActionListener;
 import java.io.ByteArrayOutputStream;
 import java.nio.channels.Channels;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -75,6 +76,23 @@ public final class DatafusionPartitionedSink implements ExchangeSink {
     private final ShuffleCompression.Config compression;
 
     private final AtomicInteger pending = new AtomicInteger(0);
+
+    /**
+     * How long {@code close()} waits for outstanding sends before giving up.
+     *
+     * <p>Was 60s, which was ample when a shuffle send only ever queued briefly. Under the pipelined
+     * consumer it is not: admission rejects while a slot's in-flight window is full, and a probe-side
+     * send legitimately waits out the consumer's ENTIRE build phase, because {@code HashJoinExec} reads
+     * its inputs sequentially. At sf=10 that is minutes, so the 60s wait expired routinely, phase 1's
+     * "all data before any isLast" guarantee broke, and the outstanding rows were dropped — 27,499 late
+     * admits on one worker.
+     *
+     * <p>Kept comfortably ABOVE {@code ShuffleSenderRetry}'s ceiling so the two agree: a send that is
+     * still retrying has not yet exhausted its own budget, so close() must not give up first. The
+     * important change is not the number but that it now fails CLOSED (below) — the old 60s wait logged
+     * a warning and shipped isLast anyway, dropping whatever was still in flight.
+     */
+    private static final long PENDING_DRAIN_DEADLINE_MILLIS = TimeUnit.MINUTES.toMillis(3);
     private final AtomicReference<Throwable> firstError = new AtomicReference<>();
     private volatile boolean closed;
     private long batchesFed;
@@ -334,10 +352,10 @@ public final class DatafusionPartitionedSink implements ExchangeSink {
      * names the wave being drained for the timeout log.
      */
     private void awaitPendingDrain(String phase) {
-        long deadlineMs = System.currentTimeMillis() + 60_000;
+        long deadlineMs = System.currentTimeMillis() + PENDING_DRAIN_DEADLINE_MILLIS;
         while (pending.get() > 0 && System.currentTimeMillis() < deadlineMs) {
             try {
-                Thread.sleep(1);
+                Thread.sleep(5);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 firstError.compareAndSet(null, e);
@@ -345,7 +363,27 @@ public final class DatafusionPartitionedSink implements ExchangeSink {
             }
         }
         if (pending.get() > 0) {
-            LOGGER.warn("DatafusionPartitionedSink: timed out draining {} for {} ({} sends still pending)", phase, logTag, pending.get());
+            // FAIL CLOSED. This used to warn and continue, which silently broke the phase-1 guarantee:
+            // shipping isLast with data still in flight lets the consumer reach end-of-stream while rows
+            // are outstanding, and those rows are then dropped — a wrong answer with no error. Stamping
+            // firstError makes close() rethrow, so the producer fragment fails the query instead.
+            //
+            // isLast is still shipped (phase 2 continues) on purpose: withholding it would leave the
+            // consumer blocked until its own liveness timeout, turning a fast loud failure into a slow
+            // one. The consumer is independently protected — a late admit invalidates its slot.
+            IllegalStateException e = new IllegalStateException(
+                "DatafusionPartitionedSink: timed out draining "
+                    + phase
+                    + " for "
+                    + logTag
+                    + " after "
+                    + PENDING_DRAIN_DEADLINE_MILLIS
+                    + "ms ("
+                    + pending.get()
+                    + " sends still pending) — shipping isLast now would drop those rows"
+            );
+            firstError.compareAndSet(null, e);
+            LOGGER.error(e.getMessage());
         }
     }
 }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
@@ -78,7 +78,12 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
      *  Real shuffle producers are far faster — a single batch RTT over local transport is
      *  microseconds. */
     private static final long DEFAULT_AWAIT_READY_TIMEOUT_MS = Long.parseLong(
-        System.getProperty("analytics.mpp.shuffle.recv_timeout_ms", "5000")
+        // 5s was safe only while the drain started AFTER every producer had finished, so a chunk was always
+        // already resident. With worker tiers scheduling eagerly the drain overlaps its producers and the
+        // FIRST chunk legitimately arrives after however long the producer needs to scan and ship — well past
+        // 5s on a large shard. This is a per-chunk liveness bound against a stuck producer, not a deadline for
+        // the query, so it must exceed the producer phase; it matches the buffer's own stream-poll timeout.
+        System.getProperty("analytics.mpp.shuffle.recv_timeout_ms", "300000")
     );
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
@@ -78,12 +78,15 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
      *  Real shuffle producers are far faster — a single batch RTT over local transport is
      *  microseconds. */
     private static final long DEFAULT_AWAIT_READY_TIMEOUT_MS = Long.parseLong(
-        // 5s was safe only while the drain started AFTER every producer had finished, so a chunk was always
-        // already resident. With worker tiers scheduling eagerly the drain overlaps its producers and the
-        // FIRST chunk legitimately arrives after however long the producer needs to scan and ship — well past
-        // 5s on a large shard. This is a per-chunk liveness bound against a stuck producer, not a deadline for
-        // the query, so it must exceed the producer phase; it matches the buffer's own stream-poll timeout.
-        System.getProperty("analytics.mpp.shuffle.recv_timeout_ms", "300000")
+        // Two-sided bound. It must EXCEED the producer phase: 5s was safe only while the drain started after
+        // every producer had finished, so a chunk was always already resident, whereas an eagerly-scheduled
+        // drain overlaps its producers and the first chunk legitimately arrives only after a producer scans
+        // and ships a shard. It must also stay SMALL enough that a drain which will never receive a chunk
+        // fails promptly: at a high partition count some partition can go unfed, and a five-minute per-chunk
+        // wait turns that into a five-minute hang instead of an error. 60s covers observed producer phases
+        // (the slowest query here completes in single digits of seconds) with an order of magnitude of headroom,
+        // and bounds the pathological wait to a minute.
+        System.getProperty("analytics.mpp.shuffle.recv_timeout_ms", "60000")
     );
 
     @Override

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
@@ -25,6 +25,7 @@ import org.opensearch.analytics.spi.FragmentInstructionHandler;
 import org.opensearch.analytics.spi.ShuffleBufferAccess;
 import org.opensearch.analytics.spi.ShuffleBufferRegistry;
 import org.opensearch.analytics.spi.ShuffleScanInstructionNode;
+import org.opensearch.analytics.spi.ShuffleSlots;
 import org.opensearch.be.datafusion.nativelib.NativeBridge;
 
 import java.io.ByteArrayInputStream;
@@ -39,14 +40,14 @@ import java.io.ByteArrayInputStream;
  * partitioned stream.
  *
  * <p>The handler runs synchronously on the data-node executor thread that processes the
- * fragment's instruction list. {@link ShuffleBufferAccess#awaitReady} blocks here until both
- * left and right producers have all reported {@code isLast} for this partition, then the
- * handler drains the buffer's accumulated IPC chunks for the {@code "left"} or {@code "right"}
- * side (the named-input id encodes which) and pushes each batch into the native sender.
+ * fragment's instruction list. {@link ShuffleBufferAccess#awaitReady} blocks here until every
+ * declared slot's producers have all reported {@code isLast} for this partition, then the handler
+ * drains the buffer's accumulated IPC chunks for its own slot (see {@link ShuffleSlots}) and pushes
+ * each batch into the native sender.
  *
  * <p>Chain-ordering requirement: same as {@link BroadcastInjectionHandler} — must run AFTER
  * {@link ShardScanInstructionHandler} so the {@code SessionContextHandle} exists. The
- * dispatcher appends two of these per partition (left, right) after the shard-scan setup.
+ * dispatcher appends one of these per (partition, slot) after the shard-scan setup.
  *
  * <p>Schema discovery: the partition's IPC chunks each include their own schema header (per
  * the Arrow IPC stream spec). The handler reads the first chunk's header to derive the schema
@@ -65,7 +66,7 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
 
     private static final Logger LOGGER = LogManager.getLogger(ShuffleScanHandler.class);
 
-    /** Cap on how long the consumer waits for both producer sides to mark {@code isLast}.
+    /** Cap on how long the consumer waits for every slot's producers to mark {@code isLast}.
      *  Real producers complete within milliseconds on a healthy cluster — the cap exists
      *  solely as a backstop against stuck producers (cancelled queries cascade through the
      *  walker faster than this). Operator-tuneable via {@code analytics.mpp.shuffle.recv_timeout}
@@ -108,40 +109,34 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
                     + "AnalyticsSearchService.setShuffleBufferRegistry must be called at plugin startup."
             );
         }
-        // The instruction carries side ("left"/"right") explicitly. namedInputId is the canonical
-        // "input-<producerStageId>" the fragment convertor emits for the StageInputScan leaf below
-        // the stripped OpenSearchShuffleExchange — that's what the worker's Substrait plan binds
+        // The instruction carries its slot label explicitly (see ShuffleSlots) — the transport is
+        // N-ary, so this is any validated slot token, not just left/right. namedInputId is the
+        // canonical "input-<producerStageId>" the fragment convertor emits for the StageInputScan leaf
+        // below the stripped OpenSearchShuffleExchange — that's what the worker's Substrait plan binds
         // its NamedScan against.
         String inputId = node.getNamedInputId();
-        String side = node.getSide();
-        boolean isLeftSide = "left".equals(side);
-        if (!isLeftSide && !"right".equals(side)) {
-            throw new IllegalStateException(
-                "ShuffleScanHandler: side must be 'left' or 'right', got '" + side + "' (namedInputId=" + inputId + ")"
-            );
-        }
+        String slot = ShuffleSlots.validate(node.getSide());
 
         ShuffleBufferAccess buffer = registry.getOrCreate(node.getQueryId(), node.getTargetStageId(), node.getShufflePartitionIndex());
-        // expectedSenders for both sides are set eagerly by the ShuffleWorkerSetupHandler
-        // (which runs before any ShuffleScanHandler) so the buffer knows BOTH sides' counts
-        // before either side's awaitReady call blocks. Setting them per-side here would
-        // deadlock — the second side's count is set only AFTER the first side's blocked.
+        // expectedSenders for EVERY slot is declared eagerly by the ShuffleWorkerSetupHandler
+        // (which runs before any ShuffleScanHandler) so the buffer knows all counts before any
+        // slot's awaitReady call blocks. Declaring them per-slot here would deadlock — a later
+        // slot's count would be set only AFTER an earlier slot's handler had already blocked.
 
         try {
             LOGGER.debug(
-                "ShuffleScanHandler: awaiting partition stream queryId={}, stage={}, partition={}, side={}, expectedSenders={}",
+                "ShuffleScanHandler: awaiting partition stream queryId={}, stage={}, partition={}, slot={}, expectedSenders={}",
                 node.getQueryId(),
                 node.getTargetStageId(),
                 node.getShufflePartitionIndex(),
-                side,
+                slot,
                 node.getExpectedSenders()
             );
-            // Block here until BOTH sides' producers have all reported isLast for this partition.
-            // The buffer's awaitReady gates on left-and-right because the handler runs once for
-            // each side; both invocations agree the buffer is fully populated before either
-            // returns. The current handler still drains only its own side, but we must wait for
-            // both because the producer-side dispatch fires concurrently and the IPC bytes for
-            // the not-yet-arrived side are racing in the same buffer.
+            // Block here until EVERY declared slot's producers have all reported isLast for this
+            // partition. The handler runs once per slot and each invocation waits for all of them, so
+            // every invocation agrees the buffer is fully populated before any returns. A handler
+            // drains only its own slot, but it must wait for all of them because the producer-side
+            // dispatch fires concurrently and other slots' IPC bytes race into the same buffer.
             if (!buffer.awaitReady(DEFAULT_AWAIT_READY_TIMEOUT_MS)) {
                 throw new RuntimeException(
                     "ShuffleScanHandler: timed out waiting for shuffle producers to finish for "
@@ -160,7 +155,7 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
         // time — the rest stream from the spill file — so an over-budget partition drains without
         // re-materializing (the whole point of disk spill). The iterator owns the spill-file handle.
         BufferAllocator alloc = shardCtx.getAllocator();
-        CloseableIterator<byte[]> chunks = isLeftSide ? buffer.drainLeft() : buffer.drainRight();
+        CloseableIterator<byte[]> chunks = buffer.drain(slot);
 
         // Peek the first chunk for the schema (one chunk in heap is fine). No first chunk → empty
         // partition: register an empty memtable and return. Close the iterator on every path here.
@@ -274,11 +269,11 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
                     chunkCount++;
                 }
                 LOGGER.debug(
-                    "ShuffleScanHandler.drain: drained {} batches across {} chunks for {} (side={}, partition={})",
+                    "ShuffleScanHandler.drain: drained {} batches across {} chunks for {} (slot={}, partition={})",
                     totalBatches,
                     chunkCount,
                     inputId,
-                    side,
+                    slot,
                     node.getShufflePartitionIndex()
                 );
             } catch (Throwable t) {
@@ -301,7 +296,7 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
                 try {
                     if (drainFailure != null) {
                         // Truncated partition: surface an error to the consumer (not a clean EOF).
-                        finalSender.fail("shuffle drain failed for " + inputId + " (side=" + side + "): " + drainFailure);
+                        finalSender.fail("shuffle drain failed for " + inputId + " (slot=" + slot + "): " + drainFailure);
                     } else {
                         finalSender.close();
                     }
@@ -309,7 +304,7 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
                     LOGGER.warn("ShuffleScanHandler.drain: sender teardown failed for " + inputId, closeErr);
                 }
             }
-        }, "shuffle-drain-" + node.getQueryId() + "-" + node.getTargetStageId() + "-" + side + "-" + node.getShufflePartitionIndex());
+        }, "shuffle-drain-" + node.getQueryId() + "-" + node.getTargetStageId() + "-" + slot + "-" + node.getShufflePartitionIndex());
         drainThread.setDaemon(true);
         drainThread.start();
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleScanHandler.java
@@ -123,39 +123,27 @@ public class ShuffleScanHandler implements FragmentInstructionHandler<ShuffleSca
         // slot's awaitReady call blocks. Declaring them per-slot here would deadlock — a later
         // slot's count would be set only AFTER an earlier slot's handler had already blocked.
 
-        try {
-            LOGGER.debug(
-                "ShuffleScanHandler: awaiting partition stream queryId={}, stage={}, partition={}, slot={}, expectedSenders={}",
-                node.getQueryId(),
-                node.getTargetStageId(),
-                node.getShufflePartitionIndex(),
-                slot,
-                node.getExpectedSenders()
-            );
-            // Block here until EVERY declared slot's producers have all reported isLast for this
-            // partition. The handler runs once per slot and each invocation waits for all of them, so
-            // every invocation agrees the buffer is fully populated before any returns. A handler
-            // drains only its own slot, but it must wait for all of them because the producer-side
-            // dispatch fires concurrently and other slots' IPC bytes race into the same buffer.
-            if (!buffer.awaitReady(DEFAULT_AWAIT_READY_TIMEOUT_MS)) {
-                throw new RuntimeException(
-                    "ShuffleScanHandler: timed out waiting for shuffle producers to finish for "
-                        + inputId
-                        + " (timeout="
-                        + DEFAULT_AWAIT_READY_TIMEOUT_MS
-                        + "ms)"
-                );
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("ShuffleScanHandler: interrupted while awaiting shuffle producers for " + inputId, e);
-        }
+        LOGGER.debug(
+            "ShuffleScanHandler: opening partition stream queryId={}, stage={}, partition={}, slot={}, expectedSenders={}",
+            node.getQueryId(),
+            node.getTargetStageId(),
+            node.getShufflePartitionIndex(),
+            slot,
+            node.getExpectedSenders()
+        );
 
-        // LAZY drain: pull chunks one at a time. With spill, only ONE chunk is heap-resident at a
-        // time — the rest stream from the spill file — so an over-budget partition drains without
-        // re-materializing (the whole point of disk spill). The iterator owns the spill-file handle.
+        // PIPELINED drain: no barrier. The previous implementation blocked here (awaitReady) until every
+        // declared slot's producers had all reported isLast, which forced the ENTIRE partition to be
+        // resident — once on-heap as byte[] and again as Arrow buffers once the drain finally ran. That
+        // double residency is what exhausted the Arrow query pool (q17) and the DataFusion pool (q18).
+        //
+        // Now the iterator is concurrent with the producers: it blocks only for the NEXT chunk and ends
+        // at the stream's end-of-stream marker, which the buffer publishes exactly when this slot's
+        // declared senders have all reported isLast. Peak residency becomes the in-flight window rather
+        // than the partition size. The per-chunk timeout is a liveness bound (stalled producers), and it
+        // FAILS rather than reporting a clean end-of-stream so a stall can never under-deliver rows.
         BufferAllocator alloc = shardCtx.getAllocator();
-        CloseableIterator<byte[]> chunks = buffer.drain(slot);
+        CloseableIterator<byte[]> chunks = buffer.drain(slot, DEFAULT_AWAIT_READY_TIMEOUT_MS);
 
         // Peek the first chunk for the schema (one chunk in heap is fine). No first chunk → empty
         // partition: register an empty memtable and return. Close the iterator on every path here.

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleWorkerSetupHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleWorkerSetupHandler.java
@@ -42,13 +42,14 @@ public class ShuffleWorkerSetupHandler implements FragmentInstructionHandler<Shu
         BackendExecutionContext backendContext
     ) {
         ShardScanExecutionContext context = (ShardScanExecutionContext) commonContext;
-        // Set both sides' expected sender counts eagerly. The buffer must know both counts
-        // BEFORE any subsequent ShuffleScanHandler calls awaitReady — otherwise the second
-        // side's latch never fires (CountDownLatch with -1 expected stays blocked).
+        // Declare EVERY slot's expected sender count eagerly, in one call. The buffer must know all
+        // of them BEFORE any subsequent ShuffleScanHandler calls awaitReady — a slot declared later
+        // would not be waited on by an already-blocked consumer, and a slot left undeclared keeps its
+        // -1 target so its latch never fires.
         ShuffleBufferRegistry registry = context.getShuffleBufferRegistry();
         if (registry != null) {
             ShuffleBufferAccess buffer = registry.getOrCreate(node.getQueryId(), node.getTargetStageId(), node.getPartitionIndex());
-            buffer.setExpectedSenders(node.getLeftExpectedSenders(), node.getRightExpectedSenders());
+            buffer.setExpectedSenders(node.getExpectedSendersBySlot());
         }
         DataFusionService dataFusionService = plugin.getDataFusionService();
         long runtimePtr = dataFusionService.getNativeRuntime().get();

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleWorkerSetupHandler.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/ShuffleWorkerSetupHandler.java
@@ -50,6 +50,13 @@ public class ShuffleWorkerSetupHandler implements FragmentInstructionHandler<Shu
         if (registry != null) {
             ShuffleBufferAccess buffer = registry.getOrCreate(node.getQueryId(), node.getTargetStageId(), node.getPartitionIndex());
             buffer.setExpectedSenders(node.getExpectedSendersBySlot());
+            // Apply the coordinator's shuffle-shape decision to THIS buffer. One-way (materialized only):
+            // the node-level pipelined.enabled switch stays the operator's kill switch. This must happen
+            // before any producer chunk is admitted, which it does — the setup instruction runs ahead of
+            // every ShuffleScanHandler, and admission consults the buffer's mode on each chunk.
+            if (node.isPipelined() == false) {
+                buffer.useMaterializedMode();
+            }
         }
         DataFusionService dataFusionService = plugin.getDataFusionService();
         long runtimePtr = dataFusionService.getNativeRuntime().get();

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -213,6 +213,9 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         applyShuffleStreamWindow(clusterService.getClusterSettings().get(AnalyticsSettings.MPP_SHUFFLE_STREAM_WINDOW));
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsSettings.MPP_SHUFFLE_STREAM_WINDOW, this::applyShuffleStreamWindow);
+        applyShufflePipelined(clusterService.getClusterSettings().get(AnalyticsSettings.MPP_SHUFFLE_PIPELINED_ENABLED));
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(AnalyticsSettings.MPP_SHUFFLE_PIPELINED_ENABLED, this::applyShufflePipelined);
         // Resolve the spill root once from the environment's first data path (settings default ""
         // means "use <path.data>/shuffle_spill"); a non-empty setting overrides it. Then wire the
         // spill config from settings (initial value + dynamic updates). Default OFF — when disabled
@@ -278,6 +281,16 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         long bytes = window == null ? 0L : window.getBytes();
         shuffleBufferManager.setStreamWindowBytes(bytes);
         logger.info("[analytics] hash-shuffle in-flight window set to {} bytes ({})", bytes, bytes <= 0 ? "disabled" : "enabled");
+    }
+
+    /**
+     * Apply the pipelined-shuffle kill switch. Enabled by default; disabling makes a consumer wait for
+     * all of its producers before draining, which restores partition-sized residency. Called at startup
+     * and on dynamic updates.
+     */
+    private void applyShufflePipelined(boolean enabled) {
+        shuffleBufferManager.setPipelinedEnabled(enabled);
+        logger.info("[analytics] hash-shuffle pipelined drain {}", enabled ? "enabled" : "disabled (waits for producers)");
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -110,6 +110,21 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
     private static final int REDUCE_POOL_SIZE = Math.max(8, Runtime.getRuntime().availableProcessors() * 4);
     private static final int REDUCE_QUEUE_SIZE = 200;
 
+    public static final String WORKER_THREAD_POOL_NAME = "analytics_worker";
+
+    // Worker fragments need the same isolation as reduces, for the same reason and then some. A shuffle
+    // WORKER blocks in its shuffle scan until its producers deliver, and in a multi-level cascade the
+    // producers are themselves fragments needing a thread. Sharing SEARCH therefore deadlocks outright
+    // once the worker tasks on a node outnumber that pool: every thread ends up held by a consumer
+    // waiting for a producer that is queued behind it, so nothing can progress and the drain times out
+    // with zero senders received. The task count grows with the shuffle partition count, so this
+    // ceiling is what caps how far partitions can be raised.
+    //
+    // Like reduce threads, these are blocked on data arrival rather than computing, so the pool is
+    // sized well above the core count: it must exceed the deepest cascade's per-node task count, and
+    // idle blocked threads are cheap. Memory stays bounded by the DataFusion pool, not by this size.
+    private static final int WORKER_QUEUE_SIZE = 1000;
+
     // Per-query coordinator allocator cap in bytes. 0 (default) → no per-query child allocator;
     // queries share the coordinator allocator with no per-query cap.
     public static final Setting<Long> COORDINATOR_BUFFER_LIMIT = Setting.longSetting(
@@ -379,12 +394,18 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         int poolSize = schedulerPoolSize();
         return List.of(
             new FixedExecutorBuilder(settings, SCHEDULER_THREAD_POOL_NAME, poolSize, SCHEDULER_QUEUE_SIZE, "analytics"),
-            new FixedExecutorBuilder(settings, REDUCE_THREAD_POOL_NAME, REDUCE_POOL_SIZE, REDUCE_QUEUE_SIZE, "analytics_reduce")
+            new FixedExecutorBuilder(settings, REDUCE_THREAD_POOL_NAME, REDUCE_POOL_SIZE, REDUCE_QUEUE_SIZE, "analytics_reduce"),
+            new FixedExecutorBuilder(settings, WORKER_THREAD_POOL_NAME, workerPoolSize(), WORKER_QUEUE_SIZE, "analytics_worker")
         );
     }
 
     static int schedulerPoolSize() {
         return Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+    }
+
+    /** Sized for blocked tasks, not for CPUs — see {@link #WORKER_THREAD_POOL_NAME}. */
+    static int workerPoolSize() {
+        return Math.max(16, Runtime.getRuntime().availableProcessors() * 8);
     }
 
     @Override

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -58,6 +58,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
@@ -209,6 +210,9 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         applyShuffleBudget(clusterService.getClusterSettings().get(AnalyticsSettings.MPP_SHUFFLE_NODE_BUDGET_PERCENT));
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(AnalyticsSettings.MPP_SHUFFLE_NODE_BUDGET_PERCENT, this::applyShuffleBudget);
+        applyShuffleStreamWindow(clusterService.getClusterSettings().get(AnalyticsSettings.MPP_SHUFFLE_STREAM_WINDOW));
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(AnalyticsSettings.MPP_SHUFFLE_STREAM_WINDOW, this::applyShuffleStreamWindow);
         // Resolve the spill root once from the environment's first data path (settings default ""
         // means "use <path.data>/shuffle_spill"); a non-empty setting overrides it. Then wire the
         // spill config from settings (initial value + dynamic updates). Default OFF — when disabled
@@ -263,6 +267,17 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin, ActionP
         }
         shuffleBufferManager.setBudgets(budget, budget);
         logger.info("[analytics] hash-shuffle node budget set to {}% of max heap = {} bytes", percent, budget);
+    }
+
+    /**
+     * Apply the pipelined-shuffle in-flight window. Unlike the node budget above (an absolute OOM
+     * backstop sized off heap), this is the drain-rate-coupled bound that keeps peak shuffle residency
+     * independent of partition size. Called at startup and on dynamic updates.
+     */
+    private void applyShuffleStreamWindow(ByteSizeValue window) {
+        long bytes = window == null ? 0L : window.getBytes();
+        shuffleBufferManager.setStreamWindowBytes(bytes);
+        logger.info("[analytics] hash-shuffle in-flight window set to {} bytes ({})", bytes, bytes <= 0 ? "disabled" : "enabled");
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
@@ -136,19 +136,31 @@ public final class AnalyticsSettings {
     );
 
     /**
-     * Whether a hash-shuffle consumer drains CONCURRENTLY with its producers (default) or waits for all
-     * of them to finish first.
+     * Node-level KILL SWITCH for the pipelined shuffle shape — whether a hash-shuffle consumer may drain
+     * CONCURRENTLY with its producers (default) or must wait for all of them first (materialized).
      *
-     * <p>Enabled by default: the barrier it removes is what forces a whole partition to be resident
-     * twice over — once as buffered chunks and again as decoded batches — which is the dominant peak in
-     * shuffle-heavy plans. Streaming makes peak residency a function of arrival rate instead of
-     * partition size.
+     * <p>The shape is normally chosen PER WORKER STAGE by the coordinator, from the same estimate that
+     * decides whether the worker join can be an in-memory hash join
+     * ({@code ShuffleEnrichment.enrichLevels}): a build that does not fit takes the materialized shape,
+     * because there a bound that cannot fail is worth more than overlap. This setting is the operator's
+     * override in the safe direction only — {@code false} forces every worker stage to materialize;
+     * {@code true} (default) lets the plan decide. A stage can narrow to materialized but never broaden
+     * back to pipelined, so the switch cannot be defeated by a plan.
      *
-     * <p>Kept as a switch purely so the streaming path can be ruled out when diagnosing a shuffle
-     * failure, since it changes the timing of every producer/consumer interaction. Turning it off is a
-     * memory regression, not a safe default: correctness is identical either way, and a stalled producer
-     * fails loudly on both paths rather than short-reading. Distinct from
-     * {@link #MPP_SHUFFLE_STREAM_WINDOW}, which paces producers WITHIN the streaming path.
+     * <p>What each shape trades:
+     * <ul>
+     *   <li>PIPELINED — the drain starts on the first chunk, so peak residency follows arrival rate
+     *       rather than partition size (the barrier it removes is what forced a whole partition to be
+     *       resident twice over, once as buffered chunks and again as decoded batches). Its backpressure
+     *       is a retryable reject, which can exhaust the sender's attempt budget and fail the query.</li>
+     *   <li>MATERIALIZED — the producers all finish first, and the accumulating buffer SPILLS
+     *       ({@link #MPP_SHUFFLE_SPILL_ENABLED}), so residency is bounded by a shallow window and a full
+     *       window is relieved by disk instead of by a retry. Slower (no overlap), but backpressure
+     *       cannot fail the query. Without spill enabled it degrades to the pre-streaming behaviour:
+     *       the whole partition resident, bounded only by the node budget.</li>
+     * </ul>
+     * Correctness is identical either way, and a stalled producer fails loudly on both paths rather than
+     * short-reading.
      */
     public static final Setting<Boolean> MPP_SHUFFLE_PIPELINED_ENABLED = Setting.boolSetting(
         "analytics.mpp.shuffle.pipelined.enabled",
@@ -162,23 +174,33 @@ public final class AnalyticsSettings {
      * queued-but-undrained on one (buffer, slot) before admission returns a retryable reject, pacing
      * producers to the consumer's drain rate.
      *
-     * <p><b>DISABLED by default (0), and it must stay that way until backpressure is a real PAUSE.</b>
-     * The intent is to bound peak residency independently of partition size. As implemented, a full
-     * window is signalled by a retryable REJECT, and that DEADLOCKS: {@code HashJoinExec} reads its
-     * inputs sequentially, so the probe-side drain blocks at the native channel's capacity until the
-     * build completes, the probe window fills, and its producers enter a re-send storm on the bounded
-     * GENERIC pool — contending with the very work that would release them. Measured at sf=10: all seven
-     * probe queries hung to the harness's 150s cap with a 64MB window; with the window off the same
-     * build passed q5/q11/q13/q19/q21 with no regressions.
+     * <p><b>Unset (0) by default, and it should stay unset for PIPELINED stages.</b> There a full window
+     * is signalled by a retryable REJECT, and a reject can fail a query: {@code ShuffleSenderRetry}
+     * gives up after a bounded number of attempts. Measured at sf=10 over 13 shuffle-heavy queries,
+     * failures rose MONOTONICALLY as the window shrank — 11/13 passing with the window off, 10/13 at
+     * 64 MB, 8/13 at 16 MB — and q3/q19 also ran 2-3x slower. Making a window safe under pipelining
+     * needs the producer to STOP PULLING while it is full (ClickHouse's {@code StreamingExchangeSink}:
+     * "Propagate back-pressure upstream: don't pull until there's room", returning {@code Status::Async})
+     * rather than to re-send; a pause cannot fail, a bounded re-send can.
      *
-     * <p>Streaming alone (this window disabled) still lowers peak residency, because the drain starts on
-     * the first chunk instead of after a barrier, so on-heap bytes are consumed as they arrive rather than
-     * accumulated — q18's heap fell 63% => 42%, q5's to 6%. The absolute backstop remains
-     * {@link #MPP_SHUFFLE_NODE_BUDGET_PERCENT}.
+     * <p>On a MATERIALIZED stage ({@link #MPP_SHUFFLE_PIPELINED_ENABLED}) the same window is safe and is
+     * applied by default, because nothing is draining yet: a full window is relieved by SPILLING the
+     * slot's oldest chunks, so the producer is never asked to retry. There, this setting overrides the
+     * derived default ({@code ShuffleBufferManager.MATERIALIZED_WINDOW_DEFAULT_BYTES}). With spill
+     * disabled the window is IGNORED on those stages rather than enforced — nothing could relieve it, so
+     * enforcing it would be a guaranteed failure for any partition larger than the window.
      *
-     * <p>Enabling this needs the producer to STOP PULLING while the window is full (ClickHouse's
-     * {@code StreamingExchangeSink}: "Propagate back-pressure upstream: don't pull until there's room",
-     * returning {@code Status::Async}), not to re-send. A pause cannot fail; a re-send storm can.
+     * <p>Note the earlier explanation of the pipelined deadlock recorded here was wrong on mechanism: it
+     * blamed GENERIC-pool contention between retries and the work that releases the window, plus
+     * {@code HashJoinExec}'s build-before-probe ordering. Neither holds — the release path runs on the
+     * worker pool and a raw drain thread, and at the time the consumer stage was not scheduled until every
+     * producer had SUCCEEDED, so during the producer phase there was no drain to release the window at
+     * all. Worker stages now schedule eagerly, which removed that structural cause; what remains is the
+     * bounded-retry ceiling above.
+     *
+     * <p>Streaming alone (this window unset) still lowers peak residency, because the drain starts on the
+     * first chunk instead of after a barrier — q18's heap fell 63% => 42%, q5's to 6%. The absolute
+     * backstop remains {@link #MPP_SHUFFLE_NODE_BUDGET_PERCENT}.
      */
     public static final Setting<ByteSizeValue> MPP_SHUFFLE_STREAM_WINDOW = Setting.byteSizeSetting(
         "analytics.mpp.shuffle.stream_window",
@@ -287,9 +309,21 @@ public final class AnalyticsSettings {
      * and the consumer drains spilled chunks back (in arrival order) followed by the in-memory tail —
      * preserving the proven buffer-all consumer contract.
      *
+     * <p>Two things trigger a spill, and the second is what makes the MATERIALIZED shuffle shape worth
+     * choosing (see {@link #MPP_SHUFFLE_PIPELINED_ENABLED}):
+     * <ul>
+     *   <li>a per-query on-heap budget breach — the original trigger, an alternative to failing fast;</li>
+     *   <li>a full per-slot in-flight window ({@link #MPP_SHUFFLE_STREAM_WINDOW}), which turns
+     *       backpressure into a disk write instead of a producer retry. Only possible while no consumer is
+     *       draining the buffer, since eviction takes from the queue head the consumer reads — i.e.
+     *       throughout a materialized stage's accumulation phase, and only before the drain starts on a
+     *       pipelined one.</li>
+     * </ul>
+     *
      * <p>When {@code false} (default), behavior is byte-identical to the pre-spill fail-fast path: a
-     * per-query budget breach still throws {@code ShuffleBufferExceededException}. The node-budget
-     * REJECT_RETRY (transient cross-query contention) path is unchanged either way.
+     * per-query budget breach still throws {@code ShuffleBufferExceededException}, and a materialized
+     * stage has no residency bound beyond that budget. The node-budget REJECT_RETRY (transient
+     * cross-query contention) path is unchanged either way.
      *
      * <p>Even with spill enabled the query still fails — re-messaged to name {@code spill.max_bytes} /
      * disk-full — once the disk ceiling {@link #MPP_SHUFFLE_SPILL_MAX_BYTES} is hit or a spill write

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
@@ -136,7 +136,39 @@ public final class AnalyticsSettings {
     );
 
     /**
-     * Size floor for the general post-CBO distribution-enforcement pass ({@code DistributionEnforcementPass},
+     * Per-slot in-flight window for the pipelined shuffle consumer: the maximum bytes that may sit
+     * queued-but-undrained on one (buffer, slot) before admission returns a retryable reject, pacing
+     * producers to the consumer's drain rate.
+     *
+     * <p><b>DISABLED by default (0), and it must stay that way until backpressure is a real PAUSE.</b>
+     * The intent is to bound peak residency independently of partition size. As implemented, a full
+     * window is signalled by a retryable REJECT, and that DEADLOCKS: {@code HashJoinExec} reads its
+     * inputs sequentially, so the probe-side drain blocks at the native channel's capacity until the
+     * build completes, the probe window fills, and its producers enter a re-send storm on the bounded
+     * GENERIC pool — contending with the very work that would release them. Measured at sf=10: all seven
+     * probe queries hung to the harness's 150s cap with a 64MB window; with the window off the same
+     * build passed q5/q11/q13/q19/q21 with no regressions.
+     *
+     * <p>Streaming alone (this window disabled) still lowers peak residency, because the drain starts on
+     * the first chunk instead of after a barrier, so on-heap bytes are consumed as they arrive rather than
+     * accumulated — q18's heap fell 63% => 42%, q5's to 6%. The absolute backstop remains
+     * {@link #MPP_SHUFFLE_NODE_BUDGET_PERCENT}.
+     *
+     * <p>Enabling this needs the producer to STOP PULLING while the window is full (ClickHouse's
+     * {@code StreamingExchangeSink}: "Propagate back-pressure upstream: don't pull until there's room",
+     * returning {@code Status::Async}), not to re-send. A pause cannot fail; a re-send storm can.
+     */
+    public static final Setting<ByteSizeValue> MPP_SHUFFLE_STREAM_WINDOW = Setting.byteSizeSetting(
+        "analytics.mpp.shuffle.stream_window",
+        new ByteSizeValue(0L),
+        new ByteSizeValue(0L),
+        new ByteSizeValue(Long.MAX_VALUE),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Size floor for distributing an operator onto a worker tier (
      * the only MPP scheduler): a join/aggregate is distributed onto a worker tier only when its larger scan
      * subtree exceeds this many rows (or a deeper operator already distributed — the cascade continues upward
      * regardless). Below the floor the operator stays coordinator-centric, matching CBO's cheap choice for
@@ -206,7 +238,7 @@ public final class AnalyticsSettings {
      * Per-strategy sub-toggle for distributed <em>aggregation</em> (the {@code HASH_SHUFFLE_AGG}
      * strategy): a decomposable {@code GROUP BY} over a distributed join is split PARTIAL (on the join's
      * worker tier, per-partition) + FINAL (gathered to the coordinator) by the general post-CBO pass
-     * {@code DistributionEnforcementPass}, instead of gathering the whole join output and aggregating
+     * CBO's trait enforcement, instead of gathering the whole join output and aggregating
      * serially on the coordinator.
      *
      * <p>Gated under {@link #MPP_ENABLED}: this only has effect when MPP is on. When {@code true}
@@ -367,6 +399,7 @@ public final class AnalyticsSettings {
         MPP_SHUFFLE_PARTITIONS,
         MPP_SHUFFLE_RECV_TIMEOUT,
         MPP_SHUFFLE_NODE_BUDGET_PERCENT,
+        MPP_SHUFFLE_STREAM_WINDOW,
         MPP_SHUFFLE_AGGREGATE_ENABLED,
         MPP_DISTRIBUTE_MIN_ROWS,
         MPP_JOIN_REORDER,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsSettings.java
@@ -136,6 +136,28 @@ public final class AnalyticsSettings {
     );
 
     /**
+     * Whether a hash-shuffle consumer drains CONCURRENTLY with its producers (default) or waits for all
+     * of them to finish first.
+     *
+     * <p>Enabled by default: the barrier it removes is what forces a whole partition to be resident
+     * twice over — once as buffered chunks and again as decoded batches — which is the dominant peak in
+     * shuffle-heavy plans. Streaming makes peak residency a function of arrival rate instead of
+     * partition size.
+     *
+     * <p>Kept as a switch purely so the streaming path can be ruled out when diagnosing a shuffle
+     * failure, since it changes the timing of every producer/consumer interaction. Turning it off is a
+     * memory regression, not a safe default: correctness is identical either way, and a stalled producer
+     * fails loudly on both paths rather than short-reading. Distinct from
+     * {@link #MPP_SHUFFLE_STREAM_WINDOW}, which paces producers WITHIN the streaming path.
+     */
+    public static final Setting<Boolean> MPP_SHUFFLE_PIPELINED_ENABLED = Setting.boolSetting(
+        "analytics.mpp.shuffle.pipelined.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Per-slot in-flight window for the pipelined shuffle consumer: the maximum bytes that may sit
      * queued-but-undrained on one (buffer, slot) before admission returns a retryable reject, pacing
      * producers to the consumer's drain rate.
@@ -400,6 +422,7 @@ public final class AnalyticsSettings {
         MPP_SHUFFLE_RECV_TIMEOUT,
         MPP_SHUFFLE_NODE_BUDGET_PERCENT,
         MPP_SHUFFLE_STREAM_WINDOW,
+        MPP_SHUFFLE_PIPELINED_ENABLED,
         MPP_SHUFFLE_AGGREGATE_ENABLED,
         MPP_DISTRIBUTE_MIN_ROWS,
         MPP_JOIN_REORDER,

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/AnalyticsSearchTransportService.java
@@ -11,6 +11,7 @@ package org.opensearch.analytics.exec;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.analytics.AnalyticsPlugin;
 import org.opensearch.analytics.backend.EngineResultBatch;
 import org.opensearch.analytics.exec.action.FetchByRowIdsAction;
 import org.opensearch.analytics.exec.action.FetchByRowIdsRequest;
@@ -174,7 +175,12 @@ public class AnalyticsSearchTransportService {
                         } catch (Exception ignored) {}
                     }
                 },
-                transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+                // Worker fragments get their OWN pool, never SEARCH: a worker blocks in its shuffle scan
+                // until its producers deliver, and those producers need a thread too. Sharing SEARCH
+                // deadlocks once a node's worker tasks outnumber that pool -- every thread held by a
+                // consumer waiting on a producer queued behind it. Shard-scan fragments stay on SEARCH
+                // precisely so consumers can never crowd the producers out.
+                transportService.getThreadPool().executor(AnalyticsPlugin.WORKER_THREAD_POOL_NAME)
             )
         );
     }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/ShuffleEnrichment.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/ShuffleEnrichment.java
@@ -22,11 +22,14 @@ import org.opensearch.analytics.spi.DataTransferCapability;
 import org.opensearch.analytics.spi.InstructionNode;
 import org.opensearch.analytics.spi.ShuffleProducerInstructionNode;
 import org.opensearch.analytics.spi.ShuffleScanInstructionNode;
+import org.opensearch.analytics.spi.ShuffleSlots;
 import org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode;
 import org.opensearch.cluster.service.ClusterService;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Shared hash-shuffle worker-tier primitives used by the general MPP scheduler (Option B — see
@@ -36,8 +39,8 @@ import java.util.List;
  *
  * <p>Holds three things, all formerly living in the deleted cascade/hash-shuffle dispatchers:
  * <ul>
- *   <li>{@link WorkerLevel} — the per-join-level descriptor (worker stage + its two shuffle producers +
- *       per-side hash keys + partition count + target node list);</li>
+ *   <li>{@link WorkerLevel} — the per-level descriptor (worker stage + its shuffle {@link WorkerInput}s,
+ *       each a producer + hash keys + slot label, plus partition count + target node list);</li>
  *   <li>{@link #enrichLevels} — attaches each level's producer/scan/worker shuffle instructions bottom-up;</li>
  *   <li>{@link #enrichProducerAlternatives} / {@link #enrichWorkerAlternatives} / {@link #canonicalInputId}
  *       — the per-stage instruction attachment + the canonical {@code input-<producerStageId>} naming the
@@ -59,12 +62,61 @@ public final class ShuffleEnrichment {
     private ShuffleEnrichment() {}
 
     /**
-     * One join level's worker-tier descriptor: the promoted worker stage, its two shuffle producer
-     * stages, the per-side hash keys the producers must partition their output on, the partition count,
-     * and the resolved target node list (one node per partition).
+     * One shuffle input of a worker level: the producer stage feeding it, the hash keys that producer
+     * must partition its output on, and the slot label the two sides meet on (see {@link ShuffleSlots}).
      */
-    public record WorkerLevel(Stage worker, Stage leftProducer, Stage rightProducer, List<Integer> leftKeys, List<Integer> rightKeys,
-        int partitionCount, List<String> targetNodeIds) {
+    public record WorkerInput(Stage producer, List<Integer> hashKeys, String slot) {
+    }
+
+    /**
+     * One worker level's tier descriptor: the promoted worker stage, its shuffle inputs (two for a
+     * hash join — more once an N-way consumer is promoted), the partition count, and the resolved
+     * target node list (one node per partition).
+     */
+    public record WorkerLevel(Stage worker, List<WorkerInput> inputs, int partitionCount, List<String> targetNodeIds) {
+
+        /** Binary convenience ctor: {@code left} → the {@code left} slot, {@code right} → {@code right}. */
+        public WorkerLevel(
+            Stage worker,
+            Stage leftProducer,
+            Stage rightProducer,
+            List<Integer> leftKeys,
+            List<Integer> rightKeys,
+            int partitionCount,
+            List<String> targetNodeIds
+        ) {
+            this(
+                worker,
+                List.of(
+                    new WorkerInput(leftProducer, leftKeys, ShuffleSlots.LEFT),
+                    new WorkerInput(rightProducer, rightKeys, ShuffleSlots.RIGHT)
+                ),
+                partitionCount,
+                targetNodeIds
+            );
+        }
+
+        /** The input on {@code slot}, or null if this level has none. */
+        public WorkerInput input(String slot) {
+            for (WorkerInput in : inputs) {
+                if (in.slot().equals(slot)) {
+                    return in;
+                }
+            }
+            return null;
+        }
+
+        /** The {@code left}-slot producer stage (binary accessor retained for tests / logging). */
+        public Stage leftProducer() {
+            WorkerInput in = input(ShuffleSlots.LEFT);
+            return in == null ? null : in.producer();
+        }
+
+        /** The {@code right}-slot producer stage (binary accessor retained for tests / logging). */
+        public Stage rightProducer() {
+            WorkerInput in = input(ShuffleSlots.RIGHT);
+            return in == null ? null : in.producer();
+        }
     }
 
     /**
@@ -100,64 +152,48 @@ public final class ShuffleEnrichment {
                 );
             }
 
-            int leftExpected = expectedSendersFor(level.leftProducer(), partitionCount, clusterService);
-            int rightExpected = expectedSendersFor(level.rightProducer(), partitionCount, clusterService);
-
-            // Producers ship to THIS worker's partitions (its node list), tagged with the side. The hash
-            // keys are THIS join level's per-side keys — passed explicitly because an intermediate-worker
+            // Producers ship to THIS worker's partitions (its node list), tagged with their slot. The hash
+            // keys are THIS level's per-input keys — passed explicitly because an intermediate-worker
             // producer's own exchange info is SINGLETON (empty keys); it must partition its join OUTPUT on
             // the parent join's keys, not its (gathered) input's.
-            enrichProducerAlternatives(
-                level.leftProducer(),
-                level.leftKeys(),
-                ctx.queryId(),
-                workerStageId,
-                partitionCount,
-                targets,
-                "left",
-                capabilityRegistry
-            );
-            enrichProducerAlternatives(
-                level.rightProducer(),
-                level.rightKeys(),
-                ctx.queryId(),
-                workerStageId,
-                partitionCount,
-                targets,
-                "right",
-                capabilityRegistry
-            );
+            Map<String, Integer> expectedBySlot = new LinkedHashMap<>();
+            Map<String, Integer> producerStageIdBySlot = new LinkedHashMap<>();
+            for (WorkerInput input : level.inputs()) {
+                expectedBySlot.put(input.slot(), expectedSendersFor(input.producer(), partitionCount, clusterService));
+                producerStageIdBySlot.put(input.slot(), input.producer().getStageId());
+                enrichProducerAlternatives(
+                    input.producer(),
+                    input.hashKeys(),
+                    ctx.queryId(),
+                    workerStageId,
+                    partitionCount,
+                    targets,
+                    input.slot(),
+                    capabilityRegistry
+                );
+            }
             // Cost decision (Spark-style, made where the stats live — on the coordinator): if the build side
-            // (right input) is estimated to exceed the sort-merge-join floor, tell the worker to use a
-            // spillable sort-merge join instead of the non-spillable hash-join build. Estimated from the
-            // right producer's largest scan subtree (the build feeds from the right producer's shuffle).
-            long buildRows = subtreeMaxScanRows(level.rightProducer().getFragment());
+            // is estimated to exceed the sort-merge-join floor, tell the worker to use a spillable
+            // sort-merge join instead of the non-spillable hash-join build. The build feeds from the LAST
+            // input's shuffle (the right side of a binary join), so estimate from that producer's largest
+            // scan subtree.
+            Stage buildProducer = level.inputs().getLast().producer();
+            long buildRows = subtreeMaxScanRows(buildProducer.getFragment());
             boolean preferHashJoin = buildRows < sortMergeJoinMinRows;
 
-            // The worker consumes its two producers' partitions. enrichWorkerAlternatives prepends a setup
-            // placeholder and appends per-(partition,side) scans; a producer instruction (added above when
+            // The worker consumes every producer's partitions. enrichWorkerAlternatives prepends a setup
+            // placeholder and appends per-(partition,slot) scans; a producer instruction (added above when
             // this worker also feeds a higher level) stays AFTER the scans because enrichProducerAlternatives
             // appended it to the worker's own alternatives.
-            enrichWorkerAlternatives(
-                worker,
-                partitionCount,
-                leftExpected,
-                rightExpected,
-                ctx.queryId(),
-                level.leftProducer().getStageId(),
-                level.rightProducer().getStageId(),
-                preferHashJoin
-            );
+            enrichWorkerAlternatives(worker, partitionCount, expectedBySlot, ctx.queryId(), producerStageIdBySlot, preferHashJoin);
 
             LOGGER.debug(
-                "[ShuffleEnrichment] level worker={} left={} right={} partitions={} leftSenders={} rightSenders={} "
+                "[ShuffleEnrichment] level worker={} producers={} partitions={} expectedSenders={} "
                     + "buildRows={} preferHashJoin={} targets={}",
                 workerStageId,
-                level.leftProducer().getStageId(),
-                level.rightProducer().getStageId(),
+                producerStageIdBySlot,
                 partitionCount,
-                leftExpected,
-                rightExpected,
+                expectedBySlot,
                 buildRows,
                 preferHashJoin,
                 targets
@@ -228,11 +264,14 @@ public final class ShuffleEnrichment {
     }
 
     /**
-     * Appends every (partition × side) {@link ShuffleScanInstructionNode} to the worker stage's plan
+     * Appends every (partition × slot) {@link ShuffleScanInstructionNode} to the worker stage's plan
      * alternatives, prefixed by a {@link ShuffleWorkerSetupInstructionNode} that bootstraps a worker-mode
-     * session context. The {@code WorkerFragmentStageExecutionFactory} filters this list down to the two
+     * session context. The {@code WorkerFragmentStageExecutionFactory} filters this list down to the
      * ShuffleScan instructions for each task's partition before sending the per-task request — the setup
      * instruction passes through unfiltered.
+     *
+     * <p>{@code expectedSendersBySlot} and {@code producerStageIdBySlot} must have the SAME key set —
+     * one entry per input stream the worker reads.
      */
     public static void enrichWorkerAlternatives(
         Stage workerStage,
@@ -244,27 +283,63 @@ public final class ShuffleEnrichment {
         int rightProducerStageId,
         boolean preferHashJoin
     ) {
+        // LinkedHashMap built left-then-right: slot order drives the per-partition scan emission order, so
+        // Map.of (unordered) would make the interleaving non-deterministic.
+        Map<String, Integer> expected = new LinkedHashMap<>();
+        expected.put(ShuffleSlots.LEFT, leftExpectedSenders);
+        expected.put(ShuffleSlots.RIGHT, rightExpectedSenders);
+        Map<String, Integer> producers = new LinkedHashMap<>();
+        producers.put(ShuffleSlots.LEFT, leftProducerStageId);
+        producers.put(ShuffleSlots.RIGHT, rightProducerStageId);
+        enrichWorkerAlternatives(workerStage, partitionCount, expected, queryId, producers, preferHashJoin);
+    }
+
+    public static void enrichWorkerAlternatives(
+        Stage workerStage,
+        int partitionCount,
+        Map<String, Integer> expectedSendersBySlot,
+        String queryId,
+        Map<String, Integer> producerStageIdBySlot,
+        boolean preferHashJoin
+    ) {
+        if (!expectedSendersBySlot.keySet().equals(producerStageIdBySlot.keySet())) {
+            throw new IllegalArgumentException(
+                "ShuffleEnrichment: expectedSenders slots "
+                    + expectedSendersBySlot.keySet()
+                    + " disagree with producer-stage slots "
+                    + producerStageIdBySlot.keySet()
+            );
+        }
         int workerStageId = workerStage.getStageId();
-        // The fragment convertor strips OpenSearchShuffleExchange, so the worker fragment ends up with two
-        // OpenSearchStageInputScan leaves the convertor rewrites to "input-<producerStageId>" NamedScans.
-        // The handler must register its streaming table under that exact name.
-        String leftInputId = canonicalInputId(leftProducerStageId);
-        String rightInputId = canonicalInputId(rightProducerStageId);
+        // The fragment convertor strips OpenSearchShuffleExchange, so the worker fragment ends up with one
+        // OpenSearchStageInputScan leaf per input, which the convertor rewrites to an
+        // "input-<producerStageId>" NamedScan. The handler must register its streaming table under that
+        // exact name.
+        int slotCount = producerStageIdBySlot.size();
         List<StagePlan> enriched = new ArrayList<>(workerStage.getPlanAlternatives().size());
         for (StagePlan sp : workerStage.getPlanAlternatives()) {
             List<InstructionNode> existing = sp.instructions();
-            List<InstructionNode> merged = new ArrayList<>(1 + existing.size() + 2 * partitionCount);
+            List<InstructionNode> merged = new ArrayList<>(1 + existing.size() + slotCount * partitionCount);
             // Placeholder setup with partition=-1 — the per-task filter in
-            // WorkerFragmentStageExecutionFactory replaces this with a partition-specific copy carrying both
-            // sides' expected sender counts. We don't know the partition at this step (one alternative serves
+            // WorkerFragmentStageExecutionFactory replaces this with a partition-specific copy carrying every
+            // slot's expected sender count. We don't know the partition at this step (one alternative serves
             // all partitions; per-task filtering picks the right one).
-            merged.add(
-                new ShuffleWorkerSetupInstructionNode(queryId, workerStageId, -1, leftExpectedSenders, rightExpectedSenders, preferHashJoin)
-            );
+            merged.add(new ShuffleWorkerSetupInstructionNode(queryId, workerStageId, -1, expectedSendersBySlot, preferHashJoin));
             merged.addAll(existing);
             for (int p = 0; p < partitionCount; p++) {
-                merged.add(new ShuffleScanInstructionNode(leftInputId, p, leftExpectedSenders, queryId, workerStageId, "left"));
-                merged.add(new ShuffleScanInstructionNode(rightInputId, p, rightExpectedSenders, queryId, workerStageId, "right"));
+                for (Map.Entry<String, Integer> e : producerStageIdBySlot.entrySet()) {
+                    String slot = e.getKey();
+                    merged.add(
+                        new ShuffleScanInstructionNode(
+                            canonicalInputId(e.getValue()),
+                            p,
+                            expectedSendersBySlot.get(slot),
+                            queryId,
+                            workerStageId,
+                            slot
+                        )
+                    );
+                }
             }
             enriched.add(sp.withInstructions(merged));
         }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/ShuffleEnrichment.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/join/ShuffleEnrichment.java
@@ -181,21 +181,57 @@ public final class ShuffleEnrichment {
             long buildRows = subtreeMaxScanRows(buildProducer.getFragment());
             boolean preferHashJoin = buildRows < sortMergeJoinMinRows;
 
+            // Shuffle SHAPE, from the same estimate and for the same reason. Pipelined (drain concurrent
+            // with the producers) buys latency and keeps residency proportional to arrival rate, but its
+            // backpressure is a retryable reject that can exhaust and fail the query, because once the
+            // consumer owns the queue nothing can spill it away. Materialized (producers finish, then the
+            // consumer drains) gives that up for a bound that cannot fail: the accumulating buffer spills,
+            // so a full window is relieved by disk.
+            //
+            // Reusing preferHashJoin rather than inventing a threshold: it is already the calibrated
+            // "this build does not fit in memory" signal, and a shuffle whose build does not fit is
+            // exactly the memory-bound class where a bound that cannot fail is worth more than overlap.
+            // Where the build does fit, the build phase is short, so the window in which an undrained
+            // probe can pile up is short too — that is the class whose latency regressed when the
+            // in-flight window was squeezed, so it keeps the pipelined shape.
+            //
+            // Restricted to MULTI-INPUT workers. The residency the materialized shape exists to bound is
+            // the side a join cannot consume yet: a hash join reads its build fully before it touches the
+            // probe, so probe bytes pile up in the consumer's buffer with nowhere to go. A single-input
+            // worker (the FINAL half of an aggregate shuffle) consumes its one stream continuously, so its
+            // drain never stalls and the pipelined shape costs it nothing. Its buildRows estimate would
+            // also be misleading: subtreeMaxScanRows measures the scan under a PARTIAL aggregate, which
+            // says nothing about how many bytes that aggregate actually ships.
+            //
+            // Refinements deliberately NOT added here: partition count and cascade depth both also drive
+            // concurrent residency, but neither has a measured threshold yet, and three uncalibrated
+            // constants would be harder to reason about than one signal that is already tuned.
+            boolean pipelined = preferHashJoin || level.inputs().size() < 2;
+
             // The worker consumes every producer's partitions. enrichWorkerAlternatives prepends a setup
             // placeholder and appends per-(partition,slot) scans; a producer instruction (added above when
             // this worker also feeds a higher level) stays AFTER the scans because enrichProducerAlternatives
             // appended it to the worker's own alternatives.
-            enrichWorkerAlternatives(worker, partitionCount, expectedBySlot, ctx.queryId(), producerStageIdBySlot, preferHashJoin);
+            enrichWorkerAlternatives(
+                worker,
+                partitionCount,
+                expectedBySlot,
+                ctx.queryId(),
+                producerStageIdBySlot,
+                preferHashJoin,
+                pipelined
+            );
 
             LOGGER.debug(
                 "[ShuffleEnrichment] level worker={} producers={} partitions={} expectedSenders={} "
-                    + "buildRows={} preferHashJoin={} targets={}",
+                    + "buildRows={} preferHashJoin={} pipelined={} targets={}",
                 workerStageId,
                 producerStageIdBySlot,
                 partitionCount,
                 expectedBySlot,
                 buildRows,
                 preferHashJoin,
+                pipelined,
                 targets
             );
         }
@@ -281,7 +317,8 @@ public final class ShuffleEnrichment {
         String queryId,
         int leftProducerStageId,
         int rightProducerStageId,
-        boolean preferHashJoin
+        boolean preferHashJoin,
+        boolean pipelined
     ) {
         // LinkedHashMap built left-then-right: slot order drives the per-partition scan emission order, so
         // Map.of (unordered) would make the interleaving non-deterministic.
@@ -291,7 +328,7 @@ public final class ShuffleEnrichment {
         Map<String, Integer> producers = new LinkedHashMap<>();
         producers.put(ShuffleSlots.LEFT, leftProducerStageId);
         producers.put(ShuffleSlots.RIGHT, rightProducerStageId);
-        enrichWorkerAlternatives(workerStage, partitionCount, expected, queryId, producers, preferHashJoin);
+        enrichWorkerAlternatives(workerStage, partitionCount, expected, queryId, producers, preferHashJoin, pipelined);
     }
 
     public static void enrichWorkerAlternatives(
@@ -300,7 +337,8 @@ public final class ShuffleEnrichment {
         Map<String, Integer> expectedSendersBySlot,
         String queryId,
         Map<String, Integer> producerStageIdBySlot,
-        boolean preferHashJoin
+        boolean preferHashJoin,
+        boolean pipelined
     ) {
         if (!expectedSendersBySlot.keySet().equals(producerStageIdBySlot.keySet())) {
             throw new IllegalArgumentException(
@@ -324,7 +362,7 @@ public final class ShuffleEnrichment {
             // WorkerFragmentStageExecutionFactory replaces this with a partition-specific copy carrying every
             // slot's expected sender count. We don't know the partition at this step (one alternative serves
             // all partitions; per-task filtering picks the right one).
-            merged.add(new ShuffleWorkerSetupInstructionNode(queryId, workerStageId, -1, expectedSendersBySlot, preferHashJoin));
+            merged.add(new ShuffleWorkerSetupInstructionNode(queryId, workerStageId, -1, expectedSendersBySlot, preferHashJoin, pipelined));
             merged.addAll(existing);
             for (int p = 0; p < partitionCount; p++) {
                 for (Map.Entry<String, Integer> e : producerStageIdBySlot.entrySet()) {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
@@ -33,9 +33,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -98,6 +101,24 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      */
     private volatile long nodeBudgetBytes = Long.MAX_VALUE;
     private volatile long perQueryMaxBytes = Long.MAX_VALUE;
+
+    /**
+     * Per-slot IN-FLIGHT WINDOW: the maximum bytes that may sit queued-but-undrained on a single
+     * (buffer, slot) before admission starts returning {@link AdmitResult#REJECT_RETRY}.
+     *
+     * <p>This is the bound that makes pipelined shuffle's promise real. The node/per-query budgets
+     * above cap the ABSOLUTE footprint (they must, as an OOM backstop), but they are sized as a
+     * percentage of heap — 80% by default, i.e. ~24GB on a 30GB heap — so on their own they let one
+     * partition accumulate until the node is pinned. The window is a much smaller, drain-rate-coupled
+     * cap: producers pace to the consumer, and peak residency becomes a function of the window rather
+     * than of partition size.
+     *
+     * <p>Enforced via REJECT_RETRY rather than by blocking on a bounded queue on purpose: admission
+     * runs on a transport thread, and parking transport threads to apply backpressure risks starving
+     * the node's thread pool. {@link ShuffleSenderRetry} already implements bounded producer-side
+     * retry, so reusing it keeps backpressure off the transport threads.
+     */
+    private volatile long streamWindowBytes = Long.MAX_VALUE;
     private final AtomicLong totalBytes = new AtomicLong();
     private final Map<String, AtomicLong> perQueryBytes = new ConcurrentHashMap<>();
 
@@ -203,6 +224,19 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
     }
 
     /**
+     * Sets the per-slot in-flight window (see {@link #streamWindowBytes}). {@code Long.MAX_VALUE}
+     * disables it, restoring accumulate-until-budget behaviour.
+     */
+    public void setStreamWindowBytes(long windowBytes) {
+        this.streamWindowBytes = windowBytes <= 0 ? Long.MAX_VALUE : windowBytes;
+    }
+
+    /** Current per-slot in-flight window in bytes (for observability/tests). */
+    public long getStreamWindowBytes() {
+        return streamWindowBytes;
+    }
+
+    /**
      * Configure hash-shuffle disk spill. {@code enabled} is the master switch; {@code directory} is
      * the root under which per-query spill subdirs are written ({@code <directory>/<queryId>/});
      * {@code maxBytes} is the hard node-wide disk ceiling (exceeding it fails the query). When
@@ -303,25 +337,38 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 key(queryId, targetStageId, partitionIndex),
                 k -> newBuffer(queryId, targetStageId, partitionIndex)
             );
-            // Defensive: NEVER append data to a buffer a consumer has begun draining — the drain
-            // snapshotted the in-memory tail, so this chunk would be silently dropped (lost rows).
-            // The producer's two-phase close (DatafusionPartitionedSink: drain all data sends before
-            // any isLast) makes this unreachable in the normal path, but a buggy/reordered late RPC
-            // must FAIL LOUD here rather than under-deliver. (codex round-5 BLOCKER #2.) Checked under
-            // admitLock, the same lock beginDrain flips `draining` under, so this read can't race a
-            // half-started drain.
-            if (buffer.isDraining()) {
+            // Defensive: NEVER append data to a slot whose EOF sentinel has been enqueued — the
+            // consumer terminates its stream at the sentinel, so this chunk would be silently dropped
+            // (lost rows). The producer's two-phase close (DatafusionPartitionedSink: all data sends
+            // before any isLast) makes this unreachable in the normal path, but a buggy/reordered late
+            // RPC must FAIL LOUD here rather than under-deliver. (codex round-5 BLOCKER #2.)
+            //
+            // This REPLACES the old `buffer.isDraining()` form. Under pipelined shuffle add and drain
+            // are concurrent BY DESIGN — `draining` is set as soon as the consumer's handler runs, long
+            // before producers finish — so "is draining" no longer means "too late". EOF does: it fires
+            // only once every declared sender on that slot has reported isLast.
+            if (buffer.isEofEnqueued(ShuffleSlots.validate(side))) {
                 buffer.recordRejected();
+                // Poison the CONSUMER as well as failing this producer. The producer-side throw can lose
+                // the race — the consumer may already have terminated at the premature EOF and produced
+                // output — so the only way truncation is never silent is to fail both ends.
+                buffer.failSlot(side);
                 throw new IllegalStateException(
                     "Shuffle data ("
                         + size
-                        + " bytes) admitted to an already-draining buffer "
+                        + " bytes) admitted after end-of-stream on buffer "
                         + key(queryId, targetStageId, partitionIndex)
                         + " side="
                         + side
-                        + " — the consumer already snapshotted this partition, so the chunk would be lost. "
+                        + " — the consumer has already terminated this slot's stream, so the chunk would be lost. "
                         + "This indicates a producer shipped data after its isLast (a close-ordering bug)."
                 );
+            }
+            // In-flight window full: the consumer has not drained this slot fast enough. Soft, retryable
+            // — room frees as the drain advances. This is the pacing signal that keeps residency bounded.
+            if (buffer.queuedBytes(ShuffleSlots.validate(side)) + size > streamWindowBytes) {
+                buffer.recordRejected();
+                return AdmitResult.REJECT_RETRY;
             }
             AtomicLong q = perQueryBytes.computeIfAbsent(queryId, k -> new AtomicLong());
             long qProjected = q.get() + size;
@@ -555,6 +602,8 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
         }
         if (removed != null) {
+            // Wake any parked drain first: the buffer is out of the map, so nothing more will arrive.
+            removed.abortStreams();
             removed.deleteSpillFiles(); // returns on-disk bytes to the node spill budget (I/O, off-lock)
         }
     }
@@ -584,6 +633,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         // is a disk leak (mirrors the in-memory cleanup). Only the caller that actually removed the
         // entry cleans up — a second remove / a concurrent clearForQuery sweep sees null and skips.
         if (removed != null) {
+            removed.abortStreams();
             removed.deleteSpillFiles();
         }
     }
@@ -684,6 +734,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         // EVERY terminal (success/fail/cancel). The buffers are already out of the map, so no admit
         // can recreate the on-disk state for this (now tombstoned) query.
         for (ShuffleBuffer b : swept) {
+            b.abortStreams();
             b.deleteSpillFiles();
         }
         deleteQuerySpillDir(queryId);
@@ -766,13 +817,71 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
          * consumer's setup handler), so no slot list needs to be known up front.
          */
         private static final class Slot {
-            private final List<byte[]> data = Collections.synchronizedList(new ArrayList<>());
+            /**
+             * Bounded FIFO of admitted chunks, drained CONCURRENTLY by the consumer. This is the
+             * pipelined-shuffle core: the old design was a {@code List} that accumulated the WHOLE
+             * partition because {@code awaitReady} blocked the drain until every producer finished, so
+             * peak residency scaled with partition size (on-heap {@code byte[]} AND again as Arrow
+             * buffers at drain). With a bounded queue, residency is {@code capacity × chunk size} —
+             * independent of partition size — and a full queue becomes producer backpressure.
+             */
+            private final BlockingQueue<byte[]> queue = new LinkedBlockingQueue<>();
             private final AtomicInteger doneCount = new AtomicInteger();
             private final CountDownLatch ready = new CountDownLatch(1);
             private volatile int expectedSenders = -1;
+            /**
+             * Enqueued-EOF guard. The sentinel must be enqueued EXACTLY once (a second one would
+             * truncate a sibling reader), and it is also the new "too late to add data" marker that
+             * replaces the old {@code draining} check in {@link ShuffleBufferManager#tryAdmit}.
+             */
+            private final AtomicBoolean eofEnqueued = new AtomicBoolean();
+            /** Chunks currently queued (not yet taken) — observability. */
+            private final AtomicInteger queuedChunks = new AtomicInteger();
+            /**
+             * Bytes currently queued but not yet taken by the consumer — the IN-FLIGHT WINDOW. This is
+             * what makes peak residency independent of partition size: admission rejects (retryably)
+             * once a slot's window is full, so producers pace themselves to the consumer's drain rate
+             * instead of accumulating the whole partition. Decremented when the drain takes a chunk or
+             * the spill path evicts one.
+             */
+            private final AtomicLong queuedBytes = new AtomicLong();
+            /**
+             * Set when this slot's stream has been INVALIDATED (a late admit past end-of-stream, or a
+             * terminal). Checked by the drain at its EOF transition, so it does not depend on queue
+             * ORDER: the poison sentinel is necessarily enqueued after the EOF sentinel, and an in-order
+             * consumer would otherwise terminate cleanly at EOF and never see it — which is exactly the
+             * silent truncation this guards against.
+             */
+            private volatile boolean invalidated;
             /** On-disk file for this slot, lazily created on first spill (null when never spilled). */
             private SpilledSide spill;
         }
+
+        /**
+         * End-of-stream marker enqueued once per slot when every declared sender has reported
+         * {@code isLast}. Compared by IDENTITY (never by content), so a real zero-length payload can
+         * never be mistaken for EOF. Replaces the {@code ready} latch as the drain's terminator.
+         */
+        static final byte[] EOF_SENTINEL = new byte[0];
+
+        /**
+         * Poison marker enqueued on every slot when a buffer is removed or its query is cleared
+         * (terminal / cancellation). Without it a drain parked in {@code queue.poll(timeout)} would sit
+         * for the full liveness timeout after its query died, holding an Arrow allocator and a thread.
+         *
+         * <p>Deliberately DISTINCT from {@link #EOF_SENTINEL}: waking a consumer with a clean
+         * end-of-stream would let it close the native sender normally, and the join would emit results
+         * from a truncated input. This one makes the drain THROW, so the caller fails the native stream.
+         */
+        static final byte[] CANCELLED_SENTINEL = new byte[0];
+
+        /**
+         * Default per-chunk wait for a streaming drain. This is a LIVENESS bound, not a data bound:
+         * the drain now blocks for the NEXT chunk rather than for the whole partition, so it only
+         * trips when producers have genuinely stalled. Matches the old whole-partition
+         * {@code awaitReady} budget so a slow-but-working shuffle behaves as before.
+         */
+        static final long DEFAULT_STREAM_POLL_TIMEOUT_MILLIS = 300_000L;
 
         /**
          * Slots by label. {@link ConcurrentHashMap} because producer RPCs (arbitrary transport
@@ -848,7 +957,47 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         public void addData(String slot, byte[] data) {
             int size = data == null ? 0 : data.length;
             currentBytes.addAndGet(size);
-            slotFor(ShuffleSlots.validate(slot)).data.add(data);
+            enqueue(slot, data);
+        }
+
+        /**
+         * Publishes {@code data} to {@code slot}'s stream. Split out from the byte accounting so
+         * {@link ShuffleBufferManager#tryAdmit} can reserve under {@code admitLock} and publish
+         * OUTSIDE it — the queue is thread-safe and the consumer drains concurrently, so holding the
+         * global admission lock across a publish would serialize every producer on the node.
+         *
+         * <p>Refuses after the slot's EOF sentinel (returns false). That is the streaming replacement
+         * for the old "never append to a draining buffer" rule: with concurrent drain, {@code draining}
+         * is set almost immediately and can no longer mean "too late", but data after EOF is still
+         * unambiguously a producer close-ordering bug.
+         */
+        boolean enqueue(String slot, byte[] data) {
+            Slot s = slotFor(ShuffleSlots.validate(slot));
+            if (s.eofEnqueued.get()) {
+                return false;
+            }
+            s.queuedChunks.incrementAndGet();
+            s.queuedBytes.addAndGet(data == null ? 0 : data.length);
+            s.queue.add(data);
+            return true;
+        }
+
+        /** Chunks currently queued but not yet taken by the consumer, on {@code slot} (0 if unknown). */
+        int queuedChunks(String slot) {
+            Slot s = slots.get(slot);
+            return s == null ? 0 : s.queuedChunks.get();
+        }
+
+        /** Bytes queued but not yet taken on {@code slot} — the in-flight window (0 if unknown). */
+        long queuedBytes(String slot) {
+            Slot s = slots.get(slot);
+            return s == null ? 0L : s.queuedBytes.get();
+        }
+
+        /** True once {@code slot}'s EOF sentinel has been enqueued (all declared senders reported isLast). */
+        boolean isEofEnqueued(String slot) {
+            Slot s = slots.get(slot);
+            return s != null && s.eofEnqueued.get();
         }
 
         /** Records a rejected/failed admission attempt against this buffer (observability). */
@@ -897,30 +1046,38 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             if (slot == null) {
                 return 0L; // nothing ever arrived on this slot
             }
-            List<byte[]> list = slot.data;
+            BlockingQueue<byte[]> queue = slot.queue;
             long evicted = 0L;
             while (evicted < targetBytes) {
-                byte[] chunk;
-                // synchronizedList: lock the list for the size-check + remove(0) so a concurrent
-                // addData (other slot / other producer) can't shift indices under us.
-                synchronized (list) {
-                    if (list.isEmpty()) {
-                        break;
-                    }
-                    chunk = list.get(0);
-                    int len = chunk == null ? 0 : chunk.length;
-                    // Disk footprint includes the 4-byte frame header append() writes, so the on-disk
-                    // total can't silently grow past the ceiling by 4×chunkCount. (codex round-2.)
-                    long diskBytes = len + SPILL_FRAME_HEADER_BYTES;
-                    // Reserve disk budget BEFORE removing from memory — if the ceiling is hit we
-                    // leave the chunk resident and fail (it's still safely in memory/accounted).
-                    if (!owner.reserveSpillBytes(diskBytes)) {
-                        throw ShuffleBufferExceededException.forDiskCeiling(owner.getSpilledTotalBytes() + diskBytes, owner.spillMaxBytes);
-                    }
-                    list.remove(0);
+                // Head-of-queue eviction, oldest first, so spill-file order stays arrival order. Safe
+                // to peek-then-poll without extra locking: only producers append (at the tail), and
+                // spillToMakeRoom runs under admitLock and SKIPS draining buffers, so no consumer is
+                // concurrently taking from this head.
+                byte[] head = queue.peek();
+                if (head == null || head == EOF_SENTINEL) {
+                    break; // nothing resident, or only the terminator is left — never spill the sentinel
                 }
-                int len = chunk == null ? 0 : chunk.length;
+                int len = head.length;
+                // Disk footprint includes the 4-byte frame header append() writes, so the on-disk
+                // total can't silently grow past the ceiling by 4×chunkCount. (codex round-2.)
                 long diskBytes = len + SPILL_FRAME_HEADER_BYTES;
+                // Reserve disk budget BEFORE removing from memory — if the ceiling is hit we
+                // leave the chunk resident and fail (it's still safely in memory/accounted).
+                if (!owner.reserveSpillBytes(diskBytes)) {
+                    throw ShuffleBufferExceededException.forDiskCeiling(owner.getSpilledTotalBytes() + diskBytes, owner.spillMaxBytes);
+                }
+                byte[] chunk = queue.poll();
+                if (chunk == null || chunk == EOF_SENTINEL) {
+                    // Raced with the terminator being enqueued: give the disk reservation back and, if
+                    // we took the sentinel, restore it so the drain still terminates.
+                    owner.releaseSpillBytes(diskBytes);
+                    if (chunk == EOF_SENTINEL) {
+                        queue.add(chunk);
+                    }
+                    break;
+                }
+                slot.queuedChunks.decrementAndGet();
+                slot.queuedBytes.addAndGet(-len);
                 try {
                     SpilledSide spill = spillFor(slotId, slot);
                     spill.append(chunk);
@@ -960,6 +1117,44 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
          * bytes to the manager's node-wide spill budget. Best-effort, idempotent; called on every
          * terminal (removeBuffer / clearForQuery). A leaked .spill file is a disk leak.
          */
+        /**
+         * Wakes any drain parked on this buffer and makes it fail. Called on every terminal path
+         * (removeBuffer / clearForQuery) BEFORE the buffer's bytes are released, so a consumer can never
+         * be left blocked on a queue whose owner has gone away. Idempotent and non-blocking: an extra
+         * poison on an already-finished slot is simply never read.
+         */
+        void abortStreams() {
+            for (Slot slot : slots.values()) {
+                slot.invalidated = true;
+                slot.queue.add(CANCELLED_SENTINEL);
+                // Release anything waiting on the old latch too (tests / awaitReady callers).
+                slot.ready.countDown();
+            }
+        }
+
+        /**
+         * Poisons ONE slot's stream so a live consumer fails instead of finishing on truncated input.
+         *
+         * <p>Safety net for a wrong {@code expectedSenders}. EOF is published when {@code doneCount}
+         * reaches the declared sender count; if that count is too LOW, EOF fires while a straggling
+         * producer still has rows to ship, the consumer terminates, and the join silently returns fewer
+         * rows — a wrong answer with an HTTP 200 (measured: 18,215 late admits on one worker while the
+         * query "succeeded"). The producer-side throw alone is not enough, because the consumer may
+         * already have finished by the time it propagates.
+         *
+         * <p>So the CONSUMER is poisoned too: whichever side notices first, the query cannot return a
+         * truncated result. Uses {@link #CANCELLED_SENTINEL}, not {@link #EOF_SENTINEL} — a clean
+         * end-of-stream is exactly what must not happen here.
+         */
+        void failSlot(String slot) {
+            Slot s = slots.get(ShuffleSlots.validate(slot));
+            if (s != null) {
+                s.invalidated = true;          // order-independent: seen even if EOF is already queued
+                s.queue.add(CANCELLED_SENTINEL); // wakes a drain parked in poll()
+                s.ready.countDown();
+            }
+        }
+
         void deleteSpillFiles() {
             for (Slot slot : slots.values()) {
                 slot.spill = closeAndDelete(slot.spill);
@@ -999,6 +1194,11 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
             int expected = slot.expectedSenders;
             if (expected >= 0 && slot.doneCount.get() >= expected) {
+                // Publish EOF exactly once, BEFORE releasing the latch: a consumer woken by the latch
+                // must find the terminator already queued, never race ahead of it.
+                if (slot.eofEnqueued.compareAndSet(false, true)) {
+                    slot.queue.add(EOF_SENTINEL);
+                }
                 slot.ready.countDown();
             }
         }
@@ -1063,89 +1263,192 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
 
         @Override
         public List<byte[]> getData(String slot) {
+            // EAGER, NON-BLOCKING form: returns what is resident RIGHT NOW (spilled chunks, then the
+            // currently-queued ones) and stops at the queue's end or the EOF sentinel. It must not wait
+            // for EOF: callers use this to inspect what has accumulated so far, with no guarantee that
+            // any sender has reported isLast, so blocking would hang them. The streaming consumer path
+            // uses drain(slot, timeout) instead.
             beginDrain();
             Slot s = slots.get(ShuffleSlots.validate(slot));
             if (s == null) {
-                return List.of(); // nothing ever arrived on this slot — an empty partition
+                return List.of(); // nothing ever arrived on this slot
             }
-            return drainSlot(s.spill, s.data);
+            List<byte[]> out = new ArrayList<>();
+            if (s.spill != null) {
+                try {
+                    out.addAll(s.spill.readBack());
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to read back shuffle spill file " + s.spill.path(), e);
+                }
+            }
+            while (true) {
+                byte[] chunk = s.queue.poll();
+                if (chunk == null) {
+                    break;
+                }
+                if (chunk == EOF_SENTINEL) {
+                    // Put the terminator back so a subsequent streaming drain still terminates.
+                    s.queue.add(chunk);
+                    break;
+                }
+                s.queuedChunks.decrementAndGet();
+                s.queuedBytes.addAndGet(-chunk.length);
+                out.add(chunk);
+            }
+            return out;
         }
 
         @Override
         public CloseableIterator<byte[]> drain(String slot) {
+            // NON-BLOCKING, and deliberately so: this is the pre-streaming SPI method, whose contract is
+            // "lazily yield what is resident". Callers of this form (tests, small non-streaming callers)
+            // do not necessarily complete their senders, so waiting for EOF here would hang them. The
+            // streaming consumer opts in explicitly via drain(slot, timeoutMillis).
             beginDrain();
-            Slot s = slots.get(ShuffleSlots.validate(slot));
-            if (s == null) {
-                return drainSlotLazy(null, List.of());
-            }
-            return drainSlotLazy(s.spill, s.data);
+            Slot s = slotFor(ShuffleSlots.validate(slot));
+            return new StreamingSlotIterator(s, 0L, slot);
+        }
+
+        @Override
+        public CloseableIterator<byte[]> drain(String slot, long timeoutMillis) {
+            beginDrain();
+            // slotFor (not slots.get): the consumer can now start draining BEFORE any producer has
+            // touched this slot, so the slot may not exist yet. Creating it here is what lets the
+            // stream block for the first chunk instead of mis-reporting an empty partition.
+            Slot s = slotFor(ShuffleSlots.validate(slot));
+            return new StreamingSlotIterator(s, timeoutMillis, slot);
         }
 
         /**
-         * LAZY drain: yields the slot's chunks in arrival order WITHOUT holding the whole partition
-         * in heap. Spilled chunks are streamed one-at-a-time from the file (the file handle lives in
-         * the returned iterator and is released on {@link CloseableIterator#close()}), then the
-         * in-memory tail is yielded. This is what lets an over-budget (spilled) partition drain
-         * through the consumer's bounded native channel rather than re-materializing and OOMing.
+         * STREAMING drain: yields any already-spilled chunks (arrival order, one at a time off disk),
+         * then blocks for live chunks off the slot's queue until the EOF sentinel.
          *
-         * <p>Runs once per slot after {@link #awaitReady}; the buffer is fully populated and no longer
-         * mutated, so a snapshot of the in-memory tail taken under its monitor is stable.
+         * <p>This replaces the old snapshot-based drain. The difference that matters: the old iterator
+         * was created AFTER {@code awaitReady} guaranteed the partition was complete, so it could
+         * safely copy the in-memory list; this one runs CONCURRENTLY with producers, so it must consume
+         * the live queue and rely on the sentinel to know when to stop. That is what removes
+         * partition-sized residency — nothing accumulates waiting for a barrier.
+         *
+         * <p>Terminates on: EOF sentinel (clean), poll timeout (producers stalled → throw, never a
+         * silent short read), or interrupt (cancellation).
          */
-        private static CloseableIterator<byte[]> drainSlotLazy(SpilledSide spill, List<byte[]> inMemory) {
-            // Snapshot the in-memory tail once (drain is single-threaded post awaitReady, but addData
-            // used a synchronizedList, so honor its monitor for safe publication).
-            final List<byte[]> tail;
-            synchronized (inMemory) {
-                tail = new ArrayList<>(inMemory);
-            }
-            if (spill == null) {
-                // No spill for this slot: just iterate the heap-resident tail, nothing to close.
-                Iterator<byte[]> it = tail.iterator();
-                return new CloseableIterator<>() {
-                    @Override
-                    public boolean hasNext() {
-                        return it.hasNext();
+        private static final class StreamingSlotIterator implements CloseableIterator<byte[]> {
+            private final Slot slot;
+            private final long timeoutMillis;
+            private final String slotLabel;
+            private Iterator<byte[]> spilled;
+            private byte[] pending;
+            private boolean eof;
+
+            StreamingSlotIterator(Slot slot, long timeoutMillis, String slotLabel) {
+                this.slot = slot;
+                this.timeoutMillis = timeoutMillis;
+                this.slotLabel = slotLabel;
+                // Spilled chunks were written before the drain began and are immutable now, so reading
+                // them back eagerly is safe. Only pre-drain accumulation can spill (spillToMakeRoom
+                // skips draining buffers), so this list is bounded by whatever arrived before the
+                // consumer started — it does not grow during the stream.
+                if (slot.spill != null) {
+                    try {
+                        this.spilled = slot.spill.readBack().iterator();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException("Failed to read back shuffle spill file " + slot.spill.path(), e);
                     }
-
-                    @Override
-                    public byte[] next() {
-                        return it.next();
-                    }
-
-                    @Override
-                    public void close() {}
-                };
-            }
-            // Spilled: stream the file chunk-by-chunk, then the in-memory tail. The DataInputStream is
-            // owned by the iterator and closed on close() / at clean EOF.
-            return new SpillThenTailIterator(spill, tail);
-        }
-
-        /**
-         * Returns the slot's chunks in ARRIVAL order. With no spill, the in-memory list is returned
-         * as-is (byte-identical to the pre-spill path). With spill, the spilled chunks are read back
-         * and deframed from the file (in write = arrival order) FIRST, then the in-memory tail is
-         * appended — reconstructing the full arrival sequence. Drain happens once per partition after
-         * {@link #awaitReady}, so reading the whole file back into a list then concatenating is
-         * acceptable. A spill read error surfaces as an {@link UncheckedIOException} that fails the
-         * fragment (correctness over silent under-delivery).
-         */
-        private static List<byte[]> drainSlot(SpilledSide spill, List<byte[]> inMemory) {
-            if (spill == null) {
-                return inMemory;
-            }
-            try {
-                List<byte[]> spilled = spill.readBack();
-                List<byte[]> combined = new ArrayList<>(spilled.size() + inMemory.size());
-                combined.addAll(spilled);
-                // Snapshot the in-memory tail under its monitor — drain is single-threaded post
-                // awaitReady, but addData uses a synchronizedList so honor its lock.
-                synchronized (inMemory) {
-                    combined.addAll(inMemory);
                 }
-                return combined;
-            } catch (IOException e) {
-                throw new UncheckedIOException("Failed to read back shuffle spill file " + spill.path(), e);
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (pending != null) {
+                    return true;
+                }
+                if (spilled != null && spilled.hasNext()) {
+                    pending = spilled.next();
+                    return true;
+                }
+                if (eof) {
+                    return false;
+                }
+                byte[] next;
+                if (timeoutMillis <= 0) {
+                    // Non-blocking mode (the legacy drain(slot) contract): yield only what is already
+                    // resident and stop. An empty queue is a normal end here, NOT a stall.
+                    next = slot.queue.poll();
+                    if (next == null) {
+                        eof = true;
+                        return false;
+                    }
+                } else {
+                    try {
+                        next = slot.queue.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        // Cancellation: surface it rather than reporting a clean end-of-stream, so the
+                        // caller fails the native stream instead of silently under-delivering.
+                        throw new IllegalStateException("Shuffle drain interrupted on slot " + slotLabel, e);
+                    }
+                }
+                if (next == null) {
+                    throw new IllegalStateException(
+                        "Shuffle drain timed out after "
+                            + timeoutMillis
+                            + "ms waiting for the next chunk on slot "
+                            + slotLabel
+                            + " (received "
+                            + slot.doneCount.get()
+                            + "/"
+                            + slot.expectedSenders
+                            + " senders) — producers appear stalled"
+                    );
+                }
+                if (next == EOF_SENTINEL) {
+                    eof = true;
+                    if (slot.invalidated) {
+                        // End-of-stream reached, but the slot was invalidated (rows arrived after EOF —
+                        // the declared sender count was too low). Finishing here would hand the join a
+                        // truncated input and return a WRONG ANSWER with no error anywhere.
+                        throw new IllegalStateException(
+                            "Shuffle drain aborted on slot "
+                                + slotLabel
+                                + " — data arrived after end-of-stream, so this partition is truncated "
+                                + "(declared "
+                                + slot.expectedSenders
+                                + " senders, "
+                                + slot.doneCount.get()
+                                + " reported done)"
+                        );
+                    }
+                    return false;
+                }
+                if (next == CANCELLED_SENTINEL) {
+                    eof = true;
+                    throw new IllegalStateException(
+                        "Shuffle drain aborted on slot " + slotLabel + " — the buffer was released (query terminated or cancelled)"
+                    );
+                }
+                slot.queuedChunks.decrementAndGet();
+                // Free the in-flight window as we consume, so blocked producers can proceed. This is
+                // the feedback loop that paces producers to the consumer instead of accumulating.
+                slot.queuedBytes.addAndGet(-next.length);
+                pending = next;
+                return true;
+            }
+
+            @Override
+            public byte[] next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("Shuffle stream exhausted on slot " + slotLabel);
+                }
+                byte[] out = pending;
+                pending = null;
+                return out;
+            }
+
+            @Override
+            public void close() {
+                // The queue is owned by the buffer (cleared by removeBuffer/clearForQuery); the spill
+                // file handle is closed by deleteSpillFiles on the terminal path. Nothing slot-local
+                // to release here.
             }
         }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
@@ -15,6 +15,7 @@ import org.opensearch.analytics.spi.CloseableIterator;
 import org.opensearch.analytics.spi.ShuffleBufferAccess;
 import org.opensearch.analytics.spi.ShuffleBufferExceededException;
 import org.opensearch.analytics.spi.ShuffleBufferRegistry;
+import org.opensearch.analytics.spi.ShuffleSlots;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -31,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -407,7 +409,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         // later releases only what's still resident (no double-release). (A receiving buffer that is
         // already draining — a retried/reordered admit landing post-drain — is skipped here too.)
         if (!buffer.isDraining()) {
-            freed += spillBufferBothSides(buffer, side, targetBytes);
+            freed += spillBufferAllSlots(buffer, side, targetBytes);
         }
         if (freed >= targetBytes) {
             return freed;
@@ -426,22 +428,27 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             if (sibling == buffer || sibling.isDraining() || !e.getKey().startsWith(stagePrefix)) {
                 continue;
             }
-            freed += spillBufferBothSides(sibling, side, targetBytes - freed);
+            freed += spillBufferAllSlots(sibling, side, targetBytes - freed);
         }
         return freed;
     }
 
     /**
-     * Spills {@code buffer}'s oldest resident chunks (the incoming {@code side} first, then the other
-     * side) until at least {@code targetBytes} are freed or the buffer runs dry, releasing the spilled
-     * bytes from this buffer's own {@code currentBytes}. Returns the bytes freed from THIS buffer. Both
-     * sides' chunks are read back in arrival order at drain (left/right drain into separate streams, so
-     * cross-side interleaving is irrelevant). MUST run under {@link #admitLock}.
+     * Spills {@code buffer}'s oldest resident chunks (the incoming {@code slot} first, then its other
+     * slots) until at least {@code targetBytes} are freed or the buffer runs dry, releasing the spilled
+     * bytes from this buffer's own {@code currentBytes}. Returns the bytes freed from THIS buffer. Every
+     * slot's chunks are read back in arrival order at drain (each slot drains into its own stream, so
+     * cross-slot interleaving is irrelevant). MUST run under {@link #admitLock}.
      */
-    private long spillBufferBothSides(ShuffleBuffer buffer, String side, long targetBytes) {
-        long freed = buffer.spillOldest(side, targetBytes);
-        if (freed < targetBytes) {
-            String other = "left".equals(side) ? "right" : "left";
+    private long spillBufferAllSlots(ShuffleBuffer buffer, String slot, long targetBytes) {
+        long freed = buffer.spillOldest(slot, targetBytes);
+        for (String other : buffer.getSlots()) {
+            if (freed >= targetBytes) {
+                break;
+            }
+            if (other.equals(slot)) {
+                continue; // already spilled above
+            }
             freed += buffer.spillOldest(other, targetBytes - freed);
         }
         buffer.releaseCurrentBytes(freed);
@@ -748,29 +755,45 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      * {@link #awaitReady} returns. Byte-budget enforcement lives in the enclosing manager, not here.
      */
     public static class ShuffleBuffer implements ShuffleBufferAccess {
-        private final List<byte[]> leftData = Collections.synchronizedList(new ArrayList<>());
-        private final List<byte[]> rightData = Collections.synchronizedList(new ArrayList<>());
-        private final AtomicInteger leftDoneCount = new AtomicInteger();
-        private final AtomicInteger rightDoneCount = new AtomicInteger();
-        private volatile int expectedLeftSenders = -1;
-        private volatile int expectedRightSenders = -1;
-        private final CountDownLatch leftReady = new CountDownLatch(1);
-        private final CountDownLatch rightReady = new CountDownLatch(1);
+
+        /**
+         * Per-slot accumulation + completion state. One entry per input stream the consumer will
+         * read (see {@link ShuffleSlots}): a binary hash join has {@code left} + {@code right}, a
+         * FINAL-aggregate worker has only {@code left}, and an N-way worker tier has one per input.
+         *
+         * <p>Created on demand by whichever thread first touches the slot ({@code addData} from a
+         * producer RPC, {@code senderDone} from an isLast, or {@code setExpectedSenders} from the
+         * consumer's setup handler), so no slot list needs to be known up front.
+         */
+        private static final class Slot {
+            private final List<byte[]> data = Collections.synchronizedList(new ArrayList<>());
+            private final AtomicInteger doneCount = new AtomicInteger();
+            private final CountDownLatch ready = new CountDownLatch(1);
+            private volatile int expectedSenders = -1;
+            /** On-disk file for this slot, lazily created on first spill (null when never spilled). */
+            private SpilledSide spill;
+        }
+
+        /**
+         * Slots by label. {@link ConcurrentHashMap} because producer RPCs (arbitrary transport
+         * threads) and the consumer's handler chain create/read entries concurrently;
+         * {@code computeIfAbsent} makes slot creation atomic so two producers racing on the same new
+         * slot cannot install two accumulation lists (which would silently drop one's rows).
+         */
+        private final Map<String, Slot> slots = new ConcurrentHashMap<>();
         private final AtomicLong currentBytes = new AtomicLong();
         private final AtomicLong rejectedCount = new AtomicLong();
 
         /**
          * Spill state. Null/disabled by default — a buffer only spills when the manager wires its
-         * spill identity via {@link #enableSpill}. {@link #leftSpill} / {@link #rightSpill} are the
-         * per-side on-disk files (lazily created on first spill). All spill state mutation happens
-         * under the manager's {@code admitLock} (spill) or after the buffer is out of the map
-         * (drain/cleanup), so the per-side fields need no further synchronization.
+         * spill identity via {@link #enableSpill}. Each {@link Slot#spill} is that slot's on-disk
+         * file (lazily created on first spill). All spill state mutation happens under the manager's
+         * {@code admitLock} (spill) or after the buffer is out of the map (drain/cleanup), so the
+         * per-slot fields need no further synchronization.
          */
         private ShuffleBufferManager owner;
         private Path querySpillDir;
         private String spillKey; // <stageId>-<partition>
-        private SpilledSide leftSpill;
-        private SpilledSide rightSpill;
 
         /**
          * Set once a consumer begins draining this buffer (snapshotting the in-memory tail / opening
@@ -796,33 +819,36 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             this.spillKey = stageId + "-" + partition;
         }
 
-        public void setExpectedSenders(int leftSenders, int rightSenders) {
-            // -1 means "leave unchanged"; allows per-side handlers to set their own count
-            // without clobbering the other side's.
-            if (leftSenders >= 0) {
-                this.expectedLeftSenders = leftSenders;
-                checkCompletion("left");
-            }
-            if (rightSenders >= 0) {
-                this.expectedRightSenders = rightSenders;
-                checkCompletion("right");
+        @Override
+        public void setExpectedSenders(Map<String, Integer> expectedSendersBySlot) {
+            for (Map.Entry<String, Integer> e : expectedSendersBySlot.entrySet()) {
+                Integer count = e.getValue();
+                if (count == null || count < 0) {
+                    continue; // negative/absent means "leave unchanged" (see the SPI contract)
+                }
+                String slotId = ShuffleSlots.validate(e.getKey());
+                slotFor(slotId).expectedSenders = count;
+                // A producer's isLast may already have arrived (it does not need the consumer's
+                // count), so re-check completion now that the target is known.
+                checkCompletion(slotId);
             }
         }
 
+        /** The slot for {@code slotId}, created on first touch. */
+        private Slot slotFor(String slotId) {
+            return slots.computeIfAbsent(slotId, k -> new Slot());
+        }
+
         /**
-         * Stores {@code data} on the named side and tracks this buffer's byte total. Admission /
+         * Stores {@code data} on the named slot and tracks this buffer's byte total. Admission /
          * budget enforcement is owned by the enclosing {@link ShuffleBufferManager#tryAdmit} (node +
          * per-query budgets); this method only stores after admission has reserved the bytes. The
          * tracked {@link #currentBytes} is read at removal time to release the reservation.
          */
-        public void addData(String side, byte[] data) {
+        public void addData(String slot, byte[] data) {
             int size = data == null ? 0 : data.length;
             currentBytes.addAndGet(size);
-            if ("left".equals(side)) {
-                leftData.add(data);
-            } else {
-                rightData.add(data);
-            }
+            slotFor(ShuffleSlots.validate(slot)).data.add(data);
         }
 
         /** Records a rejected/failed admission attempt against this buffer (observability). */
@@ -863,16 +889,20 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
          * it is still spilled whole (resident then drops below the budget). Throws a re-messaged
          * {@link ShuffleBufferExceededException} if the node-wide disk ceiling is hit or a write fails.
          */
-        long spillOldest(String side, long targetBytes) {
+        long spillOldest(String slotId, long targetBytes) {
             if (querySpillDir == null || targetBytes <= 0) {
                 return 0L;
             }
-            List<byte[]> list = "left".equals(side) ? leftData : rightData;
+            Slot slot = slots.get(slotId);
+            if (slot == null) {
+                return 0L; // nothing ever arrived on this slot
+            }
+            List<byte[]> list = slot.data;
             long evicted = 0L;
             while (evicted < targetBytes) {
                 byte[] chunk;
                 // synchronizedList: lock the list for the size-check + remove(0) so a concurrent
-                // addData (other side / other producer) can't shift indices under us.
+                // addData (other slot / other producer) can't shift indices under us.
                 synchronized (list) {
                     if (list.isEmpty()) {
                         break;
@@ -892,7 +922,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 int len = chunk == null ? 0 : chunk.length;
                 long diskBytes = len + SPILL_FRAME_HEADER_BYTES;
                 try {
-                    SpilledSide spill = spillFor(side);
+                    SpilledSide spill = spillFor(slotId, slot);
                     spill.append(chunk);
                 } catch (IOException e) {
                     // The disk bytes for THIS chunk were reserved (reserveSpillBytes above) but the
@@ -911,33 +941,29 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             return evicted;
         }
 
-        /** Lazily opens (and remembers) the per-side spill file's append stream. */
-        private SpilledSide spillFor(String side) throws IOException {
-            if ("left".equals(side)) {
-                if (leftSpill == null) {
-                    leftSpill = new SpilledSide(spillFilePath("left"));
-                }
-                return leftSpill;
-            } else {
-                if (rightSpill == null) {
-                    rightSpill = new SpilledSide(spillFilePath("right"));
-                }
-                return rightSpill;
+        /** Lazily opens (and remembers) the slot's spill file append stream. */
+        private SpilledSide spillFor(String slotId, Slot slot) throws IOException {
+            if (slot.spill == null) {
+                slot.spill = new SpilledSide(spillFilePath(slotId));
             }
+            return slot.spill;
         }
 
-        private Path spillFilePath(String side) {
-            return querySpillDir.resolve(spillKey + "-" + side + ".spill");
+        /** Spill-file path for one slot. The slot label is validated on the way in
+         *  ({@link ShuffleSlots#validate}), so it cannot escape {@link #querySpillDir}. */
+        private Path spillFilePath(String slotId) {
+            return querySpillDir.resolve(spillKey + "-" + slotId + ".spill");
         }
 
         /**
-         * Deletes both sides' spill files (closing their streams first) and returns their on-disk
+         * Deletes every slot's spill file (closing their streams first) and returns their on-disk
          * bytes to the manager's node-wide spill budget. Best-effort, idempotent; called on every
          * terminal (removeBuffer / clearForQuery). A leaked .spill file is a disk leak.
          */
         void deleteSpillFiles() {
-            leftSpill = closeAndDelete(leftSpill);
-            rightSpill = closeAndDelete(rightSpill);
+            for (Slot slot : slots.values()) {
+                slot.spill = closeAndDelete(slot.spill);
+            }
         }
 
         private SpilledSide closeAndDelete(SpilledSide spill) {
@@ -960,41 +986,54 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             return null;
         }
 
-        public void senderDone(String side) {
-            if ("left".equals(side)) {
-                leftDoneCount.incrementAndGet();
-                checkCompletion("left");
-            } else {
-                rightDoneCount.incrementAndGet();
-                checkCompletion("right");
+        public void senderDone(String slot) {
+            String slotId = ShuffleSlots.validate(slot);
+            slotFor(slotId).doneCount.incrementAndGet();
+            checkCompletion(slotId);
+        }
+
+        private void checkCompletion(String slotId) {
+            Slot slot = slots.get(slotId);
+            if (slot == null) {
+                return;
+            }
+            int expected = slot.expectedSenders;
+            if (expected >= 0 && slot.doneCount.get() >= expected) {
+                slot.ready.countDown();
             }
         }
 
-        private void checkCompletion(String side) {
-            if ("left".equals(side)) {
-                if (expectedLeftSenders >= 0 && leftDoneCount.get() >= expectedLeftSenders) {
-                    leftReady.countDown();
-                }
-            } else {
-                if (expectedRightSenders >= 0 && rightDoneCount.get() >= expectedRightSenders) {
-                    rightReady.countDown();
-                }
-            }
-        }
-
-        /** Wait for both sides' senders to complete. Returns {@code false} on timeout. */
+        /**
+         * Wait for every DECLARED slot's senders to complete. Returns {@code false} on timeout.
+         *
+         * <p>Waits only on slots whose expected count has been set: an undeclared slot (one that
+         * exists solely because a producer's payload arrived early) has no target to compare against,
+         * so waiting on it could never succeed. The consumer's setup handler declares all of its
+         * slots in one call BEFORE any drain, which is what makes this set complete — see
+         * {@link ShuffleBufferAccess#setExpectedSenders(Map)}.
+         */
         public boolean awaitReady(long timeoutMillis) throws InterruptedException {
             long deadline = System.currentTimeMillis() + timeoutMillis;
-            long remaining = timeoutMillis;
-            if (!leftReady.await(remaining, TimeUnit.MILLISECONDS)) {
-                LOGGER.warn("Shuffle left side timed out: received {}/{} senders", leftDoneCount.get(), expectedLeftSenders);
-                return false;
-            }
-            remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0) return false;
-            if (!rightReady.await(remaining, TimeUnit.MILLISECONDS)) {
-                LOGGER.warn("Shuffle right side timed out: received {}/{} senders", rightDoneCount.get(), expectedRightSenders);
-                return false;
+            // Snapshot the slot set so a concurrently-created slot (an early producer payload for a
+            // slot this consumer never declared) can't extend the wait mid-loop.
+            for (Map.Entry<String, Slot> e : new ArrayList<>(slots.entrySet())) {
+                Slot slot = e.getValue();
+                if (slot.expectedSenders < 0) {
+                    continue; // never declared by the consumer — nothing to wait for
+                }
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return false;
+                }
+                if (!slot.ready.await(remaining, TimeUnit.MILLISECONDS)) {
+                    LOGGER.warn(
+                        "Shuffle slot {} timed out: received {}/{} senders",
+                        e.getKey(),
+                        slot.doneCount.get(),
+                        slot.expectedSenders
+                    );
+                    return false;
+                }
             }
             return true;
         }
@@ -1022,39 +1061,37 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             return draining;
         }
 
-        public List<byte[]> getLeftData() {
+        @Override
+        public List<byte[]> getData(String slot) {
             beginDrain();
-            return drainSide(leftSpill, leftData);
-        }
-
-        public List<byte[]> getRightData() {
-            beginDrain();
-            return drainSide(rightSpill, rightData);
+            Slot s = slots.get(ShuffleSlots.validate(slot));
+            if (s == null) {
+                return List.of(); // nothing ever arrived on this slot — an empty partition
+            }
+            return drainSlot(s.spill, s.data);
         }
 
         @Override
-        public CloseableIterator<byte[]> drainLeft() {
+        public CloseableIterator<byte[]> drain(String slot) {
             beginDrain();
-            return drainSideLazy(leftSpill, leftData);
-        }
-
-        @Override
-        public CloseableIterator<byte[]> drainRight() {
-            beginDrain();
-            return drainSideLazy(rightSpill, rightData);
+            Slot s = slots.get(ShuffleSlots.validate(slot));
+            if (s == null) {
+                return drainSlotLazy(null, List.of());
+            }
+            return drainSlotLazy(s.spill, s.data);
         }
 
         /**
-         * LAZY drain: yields the side's chunks in arrival order WITHOUT holding the whole partition
+         * LAZY drain: yields the slot's chunks in arrival order WITHOUT holding the whole partition
          * in heap. Spilled chunks are streamed one-at-a-time from the file (the file handle lives in
          * the returned iterator and is released on {@link CloseableIterator#close()}), then the
          * in-memory tail is yielded. This is what lets an over-budget (spilled) partition drain
          * through the consumer's bounded native channel rather than re-materializing and OOMing.
          *
-         * <p>Runs once per side after {@link #awaitReady}; the buffer is fully populated and no longer
+         * <p>Runs once per slot after {@link #awaitReady}; the buffer is fully populated and no longer
          * mutated, so a snapshot of the in-memory tail taken under its monitor is stable.
          */
-        private static CloseableIterator<byte[]> drainSideLazy(SpilledSide spill, List<byte[]> inMemory) {
+        private static CloseableIterator<byte[]> drainSlotLazy(SpilledSide spill, List<byte[]> inMemory) {
             // Snapshot the in-memory tail once (drain is single-threaded post awaitReady, but addData
             // used a synchronizedList, so honor its monitor for safe publication).
             final List<byte[]> tail;
@@ -1062,7 +1099,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 tail = new ArrayList<>(inMemory);
             }
             if (spill == null) {
-                // No spill for this side: just iterate the heap-resident tail, nothing to close.
+                // No spill for this slot: just iterate the heap-resident tail, nothing to close.
                 Iterator<byte[]> it = tail.iterator();
                 return new CloseableIterator<>() {
                     @Override
@@ -1085,7 +1122,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         }
 
         /**
-         * Returns the side's chunks in ARRIVAL order. With no spill, the in-memory list is returned
+         * Returns the slot's chunks in ARRIVAL order. With no spill, the in-memory list is returned
          * as-is (byte-identical to the pre-spill path). With spill, the spilled chunks are read back
          * and deframed from the file (in write = arrival order) FIRST, then the in-memory tail is
          * appended — reconstructing the full arrival sequence. Drain happens once per partition after
@@ -1093,7 +1130,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
          * acceptable. A spill read error surfaces as an {@link UncheckedIOException} that fails the
          * fragment (correctness over silent under-delivery).
          */
-        private static List<byte[]> drainSide(SpilledSide spill, List<byte[]> inMemory) {
+        private static List<byte[]> drainSlot(SpilledSide spill, List<byte[]> inMemory) {
             if (spill == null) {
                 return inMemory;
             }
@@ -1112,20 +1149,37 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
         }
 
+        /** Expected sender count declared for {@code slot}, or -1 if the slot was never declared. */
+        public int getExpectedSenders(String slot) {
+            Slot s = slots.get(slot);
+            return s == null ? -1 : s.expectedSenders;
+        }
+
+        /** Number of senders that have reported {@code isLast} on {@code slot} (0 if unknown slot). */
+        public int getDoneCount(String slot) {
+            Slot s = slots.get(slot);
+            return s == null ? 0 : s.doneCount.get();
+        }
+
+        /** Slot labels this buffer has seen (declared by the consumer or created by a producer). */
+        public Set<String> getSlots() {
+            return Set.copyOf(slots.keySet());
+        }
+
         public int getExpectedLeftSenders() {
-            return expectedLeftSenders;
+            return getExpectedSenders(ShuffleSlots.LEFT);
         }
 
         public int getExpectedRightSenders() {
-            return expectedRightSenders;
+            return getExpectedSenders(ShuffleSlots.RIGHT);
         }
 
         public int getLeftDoneCount() {
-            return leftDoneCount.get();
+            return getDoneCount(ShuffleSlots.LEFT);
         }
 
         public int getRightDoneCount() {
-            return rightDoneCount.get();
+            return getDoneCount(ShuffleSlots.RIGHT);
         }
 
         /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
@@ -123,6 +123,17 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
     private final Map<String, AtomicLong> perQueryBytes = new ConcurrentHashMap<>();
 
     /**
+     * Whether a streaming drain overlaps its producers (default) or waits for them first.
+     *
+     * <p>ON: the consumer reads chunks as they arrive, so peak residency is the in-flight window rather
+     * than the whole partition. OFF: the drain blocks until every declared sender has finished, which is
+     * the pre-streaming behaviour and holds the entire partition — once as buffered chunks and again as
+     * decoded batches. Exists as an operator kill switch for the streaming path; correctness does not
+     * depend on which side it is on, only peak memory and how early rows start flowing.
+     */
+    private volatile boolean pipelinedEnabled = true;
+
+    /**
      * Disk-spill configuration (default OFF). When {@link #spillEnabled} is true and a chunk would
      * breach the PER-QUERY on-heap budget, {@link #tryAdmit} evicts oldest in-memory chunks of the
      * target side to a per-(query,stage,partition,side) spill file under {@link #spillDir} instead of
@@ -234,6 +245,23 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
     /** Current per-slot in-flight window in bytes (for observability/tests). */
     public long getStreamWindowBytes() {
         return streamWindowBytes;
+    }
+
+    /**
+     * Enables or disables pipelined draining (see {@link #pipelinedEnabled}). Applies to buffers that
+     * already exist as well as new ones, so the switch takes effect on in-flight queries rather than
+     * only the next one — the point of a kill switch is to act on the query that is misbehaving.
+     */
+    public void setPipelinedEnabled(boolean enabled) {
+        this.pipelinedEnabled = enabled;
+        for (ShuffleBuffer buffer : buffers.values()) {
+            buffer.setPipelined(enabled);
+        }
+    }
+
+    /** Whether pipelined draining is active (for observability/tests). */
+    public boolean isPipelinedEnabled() {
+        return pipelinedEnabled;
     }
 
     /**
@@ -426,6 +454,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      */
     private ShuffleBuffer newBuffer(String queryId, int targetStageId, int partitionIndex) {
         ShuffleBuffer buffer = new ShuffleBuffer();
+        buffer.setPipelined(pipelinedEnabled);
         if (spillEnabled && spillDir != null) {
             buffer.enableSpill(this, spillDir, queryId, targetStageId, partitionIndex);
         }
@@ -915,7 +944,20 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
          */
         private volatile boolean draining;
 
+        /**
+         * Mirror of the manager's pipelining switch (see
+         * {@link ShuffleBufferManager#setPipelinedEnabled(boolean)}). Held per-buffer because this is a
+         * static nested class with no implicit manager reference, and the existing {@code owner} field is
+         * wired only on the spill path.
+         */
+        private volatile boolean pipelined = true;
+
         public ShuffleBuffer() {}
+
+        /** Sets whether a drain on this buffer overlaps its producers. */
+        void setPipelined(boolean enabled) {
+            this.pipelined = enabled;
+        }
 
         /**
          * Wires this buffer's spill identity (lazy — no file is opened here). Once set, a per-query
@@ -1311,12 +1353,40 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
 
         @Override
         public CloseableIterator<byte[]> drain(String slot, long timeoutMillis) {
+            // Kill switch: barrier FIRST, so the iterator only ever sees a completed partition. That
+            // restores the pre-streaming contract (whole partition resident before any row is read) for
+            // an operator who needs to rule the streaming path out. Pipelining is the default because the
+            // barrier is what forces partition-sized residency — the cost this exists to avoid.
+            if (!pipelined) {
+                awaitCompleteOrThrow(timeoutMillis, slot);
+            }
             beginDrain();
             // slotFor (not slots.get): the consumer can now start draining BEFORE any producer has
             // touched this slot, so the slot may not exist yet. Creating it here is what lets the
             // stream block for the first chunk instead of mis-reporting an empty partition.
             Slot s = slotFor(ShuffleSlots.validate(slot));
             return new StreamingSlotIterator(s, timeoutMillis, slot);
+        }
+
+        /**
+         * Blocks until every declared slot's senders have finished, for the non-pipelined path. Failing
+         * loudly on timeout is deliberate: returning here with producers still in flight would let the
+         * iterator report a clean end-of-stream over a partial partition, i.e. silently drop rows.
+         */
+        private void awaitCompleteOrThrow(long timeoutMillis, String slot) {
+            try {
+                if (!awaitReady(timeoutMillis)) {
+                    throw new IllegalStateException(
+                        "ShuffleBufferManager: timed out after "
+                            + timeoutMillis
+                            + "ms waiting for shuffle producers to finish before a non-pipelined drain of slot "
+                            + slot
+                    );
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("ShuffleBufferManager: interrupted awaiting shuffle producers for slot " + slot, e);
+            }
         }
 
         /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
@@ -113,6 +113,10 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      * cap: producers pace to the consumer, and peak residency becomes a function of the window rather
      * than of partition size.
      *
+     * <p>The bound is SOFT: an empty slot admits one chunk of any size, so residency per slot is
+     * window + one chunk. That escape is what stops the window from deadlocking a chunk larger than
+     * itself — see {@link #tryAdmit}.
+     *
      * <p>Enforced via REJECT_RETRY rather than by blocking on a bounded queue on purpose: admission
      * runs on a transport thread, and parking transport threads to apply backpressure risks starving
      * the node's thread pool. {@link ShuffleSenderRetry} already implements bounded producer-side
@@ -394,7 +398,17 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
             // In-flight window full: the consumer has not drained this slot fast enough. Soft, retryable
             // — room frees as the drain advances. This is the pacing signal that keeps residency bounded.
-            if (buffer.queuedBytes(ShuffleSlots.validate(side)) + size > streamWindowBytes) {
+            //
+            // An EMPTY slot always admits, however large the chunk. Without that escape a chunk bigger
+            // than the window is rejected forever: nothing is queued, so no drain can ever free room, and
+            // the producer retries until it exhausts its budget and fails the query. A window that can
+            // reach zero admissible items is not backpressure, it is a deadlock — so the invariant is that
+            // at least one chunk is always admissible, which keeps the drain fed and therefore keeps room
+            // becoming available. The cost is that residency is bounded by window + one chunk rather than
+            // by the window exactly; that is the same soft bound Spark and Presto accept for the same
+            // reason.
+            long queued = buffer.queuedBytes(ShuffleSlots.validate(side));
+            if (queued > 0 && queued + size > streamWindowBytes) {
                 buffer.recordRejected();
                 return AdmitResult.REJECT_RETRY;
             }
@@ -454,6 +468,10 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      */
     private ShuffleBuffer newBuffer(String queryId, int targetStageId, int partitionIndex) {
         ShuffleBuffer buffer = new ShuffleBuffer();
+        // Identity for diagnostics. A truncation abort has to name WHICH slot mis-declared its sender
+        // count, otherwise the error says a count is wrong without saying whose, and the level that
+        // declared it cannot be identified from the message alone.
+        buffer.bufferKey = key(queryId, targetStageId, partitionIndex);
         buffer.setPipelined(pipelinedEnabled);
         if (spillEnabled && spillDir != null) {
             buffer.enableSpill(this, spillDir, queryId, targetStageId, partitionIndex);
@@ -835,6 +853,9 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      * {@link #awaitReady} returns. Byte-budget enforcement lives in the enclosing manager, not here.
      */
     public static class ShuffleBuffer implements ShuffleBufferAccess {
+
+        /** {@code queryId:targetStageId:partitionIndex}, for error messages. Null only in unit tests. */
+        private volatile String bufferKey;
 
         /**
          * Per-slot accumulation + completion state. One entry per input stream the consumer will
@@ -1348,7 +1369,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             // streaming consumer opts in explicitly via drain(slot, timeoutMillis).
             beginDrain();
             Slot s = slotFor(ShuffleSlots.validate(slot));
-            return new StreamingSlotIterator(s, 0L, slot);
+            return new StreamingSlotIterator(s, 0L, slot, bufferKey);
         }
 
         @Override
@@ -1365,7 +1386,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             // touched this slot, so the slot may not exist yet. Creating it here is what lets the
             // stream block for the first chunk instead of mis-reporting an empty partition.
             Slot s = slotFor(ShuffleSlots.validate(slot));
-            return new StreamingSlotIterator(s, timeoutMillis, slot);
+            return new StreamingSlotIterator(s, timeoutMillis, slot, bufferKey);
         }
 
         /**
@@ -1406,14 +1427,16 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             private final Slot slot;
             private final long timeoutMillis;
             private final String slotLabel;
+            private final String bufferKey;
             private Iterator<byte[]> spilled;
             private byte[] pending;
             private boolean eof;
 
-            StreamingSlotIterator(Slot slot, long timeoutMillis, String slotLabel) {
+            StreamingSlotIterator(Slot slot, long timeoutMillis, String slotLabel, String bufferKey) {
                 this.slot = slot;
                 this.timeoutMillis = timeoutMillis;
                 this.slotLabel = slotLabel;
+                this.bufferKey = bufferKey;
                 // Spilled chunks were written before the drain began and are immutable now, so reading
                 // them back eagerly is safe. Only pre-drain accumulation can spill (spillToMakeRoom
                 // skips draining buffers), so this list is bounded by whatever arrived before the
@@ -1480,12 +1503,15 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                         throw new IllegalStateException(
                             "Shuffle drain aborted on slot "
                                 + slotLabel
+                                + " of buffer "
+                                + bufferKey
                                 + " — data arrived after end-of-stream, so this partition is truncated "
                                 + "(declared "
                                 + slot.expectedSenders
                                 + " senders, "
                                 + slot.doneCount.get()
-                                + " reported done)"
+                                + " reported done). The declared count is too LOW: more senders shipped to "
+                                + "this slot than the consumer was told to expect."
                         );
                     }
                     return false;

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferManager.java
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -117,12 +116,32 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
      * window + one chunk. That escape is what stops the window from deadlocking a chunk larger than
      * itself — see {@link #tryAdmit}.
      *
-     * <p>Enforced via REJECT_RETRY rather than by blocking on a bounded queue on purpose: admission
-     * runs on a transport thread, and parking transport threads to apply backpressure risks starving
-     * the node's thread pool. {@link ShuffleSenderRetry} already implements bounded producer-side
-     * retry, so reusing it keeps backpressure off the transport threads.
+     * <p>Never enforced by BLOCKING on a bounded queue: admission runs on a transport thread, and
+     * parking transport threads to apply backpressure risks starving the node's thread pool. A full
+     * window is instead relieved in one of two ways, and which one decides whether backpressure can fail
+     * a query:
+     * <ul>
+     *   <li>by SPILLING the slot's oldest chunks to disk, when no consumer has begun draining the buffer
+     *       (always true for the whole accumulation phase of a materialized buffer). The producer is
+     *       never asked to retry, so there is no terminal state.</li>
+     *   <li>otherwise by {@link AdmitResult#REJECT_RETRY} + {@link ShuffleSenderRetry}'s bounded
+     *       producer-side retry — which CAN exhaust and fail the query. This is the pipelined mode's
+     *       remaining gap, and it is why a window under pipelining stays opt-in.</li>
+     * </ul>
      */
     private volatile long streamWindowBytes = Long.MAX_VALUE;
+
+    /**
+     * Window used for a materialized, spill-capable buffer when no window is configured (see
+     * {@link #effectiveWindowBytes}). 64 MiB matches the order of magnitude every comparable engine
+     * picks for a per-consumer in-flight bound (Spark's fetch window is 48 MB, ClickHouse's per-sink cap
+     * 16 MiB) and is small enough that the heap holds a shuffle's working set rather than its total.
+     *
+     * <p>The node-level bound is this times (partitions of this stage hosted here) times (slots per
+     * partition), so it is a per-slot figure, not a node budget — {@link #nodeBudgetBytes} remains the
+     * absolute backstop.
+     */
+    static final long MATERIALIZED_WINDOW_DEFAULT_BYTES = 64L * 1024 * 1024;
     private final AtomicLong totalBytes = new AtomicLong();
     private final Map<String, AtomicLong> perQueryBytes = new ConcurrentHashMap<>();
 
@@ -369,6 +388,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 key(queryId, targetStageId, partitionIndex),
                 k -> newBuffer(queryId, targetStageId, partitionIndex)
             );
+            String slot = ShuffleSlots.validate(side);
             // Defensive: NEVER append data to a slot whose EOF sentinel has been enqueued — the
             // consumer terminates its stream at the sentinel, so this chunk would be silently dropped
             // (lost rows). The producer's two-phase close (DatafusionPartitionedSink: all data sends
@@ -379,7 +399,7 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             // are concurrent BY DESIGN — `draining` is set as soon as the consumer's handler runs, long
             // before producers finish — so "is draining" no longer means "too late". EOF does: it fires
             // only once every declared sender on that slot has reported isLast.
-            if (buffer.isEofEnqueued(ShuffleSlots.validate(side))) {
+            if (buffer.isEofEnqueued(slot)) {
                 buffer.recordRejected();
                 // Poison the CONSUMER as well as failing this producer. The producer-side throw can lose
                 // the race — the consumer may already have terminated at the premature EOF and produced
@@ -407,10 +427,27 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             // becoming available. The cost is that residency is bounded by window + one chunk rather than
             // by the window exactly; that is the same soft bound Spark and Presto accept for the same
             // reason.
-            long queued = buffer.queuedBytes(ShuffleSlots.validate(side));
-            if (queued > 0 && queued + size > streamWindowBytes) {
-                buffer.recordRejected();
-                return AdmitResult.REJECT_RETRY;
+            long window = effectiveWindowBytes(buffer);
+            long queued = buffer.queuedBytes(slot);
+            if (queued > 0 && queued + size > window) {
+                // A full window is relieved by DISK whenever this buffer can still spill — i.e. no
+                // consumer has begun draining it. That is what makes the window usable at all: the
+                // producer is never told to retry, so backpressure cannot walk into the terminal
+                // "rejected N times, query failed" state, and heap residency is bounded by the window
+                // instead of by the per-query budget (80% of heap, the value that pins old-gen).
+                //
+                // Once a drain owns the queue, spill would mutate a head the consumer is taking from,
+                // so the pipelined mode necessarily falls back to the retryable reject below. The
+                // materialized mode never reaches that state: its drain blocks until every sender is
+                // done, so the whole accumulation phase runs with the buffer non-draining.
+                if (spillEnabled && buffer.isDraining() == false) {
+                    spillSlotHead(buffer, queryId, slot, queued + size - window);
+                }
+                long stillQueued = buffer.queuedBytes(slot);
+                if (stillQueued > 0 && stillQueued + size > window) {
+                    buffer.recordRejected();
+                    return AdmitResult.REJECT_RETRY;
+                }
             }
             AtomicLong q = perQueryBytes.computeIfAbsent(queryId, k -> new AtomicLong());
             long qProjected = q.get() + size;
@@ -458,6 +495,61 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             buffer.addData(side, data);
         }
         return AdmitResult.ACCEPTED;
+    }
+
+    /**
+     * In-flight window applied to {@code buffer}: the explicit {@code analytics.mpp.shuffle.stream_window}
+     * when an operator set one, else a derived default for a MATERIALIZED, spill-capable buffer, else
+     * unbounded (accumulate until the per-query budget).
+     *
+     * <p>The derived default exists because a materialized buffer with no window is bounded only by the
+     * per-query budget — 80% of heap — which is the footprint that pins old-gen for the rest of the
+     * query. It is applied ONLY when spill is enabled and pipelining is off, because that is exactly the
+     * combination in which a window cannot fail a query: a full window is relieved by writing to disk
+     * rather than by waiting for a drain that has not started. Under pipelining the same default would
+     * reintroduce the measured failure mode (a smaller window failed monotonically more queries), so it
+     * stays unbounded there unless an operator opts in.
+     *
+     * <p>The materialized-without-spill case deliberately IGNORES an explicit window, because there
+     * nothing can relieve it: no consumer drains until every sender is done, so a rejected producer
+     * retries against a queue that cannot shrink and fails once its attempt budget runs out —
+     * guaranteed, for any partition larger than the window. That is the same "a window with no
+     * admissible item is a deadlock, not backpressure" rule as the empty-slot escape. Accumulating to
+     * the budget instead is worse for residency but cannot invent a failure.
+     */
+    private long effectiveWindowBytes(ShuffleBuffer buffer) {
+        if (buffer.isPipelined() == false) {
+            if (spillEnabled == false) {
+                return Long.MAX_VALUE; // no relief path exists — see above
+            }
+            return streamWindowBytes != Long.MAX_VALUE ? streamWindowBytes : MATERIALIZED_WINDOW_DEFAULT_BYTES;
+        }
+        // Pipelined: a drain is already running, so a reject CAN be relieved by it (and spill relieves
+        // it too until the drain takes ownership). No derived default — the measured behaviour of a
+        // window under pipelining is that failures rise as it shrinks.
+        return streamWindowBytes;
+    }
+
+    /**
+     * Evicts {@code slot}'s oldest chunks to its spill file until at least {@code targetBytes} of HEAP
+     * are freed, and returns the bytes freed. Narrower than {@link #spillToMakeRoom} on purpose: the
+     * in-flight window is PER-SLOT, so spilling any other slot (or a sibling partition) would write to
+     * disk without freeing the window that is actually full.
+     *
+     * <p>MUST run with {@link #admitLock} held, and only on a buffer that is not yet draining: eviction
+     * takes from the queue HEAD, which is where a live consumer reads. Arrival order survives because
+     * the drain reads the spill file before the resident queue, and every spilled chunk is older than
+     * everything left in the queue.
+     */
+    private long spillSlotHead(ShuffleBuffer buffer, String queryId, String slot, long targetBytes) {
+        long freed = buffer.spillOldest(slot, targetBytes);
+        if (freed > 0) {
+            // Same accounting path as spillToMakeRoom: the buffer's own resident counter, then the
+            // query + node aggregates, so perQueryBytes stays the single source of truth.
+            buffer.releaseCurrentBytes(freed);
+            releaseLocked(queryId, freed);
+        }
+        return freed;
     }
 
     /**
@@ -926,12 +1018,28 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         static final byte[] CANCELLED_SENTINEL = new byte[0];
 
         /**
-         * Default per-chunk wait for a streaming drain. This is a LIVENESS bound, not a data bound:
-         * the drain now blocks for the NEXT chunk rather than for the whole partition, so it only
-         * trips when producers have genuinely stalled. Matches the old whole-partition
-         * {@code awaitReady} budget so a slow-but-working shuffle behaves as before.
+         * Wait for the MATERIALIZED barrier — every declared sender of a slot reporting {@code isLast}.
+         *
+         * <p>Deliberately NOT the per-chunk timeout the caller passes to {@link #drain(String, long)}.
+         * The two bound different things and differ by an order of magnitude:
+         * <ul>
+         *   <li>the caller's value bounds the wait for ONE chunk while producers are already shipping, so
+         *       it is kept small on purpose — at a high partition count a partition that will never be fed
+         *       must fail in a minute rather than hang for five;</li>
+         *   <li>this bounds the WHOLE producer phase, which at scale is minutes: sf=100 fact-table
+         *       producers run far longer than the per-chunk value, so reusing it made every materialized
+         *       stage die at the barrier having received {@code 0/N senders} — measured on the sf=100
+         *       cluster, where q9's shuffle had already written 3.8 GB per node to disk (so the data path
+         *       was healthy) before the barrier expired at 60s and failed the query.</li>
+         * </ul>
+         *
+         * <p>This value is a BACKSTOP, not the primary liveness mechanism: a failed or cancelled query
+         * calls {@code clearForQuery} → {@code abortStreams}, which counts the barrier latch down and
+         * makes the drain fail immediately. It only governs the case where nothing terminates the query at
+         * all, so it trades a longer worst-case hold of one worker thread for the ability to run a
+         * materialized shuffle whose producers legitimately take minutes.
          */
-        static final long DEFAULT_STREAM_POLL_TIMEOUT_MILLIS = 300_000L;
+        static final long MATERIALIZED_BARRIER_TIMEOUT_MILLIS = 300_000L;
 
         /**
          * Slots by label. {@link ConcurrentHashMap} because producer RPCs (arbitrary transport
@@ -978,6 +1086,22 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         /** Sets whether a drain on this buffer overlaps its producers. */
         void setPipelined(boolean enabled) {
             this.pipelined = enabled;
+        }
+
+        /**
+         * Narrows this buffer to the materialized shape, as requested by its worker stage's setup
+         * instruction. One-way (see the SPI contract): the node-level switch stays the operator's kill
+         * switch, and a per-stage decision must not be able to re-enable pipelining against it.
+         */
+        @Override
+        public void useMaterializedMode() {
+            setPipelined(false);
+        }
+
+        /** True when a drain on this buffer overlaps its producers (pipelined) rather than waiting for
+         *  all of them first (materialized). */
+        boolean isPipelined() {
+            return pipelined;
         }
 
         /**
@@ -1055,6 +1179,15 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         long queuedBytes(String slot) {
             Slot s = slots.get(slot);
             return s == null ? 0L : s.queuedBytes.get();
+        }
+
+        /**
+         * Spilled frames read back on {@code slot} so far (0 when it never spilled). Test hook for the
+         * LAZINESS of the spilled phase: consuming one chunk must read one frame, not the whole file.
+         */
+        long spilledFramesRead(String slot) {
+            Slot s = slots.get(ShuffleSlots.validate(slot));
+            return s == null || s.spill == null ? 0L : s.spill.framesRead();
         }
 
         /** True once {@code slot}'s EOF sentinel has been enqueued (all declared senders reported isLast). */
@@ -1338,8 +1471,16 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
             List<byte[]> out = new ArrayList<>();
             if (s.spill != null) {
-                try {
-                    out.addAll(s.spill.readBack());
+                // Frame-at-a-time off disk. This form materializes the result as a List by contract, so
+                // it cannot bound residency the way the streaming iterator does; reading frame-by-frame
+                // at least keeps ONE reader implementation, so a fix to it can never miss this path.
+                try (DataInputStream in = s.spill.openForRead()) {
+                    if (in != null) {
+                        byte[] frame;
+                        while ((frame = s.spill.readFrame(in)) != null) {
+                            out.add(frame);
+                        }
+                    }
                 } catch (IOException e) {
                     throw new UncheckedIOException("Failed to read back shuffle spill file " + s.spill.path(), e);
                 }
@@ -1374,12 +1515,13 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
 
         @Override
         public CloseableIterator<byte[]> drain(String slot, long timeoutMillis) {
-            // Kill switch: barrier FIRST, so the iterator only ever sees a completed partition. That
-            // restores the pre-streaming contract (whole partition resident before any row is read) for
-            // an operator who needs to rule the streaming path out. Pipelining is the default because the
-            // barrier is what forces partition-sized residency — the cost this exists to avoid.
+            // MATERIALIZED: barrier FIRST, so the iterator only ever sees a completed partition, and the
+            // accumulating buffer spills (nothing is draining, so eviction is safe) instead of holding the
+            // partition on heap. Bounded by MATERIALIZED_BARRIER_TIMEOUT_MILLIS, NOT by the caller's
+            // per-chunk timeout: this waits out the entire producer phase, which is minutes at scale, and
+            // conflating the two failed every materialized stage at 0/N senders.
             if (!pipelined) {
-                awaitCompleteOrThrow(timeoutMillis, slot);
+                awaitCompleteOrThrow(MATERIALIZED_BARRIER_TIMEOUT_MILLIS, slot);
             }
             beginDrain();
             // slotFor (not slots.get): the consumer can now start draining BEFORE any producer has
@@ -1411,8 +1553,8 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         }
 
         /**
-         * STREAMING drain: yields any already-spilled chunks (arrival order, one at a time off disk),
-         * then blocks for live chunks off the slot's queue until the EOF sentinel.
+         * STREAMING drain: yields any already-spilled chunks (arrival order, ONE FRAME AT A TIME off
+         * disk), then blocks for live chunks off the slot's queue until the EOF sentinel.
          *
          * <p>This replaces the old snapshot-based drain. The difference that matters: the old iterator
          * was created AFTER {@code awaitReady} guaranteed the partition was complete, so it could
@@ -1428,7 +1570,10 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             private final long timeoutMillis;
             private final String slotLabel;
             private final String bufferKey;
-            private Iterator<byte[]> spilled;
+            /** This slot's spill file, or null when it never spilled. */
+            private final SpilledSide spill;
+            /** Open read stream over {@link #spill}; null before the first read and once exhausted. */
+            private DataInputStream spillIn;
             private byte[] pending;
             private boolean eof;
 
@@ -1437,15 +1582,18 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 this.timeoutMillis = timeoutMillis;
                 this.slotLabel = slotLabel;
                 this.bufferKey = bufferKey;
-                // Spilled chunks were written before the drain began and are immutable now, so reading
-                // them back eagerly is safe. Only pre-drain accumulation can spill (spillToMakeRoom
-                // skips draining buffers), so this list is bounded by whatever arrived before the
-                // consumer started — it does not grow during the stream.
-                if (slot.spill != null) {
+                this.spill = slot.spill;
+                // Spilled chunks were written before the drain began and are immutable now (only
+                // pre-drain accumulation spills — spillToMakeRoom skips draining buffers), so the file
+                // can be streamed. It is opened here but read ONE FRAME AT A TIME below: reading it back
+                // into a List would put the whole spilled prefix on the heap in one go, which is exactly
+                // the residency spill exists to remove — an over-budget partition would spill to disk and
+                // then be fully re-materialized at drain, so the heap peak would be unchanged.
+                if (spill != null) {
                     try {
-                        this.spilled = slot.spill.readBack().iterator();
+                        this.spillIn = spill.openForRead();
                     } catch (IOException e) {
-                        throw new UncheckedIOException("Failed to read back shuffle spill file " + slot.spill.path(), e);
+                        throw new UncheckedIOException("Failed to open shuffle spill file " + spill.path(), e);
                     }
                 }
             }
@@ -1455,9 +1603,13 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 if (pending != null) {
                     return true;
                 }
-                if (spilled != null && spilled.hasNext()) {
-                    pending = spilled.next();
-                    return true;
+                if (spillIn != null) {
+                    byte[] fromDisk = spill.readFrame(spillIn);
+                    if (fromDisk != null) {
+                        pending = fromDisk;
+                        return true;
+                    }
+                    close(); // spilled phase exhausted — release the file handle, fall through to the queue
                 }
                 if (eof) {
                     return false;
@@ -1540,11 +1692,22 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
                 return out;
             }
 
+            /**
+             * Releases the spill read stream. The queue itself is owned by the buffer (cleared by
+             * removeBuffer / clearForQuery), so only the file handle is ours. Idempotent — also called
+             * mid-iteration when the spilled phase is exhausted, and again by the consumer's
+             * try-with-resources / finally.
+             */
             @Override
             public void close() {
-                // The queue is owned by the buffer (cleared by removeBuffer/clearForQuery); the spill
-                // file handle is closed by deleteSpillFiles on the terminal path. Nothing slot-local
-                // to release here.
+                if (spillIn != null) {
+                    try {
+                        spillIn.close();
+                    } catch (IOException e) {
+                        LOGGER.debug(new ParameterizedMessage("Failed to close shuffle spill read stream {}", spill.path()), e);
+                    }
+                    spillIn = null;
+                }
             }
         }
 
@@ -1582,113 +1745,20 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
         }
 
         /**
-         * Lazy drain iterator: yields spilled chunks streamed one-at-a-time from {@code spill}'s file
-         * (deframing the big-endian length prefix), then the heap-resident {@code tail}. Only ONE
-         * chunk is in heap at a time during the spilled phase — that is the property that lets an
-         * over-budget partition drain through the consumer's bounded native channel without OOM.
-         * Closing it releases the spill-file stream; it is also closed automatically at clean EOF of
-         * the spilled phase. Reading past a corrupt/short frame surfaces an {@link UncheckedIOException}
-         * (correctness over silent under-delivery — matches the eager {@code drainSide}).
-         */
-        private static final class SpillThenTailIterator implements CloseableIterator<byte[]> {
-            private DataInputStream in;          // null once the spilled phase is exhausted/closed
-            private final Iterator<byte[]> tail;
-            private final Path spillPath;
-            private byte[] nextChunk;            // one-chunk lookahead from the file
-            private boolean nextLoaded;
-
-            SpillThenTailIterator(SpilledSide spill, List<byte[]> tail) {
-                this.tail = tail.iterator();
-                this.spillPath = spill.path();
-                try {
-                    this.in = spill.openForRead();  // may be null if nothing was written
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Failed to open shuffle spill file " + spillPath, e);
-                }
-            }
-
-            @Override
-            public boolean hasNext() {
-                if (nextLoaded) {
-                    return true;
-                }
-                if (in != null) {
-                    nextChunk = readNextChunk();
-                    if (nextChunk != null) {
-                        nextLoaded = true;
-                        return true;
-                    }
-                    // Spilled phase exhausted — release the file handle and fall through to the tail.
-                    close();
-                }
-                return tail.hasNext();
-            }
-
-            @Override
-            public byte[] next() {
-                if (nextLoaded) {
-                    byte[] c = nextChunk;
-                    nextChunk = null;
-                    nextLoaded = false;
-                    return c;
-                }
-                if (in != null) {
-                    byte[] c = readNextChunk();
-                    if (c != null) {
-                        return c;
-                    }
-                    close();
-                }
-                if (!tail.hasNext()) {
-                    throw new NoSuchElementException();
-                }
-                return tail.next();
-            }
-
-            /** Reads one length-prefixed chunk, or {@code null} at clean EOF. */
-            private byte[] readNextChunk() {
-                try {
-                    int len;
-                    try {
-                        len = in.readInt();
-                    } catch (EOFException eof) {
-                        return null; // clean end of file
-                    }
-                    byte[] chunk = new byte[len];
-                    in.readFully(chunk);
-                    return chunk;
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Failed to read back shuffle spill file " + spillPath, e);
-                }
-            }
-
-            @Override
-            public void close() {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (IOException e) {
-                        LOGGER.debug(new ParameterizedMessage("Failed to close shuffle spill read stream {}", spillPath), e);
-                    }
-                    in = null;
-                }
-            }
-        }
-
-        /**
          * One side's on-disk spill file: a sequence of length-prefixed Arrow-IPC chunks
          * ({@code int length} big-endian, then {@code length} bytes), appended in arrival order.
          * Each chunk is already a self-describing Arrow IPC stream, so the frame just needs to record
          * its byte length to split the concatenation back apart on read.
          *
          * <p>Writes happen under the manager's {@code admitLock} (one writer at a time);
-         * {@link #readBack} runs once at drain after the buffer is fully populated. The append stream
-         * is buffered and flushed per chunk so a crash-free terminal can always read back the file.
+         * {@link #readFrame} is pulled by the drain, one frame per consumed chunk. The append stream is
+         * buffered and flushed per chunk so a crash-free terminal can always read back the file.
          */
         private static final class SpilledSide {
             private final Path path;
             private OutputStream out;
             private long bytesOnDisk;
+            private long framesRead;
 
             SpilledSide(Path path) throws IOException {
                 this.path = path;
@@ -1730,29 +1800,36 @@ public class ShuffleBufferManager implements ShuffleBufferRegistry {
             }
 
             /**
-             * Reads every spilled chunk back, in write (= arrival) order, deframing on the length
-             * prefix. Closes the append stream first so all buffered bytes are flushed.
+             * Reads ONE length-prefixed chunk from {@code in}, or {@code null} at clean end of file.
+             *
+             * <p>The only spill reader. Deliberately frame-at-a-time: a whole-file variant used to exist
+             * beside it and was what the streaming drain called, so an over-budget partition spilled to
+             * disk and was then fully re-materialized on the heap at drain — the peak that spill exists
+             * to remove came straight back. Keeping one reader means a caller cannot pick the eager one
+             * by accident. A corrupt/short frame surfaces as {@link UncheckedIOException} rather than a
+             * short read (correctness over silent under-delivery).
              */
-            List<byte[]> readBack() throws IOException {
-                closeOut();
-                List<byte[]> chunks = new ArrayList<>();
-                if (!Files.exists(path)) {
-                    return chunks;
-                }
-                try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(path)))) {
-                    while (true) {
-                        int len;
-                        try {
-                            len = in.readInt();
-                        } catch (EOFException eof) {
-                            break; // clean end of file
-                        }
-                        byte[] chunk = new byte[len];
-                        in.readFully(chunk);
-                        chunks.add(chunk);
+            byte[] readFrame(DataInputStream in) {
+                try {
+                    int len;
+                    try {
+                        len = in.readInt();
+                    } catch (EOFException eof) {
+                        return null; // clean end of file
                     }
+                    byte[] chunk = new byte[len];
+                    in.readFully(chunk);
+                    framesRead++;
+                    return chunk;
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to read back shuffle spill file " + path, e);
                 }
-                return chunks;
+            }
+
+            /** Frames handed back by {@link #readFrame} so far. Lets a test assert the read is LAZY —
+             *  pulling one chunk must not consume the file — rather than only asserting chunk order. */
+            long framesRead() {
+                return framesRead;
             }
 
             long bytesOnDisk() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleSenderRetry.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/shuffle/ShuffleSenderRetry.java
@@ -10,10 +10,12 @@ package org.opensearch.analytics.exec.shuffle;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.analytics.exec.action.AnalyticsShuffleDataRequest;
 import org.opensearch.analytics.exec.action.AnalyticsShuffleDataResponse;
 import org.opensearch.core.action.ActionListener;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 /**
@@ -34,9 +36,32 @@ public final class ShuffleSenderRetry {
 
     private static final Logger LOGGER = LogManager.getLogger(ShuffleSenderRetry.class);
 
+    /**
+     * Backoff for a TRANSIENT backpressure reject: 8 attempts, 50ms doubling to a 5s cap (~15s total).
+     *
+     * <p>These are the original values, deliberately chosen for the case a reject actually represents
+     * today — another query momentarily filled the node budget. Failing a contended query reasonably
+     * fast is safer than queueing behind an accumulation that could OOM the node.
+     *
+     * <p>They were briefly raised (500 attempts, then unbounded with a 30-minute ceiling) to serve the
+     * in-flight window's pacing, where a full window is a NORMAL steady state rather than a blip. That
+     * pacing scheme is disabled ({@code analytics.mpp.shuffle.stream_window} defaults to 0) because it
+     * deadlocks — see that setting. Raising these again is only correct alongside a real producer-side
+     * pause; a re-send storm on the bounded GENERIC pool is what hung all seven probe queries at sf=10.
+     */
     private static final int DEFAULT_MAX_ATTEMPTS = 8;
     private static final long DEFAULT_INITIAL_BACKOFF_MILLIS = 50;
     private static final long DEFAULT_MAX_BACKOFF_MILLIS = 5_000;
+
+    /**
+     * Wall-clock ceiling on backpressure waiting, independent of the attempt count.
+     *
+     * <p>Kept as a second bound because attempts alone do not bound TIME (the backoff grows), and a
+     * caller must not wait unboundedly on a consumer that will never drain. 2 minutes is well past the
+     * ~15s the attempt budget allows, so in practice the attempt count is what trips first; this is the
+     * backstop for a pathologically slow scheduler.
+     */
+    private static final long DEFAULT_MAX_TOTAL_WAIT_MILLIS = TimeUnit.MINUTES.toMillis(2);
 
     private ShuffleSenderRetry() {}
 
@@ -57,7 +82,51 @@ public final class ShuffleSenderRetry {
         BiConsumer<Long, Runnable> scheduler,
         ActionListener<AnalyticsShuffleDataResponse> finalListener
     ) {
-        sendWithRetry(request, sender, scheduler, finalListener, DEFAULT_MAX_ATTEMPTS, DEFAULT_INITIAL_BACKOFF_MILLIS, 1);
+        sendWithRetry(
+            request,
+            sender,
+            scheduler,
+            finalListener,
+            DEFAULT_MAX_ATTEMPTS,
+            DEFAULT_INITIAL_BACKOFF_MILLIS,
+            1,
+            System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DEFAULT_MAX_TOTAL_WAIT_MILLIS)
+        );
+    }
+
+    /** {@link #sendWithRetry} with an explicit wait ceiling. Visible for tests, which must not inherit
+     *  the production ceiling when driving the loop with an inline scheduler. */
+    static void sendWithRetry(
+        AnalyticsShuffleDataRequest request,
+        BiConsumer<AnalyticsShuffleDataRequest, ActionListener<AnalyticsShuffleDataResponse>> sender,
+        BiConsumer<Long, Runnable> scheduler,
+        ActionListener<AnalyticsShuffleDataResponse> finalListener,
+        long maxTotalWaitMillis
+    ) {
+        sendWithRetry(request, sender, scheduler, finalListener, maxTotalWaitMillis, DEFAULT_MAX_ATTEMPTS);
+    }
+
+    /** {@link #sendWithRetry} with an explicit wait ceiling AND attempt budget. Visible for tests so the
+     *  backoff arithmetic can be driven past the shift width that used to overflow, independently of the
+     *  production budget. */
+    static void sendWithRetry(
+        AnalyticsShuffleDataRequest request,
+        BiConsumer<AnalyticsShuffleDataRequest, ActionListener<AnalyticsShuffleDataResponse>> sender,
+        BiConsumer<Long, Runnable> scheduler,
+        ActionListener<AnalyticsShuffleDataResponse> finalListener,
+        long maxTotalWaitMillis,
+        int maxAttempts
+    ) {
+        sendWithRetry(
+            request,
+            sender,
+            scheduler,
+            finalListener,
+            maxAttempts,
+            DEFAULT_INITIAL_BACKOFF_MILLIS,
+            1,
+            System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(maxTotalWaitMillis)
+        );
     }
 
     private static void sendWithRetry(
@@ -67,7 +136,8 @@ public final class ShuffleSenderRetry {
         ActionListener<AnalyticsShuffleDataResponse> finalListener,
         int maxAttempts,
         long initialBackoffMillis,
-        int attempt
+        int attempt,
+        long deadlineNanos
     ) {
         sender.accept(request, new ActionListener<>() {
             @Override
@@ -76,18 +146,30 @@ public final class ShuffleSenderRetry {
                     finalListener.onResponse(response);
                     return;
                 }
-                if (attempt >= maxAttempts) {
+                // Give up on TIME, not on attempt count (see DEFAULT_MAX_TOTAL_WAIT_MILLIS): a paced
+                // producer legitimately waits out the consumer's whole build phase.
+                boolean outOfTime = deadlineNanos - System.nanoTime() <= 0;
+                if (outOfTime || attempt >= maxAttempts) {
                     LOGGER.warn(
-                        "Shuffle sender gave up after {} attempts for query={}, stage={}, partition={}",
-                        attempt,
-                        request.getQueryId(),
-                        request.getTargetStageId(),
-                        request.getPartitionIndex()
+                        new ParameterizedMessage(
+                            "Shuffle sender gave up after {} attempts ({}) for query={}, stage={}, partition={}",
+                            attempt,
+                            outOfTime ? "wait ceiling reached" : "attempt ceiling reached",
+                            request.getQueryId(),
+                            request.getTargetStageId(),
+                            request.getPartitionIndex()
+                        )
                     );
                     finalListener.onResponse(response);
                     return;
                 }
-                long backoff = Math.min(DEFAULT_MAX_BACKOFF_MILLIS, initialBackoffMillis << (attempt - 1));
+                // Clamp the shift exponent. Java's << on a long uses only the LOW 6 BITS of the shift
+                // count, so `initial << (attempt-1)` silently wraps once attempt-1 >= 64 and overflows
+                // NEGATIVE well before that — producing `duration cannot be negative` from the
+                // scheduler and failing the query. This was unreachable at the old 8-attempt budget
+                // (shift <= 7) and became reachable the moment the budget grew for pacing.
+                int shift = Math.min(attempt - 1, 32);
+                long backoff = Math.min(DEFAULT_MAX_BACKOFF_MILLIS, initialBackoffMillis << shift);
                 LOGGER.debug(
                     "Shuffle backpressure-rejected, retrying in {}ms (attempt {}/{}): query={}, stage={}, partition={}",
                     backoff,
@@ -99,7 +181,16 @@ public final class ShuffleSenderRetry {
                 );
                 scheduler.accept(
                     backoff,
-                    () -> sendWithRetry(request, sender, scheduler, finalListener, maxAttempts, initialBackoffMillis, attempt + 1)
+                    () -> sendWithRetry(
+                        request,
+                        sender,
+                        scheduler,
+                        finalListener,
+                        maxAttempts,
+                        initialBackoffMillis,
+                        attempt + 1,
+                        deadlineNanos
+                    )
                 );
             }
 

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecution.java
@@ -64,6 +64,28 @@ public class WorkerFragmentStageExecution extends AbstractStageExecution impleme
         this.runner = new WorkerTaskRunner(this, config, dispatcher, requestBuilder);
     }
 
+    /**
+     * Worker tiers schedule EAGERLY — on the first producer RUNNING, not on all producers SUCCEEDED.
+     *
+     * <p>With the default (all-children-SUCCEEDED) a worker's drain cannot begin until every producer has
+     * finished, so an entire shuffle partition is resident before a single row is consumed. The drain then
+     * decodes all of it into Arrow buffers bounded by the query pool, and a large partition exhausts that pool
+     * — measured as {@code shuffle drain failed for input-N: Unable to allocate ... Current allocation:
+     * 1356648008} against a 1,357,503,692-byte pool, i.e. full to within 0.06%.
+     *
+     * <p>Overlapping the drain with its producers is what makes peak residency a function of arrival rate
+     * rather than partition size. It is also the prerequisite for any in-flight window to work at all: while
+     * the consumer does not exist during the producer phase, there is no drain to release a window, so every
+     * window deadlocks regardless of how backpressure is signalled.
+     *
+     * <p>Cost: a worker now holds its executor thread for the query's duration rather than only its own
+     * compute, so a plan with many stages x partitions consumes more of the pool concurrently.
+     */
+    @Override
+    public boolean schedulesEagerly() {
+        return true;
+    }
+
     @Override
     protected List<StageTask> materializeTasks() {
         List<ExecutionTarget> resolved = stage.getTargetResolver().resolve(clusterService.state(), null);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecution.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecution.java
@@ -65,21 +65,30 @@ public class WorkerFragmentStageExecution extends AbstractStageExecution impleme
     }
 
     /**
-     * Worker tiers schedule EAGERLY — on the first producer RUNNING, not on all producers SUCCEEDED.
+     * Worker tiers schedule EAGERLY — on the first producer RUNNING, not on all producers SUCCEEDED —
+     * in BOTH shuffle shapes.
      *
-     * <p>With the default (all-children-SUCCEEDED) a worker's drain cannot begin until every producer has
-     * finished, so an entire shuffle partition is resident before a single row is consumed. The drain then
-     * decodes all of it into Arrow buffers bounded by the query pool, and a large partition exhausts that pool
-     * — measured as {@code shuffle drain failed for input-N: Unable to allocate ... Current allocation:
-     * 1356648008} against a 1,357,503,692-byte pool, i.e. full to within 0.06%.
+     * <p>For a pipelined worker this is what makes the drain overlap its producers. Under the default
+     * (all-children-SUCCEEDED) a worker's drain cannot begin until every producer has finished, so an
+     * entire shuffle partition is resident before a single row is consumed; the drain then decodes all of
+     * it into Arrow buffers bounded by the query pool, and a large partition exhausts that pool —
+     * measured as {@code shuffle drain failed for input-N: Unable to allocate ... Current allocation:
+     * 1356648008} against a 1,357,503,692-byte pool, i.e. full to within 0.06%. It is also the
+     * prerequisite for any in-flight window: with no consumer during the producer phase there is no drain
+     * to release a window, so every window deadlocks however backpressure is signalled.
      *
-     * <p>Overlapping the drain with its producers is what makes peak residency a function of arrival rate
-     * rather than partition size. It is also the prerequisite for any in-flight window to work at all: while
-     * the consumer does not exist during the producer phase, there is no drain to release a window, so every
-     * window deadlocks regardless of how backpressure is signalled.
+     * <p>A MATERIALIZED worker keeps it for a different reason: this stage's
+     * {@link org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode} is the only channel that
+     * carries the shuffle shape (and the expected-sender counts) to the consumer NODE, and it only runs
+     * when this stage is dispatched. Waiting for all producers would deliver the shape after every chunk
+     * had already been admitted, so the buffer would spend the whole accumulation phase in the node
+     * default — and the residency bound the materialized shape exists for would never apply.
      *
-     * <p>Cost: a worker now holds its executor thread for the query's duration rather than only its own
-     * compute, so a plan with many stages x partitions consumes more of the pool concurrently.
+     * <p>Cost, in both shapes: a worker holds a thread from {@code analytics_worker} for the query's
+     * duration rather than only its own compute — the materialized one parked in its barrier, the
+     * pipelined one blocked on chunk arrival. That pool is sized for blocked tasks
+     * ({@code max(16, cores*8)}) precisely to absorb this; SEARCH is not, which is why worker fragments
+     * were moved off it.
      */
     @Override
     public boolean schedulesEagerly() {

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecutionFactory.java
@@ -24,14 +24,16 @@ import org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode;
 import org.opensearch.cluster.service.ClusterService;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
  * Builds a {@link WorkerFragmentStageExecution} that fans out one fragment request per
- * resolved {@link WorkerExecutionTarget}. Each per-task request carries only the two
+ * resolved {@link WorkerExecutionTarget}. Each per-task request carries only the
  * {@link ShuffleScanInstructionNode}s for that target's partition — the consumer-stage's
- * full instruction list (with all 2N partition-side scans appended) is filtered down so
+ * full instruction list (with every partition × slot scan appended) is filtered down so
  * each worker session registers only its own per-partition streaming tables.
  *
  * @opensearch.internal
@@ -62,37 +64,27 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
      * Filters every {@link StagePlan}'s instruction list to keep only the ShuffleScan
      * instructions for {@code partitionIndex}. Replaces the partition-agnostic
      * {@link ShuffleWorkerSetupInstructionNode} placeholder with a partition-specific copy so
-     * the setup handler can eagerly register both sides' expected sender counts on the buffer
+     * the setup handler can eagerly declare EVERY slot's expected sender count on the buffer
      * BEFORE any ShuffleScanHandler calls awaitReady.
      *
      * <p>The returned alternatives are the wire payload sent to the worker task; the
-     * data-node-side handler chain runs setup → register-left-stream → register-right-stream →
-     * execute.
+     * data-node-side handler chain runs setup → one register-stream per slot → execute.
      */
     private static List<FragmentExecutionRequest.PlanAlternative> filterPlanAlternativesForPartition(Stage stage, int partitionIndex) {
         List<FragmentExecutionRequest.PlanAlternative> alts = new ArrayList<>();
         for (StagePlan plan : stage.getPlanAlternatives()) {
-            // Compute per-partition setup parameters from the partition's own scan instructions
-            // (left + right). The expected sender counts come from the ShuffleScan instructions
-            // (each scan carries the count for its side); the placeholder setup at the head
-            // doesn't have them yet because it was added before per-partition info was known.
-            // Default to -1 ("leave unchanged" in setExpectedSenders) and let the placeholder's
-            // own value be the fallback for sides with no ShuffleScan — that's how the M3
-            // single-side aggregate path tells the worker buffer that the right side has zero
-            // expected senders (placeholder carries rightExpectedSenders=0).
-            int leftExpected = -1;
-            int rightExpected = -1;
+            // Compute per-partition setup parameters from the partition's own scan instructions —
+            // one per slot the consumer reads. The expected sender counts come from the ShuffleScan
+            // instructions (each carries the count for its own slot); the placeholder setup at the
+            // head doesn't have them yet because it was added before per-partition info was known.
+            Map<String, Integer> expectedBySlot = new LinkedHashMap<>();
             String queryId = null;
             int targetStageId = -1;
             boolean preferHashJoin = true;
             ShuffleWorkerSetupInstructionNode placeholderSetup = null;
             for (InstructionNode node : plan.instructions()) {
                 if (node instanceof ShuffleScanInstructionNode scan && scan.getShufflePartitionIndex() == partitionIndex) {
-                    if ("left".equals(scan.getSide())) {
-                        leftExpected = scan.getExpectedSenders();
-                    } else if ("right".equals(scan.getSide())) {
-                        rightExpected = scan.getExpectedSenders();
-                    }
+                    expectedBySlot.put(scan.getSide(), scan.getExpectedSenders());
                     if (queryId == null) {
                         queryId = scan.getQueryId();
                         targetStageId = scan.getTargetStageId();
@@ -101,12 +93,12 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
                     placeholderSetup = setup;
                 }
             }
-            // For sides with no ShuffleScan instruction (M3 agg shuffle has only "left" scans),
-            // fall back to the placeholder's stored value so a configured "rightExpected=0"
-            // pre-fires the right-side latch and doesn't get clobbered to -1.
+            // Merge in any slot the placeholder declares that has NO ShuffleScan instruction. That is
+            // how the M3 agg-shuffle path (only a "left" scan) tells the worker buffer the right slot
+            // has zero expected senders, pre-firing its latch. putIfAbsent so a slot's own scan
+            // instruction always wins over the placeholder's pre-partition estimate.
             if (placeholderSetup != null) {
-                if (leftExpected < 0) leftExpected = placeholderSetup.getLeftExpectedSenders();
-                if (rightExpected < 0) rightExpected = placeholderSetup.getRightExpectedSenders();
+                placeholderSetup.getExpectedSendersBySlot().forEach(expectedBySlot::putIfAbsent);
                 if (queryId == null) {
                     queryId = placeholderSetup.getQueryId();
                     targetStageId = placeholderSetup.getTargetStageId();
@@ -123,18 +115,11 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
                         filtered.add(scan);
                     }
                 } else if (node instanceof ShuffleWorkerSetupInstructionNode) {
-                    // Replace the placeholder setup with a partition-specific copy carrying
-                    // both sides' expected counts.
+                    // Replace the placeholder setup with a partition-specific copy carrying every
+                    // slot's expected count.
                     if (queryId != null) {
                         filtered.add(
-                            new ShuffleWorkerSetupInstructionNode(
-                                queryId,
-                                targetStageId,
-                                partitionIndex,
-                                leftExpected,
-                                rightExpected,
-                                preferHashJoin
-                            )
+                            new ShuffleWorkerSetupInstructionNode(queryId, targetStageId, partitionIndex, expectedBySlot, preferHashJoin)
                         );
                     } else {
                         filtered.add(node);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecutionFactory.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentStageExecutionFactory.java
@@ -69,8 +69,12 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
      *
      * <p>The returned alternatives are the wire payload sent to the worker task; the
      * data-node-side handler chain runs setup → one register-stream per slot → execute.
+     *
+     * <p>Package-private so a test can pin the per-task rebuild directly: every coordinator decision on
+     * the placeholder (join algorithm, shuffle shape) has to be copied onto the partition-specific node,
+     * and silently dropping one reverts that decision for every task with nothing to show it.
      */
-    private static List<FragmentExecutionRequest.PlanAlternative> filterPlanAlternativesForPartition(Stage stage, int partitionIndex) {
+    static List<FragmentExecutionRequest.PlanAlternative> filterPlanAlternativesForPartition(Stage stage, int partitionIndex) {
         List<FragmentExecutionRequest.PlanAlternative> alts = new ArrayList<>();
         for (StagePlan plan : stage.getPlanAlternatives()) {
             // Compute per-partition setup parameters from the partition's own scan instructions —
@@ -81,6 +85,7 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
             String queryId = null;
             int targetStageId = -1;
             boolean preferHashJoin = true;
+            boolean pipelined = true;
             ShuffleWorkerSetupInstructionNode placeholderSetup = null;
             for (InstructionNode node : plan.instructions()) {
                 if (node instanceof ShuffleScanInstructionNode scan && scan.getShufflePartitionIndex() == partitionIndex) {
@@ -103,9 +108,10 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
                     queryId = placeholderSetup.getQueryId();
                     targetStageId = placeholderSetup.getTargetStageId();
                 }
-                // Carry the coordinator's per-worker-stage sort-merge-join decision through the
-                // placeholder → partition-specific rebuild below.
+                // Carry the coordinator's per-worker-stage decisions (join algorithm + shuffle shape)
+                // through the placeholder → partition-specific rebuild below.
                 preferHashJoin = placeholderSetup.getPreferHashJoin();
+                pipelined = placeholderSetup.isPipelined();
             }
 
             List<InstructionNode> filtered = new ArrayList<>();
@@ -119,7 +125,14 @@ public final class WorkerFragmentStageExecutionFactory implements StageExecution
                     // slot's expected count.
                     if (queryId != null) {
                         filtered.add(
-                            new ShuffleWorkerSetupInstructionNode(queryId, targetStageId, partitionIndex, expectedBySlot, preferHashJoin)
+                            new ShuffleWorkerSetupInstructionNode(
+                                queryId,
+                                targetStageId,
+                                partitionIndex,
+                                expectedBySlot,
+                                preferHashJoin,
+                                pipelined
+                            )
                         );
                     } else {
                         filtered.add(node);

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/GeneralShuffleDAGRewriter.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/dag/GeneralShuffleDAGRewriter.java
@@ -12,6 +12,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinInfo;
 import org.opensearch.analytics.exec.join.DistributionEnforcementPass;
 import org.opensearch.analytics.exec.join.ShuffleEnrichment;
+import org.opensearch.analytics.exec.join.ShuffleEnrichment.WorkerInput;
 import org.opensearch.analytics.exec.join.ShuffleEnrichment.WorkerLevel;
 import org.opensearch.analytics.exec.join.UnifiedDispatch;
 import org.opensearch.analytics.planner.CapabilityRegistry;
@@ -20,10 +21,12 @@ import org.opensearch.analytics.planner.rel.OpenSearchJoin;
 import org.opensearch.analytics.planner.rel.OpenSearchShuffleExchange;
 import org.opensearch.analytics.planner.rel.OpenSearchStageInputScan;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.analytics.spi.ShuffleSlots;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,10 +175,16 @@ public final class GeneralShuffleDAGRewriter {
             for (Stage s : bottomUpRef) {
                 JoinShuffleInfo d = descRef.get(s.getStageId());
                 Stage worker = rewrittenById.get(s.getStageId());
-                Stage leftProducer = rewrittenById.get(d.leftProducerId());
-                Stage rightProducer = rewrittenById.get(d.rightProducerId());
                 List<String> nodes = nodesRef.get(s.getStageId());
-                levels.add(new WorkerLevel(worker, leftProducer, rightProducer, d.leftKeys(), d.rightKeys(), d.partitionCount(), nodes));
+                // One worker slot per shuffle input, in the join tree's left-to-right leaf order — so a
+                // binary join keeps the historical left/right labels (see ShuffleSlots.forInput).
+                List<WorkerInput> inputs = new ArrayList<>(d.inputs().size());
+                int arity = d.inputs().size();
+                for (int i = 0; i < arity; i++) {
+                    ShuffleInput in = d.inputs().get(i);
+                    inputs.add(new WorkerInput(rewrittenById.get(in.producerStageId()), in.hashKeys(), ShuffleSlots.forInput(i, arity)));
+                }
+                levels.add(new WorkerLevel(worker, inputs, d.partitionCount(), nodes));
             }
             return levels;
         });
@@ -232,69 +241,89 @@ public final class GeneralShuffleDAGRewriter {
         return copy;
     }
 
-    /** Per-join-shuffle-stage analysis: producer child stage ids + per-side hash keys + partition count. */
-    private record JoinShuffleInfo(int leftProducerId, int rightProducerId, List<Integer> leftKeys, List<Integer> rightKeys,
-        int partitionCount) {
+    /** Per-join-shuffle-stage analysis: one {@link ShuffleInput} per shuffle-fed join input, plus the
+     *  common partition count. */
+    private record JoinShuffleInfo(List<ShuffleInput> inputs, int partitionCount) {
+    }
+
+    /** One shuffle-fed input of a promoted join: its producer child stage id and its hash keys. */
+    private record ShuffleInput(int producerStageId, List<Integer> hashKeys) {
     }
 
     /**
-     * Extracts the join's two shuffle inputs' producer stage ids + keys. Defense-in-depth: each side's
-     * shuffle must be partitioned on THIS join's equi keys, and both sides must agree on the partition count
-     * — the enforcement pass guarantees this (it builds each shuffle from the join's per-side keys), but a
-     * future DAG-shape change must not silently promote a mis-keyed shuffle into a worker.
+     * Extracts each shuffle input's producer stage id + keys. Defense-in-depth: every input's shuffle
+     * must be partitioned on THIS join's equi keys for that input, and all inputs must agree on the
+     * partition count — the enforcement pass guarantees this (it builds each shuffle from the join's
+     * per-input keys), but a future DAG-shape change must not silently promote a mis-keyed shuffle into
+     * a worker.
      */
     private static JoinShuffleInfo analyze(Stage stage) {
-        OpenSearchJoin join = findJoinOverTwoShuffles(stage.getFragment());
+        OpenSearchJoin join = findJoinOverShuffles(stage.getFragment());
         if (join == null) {
-            throw new IllegalStateException("GeneralShuffleDAGRewriter: stage " + stage.getStageId() + " has no join over two shuffles");
+            throw new IllegalStateException("GeneralShuffleDAGRewriter: stage " + stage.getStageId() + " has no join over shuffles");
         }
-        OpenSearchShuffleExchange leftShuffle = asShuffle(join.getInput(0), stage.getStageId(), "left");
-        OpenSearchShuffleExchange rightShuffle = asShuffle(join.getInput(1), stage.getStageId(), "right");
-        JoinInfo info = join.analyzeCondition();
-        if (!leftShuffle.getHashKeys().equals(info.leftKeys) || !rightShuffle.getHashKeys().equals(info.rightKeys)) {
-            throw new IllegalStateException(
-                "GeneralShuffleDAGRewriter: stage "
-                    + stage.getStageId()
-                    + " shuffle keys do not match join equi keys (leftShuffle="
-                    + leftShuffle.getHashKeys()
-                    + " leftJoin="
-                    + info.leftKeys
-                    + ", rightShuffle="
-                    + rightShuffle.getHashKeys()
-                    + " rightJoin="
-                    + info.rightKeys
-                    + ")"
-            );
+        // Collect the shuffle leaves of this stage's join TREE, left-to-right. A binary join contributes
+        // two; a collapsed N-way tree (Join(Shuffle, Join(Shuffle, Shuffle)) in one fragment) contributes
+        // one per leaf, each becoming its own worker slot.
+        List<OpenSearchShuffleExchange> shuffles = new ArrayList<>();
+        collectShuffleLeaves(join, shuffles, stage.getStageId());
+        List<ShuffleInput> inputs = new ArrayList<>(shuffles.size());
+        int partitionCount = -1;
+        // Every equi key a join in this tree partitions on, so a leaf's keys can be checked against the
+        // set the tree actually demands. Position-wise checking doesn't generalize: in a collapsed tree a
+        // leaf feeds an INNER join whose own left/right key lists are relative to that join, not the root.
+        Set<List<Integer>> treeKeys = new HashSet<>();
+        collectJoinKeys(join, treeKeys);
+        for (int i = 0; i < shuffles.size(); i++) {
+            OpenSearchShuffleExchange shuffle = shuffles.get(i);
+            if (!treeKeys.contains(shuffle.getHashKeys())) {
+                throw new IllegalStateException(
+                    "GeneralShuffleDAGRewriter: stage "
+                        + stage.getStageId()
+                        + " input "
+                        + i
+                        + " shuffle keys "
+                        + shuffle.getHashKeys()
+                        + " match none of the join tree's equi keys "
+                        + treeKeys
+                );
+            }
+            if (partitionCount < 0) {
+                partitionCount = shuffle.getPartitionCount();
+            } else if (partitionCount != shuffle.getPartitionCount()) {
+                throw new IllegalStateException(
+                    "GeneralShuffleDAGRewriter: stage "
+                        + stage.getStageId()
+                        + " shuffle partition counts disagree ("
+                        + partitionCount
+                        + " vs "
+                        + shuffle.getPartitionCount()
+                        + " on input "
+                        + i
+                        + ")"
+                );
+            }
+            inputs.add(new ShuffleInput(childStageId(shuffle), shuffle.getHashKeys()));
         }
-        if (leftShuffle.getPartitionCount() != rightShuffle.getPartitionCount()) {
-            throw new IllegalStateException(
-                "GeneralShuffleDAGRewriter: stage "
-                    + stage.getStageId()
-                    + " left/right shuffle partition counts disagree ("
-                    + leftShuffle.getPartitionCount()
-                    + " vs "
-                    + rightShuffle.getPartitionCount()
-                    + ")"
-            );
+        // Each worker input is an INDEPENDENT producer stream (one sink per slot), so the shuffle inputs
+        // MUST resolve to distinct producer stages — DAGBuilder.cutShuffle mints a fresh stage id per
+        // shuffle-input cut, so even a self-join (a ⋈ a) yields two stages. A shared id would make
+        // enrichLevels enrich one producer under two slots against a single sink → the worker's awaitReady
+        // never completes for one slot → hang. Fail loud (tripwire) rather than hang if a future DAG-shape
+        // change ever collapses them. (codex round-3 review.)
+        Set<Integer> distinctProducers = new HashSet<>();
+        for (ShuffleInput in : inputs) {
+            if (!distinctProducers.add(in.producerStageId())) {
+                throw new IllegalStateException(
+                    "GeneralShuffleDAGRewriter: stage "
+                        + stage.getStageId()
+                        + " join has two shuffle inputs resolving to the SAME producer stage "
+                        + in.producerStageId()
+                        + " — the shuffle transport requires one distinct producer stage per worker slot."
+                );
+            }
         }
-        int leftId = childStageId(leftShuffle);
-        int rightId = childStageId(rightShuffle);
-        // The binary shuffle transport gives each worker TWO independent producer streams (one sink per
-        // side). The two shuffle inputs MUST therefore be distinct producer stages — DAGBuilder.cutShuffle
-        // mints a fresh stage id per shuffle-input cut, so even a self-join (a ⋈ a) yields two stages. A
-        // shared id would make enrichLevels enrich one producer as BOTH "left" and "right" against a single
-        // sink → the worker's awaitReady never completes for one side → hang. Fail loud (tripwire) rather
-        // than hang if a future DAG-shape change ever collapses them. (codex round-3 review.)
-        if (leftId == rightId) {
-            throw new IllegalStateException(
-                "GeneralShuffleDAGRewriter: stage "
-                    + stage.getStageId()
-                    + " join's two shuffle inputs resolve to the SAME producer stage "
-                    + leftId
-                    + " — the binary shuffle transport requires two distinct producer stages per worker (one sink per side)."
-            );
-        }
-        return new JoinShuffleInfo(leftId, rightId, leftShuffle.getHashKeys(), rightShuffle.getHashKeys(), leftShuffle.getPartitionCount());
+        return new JoinShuffleInfo(inputs, partitionCount);
     }
 
     private static OpenSearchShuffleExchange asShuffle(RelNode input, int stageId, String side) {
@@ -305,6 +334,34 @@ public final class GeneralShuffleDAGRewriter {
         throw new IllegalStateException(
             "GeneralShuffleDAGRewriter: stage " + stageId + " join " + side + " input is not a shuffle: " + n.getRelTypeName()
         );
+    }
+
+    /**
+     * Collects the {@link OpenSearchShuffleExchange} leaves of a join tree, left-to-right. A nested
+     * {@link OpenSearchJoin} input is recursed into (that is the collapsed N-way shape); anything else
+     * must be a shuffle, else {@link #asShuffle} fails loud.
+     */
+    private static void collectShuffleLeaves(OpenSearchJoin join, List<OpenSearchShuffleExchange> out, int stageId) {
+        for (int i = 0; i < join.getInputs().size(); i++) {
+            RelNode input = RelNodeUtils.unwrapHep(join.getInput(i));
+            if (input instanceof OpenSearchJoin nested) {
+                collectShuffleLeaves(nested, out, stageId);
+            } else {
+                out.add(asShuffle(input, stageId, "input " + i));
+            }
+        }
+    }
+
+    /** Collects every per-side equi-key list of every join in the tree rooted at {@code join}. */
+    private static void collectJoinKeys(OpenSearchJoin join, Set<List<Integer>> out) {
+        JoinInfo info = join.analyzeCondition();
+        out.add(info.leftKeys);
+        out.add(info.rightKeys);
+        for (RelNode input : join.getInputs()) {
+            if (RelNodeUtils.unwrapHep(input) instanceof OpenSearchJoin nested) {
+                collectJoinKeys(nested, out);
+            }
+        }
     }
 
     private static int childStageId(OpenSearchShuffleExchange shuffle) {
@@ -321,7 +378,7 @@ public final class GeneralShuffleDAGRewriter {
         if (stage == null) {
             return;
         }
-        if (findJoinOverTwoShuffles(stage.getFragment()) != null) {
+        if (findJoinOverShuffles(stage.getFragment()) != null) {
             out.add(stage);
         }
         for (Stage child : stage.getChildStages()) {
@@ -330,14 +387,18 @@ public final class GeneralShuffleDAGRewriter {
     }
 
     /**
-     * Returns the UNIQUE {@link OpenSearchJoin} in {@code fragment} whose two inputs are both
-     * {@link OpenSearchShuffleExchange}, or {@code null} if there is none / more than one. Accepts ANY join
-     * type (the enforcement pass co-partitions outer/semi/anti too). A join-over-two-shuffles' inputs are
-     * StageInputScan leaves (lower tiers are separate stages), so there is at most one such join per
-     * fragment in the enforced DAG; the uniqueness guard rejects a malformed multi-join fragment rather than
-     * silently promoting one arbitrarily.
+     * Returns the UNIQUE ROOT {@link OpenSearchJoin} in {@code fragment} whose every leaf input is an
+     * {@link OpenSearchShuffleExchange}, or {@code null} if there is none / more than one. Accepts ANY
+     * join type (the enforcement pass co-partitions outer/semi/anti too) and any arity: a binary join
+     * over two shuffles, or a COLLAPSED N-way tree in one fragment
+     * ({@code Join(Shuffle, Join(Shuffle, Shuffle))}) whose leaves each become a worker slot.
+     *
+     * <p>Only the OUTERMOST qualifying join is returned — a nested join inside the tree is part of the
+     * same worker fragment, not a separate promotion. Each shuffle leaf's input is a StageInputScan
+     * (lower tiers are separate stages), so a fragment has at most one such tree in the enforced DAG;
+     * the uniqueness guard rejects a malformed multi-tree fragment rather than promoting one arbitrarily.
      */
-    private static OpenSearchJoin findJoinOverTwoShuffles(RelNode fragment) {
+    private static OpenSearchJoin findJoinOverShuffles(RelNode fragment) {
         if (fragment == null) {
             return null;
         }
@@ -347,17 +408,30 @@ public final class GeneralShuffleDAGRewriter {
     }
 
     private static void collect(RelNode node, Set<OpenSearchJoin> out) {
-        if (node instanceof OpenSearchJoin join
-            && RelNodeUtils.unwrapHep(join.getInput(0)) instanceof OpenSearchShuffleExchange
-            && RelNodeUtils.unwrapHep(join.getInput(1)) instanceof OpenSearchShuffleExchange) {
+        if (node instanceof OpenSearchJoin join && allLeavesAreShuffles(join)) {
             out.add(join);
-            // The shuffle inputs are StageInputScan leaves — no deeper join-over-two-shuffles in THIS
-            // fragment (lower tiers are separate child stages).
+            // Do NOT descend: a nested join below belongs to THIS tree (one worker fragment), and the
+            // shuffle leaves' own inputs are StageInputScans whose lower tiers are separate child stages.
             return;
         }
         for (RelNode input : node.getInputs()) {
             collect(RelNodeUtils.unwrapHep(input), out);
         }
+    }
+
+    /** True if every leaf of {@code join}'s tree (recursing through nested joins) is a shuffle exchange. */
+    private static boolean allLeavesAreShuffles(OpenSearchJoin join) {
+        for (RelNode input : join.getInputs()) {
+            RelNode n = RelNodeUtils.unwrapHep(input);
+            if (n instanceof OpenSearchJoin nested) {
+                if (!allLeavesAreShuffles(nested)) {
+                    return false;
+                }
+            } else if (!(n instanceof OpenSearchShuffleExchange)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /** Backend id to drive worker promotion + the convert pipeline. Reads the first join-shuffle stage's

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/AnalyticsThreadPoolIsolationTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/AnalyticsThreadPoolIsolationTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Guards the thread-pool isolation that keeps blocking fragments from deadlocking each other.
+ *
+ * <p>A shuffle WORKER fragment blocks in its shuffle scan until its producers deliver, and in a
+ * multi-level cascade those producers are themselves fragments that need a thread. If consumers and
+ * producers draw from one bounded pool, then as soon as a node's worker tasks outnumber that pool every
+ * thread ends up held by a consumer waiting on a producer queued behind it: no progress, no rejections,
+ * and the drain eventually fails having received nothing. Observed directly on a shuffling multi-way
+ * join — the search pool pinned at its full size with a queue that never drained.
+ *
+ * <p>Worker tasks scale with the shuffle partition count, so this is also what bounds how far partitions
+ * can be raised, which is the lever that decides whether a memory-heavy join fits.
+ */
+public class AnalyticsThreadPoolIsolationTests extends OpenSearchTestCase {
+
+    /** Worker fragments must have their own pool, not share one with the fragments they wait on. */
+    public void testWorkerFragmentsGetADedicatedPool() {
+        assertEquals(
+            "the plugin must register a worker pool alongside the scheduler and reduce pools",
+            3,
+            new AnalyticsPlugin().getExecutorBuilders(Settings.EMPTY).size()
+        );
+    }
+
+    /** It must be distinct from SEARCH (where the shard-scan producers run) and from the other pools. */
+    public void testWorkerPoolIsDistinctFromSearchAndTheOtherAnalyticsPools() {
+        assertNotEquals(ThreadPool.Names.SEARCH, AnalyticsPlugin.WORKER_THREAD_POOL_NAME);
+        assertNotEquals(AnalyticsPlugin.REDUCE_THREAD_POOL_NAME, AnalyticsPlugin.WORKER_THREAD_POOL_NAME);
+        assertNotEquals(AnalyticsPlugin.SCHEDULER_THREAD_POOL_NAME, AnalyticsPlugin.WORKER_THREAD_POOL_NAME);
+    }
+
+    /**
+     * The pool must be sized well above the core count. These threads are blocked on data arrival rather
+     * than computing, and the pool has to exceed the deepest cascade's per-node task count — a
+     * core-count-sized pool is exactly the configuration that deadlocked.
+     */
+    public void testWorkerPoolIsSizedForBlockedTasksNotForCpus() {
+        int size = AnalyticsPlugin.workerPoolSize();
+        int processors = Runtime.getRuntime().availableProcessors();
+        assertTrue(
+            "worker pool ("
+                + size
+                + ") must exceed the processor count ("
+                + processors
+                + "): a pool sized for "
+                + "CPUs deadlocks once a cascade's per-node worker tasks outnumber it",
+            size > processors
+        );
+        assertTrue("worker pool must have a usable floor on small hosts", size >= 16);
+        assertTrue("the worker pool must be larger than the scheduler pool", size > AnalyticsPlugin.schedulerPoolSize());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/ShuffleEnrichmentTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/ShuffleEnrichmentTests.java
@@ -22,7 +22,9 @@ import org.opensearch.analytics.spi.ShuffleScanInstructionNode;
 import org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
@@ -177,6 +179,61 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
         assertEquals("qid", setup.getQueryId());
         assertEquals(4, setup.getTargetStageId());
         assertFalse("preferHashJoin flows through to the setup placeholder", setup.getPreferHashJoin());
+    }
+
+    public void testEnrichWorkerAlternativesForThreeSlots() {
+        // N-ary transport: a 3-input worker gets 2 partitions × 3 slots = 6 scans + 1 setup. This is the
+        // shape a collapsed N-way join tier needs; the binary case is asserted above.
+        Stage consumer = new Stage(/* stageId */ 20, null, List.of(), null, null, null);
+        consumer.setPlanAlternatives(List.of(new StagePlan(null, "df")));
+
+        Map<String, Integer> expected = new LinkedHashMap<>();
+        expected.put("in0", 5);
+        expected.put("in1", 4);
+        expected.put("in2", 3);
+        Map<String, Integer> producers = new LinkedHashMap<>();
+        producers.put("in0", 31);
+        producers.put("in1", 32);
+        producers.put("in2", 33);
+
+        ShuffleEnrichment.enrichWorkerAlternatives(consumer, /* partitionCount */ 2, expected, "qid-n", producers, true);
+
+        List<InstructionNode> instr = consumer.getPlanAlternatives().get(0).instructions();
+        assertEquals("1 setup + 2 partitions × 3 slots = 7 instructions", 7, instr.size());
+        ShuffleWorkerSetupInstructionNode setup = (ShuffleWorkerSetupInstructionNode) instr.get(0);
+        assertEquals("setup declares every slot in one call", expected, setup.getExpectedSendersBySlot());
+
+        // Each (partition, slot) pair appears exactly once, bound to its own producer's named input.
+        Set<String> seen = new java.util.HashSet<>();
+        for (int i = 1; i < instr.size(); i++) {
+            ShuffleScanInstructionNode scan = (ShuffleScanInstructionNode) instr.get(i);
+            assertTrue("duplicate (partition,slot) scan", seen.add(scan.getShufflePartitionIndex() + ":" + scan.getSide()));
+            assertEquals("input-" + producers.get(scan.getSide()), scan.getNamedInputId());
+            assertEquals(expected.get(scan.getSide()).intValue(), scan.getExpectedSenders());
+            assertEquals(20, scan.getTargetStageId());
+            assertEquals("qid-n", scan.getQueryId());
+        }
+        assertEquals(6, seen.size());
+    }
+
+    public void testEnrichWorkerAlternativesRejectsSlotSetMismatch() {
+        // expectedSenders and producer-stage maps must describe the SAME slots — a mismatch would emit a
+        // scan with a null expected count (or omit a slot the buffer awaits) and hang the worker.
+        Stage consumer = new Stage(/* stageId */ 21, null, List.of(), null, null, null);
+        consumer.setPlanAlternatives(List.of(new StagePlan(null, "df")));
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> ShuffleEnrichment.enrichWorkerAlternatives(
+                consumer,
+                2,
+                new LinkedHashMap<>(Map.of("in0", 1, "in1", 1)),
+                "qid",
+                new LinkedHashMap<>(Map.of("in0", 5)),
+                true
+            )
+        );
+        assertTrue("must name the disagreeing slot sets", ex.getMessage().contains("disagree"));
     }
 
     private static Stage newProducerStage(int stageId, int partitionCount, List<Integer> hashKeys) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/ShuffleEnrichmentTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/join/ShuffleEnrichmentTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.analytics.exec.join;
 
+import org.opensearch.analytics.exec.QueryContext;
 import org.opensearch.analytics.planner.CapabilityRegistry;
 import org.opensearch.analytics.planner.dag.ExchangeInfo;
 import org.opensearch.analytics.planner.dag.Stage;
@@ -20,6 +21,7 @@ import org.opensearch.analytics.spi.ShardScanInstructionNode;
 import org.opensearch.analytics.spi.ShuffleProducerInstructionNode;
 import org.opensearch.analytics.spi.ShuffleScanInstructionNode;
 import org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.LinkedHashMap;
@@ -127,7 +129,8 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
             /* queryId */ "qid-test",
             /* leftProducerStageId */ 11,
             /* rightProducerStageId */ 12,
-            /* preferHashJoin */ true
+            /* preferHashJoin */ true,
+            /* pipelined */ true
         );
 
         List<InstructionNode> instr = consumer.getPlanAlternatives().get(0).instructions();
@@ -167,7 +170,17 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
         Stage consumer = new Stage(/* stageId */ 4, null, List.of(), null, null, null);
         consumer.setPlanAlternatives(List.of(new StagePlan(null, "df")));
 
-        ShuffleEnrichment.enrichWorkerAlternatives(consumer, /* partitionCount */ 2, 7, 3, "qid", 1, 2, /* preferHashJoin */ false);
+        ShuffleEnrichment.enrichWorkerAlternatives(
+            consumer,
+            /* partitionCount */ 2,
+            7,
+            3,
+            "qid",
+            1,
+            2,
+            /* preferHashJoin */ false,
+            /* pipelined */ false
+        );
 
         ShuffleWorkerSetupInstructionNode setup = (ShuffleWorkerSetupInstructionNode) consumer.getPlanAlternatives()
             .get(0)
@@ -179,6 +192,7 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
         assertEquals("qid", setup.getQueryId());
         assertEquals(4, setup.getTargetStageId());
         assertFalse("preferHashJoin flows through to the setup placeholder", setup.getPreferHashJoin());
+        assertFalse("the shuffle shape flows through the same placeholder", setup.isPipelined());
     }
 
     public void testEnrichWorkerAlternativesForThreeSlots() {
@@ -196,7 +210,7 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
         producers.put("in1", 32);
         producers.put("in2", 33);
 
-        ShuffleEnrichment.enrichWorkerAlternatives(consumer, /* partitionCount */ 2, expected, "qid-n", producers, true);
+        ShuffleEnrichment.enrichWorkerAlternatives(consumer, /* partitionCount */ 2, expected, "qid-n", producers, true, /* pipelined */ true);
 
         List<InstructionNode> instr = consumer.getPlanAlternatives().get(0).instructions();
         assertEquals("1 setup + 2 partitions × 3 slots = 7 instructions", 7, instr.size());
@@ -230,10 +244,67 @@ public class ShuffleEnrichmentTests extends OpenSearchTestCase {
                 new LinkedHashMap<>(Map.of("in0", 1, "in1", 1)),
                 "qid",
                 new LinkedHashMap<>(Map.of("in0", 5)),
-                true
+                true,
+                /* pipelined */ true
             )
         );
         assertTrue("must name the disagreeing slot sets", ex.getMessage().contains("disagree"));
+    }
+
+    /**
+     * The shuffle SHAPE decision. A worker join whose build is estimated not to fit in memory takes the
+     * materialized shape (producers finish, then the consumer drains its spilling buffer), because there a
+     * residency bound that cannot fail a query is worth more than overlapping the drain with its
+     * producers. A build that does fit keeps the pipelined shape, which is the class whose latency
+     * regressed when the in-flight window was squeezed.
+     *
+     * <p>Driven through {@code sortMergeJoinMinRows}: with null fragments every build estimates 0 rows, so
+     * a floor of 0 makes the estimate fail it ({@code 0 < 0} is false) and a floor of 1 makes it pass.
+     */
+    public void testShuffleShapeFollowsTheBuildFitsInMemoryEstimate() {
+        assertFalse("a build that does not fit takes the materialized shape", shapeFor(/* smjMinRows */ 0, /* inputs */ 2));
+        assertTrue("a build that fits keeps the pipelined shape", shapeFor(/* smjMinRows */ 1, /* inputs */ 2));
+    }
+
+    /**
+     * ...but only for a JOIN worker. A single-input worker — the FINAL half of an aggregate shuffle —
+     * consumes its one stream continuously, so its drain never stalls and materializing would cost latency
+     * for nothing. Its estimate is also the wrong quantity: it measures the scan under a PARTIAL aggregate,
+     * not the bytes that aggregate ships.
+     */
+    public void testSingleInputWorkerStaysPipelinedEvenWhenTheEstimateFails() {
+        assertTrue("an aggregate-shuffle worker must not be materialized by a join heuristic", shapeFor(0, /* inputs */ 1));
+    }
+
+    /** Runs {@code enrichLevels} for one worker level with {@code inputCount} producers and returns the
+     *  shuffle shape it stamped on the setup placeholder. */
+    private static boolean shapeFor(long sortMergeJoinMinRows, int inputCount) {
+        Stage worker = new Stage(/* stageId */ 30, null, List.of(), null, null, null);
+        worker.setPlanAlternatives(List.of(new StagePlan(null, "df")));
+        List<ShuffleEnrichment.WorkerInput> inputs = new java.util.ArrayList<>();
+        for (int i = 0; i < inputCount; i++) {
+            Stage producer = newProducerStage(/* stageId */ 40 + i, /* partitionCount */ 1, List.of(0));
+            producer.setPlanAlternatives(List.of(new StagePlan(null, "df").withInstructions(List.of(new ShardScanInstructionNode()))));
+            inputs.add(new ShuffleEnrichment.WorkerInput(producer, List.of(0), inputCount == 1 ? "left" : (i == 0 ? "left" : "right")));
+        }
+        ShuffleEnrichment.WorkerLevel level = new ShuffleEnrichment.WorkerLevel(worker, inputs, 1, List.of("node-0"));
+
+        QueryContext ctx = mock(QueryContext.class);
+        when(ctx.queryId()).thenReturn("qid-shape");
+        ShuffleEnrichment.enrichLevels(
+            List.of(level),
+            ctx,
+            mock(ClusterService.class),
+            shuffleCapableRegistry("df"),
+            sortMergeJoinMinRows
+        );
+
+        for (InstructionNode node : worker.getPlanAlternatives().get(0).instructions()) {
+            if (node instanceof ShuffleWorkerSetupInstructionNode setup) {
+                return setup.isPipelined();
+            }
+        }
+        throw new AssertionError("enrichLevels emitted no worker setup instruction");
     }
 
     private static Stage newProducerStage(int stageId, int partitionCount, List<Integer> hashKeys) {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferNarySlotTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleBufferNarySlotTests.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.shuffle;
+
+import org.opensearch.analytics.spi.CloseableIterator;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests the N-ARY (slot-keyed) shuffle buffer: a consumer with more than two input streams. The binary
+ * left/right path is covered by {@link ShuffleBufferManagerTests}; this class pins the properties that
+ * only an N-input consumer can exercise — per-slot isolation, per-slot completion latches, per-slot spill
+ * files, and the invariant that {@code awaitReady} waits for EVERY declared slot.
+ */
+public class ShuffleBufferNarySlotTests extends OpenSearchTestCase {
+
+    public void testThreeSlotsAccumulateIndependently() {
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        buffer.addData("in0", new byte[] { 1 });
+        buffer.addData("in1", new byte[] { 2, 2 });
+        buffer.addData("in2", new byte[] { 3, 3, 3 });
+
+        // Cross-slot leakage would silently feed one join input's rows to another.
+        assertEquals(List.of(1), firstBytes(buffer.getData("in0")));
+        assertEquals(List.of(2), firstBytes(buffer.getData("in1")));
+        assertEquals(List.of(3), firstBytes(buffer.getData("in2")));
+        assertEquals("byte accounting is buffer-wide across slots", 6L, buffer.getCurrentBytes());
+        assertEquals(java.util.Set.of("in0", "in1", "in2"), buffer.getSlots());
+    }
+
+    public void testAwaitReadyWaitsForEverySlot() throws Exception {
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        bySlot.put("in0", 1);
+        bySlot.put("in1", 1);
+        bySlot.put("in2", 1);
+        buffer.setExpectedSenders(bySlot);
+
+        buffer.senderDone("in0");
+        buffer.senderDone("in1");
+        // in2 outstanding — a buffer that returned ready here would let the worker drain a partition
+        // whose third input has not arrived, producing silently-missing rows.
+        assertFalse("must not be ready while one slot is outstanding", buffer.awaitReady(50));
+
+        buffer.senderDone("in2");
+        assertTrue("ready once every declared slot is complete", buffer.awaitReady(1000));
+    }
+
+    public void testMultipleSendersPerSlot() throws Exception {
+        // Each slot's expected count is independent — a slot fed by 3 shard producers must not be
+        // considered complete after 1.
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        bySlot.put("in0", 3);
+        bySlot.put("in1", 1);
+        buffer.setExpectedSenders(bySlot);
+
+        buffer.senderDone("in0");
+        buffer.senderDone("in1");
+        assertFalse("in0 still awaits 2 more senders", buffer.awaitReady(50));
+        buffer.senderDone("in0");
+        buffer.senderDone("in0");
+        assertTrue(buffer.awaitReady(1000));
+        assertEquals(3, buffer.getDoneCount("in0"));
+        assertEquals(3, buffer.getExpectedSenders("in0"));
+    }
+
+    public void testUndeclaredSlotDoesNotBlockAwaitReady() throws Exception {
+        // A producer payload can arrive for a slot this consumer never declares (a stray/late RPC),
+        // creating the slot with expectedSenders=-1. awaitReady must ignore it rather than hang: -1 is a
+        // target no sender count can ever reach.
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        buffer.setExpectedSenders(Map.of("in0", 1));
+        buffer.addData("in-stray", new byte[] { 9 });
+
+        buffer.senderDone("in0");
+        assertTrue("an undeclared slot must not extend the wait", buffer.awaitReady(1000));
+    }
+
+    public void testSetExpectedSendersIgnoresNegativeCounts() throws Exception {
+        // Negative means "leave unchanged" (the single-slot agg path's unused right side).
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        Map<String, Integer> bySlot = new LinkedHashMap<>();
+        bySlot.put("in0", 1);
+        bySlot.put("in1", -1);
+        buffer.setExpectedSenders(bySlot);
+
+        assertEquals("negative-count slot is not declared", -1, buffer.getExpectedSenders("in1"));
+        buffer.senderDone("in0");
+        assertTrue(buffer.awaitReady(1000));
+    }
+
+    public void testEmptySlotDrainsAsZeroChunks() {
+        // A partition where a slot received nothing must drain as an empty stream, not NPE — the worker
+        // still registers a resolvable table so the plan binds and the join yields 0 rows for it.
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        buffer.addData("in0", new byte[] { 1 });
+
+        assertTrue(buffer.getData("in1").isEmpty());
+        try (CloseableIterator<byte[]> it = buffer.drain("in1")) {
+            assertFalse(it.hasNext());
+        }
+    }
+
+    public void testEachSlotSpillsToItsOwnFile() throws Exception {
+        // Per-slot spill files must not collide: a shared name would interleave two inputs' chunks into
+        // one stream, so the consumer would read another slot's rows.
+        Path spillRoot = createTempDir();
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setSpillConfig(true, spillRoot, Long.MAX_VALUE);
+        // A tiny per-query budget forces every admit past the first to spill.
+        mgr.setBudgets(Long.MAX_VALUE, 4L);
+
+        for (String slot : List.of("in0", "in1", "in2")) {
+            assertEquals(ShuffleBufferManager.AdmitResult.ACCEPTED, mgr.tryAdmit("q-nary", 7, 0, slot, new byte[] { 1, 2, 3 }));
+            assertEquals(ShuffleBufferManager.AdmitResult.ACCEPTED, mgr.tryAdmit("q-nary", 7, 0, slot, new byte[] { 4, 5, 6 }));
+        }
+
+        Path queryDir = spillRoot.resolve("q-nary");
+        assertTrue("spill dir must exist once the budget forced eviction", Files.isDirectory(queryDir));
+        try (var files = Files.list(queryDir)) {
+            List<String> names = files.map(p -> p.getFileName().toString()).sorted().toList();
+            // One file per slot that spilled, each naming its own slot.
+            assertTrue("expected per-slot spill files, got " + names, names.stream().anyMatch(n -> n.endsWith("-in0.spill")));
+            assertTrue("expected per-slot spill files, got " + names, names.stream().anyMatch(n -> n.endsWith("-in1.spill")));
+        }
+
+        // Read-back must reconstruct each slot's own chunks (spilled head then in-memory tail), with no
+        // cross-slot contamination.
+        ShuffleBufferManager.ShuffleBuffer buffer = mgr.getBuffer("q-nary", 7, 0);
+        for (String slot : List.of("in0", "in1", "in2")) {
+            List<byte[]> chunks = new ArrayList<>();
+            try (CloseableIterator<byte[]> it = buffer.drain(slot)) {
+                while (it.hasNext()) {
+                    chunks.add(it.next());
+                }
+            }
+            assertEquals("slot " + slot + " must yield both its chunks", 2, chunks.size());
+            assertEquals("slot " + slot + " chunk order is arrival order", 1, chunks.get(0)[0]);
+            assertEquals(4, chunks.get(1)[0]);
+        }
+        mgr.clearForQuery("q-nary");
+    }
+
+    public void testClearForQueryReleasesAllSlots() {
+        Path spillRoot = createTempDir();
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setSpillConfig(true, spillRoot, Long.MAX_VALUE);
+        mgr.setBudgets(Long.MAX_VALUE, 4L);
+        for (String slot : List.of("in0", "in1", "in2")) {
+            mgr.tryAdmit("q-clear", 3, 0, slot, new byte[] { 1, 2, 3 });
+            mgr.tryAdmit("q-clear", 3, 0, slot, new byte[] { 4, 5, 6 });
+        }
+
+        assertEquals(1, mgr.clearForQuery("q-clear"));
+        assertEquals("every slot's on-heap reservation is released", 0L, mgr.getQueryBytes("q-clear"));
+        assertEquals("node total is released", 0L, mgr.getTotalBytes());
+        assertEquals("every slot's disk bytes are released", 0L, mgr.getSpilledTotalBytes());
+        assertFalse("per-query spill dir is swept", Files.isDirectory(spillRoot.resolve("q-clear")));
+    }
+
+    public void testRejectsUnsafeSlotLabel() {
+        ShuffleBufferManager.ShuffleBuffer buffer = new ShuffleBufferManager.ShuffleBuffer();
+        // Validated at every entry point so a hostile label can never reach spillFilePath().
+        expectThrows(IllegalArgumentException.class, () -> buffer.addData("../escape", new byte[] { 1 }));
+        expectThrows(IllegalArgumentException.class, () -> buffer.senderDone("a/b"));
+    }
+
+    /** First byte of each chunk, as ints — a compact way to assert chunk identity and order. */
+    private static List<Integer> firstBytes(List<byte[]> chunks) {
+        return chunks.stream().map(c -> (int) c[0]).toList();
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleMaterializedModeTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleMaterializedModeTests.java
@@ -1,0 +1,344 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.shuffle;
+
+import org.opensearch.analytics.exec.shuffle.ShuffleBufferManager.AdmitResult;
+import org.opensearch.analytics.spi.CloseableIterator;
+import org.opensearch.analytics.spi.ShuffleSlots;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The MATERIALIZED shuffle mode: a barrier before the drain (pipelining off) plus disk, which is the
+ * combination that makes a bounded in-flight window safe.
+ *
+ * <p>The distinction these pin is scheduling, not storage. Pipelined means the consumer drains
+ * concurrently with its producers; materialized means it waits for all of them. Whether bytes touch a
+ * disk is orthogonal — and it is precisely what the barrier has to buy, because a barrier without a
+ * durable home pays for lost overlap and gets nothing back: peak residency is still the whole partition
+ * (that was the pre-streaming behaviour), backpressure can still fail a query, and there is no
+ * re-readable copy.
+ *
+ * <p>So the two properties asserted here are:
+ * <ul>
+ *   <li>a full window is relieved by SPILLING, so admission never returns a retryable reject and the
+ *       "rejected N times, query failed" terminal state cannot arise;</li>
+ *   <li>the spilled prefix is read back ONE FRAME AT A TIME, so an over-budget partition is not
+ *       re-materialized on the heap at drain — which would hand the peak straight back.</li>
+ * </ul>
+ */
+public class ShuffleMaterializedModeTests extends OpenSearchTestCase {
+
+    private static final String Q = "q-materialized";
+    private static final String LEFT = ShuffleSlots.LEFT;
+
+    /** A chunk whose first byte carries {@code marker}, so arrival order is checkable after a spill. */
+    private static byte[] chunk(int marker, int size) {
+        byte[] b = new byte[size];
+        b[0] = (byte) marker;
+        return b;
+    }
+
+    /** Manager with spill on and pipelining off — the materialized mode. */
+    private ShuffleBufferManager materializedManager(Path spillDir) {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setPipelinedEnabled(false);
+        mgr.setSpillConfig(true, spillDir, /* maxBytes */ 100L * 1024 * 1024);
+        return mgr;
+    }
+
+    private static List<byte[]> drainAll(ShuffleBufferManager.ShuffleBuffer buf, String slot) {
+        List<byte[]> out = new ArrayList<>();
+        try (CloseableIterator<byte[]> it = buf.drain(slot, 30_000)) {
+            while (it.hasNext()) {
+                out.add(it.next());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The headline property of this mode: with a window configured and spill available, EVERY admit is
+     * accepted. A retryable reject is what lets backpressure fail a query (the sender's attempt budget is
+     * finite), so a mode that never rejects cannot fail for backpressure at all — the ceiling becomes
+     * disk, which is a real resource limit rather than a timing artefact.
+     */
+    public void testFullWindowSpillsRatherThanRejecting() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        mgr.setStreamWindowBytes(400);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        for (int i = 0; i < 40; i++) {
+            assertEquals(
+                "admit " + i + " must be accepted: a full window is relieved by disk, never by a retry",
+                AdmitResult.ACCEPTED,
+                mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, 100))
+            );
+        }
+        assertEquals("no admission may have been rejected", 0L, buf.getRejectedCount());
+        assertTrue("the overflow must be on disk, was " + mgr.getSpilledTotalBytes(), mgr.getSpilledTotalBytes() > 0);
+        assertTrue("heap residency must stay within the window, was " + buf.queuedBytes(LEFT), buf.queuedBytes(LEFT) <= 400);
+
+        // Terminal (as every query does, on success or failure): the spill file is closed and deleted and
+        // its disk bytes returned, so relief cannot leak disk across queries.
+        mgr.clearForQuery(Q);
+        assertEquals("disk accounting fully reclaimed", 0L, mgr.getSpilledTotalBytes());
+    }
+
+    /** Window relief must preserve ARRIVAL order across the spill/resident boundary: the drain reads the
+     *  spill file (oldest chunks, in write order) and only then the resident queue. */
+    public void testWindowSpillPreservesArrivalOrder() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        mgr.setStreamWindowBytes(400);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        int n = 40;
+        for (int i = 0; i < n; i++) {
+            assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, 100)));
+        }
+        buf.senderDone(LEFT);
+
+        List<byte[]> drained = drainAll(buf, LEFT);
+        assertEquals("every chunk must be delivered exactly once", n, drained.size());
+        for (int i = 0; i < n; i++) {
+            assertEquals("chunk " + i + " out of arrival order", (byte) i, drained.get(i)[0]);
+            assertEquals(100, drained.get(i).length);
+        }
+        mgr.clearForQuery(Q);
+        assertEquals("disk accounting fully reclaimed after the drain", 0L, mgr.getSpilledTotalBytes());
+    }
+
+    /**
+     * The guard that keeps relief safe: once a consumer owns the queue, eviction would take from the head
+     * the consumer is reading, so the window falls back to the retryable reject. This is the control arm
+     * for the test above — without it, "spill relieves the window" would silently also apply to a live
+     * drain and drop or duplicate rows.
+     */
+    public void testFullWindowStillRejectsOnceTheDrainOwnsTheQueue() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = new ShuffleBufferManager(); // pipelined (default) => drain starts at once
+        mgr.setSpillConfig(true, spillDir, 100L * 1024 * 1024);
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        try (CloseableIterator<byte[]> ignored = buf.drain(LEFT, 100)) {
+            assertTrue("the drain must own the queue for this arm", buf.isDraining());
+            assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(0, 60)));
+            assertEquals(
+                "a draining buffer must not be spilled from under its consumer — reject instead",
+                AdmitResult.REJECT_RETRY,
+                mgr.tryAdmit(Q, 0, 0, LEFT, chunk(1, 60))
+            );
+            assertEquals("nothing may have been written to disk", 0L, mgr.getSpilledTotalBytes());
+        }
+    }
+
+    /** A chunk larger than the window still goes into an EMPTY slot: relief cannot split a chunk, so the
+     *  one-item escape has to survive the spill path (otherwise that chunk is rejected forever). */
+    public void testChunkLargerThanTheWindowStillAdmittedIntoAnEmptySlot() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(0, 500)));
+        // Queue non-empty and already over the window: relief spills the 500-byte chunk, so the next one
+        // is admitted rather than rejected.
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(1, 500)));
+        assertTrue("the first chunk must have gone to disk", mgr.getSpilledTotalBytes() > 0);
+
+        buf.senderDone(LEFT);
+        List<byte[]> drained = drainAll(buf, LEFT);
+        assertEquals(2, drained.size());
+        assertEquals((byte) 0, drained.get(0)[0]);
+        assertEquals((byte) 1, drained.get(1)[0]);
+    }
+
+    /**
+     * The spilled phase must be read frame-at-a-time. Pulling ONE chunk from a partition with many
+     * spilled chunks must read exactly one frame — the whole-file read that used to sit here meant a
+     * partition spilled to disk and was then fully re-loaded onto the heap at drain, so the peak that
+     * spill exists to remove came right back.
+     */
+    public void testSpilledPhaseIsReadOneFrameAtATime() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        mgr.setStreamWindowBytes(200);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        int n = 30;
+        for (int i = 0; i < n; i++) {
+            assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, 100)));
+        }
+        buf.senderDone(LEFT);
+        assertTrue("this test needs a spilled prefix", mgr.getSpilledTotalBytes() > 0);
+
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 30_000)) {
+            assertTrue(it.hasNext());
+            assertEquals("the oldest chunk must come first", (byte) 0, it.next()[0]);
+            assertEquals("one consumed chunk must cost exactly one frame read", 1L, buf.spilledFramesRead(LEFT));
+
+            assertTrue(it.hasNext());
+            assertEquals((byte) 1, it.next()[0]);
+            assertEquals(2L, buf.spilledFramesRead(LEFT));
+        }
+    }
+
+    /**
+     * The derived default: a materialized, spill-capable buffer with NO configured window is bounded by
+     * {@link ShuffleBufferManager#MATERIALIZED_WINDOW_DEFAULT_BYTES} rather than by the per-query budget
+     * (80% of heap in production, which is the footprint that pins old-gen for the rest of the query).
+     */
+    public void testMaterializedModeBoundsResidencyWithoutAConfiguredWindow() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        assertEquals("no window configured for this test", Long.MAX_VALUE, mgr.getStreamWindowBytes());
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        int chunkSize = 2 * 1024 * 1024;
+        int n = (int) (ShuffleBufferManager.MATERIALIZED_WINDOW_DEFAULT_BYTES / chunkSize) + 2;
+        for (int i = 0; i < n; i++) {
+            assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, chunkSize)));
+        }
+        assertTrue(
+            "residency must be bounded by the derived window, was " + buf.queuedBytes(LEFT),
+            buf.queuedBytes(LEFT) <= ShuffleBufferManager.MATERIALIZED_WINDOW_DEFAULT_BYTES
+        );
+        assertTrue("the overflow must be on disk", mgr.getSpilledTotalBytes() > 0);
+        mgr.clearForQuery(Q);
+        assertEquals("disk accounting fully reclaimed", 0L, mgr.getSpilledTotalBytes());
+    }
+
+    /**
+     * ...and the derived default is materialized-ONLY. Under pipelining the same window would be relieved
+     * by a retryable reject, which is the measured failure mode (the smaller the window, the more queries
+     * failed), so pipelined buffers stay unbounded unless an operator opts in.
+     */
+    public void testDerivedWindowDoesNotApplyUnderPipelining() {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = new ShuffleBufferManager(); // pipelined by default
+        mgr.setSpillConfig(true, spillDir, 100L * 1024 * 1024);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        int chunkSize = 2 * 1024 * 1024;
+        int n = (int) (ShuffleBufferManager.MATERIALIZED_WINDOW_DEFAULT_BYTES / chunkSize) + 2;
+        for (int i = 0; i < n; i++) {
+            assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, chunkSize)));
+        }
+        assertEquals("no window applies under pipelining, so nothing may spill", 0L, mgr.getSpilledTotalBytes());
+        assertEquals("everything stays resident", (long) n * chunkSize, buf.queuedBytes(LEFT));
+    }
+
+    /**
+     * Materialized with spill DISABLED must IGNORE the window rather than enforce it.
+     *
+     * <p>Enforcing it there is a guaranteed failure, not backpressure: no consumer drains until every
+     * sender is done, so a rejected producer retries against a queue that cannot shrink and fails when
+     * its attempt budget runs out — for any partition bigger than the window. Same rule as the
+     * empty-slot escape: a window with no admissible item is a deadlock. Accumulating to the per-query
+     * budget is worse for residency but cannot invent a failure.
+     */
+    public void testMaterializedWithoutSpillIgnoresTheWindowRatherThanFailing() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setPipelinedEnabled(false);
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(
+                "no relief path exists, so the window must not reject",
+                AdmitResult.ACCEPTED,
+                mgr.tryAdmit(Q, 0, 0, LEFT, chunk(i, 60))
+            );
+        }
+        assertEquals("everything stays resident (bounded by the per-query budget, not the window)", 300L, buf.queuedBytes(LEFT));
+    }
+
+    /** A PIPELINED buffer keeps enforcing the window with a reject when spill is unavailable: there a
+     *  drain is already running, so a reject genuinely can be relieved. */
+    public void testPipelinedWithoutSpillStillRejects() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(0, 60)));
+        assertEquals(AdmitResult.REJECT_RETRY, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(1, 60)));
+    }
+
+    /**
+     * The barrier must NOT be bounded by the caller's PER-CHUNK timeout.
+     *
+     * <p>The two bound different things: the caller's value is how long to wait for one chunk while
+     * producers are already shipping (kept small so an unfed partition fails in a minute, not five), while
+     * the barrier waits out the whole producer phase, which is minutes at scale. Conflating them is not a
+     * tuning mistake but a correctness one — every materialized stage dies at the barrier reporting
+     * {@code 0/N senders} however healthy the data path is. Measured on the sf=100 cluster: q9's shuffle
+     * had already written 3.8 GB per node to disk when the 60s per-chunk value expired and failed the
+     * query.
+     *
+     * <p>Pinned with a 1 ms per-chunk timeout and a sender that finishes later: if the barrier used the
+     * argument, this could not pass.
+     */
+    public void testBarrierIsNotBoundedByThePerChunkTimeout() throws Exception {
+        Path spillDir = createTempDir();
+        ShuffleBufferManager mgr = materializedManager(spillDir);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(0, 16)));
+
+        Thread producer = new Thread(() -> {
+            try {
+                Thread.sleep(300); // far longer than the per-chunk timeout below
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            buf.senderDone(LEFT);
+        }, "test-slow-producer");
+        producer.setDaemon(true);
+        producer.start();
+
+        // 1 ms per-chunk timeout. The barrier has to use its own, much larger bound, so this must return
+        // the chunk rather than throw "timed out ... waiting for shuffle producers".
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, /* perChunkMillis */ 1)) {
+            assertTrue("the barrier must wait for the producer, not for the per-chunk timeout", it.hasNext());
+            assertEquals((byte) 0, it.next()[0]);
+        }
+        producer.join(TimeUnit.SECONDS.toMillis(10));
+    }
+
+    /** The mode is per worker stage, and an instruction can only NARROW to materialized — the node-level
+     *  kill switch must not be overridable by a plan. */
+    public void testUseMaterializedModeIsOneWay() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        assertTrue("buffers inherit the node default", buf.isPipelined());
+
+        buf.useMaterializedMode();
+        assertFalse("the stage's decision must take effect", buf.isPipelined());
+
+        buf.useMaterializedMode();
+        assertFalse("idempotent", buf.isPipelined());
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleSenderRetryTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleSenderRetryTests.java
@@ -15,6 +15,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -55,18 +56,67 @@ public class ShuffleSenderRetryTests extends OpenSearchTestCase {
         assertEquals(3, sendAttempts.get());
     }
 
-    public void testGiveUpAfterMaxAttempts() {
+    public void testGiveUpWhenWaitCeilingReached() {
         AtomicInteger sendAttempts = new AtomicInteger();
         BiConsumer<AnalyticsShuffleDataRequest, ActionListener<AnalyticsShuffleDataResponse>> sender = (r, listener) -> {
             sendAttempts.incrementAndGet();
             listener.onResponse(AnalyticsShuffleDataResponse.backpressureReject());
         };
         AtomicReference<AnalyticsShuffleDataResponse> result = new AtomicReference<>();
-        ShuffleSenderRetry.sendWithRetry(req(), sender, inlineScheduler(), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+        // Wait ceiling of 0 => already out of time at the first reject, so it gives up immediately.
+        // Two bounds exist: the attempt budget (8, which trips first in production) and this wall-clock
+        // ceiling, which exists because attempts alone do not bound TIME as the backoff grows.
+        ShuffleSenderRetry.sendWithRetry(req(), sender, inlineScheduler(), ActionListener.wrap(result::set, e -> fail(e.getMessage())), 0L);
         assertNotNull(result.get());
         assertTrue("final result must still reflect reject", result.get().isBackpressureRejected());
-        // Default max attempts is 8.
-        assertEquals(8, sendAttempts.get());
+        assertEquals("a zero wait ceiling must give up after a single attempt", 1, sendAttempts.get());
+    }
+
+    /**
+     * Every scheduled backoff must be non-negative and within the cap. Regression guard: the backoff
+     * was computed as {@code initial << (attempt-1)}, and Java's {@code <<} on a long uses only the LOW
+     * 6 BITS of the shift count — so past ~32 attempts it overflowed NEGATIVE and the scheduler threw
+     * "duration cannot be negative", failing the query. Unreachable at the original 8-attempt budget;
+     * reachable as soon as the budget grew to serve steady-state pacing.
+     */
+    public void testBackoffNeverNegativeAcrossTheFullAttemptBudget() {
+        // Accept at attempt 200 rather than spinning on a wall-clock ceiling: the inline scheduler
+        // recurses synchronously, so an open-ended spin would overflow the stack rather than test the
+        // backoff. 200 comfortably passes the wrap point — the old formula went negative once
+        // `attempt-1` reached the 59..63 range (20 << 59 overflows a long).
+        final int acceptAt = 200;
+        List<Long> delays = new ArrayList<>();
+        AtomicInteger sendAttempts = new AtomicInteger();
+        BiConsumer<AnalyticsShuffleDataRequest, ActionListener<AnalyticsShuffleDataResponse>> sender = (r, listener) -> {
+            if (sendAttempts.incrementAndGet() < acceptAt) {
+                listener.onResponse(AnalyticsShuffleDataResponse.backpressureReject());
+            } else {
+                listener.onResponse(new AnalyticsShuffleDataResponse(false));
+            }
+        };
+        BiConsumer<Long, Runnable> recordingScheduler = (delay, task) -> {
+            delays.add(delay);
+            task.run();
+        };
+        AtomicReference<AnalyticsShuffleDataResponse> result = new AtomicReference<>();
+        // Explicit 200-attempt budget: the production budget is 8 (shift <= 7), which would never reach
+        // the wrap point this guards. A generous wait ceiling keeps TIME from ending the loop first.
+        ShuffleSenderRetry.sendWithRetry(
+            req(),
+            sender,
+            recordingScheduler,
+            ActionListener.wrap(result::set, e -> fail(e.getMessage())),
+            TimeUnit.MINUTES.toMillis(5),
+            acceptAt
+        );
+
+        assertEquals(acceptAt, sendAttempts.get());
+        assertEquals("every reject must have scheduled exactly one retry", acceptAt - 1, delays.size());
+        for (int i = 0; i < delays.size(); i++) {
+            long d = delays.get(i);
+            assertTrue("backoff #" + i + " must be non-negative, was " + d, d >= 0);
+            assertTrue("backoff #" + i + " must respect the cap, was " + d, d <= 5_000);
+        }
     }
 
     public void testTransportFailureBubblesUpWithoutRetry() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
@@ -307,4 +307,59 @@ public class ShuffleStreamingConsumerTests extends OpenSearchTestCase {
         assertEquals("every chunk must be delivered exactly once", chunks, received);
         assertTrue("peak queued bytes " + peak.get() + " must stay within the in-flight window " + window, peak.get() <= window);
     }
+
+    /**
+     * The kill switch is DEFAULT ON, and turning it off restores the barrier: the drain must not return
+     * until every declared sender has finished. Guards the two directions separately because only the
+     * default keeps peak residency independent of partition size.
+     */
+    public void testPipelinedIsEnabledByDefault() {
+        assertTrue(new ShuffleBufferManager().isPipelinedEnabled());
+    }
+
+    public void testPipelinedDisabledWaitsForSendersBeforeDraining() throws Exception {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setPipelinedEnabled(false);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(16)));
+
+        CountDownLatch drainReturned = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread consumer = new Thread(() -> {
+            try (CloseableIterator<byte[]> it = buf.drain(LEFT, 30_000)) {
+                drainReturned.countDown();
+                while (it.hasNext()) {
+                    it.next();
+                }
+            } catch (Throwable t) {
+                failure.set(t);
+                drainReturned.countDown();
+            }
+        });
+        consumer.start();
+
+        // The sender has not finished, so with pipelining OFF the drain call itself must still be parked.
+        assertFalse("drain must block until senders finish when pipelining is off", drainReturned.await(300, TimeUnit.MILLISECONDS));
+
+        buf.senderDone(LEFT);
+        assertTrue("completing the sender must release the drain", drainReturned.await(10, TimeUnit.SECONDS));
+        consumer.join(10_000);
+        assertNull(failure.get());
+    }
+
+    /**
+     * With pipelining off, a sender that never finishes must FAIL the drain rather than let it proceed
+     * over a partial partition — that would silently drop rows.
+     */
+    public void testPipelinedDisabledFailsWhenSendersNeverFinish() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setPipelinedEnabled(false);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(16)));
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> buf.drain(LEFT, 50));
+        assertTrue("must name the wait it gave up on: " + ex.getMessage(), ex.getMessage().contains("waiting for shuffle producers"));
+    }
 }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
@@ -1,0 +1,310 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.shuffle;
+
+import org.opensearch.analytics.exec.shuffle.ShuffleBufferManager.AdmitResult;
+import org.opensearch.analytics.spi.CloseableIterator;
+import org.opensearch.analytics.spi.ShuffleSlots;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Pipelined-shuffle consumer semantics: the drain runs CONCURRENTLY with producers instead of after a
+ * barrier, so residency is bounded by the in-flight window rather than by partition size.
+ *
+ * <p>These pin the properties that replaced the old buffer-all invariants:
+ * <ul>
+ *   <li>a drain can start and consume before any sender has reported {@code isLast};</li>
+ *   <li>the EOF sentinel — not a latch — is what ends the stream, including for an empty partition;</li>
+ *   <li>a full in-flight window applies backpressure as a RETRYABLE reject (never a blocked transport
+ *       thread, never a silent drop);</li>
+ *   <li>data admitted after end-of-stream fails LOUD (it would otherwise be lost rows);</li>
+ *   <li>a terminal/cancel unblocks a parked drain and makes it fail rather than report a clean end of
+ *       stream (which would let a join emit results from truncated input).</li>
+ * </ul>
+ */
+public class ShuffleStreamingConsumerTests extends OpenSearchTestCase {
+
+    private static final String Q = "q-stream";
+    private static final String LEFT = ShuffleSlots.LEFT;
+
+    private static byte[] chunk(int size) {
+        byte[] b = new byte[size];
+        for (int i = 0; i < size; i++) {
+            b[i] = (byte) (i % 127);
+        }
+        return b;
+    }
+
+    /**
+     * The core behavioural change: chunks are readable BEFORE any {@code isLast}. Under the old
+     * barrier model {@code awaitReady} had to return first, which is exactly what forced the whole
+     * partition to be resident.
+     */
+    public void testDrainYieldsChunksBeforeAnySenderIsDone() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(2, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(16)));
+
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 5_000)) {
+            assertTrue("chunk must be visible without waiting for isLast", it.hasNext());
+            assertEquals(16, it.next().length);
+        }
+        // No sender has completed, so the stream is deliberately NOT terminated yet.
+        assertFalse(buf.isEofEnqueued(LEFT));
+    }
+
+    /** All declared senders done => EOF sentinel published => the stream ends cleanly. */
+    public void testEofSentinelTerminatesStream() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(8)));
+        buf.senderDone(LEFT);
+        assertTrue("all senders done must publish EOF", buf.isEofEnqueued(LEFT));
+
+        List<byte[]> got = new ArrayList<>();
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 5_000)) {
+            while (it.hasNext()) {
+                got.add(it.next());
+            }
+        }
+        assertEquals(1, got.size());
+        assertEquals(8, got.get(0).length);
+    }
+
+    /**
+     * An empty partition must terminate immediately once its senders are done — this is the path that
+     * lets a consumer register an empty table instead of hanging.
+     */
+    public void testEmptyPartitionTerminatesWithoutBlocking() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        buf.senderDone(LEFT);
+
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 5_000)) {
+            assertFalse("empty partition must report end-of-stream, not block", it.hasNext());
+        }
+    }
+
+    /**
+     * The in-flight window is the residency bound. Once it is full admission must return the RETRYABLE
+     * reject — not accept (unbounded growth), not throw (a retryable condition must not fail a query),
+     * and not block a transport thread.
+     */
+    public void testFullInFlightWindowRejectsRetryably() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+        assertEquals("second chunk overflows the 100-byte window", AdmitResult.REJECT_RETRY, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+        assertEquals(60L, buf.queuedBytes(LEFT));
+    }
+
+    /** Draining frees the window, so a previously-rejected producer can proceed. This is the pacing loop. */
+    public void testDrainingFreesTheWindow() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+        assertEquals(AdmitResult.REJECT_RETRY, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 5_000)) {
+            assertTrue(it.hasNext());
+            it.next(); // consume 60 bytes -> window has room again
+        }
+        assertEquals(0L, buf.queuedBytes(LEFT));
+        assertEquals("window freed by the drain must admit the retry", AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+    }
+
+    /**
+     * Data after end-of-stream is a producer close-ordering bug and would be silently lost rows, so it
+     * must fail loud. This replaces the old "admitted to an already-draining buffer" check, which can no
+     * longer mean "too late" now that add and drain are concurrent by design.
+     */
+    public void testDataAfterEndOfStreamFailsLoud() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+        buf.senderDone(LEFT);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> mgr.tryAdmit(Q, 0, 0, LEFT, chunk(4)));
+        assertTrue("message must name the end-of-stream cause: " + e.getMessage(), e.getMessage().contains("after end-of-stream"));
+    }
+
+    /**
+     * A drain that starts before its producers must NOT be treated as "too late to add" — the whole
+     * point of pipelining. Guards against reintroducing the old {@code isDraining()} rejection.
+     */
+    public void testAdmitAfterDrainStartedStillAccepted() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        try (CloseableIterator<byte[]> ignored = buf.drain(LEFT, 100)) {
+            assertTrue("drain must have marked the buffer as draining", buf.isDraining());
+            assertEquals(
+                "a concurrent drain must not reject admission under pipelining",
+                AdmitResult.ACCEPTED,
+                mgr.tryAdmit(Q, 0, 0, LEFT, chunk(8))
+            );
+        }
+    }
+
+    /**
+     * Clearing a query must wake a parked drain and make it THROW. A clean end-of-stream here would let
+     * the consumer close its native sender normally and the join would emit results from truncated
+     * input — silent wrong answers.
+     */
+    public void testClearForQueryUnblocksParkedDrainWithFailure() throws Exception {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        CountDownLatch parked = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread consumer = new Thread(() -> {
+            try (CloseableIterator<byte[]> it = buf.drain(LEFT, 30_000)) {
+                parked.countDown();
+                it.hasNext(); // parks: no data, no EOF
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                finished.countDown();
+            }
+        }, "test-shuffle-drain");
+        consumer.setDaemon(true);
+        consumer.start();
+
+        assertTrue(parked.await(10, TimeUnit.SECONDS));
+        mgr.clearForQuery(Q);
+
+        assertTrue("clearForQuery must unblock the parked drain promptly", finished.await(10, TimeUnit.SECONDS));
+        assertNotNull("an aborted drain must fail, never report a clean end-of-stream", thrown.get());
+        assertTrue(thrown.get() instanceof IllegalStateException);
+        assertTrue(thrown.get().getMessage(), thrown.get().getMessage().contains("aborted"));
+    }
+
+    /**
+     * An UNDER-DECLARED {@code expectedSenders} must fail both ends loudly — never silently truncate.
+     *
+     * <p>This is the test whose absence let a wrong-answer bug reach the cluster. EOF is published when
+     * {@code doneCount} reaches the declared count, so if the count is too low, EOF fires while a
+     * straggling producer still has rows, the consumer terminates early, and the join returns fewer rows
+     * with an HTTP 200. Every other test in this class declares the count correctly by construction, so
+     * none of them could see it. At sf=10 this produced 18,215 late admits on a single worker while the
+     * query "succeeded" with a wrong result.
+     *
+     * <p>Two producers, but only ONE declared. After the first reports isLast the slot is at end-of-stream;
+     * the second producer's data must then (a) fail the producer, and (b) poison the consumer's stream so
+     * a live drain cannot finish on truncated input.
+     */
+    public void testUnderDeclaredExpectedSendersFailsLoudlyNotSilently() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1); // WRONG: two producers will actually ship
+
+        // Producer 1: data then isLast -> publishes EOF (correctly, per the declared count).
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(32)));
+        buf.senderDone(LEFT);
+        assertTrue(buf.isEofEnqueued(LEFT));
+
+        // Producer 2 still has rows. This must NOT be quietly dropped.
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> mgr.tryAdmit(Q, 0, 0, LEFT, chunk(32)));
+        assertTrue("must name end-of-stream: " + e.getMessage(), e.getMessage().contains("after end-of-stream"));
+
+        // And the CONSUMER must fail rather than report a clean end after the one chunk it did see —
+        // the producer-side throw alone can lose the race if the consumer already finished.
+        IllegalStateException consumerFailure = expectThrows(IllegalStateException.class, () -> {
+            try (CloseableIterator<byte[]> it = buf.drain(LEFT, 5_000)) {
+                while (it.hasNext()) {
+                    it.next();
+                }
+            }
+        });
+        assertTrue(
+            "consumer must abort, not finish cleanly: " + consumerFailure.getMessage(),
+            consumerFailure.getMessage().contains("aborted")
+        );
+    }
+
+    /** A stalled producer must surface as a failure, never as a short read. */
+    public void testStalledProducerTimesOutRatherThanUnderDelivering() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 50)) {
+            IllegalStateException e = expectThrows(IllegalStateException.class, it::hasNext);
+            assertTrue(e.getMessage(), e.getMessage().contains("timed out"));
+        }
+    }
+
+    /**
+     * Residency stays bounded by the window across a partition far larger than it — the property the
+     * whole change exists for. Producer and consumer run concurrently; the queued bytes must never
+     * exceed the window even though total volume is ~40x it.
+     */
+    public void testResidencyStaysBoundedAcrossALargePartition() throws Exception {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        final int window = 4096;
+        mgr.setStreamWindowBytes(window);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        final int chunks = 200;
+        final int chunkSize = 800; // 160_000 bytes total, ~39x the window
+        AtomicReference<Throwable> producerError = new AtomicReference<>();
+        AtomicReference<Long> peak = new AtomicReference<>(0L);
+
+        Thread producer = new Thread(() -> {
+            try {
+                for (int i = 0; i < chunks; i++) {
+                    // Mirror ShuffleSenderRetry: a retryable reject is retried, not failed.
+                    while (mgr.tryAdmit(Q, 0, 0, LEFT, chunk(chunkSize)) == AdmitResult.REJECT_RETRY) {
+                        Thread.onSpinWait();
+                    }
+                    peak.updateAndGet(p -> Math.max(p, buf.queuedBytes(LEFT)));
+                }
+                buf.senderDone(LEFT);
+            } catch (Throwable t) {
+                producerError.set(t);
+                buf.senderDone(LEFT); // never leave the consumer parked
+            }
+        }, "test-shuffle-producer");
+        producer.setDaemon(true);
+        producer.start();
+
+        int received = 0;
+        try (CloseableIterator<byte[]> it = buf.drain(LEFT, 30_000)) {
+            while (it.hasNext()) {
+                assertEquals(chunkSize, it.next().length);
+                received++;
+            }
+        }
+        producer.join(TimeUnit.SECONDS.toMillis(30));
+
+        assertNull(producerError.get());
+        assertEquals("every chunk must be delivered exactly once", chunks, received);
+        assertTrue("peak queued bytes " + peak.get() + " must stay within the in-flight window " + window, peak.get() <= window);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/shuffle/ShuffleStreamingConsumerTests.java
@@ -117,6 +117,80 @@ public class ShuffleStreamingConsumerTests extends OpenSearchTestCase {
         assertEquals(60L, buf.queuedBytes(LEFT));
     }
 
+    /**
+     * A chunk LARGER than the window must still be admitted into an empty slot.
+     *
+     * <p>Without this escape the window is a deadlock, not backpressure: nothing is queued, so no drain
+     * can free room, so the reject can never clear. The producer retries until its budget runs out and
+     * the query fails — with a "consumer too slow" signal, when in truth the consumer was never given
+     * anything to consume. The window is a pacing device, and pacing has to admit a first item.
+     */
+    public void testChunkLargerThanTheWindowIsAdmittedIntoAnEmptySlot() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(
+            "an empty slot must admit a chunk of any size; rejecting it can never be retried successfully",
+            AdmitResult.ACCEPTED,
+            mgr.tryAdmit(Q, 0, 0, LEFT, chunk(500))
+        );
+        assertEquals(500L, buf.queuedBytes(LEFT));
+    }
+
+    /** The escape is for the EMPTY slot only — once something is queued the window applies again. */
+    public void testOversizedChunkStillRejectsWhenTheSlotIsNotEmpty() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(60)));
+        assertEquals(
+            "with 60 bytes already queued the drain CAN free room, so the window must still push back",
+            AdmitResult.REJECT_RETRY,
+            mgr.tryAdmit(Q, 0, 0, LEFT, chunk(500))
+        );
+        assertEquals(60L, buf.queuedBytes(LEFT));
+    }
+
+    /**
+     * The invariant, stated directly: for any window and any chunk size, an empty slot admits. This is
+     * what makes "the drain always has something to consume" true, and therefore what makes room always
+     * eventually become available.
+     */
+    public void testEveryWindowSizeAdmitsAtLeastOneChunk() {
+        for (int window : new int[] { 1, 64, 4096 }) {
+            for (int size : new int[] { 1, 65, 8192, 1 << 20 }) {
+                ShuffleBufferManager mgr = new ShuffleBufferManager();
+                mgr.setStreamWindowBytes(window);
+                mgr.getOrCreateBuffer(Q, 0, 0).setExpectedSenders(1, -1);
+                assertEquals(
+                    "window=" + window + " chunk=" + size + " must be admissible into an empty slot",
+                    AdmitResult.ACCEPTED,
+                    mgr.tryAdmit(Q, 0, 0, LEFT, chunk(size))
+                );
+            }
+        }
+    }
+
+    /**
+     * The bound the escape trades for deadlock-freedom: residency per slot is window + one chunk, not the
+     * window exactly. Worth pinning so the relaxation is deliberate rather than discovered later.
+     */
+    public void testResidencyBoundIsWindowPlusOneChunk() {
+        ShuffleBufferManager mgr = new ShuffleBufferManager();
+        mgr.setStreamWindowBytes(100);
+        ShuffleBufferManager.ShuffleBuffer buf = mgr.getOrCreateBuffer(Q, 0, 0);
+        buf.setExpectedSenders(1, -1);
+
+        assertEquals(AdmitResult.ACCEPTED, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(500)));
+        // Already over the window, so nothing further is admitted until the drain runs.
+        assertEquals(AdmitResult.REJECT_RETRY, mgr.tryAdmit(Q, 0, 0, LEFT, chunk(1)));
+        assertEquals("residency is capped at one over-sized chunk, not at an unbounded pile", 500L, buf.queuedBytes(LEFT));
+    }
+
     /** Draining frees the window, so a previously-rejected producer can proceed. This is the pacing loop. */
     public void testDrainingFreesTheWindow() {
         ShuffleBufferManager mgr = new ShuffleBufferManager();

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentPerTaskSetupTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/stage/worker/WorkerFragmentPerTaskSetupTests.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec.stage.worker;
+
+import org.opensearch.analytics.exec.action.FragmentExecutionRequest;
+import org.opensearch.analytics.exec.join.ShuffleEnrichment;
+import org.opensearch.analytics.planner.dag.Stage;
+import org.opensearch.analytics.planner.dag.StagePlan;
+import org.opensearch.analytics.spi.InstructionNode;
+import org.opensearch.analytics.spi.ShuffleScanInstructionNode;
+import org.opensearch.analytics.spi.ShuffleWorkerSetupInstructionNode;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+/**
+ * The placeholder → per-task rebuild of {@link ShuffleWorkerSetupInstructionNode}.
+ *
+ * <p>The coordinator makes two per-worker-stage decisions (join algorithm and shuffle shape) and puts
+ * them on a partition-agnostic placeholder; dispatch replaces that placeholder with a partition-specific
+ * copy. Anything not copied across is silently reverted to its default for EVERY task, with no error and
+ * no log line — which is why each decision gets an explicit assertion here.
+ */
+public class WorkerFragmentPerTaskSetupTests extends OpenSearchTestCase {
+
+    private static Stage workerStageWith(boolean preferHashJoin, boolean pipelined) {
+        Stage consumer = new Stage(/* stageId */ 7, null, List.of(), null, null, null);
+        consumer.setPlanAlternatives(List.of(new StagePlan(null, "df")));
+        ShuffleEnrichment.enrichWorkerAlternatives(
+            consumer,
+            /* partitionCount */ 3,
+            /* leftExpectedSenders */ 5,
+            /* rightExpectedSenders */ 4,
+            /* queryId */ "q-per-task",
+            /* leftProducerStageId */ 11,
+            /* rightProducerStageId */ 12,
+            preferHashJoin,
+            pipelined
+        );
+        return consumer;
+    }
+
+    private static ShuffleWorkerSetupInstructionNode setupOf(List<FragmentExecutionRequest.PlanAlternative> alts) {
+        for (InstructionNode node : alts.get(0).getInstructions()) {
+            if (node instanceof ShuffleWorkerSetupInstructionNode setup) {
+                return setup;
+            }
+        }
+        throw new AssertionError("no setup instruction survived the per-partition filter");
+    }
+
+    /** Materialized: the shape must reach the task, else the data node would run the whole shuffle in the
+     *  node default and the residency bound the shape exists for would never apply. */
+    public void testMaterializedShapeSurvivesThePerTaskRebuild() {
+        Stage stage = workerStageWith(/* preferHashJoin */ false, /* pipelined */ false);
+
+        for (int partition = 0; partition < 3; partition++) {
+            ShuffleWorkerSetupInstructionNode setup = setupOf(
+                WorkerFragmentStageExecutionFactory.filterPlanAlternativesForPartition(stage, partition)
+            );
+            assertEquals("the rebuild must bind this task's partition", partition, setup.getPartitionIndex());
+            assertFalse("shuffle shape must survive the rebuild for partition " + partition, setup.isPipelined());
+            assertFalse("join algorithm must survive it too", setup.getPreferHashJoin());
+        }
+    }
+
+    /** ...and the pipelined shape survives just as well — the flag is copied, not defaulted. */
+    public void testPipelinedShapeSurvivesThePerTaskRebuild() {
+        Stage stage = workerStageWith(/* preferHashJoin */ true, /* pipelined */ true);
+        ShuffleWorkerSetupInstructionNode setup = setupOf(
+            WorkerFragmentStageExecutionFactory.filterPlanAlternativesForPartition(stage, 1)
+        );
+        assertTrue(setup.isPipelined());
+        assertTrue(setup.getPreferHashJoin());
+    }
+
+    /** The filter keeps only this partition's scans, and the setup still declares every slot — the two
+     *  properties the rebuild exists for, asserted alongside the flags so a change to one is visible. */
+    public void testFilterKeepsOnlyThisPartitionsScans() {
+        Stage stage = workerStageWith(true, true);
+        List<FragmentExecutionRequest.PlanAlternative> alts = WorkerFragmentStageExecutionFactory
+            .filterPlanAlternativesForPartition(stage, 2);
+
+        int scans = 0;
+        for (InstructionNode node : alts.get(0).getInstructions()) {
+            if (node instanceof ShuffleScanInstructionNode scan) {
+                assertEquals("only partition 2's scans may survive", 2, scan.getShufflePartitionIndex());
+                scans++;
+            }
+        }
+        assertEquals("one scan per slot", 2, scans);
+        ShuffleWorkerSetupInstructionNode setup = setupOf(alts);
+        assertEquals(5, setup.getLeftExpectedSenders());
+        assertEquals(4, setup.getRightExpectedSenders());
+    }
+}


### PR DESCRIPTION
### Description
Makes the MPP (massively parallel processing) hash-shuffle consumer stream, and gives the exchange two shapes with the planner choosing one per worker stage.

Today the consumer is buffer-all-then-drain: the worker blocks until every producer of every side reports `isLast`, so the whole partition is resident twice over — first as on-heap Arrow-IPC chunks, then again as decoded Arrow buffers as the drain feeds the native operator — and peak residency scales with partition size rather than with anything an operator can bound. The barrier is structural rather than incidental: a worker stage is scheduled only after every child has SUCCEEDED and a producer cannot succeed before its sink closes, so during the whole producer phase there is no consumer at all, which is why no in-flight window of any kind could work before this change.

The change has two halves. The consumer becomes streaming — slot-keyed buffers so a worker tier can have N inputs, a bounded queue plus an end-of-stream sentinel in place of the accumulation list and completion latch, the worker tier scheduled eagerly so the drain actually overlaps its producers, and worker fragments moved to their own thread pool because a consumer that blocks on its producers must not hold a thread those producers need. Then the exchange gets a second shape: *materialized*, where the producers finish first, which is exactly what makes the accumulating buffer safe to spill — a full in-flight window is relieved by writing to disk instead of by asking a producer to retry, so backpressure can no longer fail a query. The shape is chosen per worker stage from the calibrated "this build does not fit in memory" estimate that already selects a spillable sort-merge join, so no new threshold or setting is introduced, and the existing node-level switch can only narrow a stage to materialized so a plan can never override an operator.

Truncation stays loud throughout: a drain error fails the native stream rather than closing it cleanly, and data admitted after end-of-stream fails both producer and consumer instead of being dropped. Two details worth calling out for review — a spilled prefix is read back one frame at a time, because reading the whole file at drain would re-materialize the partition on heap and hand back the peak that spilling exists to remove; and the materialized barrier is bounded separately from the per-chunk drain wait, since one waits out an entire producer phase (minutes at scale) while the other bounds a gap between chunks (deliberately a minute, so an unfed partition fails fast).

TPC-H at scale factor 100 on a 10-node cluster (8 data nodes, 12 GiB heap and 30.75 GiB RAM each, 90 shards, disk spill enabled).

| query | before | after | heap before | heap after |
|---|---|---|---|---|
| q1 | PASS 0.6s | PASS 0.6s | 34% | 34% |
| q2 | PASS 6.9s | PASS 7.0s | 53% | 56% |
| q3 | PASS 24.3s | PASS 23.8s | 70% | 66% |
| q4 | FAIL | FAIL | 78% | 71% |
| q5 | PASS 45.8s | PASS 42.9s | 78% | 72% |
| q6 | PASS 0.3s | PASS 0.3s | 52% | 64% |
| q7 | FAIL | FAIL | 63% | 76% |
| q8 | FAIL | FAIL | 63% | 56% |
| q9 | FAIL | FAIL | 58% | 61% |
| q10 | FAIL | **PASS 37.4s** | 59% | 72% |
| q11 | FAIL | FAIL | 93% | 76% |
| q12 | FAIL | **PASS 15.8s** | 93% | 60% |
| q13 | FAIL | **PASS 117.0s** | 93% | 78% |
| q14 | FAIL | **PASS 23.9s** | 93% | 62% |
| q15 | FAIL | **PASS 2.6s** | 89% | 63% |
| q16 | FAIL | FAIL | 89% | 53% |
| q17 | FAIL | FAIL | 89% | 77% |
| q18 | FAIL | FAIL | 93% | 70% |
| q19 | FAIL | FAIL | 94% | 70% |
| q20 | FAIL | FAIL | 94% | 70% |
| q21 | FAIL | FAIL | 94% | 70% |
| q22 | FAIL | FAIL | 94% | 70% |
| **total** | **5/22** | **10/22** | pins at 93-94% from q11 on | peaks 78%, recovers between queries |

The heap column is the point as much as the pass count: before, heap climbs monotonically and never comes back, after which the parent circuit breaker rejects the shuffle transport action itself and every later query fails on a cluster that cannot recover — which is why queries as trivial as q22 fail in the "before" arm. Latency is at parity on the queries that pass in both arms.


### Related Issues
Resolves #22995 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
