### PR TITLE
Make ParquetDocumentInput.getFieldCount O(1)

### DIFF
--- a/sandbox/plugins/parquet-data-format/benchmarks/build.gradle
+++ b/sandbox/plugins/parquet-data-format/benchmarks/build.gradle
@@ -37,6 +37,10 @@ dependencies {
   // compileOnly (not exported), so the benchmark must declare it directly.
   compileOnly project(':plugins:arrow-base')
 
+  // plugin-stats-spi is compileOnly in parquet-data-format (provided by the stats plugin at
+  // runtime); ParquetDataFormatPlugin references it, so the benchmark JVM needs it on its classpath.
+  runtimeOnly project(':sandbox:libs:plugin-stats-spi')
+
   // JMH dependencies
   api "org.openjdk.jmh:jmh-core:$versions.jmh"
   annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$versions.jmh"

--- a/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/DocumentInputCollectBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/DocumentInputCollectBenchmark.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.benchmark;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.VersionFieldMapper;
+import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.writer.FieldValuePair;
+import org.opensearch.parquet.writer.ParquetDocumentInput;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Replays, per document, the exact {@link ParquetDocumentInput} call sequence the mapper layer
+ * performs while parsing a ClickBench {@code hits} row (106 columns: 25 keyword, 49 short,
+ * 19 integer, 6 long, 4 date, in the real column order), plus the four metadata fields.
+ *
+ * <p>For every keyword field in the default {@code multi_value: auto} state,
+ * {@code ParametrizedFieldMapper#addFieldForPluggableFormat} first asks
+ * {@link DocumentInput#getFieldCount(String)} whether the field was already seen (to decide on
+ * scalar-to-LIST promotion) and only then calls {@link DocumentInput#addField}. The
+ * {@code preCheck} param toggles that call so its cost can be isolated from the plain collect path.
+ *
+ * <p>Run with:
+ * <pre>
+ * ./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:benchmarks:run \
+ *     --args='DocumentInputCollectBenchmark'
+ * </pre>
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DocumentInputCollectBenchmark {
+
+    /** ClickBench hits column types in mapping order: K=keyword S=short I=integer L=long D=date. */
+    private static final String CLICKBENCH_COLUMN_SHAPE =
+        "SSKKIDISIISSIISDDLISSSKSISSSKISSSSSSSSSSSSSDSKSSSIKKKKKKKSKLKKSLIIISSSIISSKISSSISSKKSKSLIKKKKKSSKLLSSIS";
+
+    /** Whether to run the mapper's promotion pre-check ({@code getFieldCount}) before each keyword value. */
+    @Param({ "true", "false" })
+    public boolean preCheck;
+
+    private static final DataFormat PARQUET = new ParquetDataFormat();
+
+    private MappedFieldType[] fieldTypes;
+    private Object[] values;
+    private boolean[] isKeyword;
+
+    private MappedFieldType idType;
+    private MappedFieldType seqNoType;
+    private MappedFieldType primaryTermType;
+    private MappedFieldType versionType;
+
+    private long rowId;
+
+    @Setup
+    public void setup() {
+        int n = CLICKBENCH_COLUMN_SHAPE.length();
+        fieldTypes = new MappedFieldType[n];
+        values = new Object[n];
+        isKeyword = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            String name = "c" + i;
+            switch (CLICKBENCH_COLUMN_SHAPE.charAt(i)) {
+                case 'K' -> {
+                    // Mapping-built keyword types are multi_value-capable and default to AUTO; the
+                    // convenience constructor leaves the flag unset, so mirror the builder path here.
+                    MappedFieldType keyword = new KeywordFieldMapper.KeywordFieldType(name);
+                    keyword.setMultiValueSupported(true);
+                    fieldTypes[i] = keyword;
+                    values[i] = "keyword-value-" + i;
+                    isKeyword[i] = true;
+                }
+                case 'S' -> {
+                    fieldTypes[i] = new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.SHORT);
+                    values[i] = (short) i;
+                }
+                case 'I' -> {
+                    fieldTypes[i] = new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.INTEGER);
+                    values[i] = i;
+                }
+                case 'L' -> {
+                    fieldTypes[i] = new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.LONG);
+                    values[i] = (long) i;
+                }
+                case 'D' -> {
+                    fieldTypes[i] = new DateFieldMapper.DateFieldType(name);
+                    values[i] = 1_700_000_000_000L + i;
+                }
+                default -> throw new IllegalStateException("unknown column shape " + CLICKBENCH_COLUMN_SHAPE.charAt(i));
+            }
+            assignCapabilities(fieldTypes[i]);
+        }
+        // Same construction the parquet unit tests use for the engine-populated metadata fields.
+        idType = new KeywordFieldMapper.KeywordFieldType(IdFieldMapper.NAME);
+        seqNoType = new NumberFieldMapper.NumberFieldType(SeqNoFieldMapper.NAME, NumberFieldMapper.NumberType.LONG);
+        primaryTermType = new NumberFieldMapper.NumberFieldType(SeqNoFieldMapper.PRIMARY_TERM_NAME, NumberFieldMapper.NumberType.LONG);
+        versionType = new NumberFieldMapper.NumberFieldType(VersionFieldMapper.NAME, NumberFieldMapper.NumberType.LONG);
+        assignCapabilities(idType);
+        assignCapabilities(seqNoType);
+        assignCapabilities(primaryTermType);
+        assignCapabilities(versionType);
+        rowId = 0;
+    }
+
+    /** Mirrors what {@code FieldCapabilityAssigner.assign} does at mapping build time. */
+    private static void assignCapabilities(MappedFieldType fieldType) {
+        PARQUET.supportedFields()
+            .stream()
+            .filter(ftc -> ftc.fieldType().equals(fieldType.typeName()))
+            .findFirst()
+            .ifPresent(ftc -> fieldType.setCapabilityMap(Map.of(PARQUET, ftc.capabilities())));
+    }
+
+    /**
+     * One full document: a fresh input (the engine calls {@code newDocumentInput()} per document),
+     * 106 source fields, 4 metadata fields, then finalization.
+     */
+    @Benchmark
+    public void collectClickBenchDocument(Blackhole bh) {
+        ParquetDocumentInput input = new ParquetDocumentInput();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            MappedFieldType ft = fieldTypes[i];
+            if (isKeyword[i] && preCheck) {
+                // ParametrizedFieldMapper#addFieldForPluggableFormat, AUTO state, scalar so far.
+                if (ft.isMultiValued() == false && ft.isMultiValueSupported() && input.getFieldCount(ft.name()) > 0) {
+                    throw new IllegalStateException("unexpected duplicate on scalar workload");
+                }
+            }
+            input.addField(ft, values[i]);
+        }
+        input.addField(seqNoType, rowId);
+        input.addField(idType, "id-" + rowId);
+        input.addField(versionType, 1L);
+        input.addField(primaryTermType, 1L);
+        input.setRowId(DocumentInput.ROW_ID_FIELD, rowId++);
+        for (FieldValuePair pair : input.getFinalInput()) {
+            bh.consume(pair);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -116,10 +116,14 @@ public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>>
     public long getFieldCount(String fieldName) {
         // Counts values, not entries: a multi-valued field is one entry holding N values, and
         // callers (single-value assertions below, the data-stream @timestamp check) mean values.
-        return collectedFields.stream()
-            .filter(fvp -> fvp.getFieldType().name().equals(fieldName))
-            .mapToLong(FieldValuePair::valueCount)
-            .sum();
+        //
+        // O(1) via the name index: addField routes every value for a name into the single pair
+        // registered under that name in `seen`, so `seen` and `collectedFields` always hold the
+        // same pairs and the lookup is exact. This is on the per-value hot path — the mapper calls
+        // it before every AUTO-state keyword value to decide on scalar-to-LIST promotion — so a
+        // linear scan of collectedFields here made document parsing quadratic in the field count.
+        FieldValuePair pair = seen.get(fieldName);
+        return pair == null ? 0 : pair.valueCount();
     }
 
     @Override


### PR DESCRIPTION
### Description

`ParquetDocumentInput.getFieldCount` was implemented as a stream scan over `collectedFields`. Since #22883 (adaptive keyword promotion), `ParametrizedFieldMapper#addFieldForPluggableFormat` calls `getFieldCount` before `addField` for **every** AUTO-state keyword value to detect a second value. That put an O(N) scan on the per-value hot path, making document parsing O(N × K) in the number of fields (N) and keyword fields (K).

On ClickBench `hits` (106 columns, 25 keyword) that is ~1,250 `String.equals` calls plus 25 stream pipelines per document — all returning `0` on a scalar workload.

**Fix:** look the pair up in the existing name-keyed `seen` map. `addField` funnels every value for a name into the single pair registered under that name, so `seen` and `collectedFields` always hold the same pairs and the lookup is exact; `valueCount()` is the same sum the stream computed. Semantics are unchanged (the multi-value and empty-array counting tests in `ParquetDocumentInputTests` pass unmodified).

Also adds `DocumentInputCollectBenchmark` (JMH, in the plugin's existing `benchmarks` module), which replays the exact per-document `addField`/`getFieldCount` sequence for a ClickBench row in real column order. Its `preCheck` param toggles the promotion pre-check so the cost can be isolated. The benchmark module needed `plugin-stats-spi` at runtime because `ParquetDataFormatPlugin` references it through a `compileOnly` dependency.

### JMH results

Per document, average time, `-f 1`, JDK 25 (`./gradlew -Dsandbox.enabled=true :sandbox:plugins:parquet-data-format:benchmarks:run --args='DocumentInputCollectBenchmark'`):

| `preCheck` | before (stream scan) | after (`seen` lookup) |
|---|---|---|
| `true` — shipping path since #22883 | **14,053 ± 118 ns** | **4,620 ± 7 ns** |
| `false` — no pre-check (pre-#22883 path, reference) | 4,318 ± 6 ns | 4,558 ± 5 ns |

The 25 pre-checks cost ~9.7 µs/doc before — 2.25× the cost of collecting all 110 fields — and ~60 ns/doc after (~2.4 ns per keyword field).

### End-to-end context

An A/B of `main` vs `main` + revert of #22883 on ClickBench `index-append` (single r7i.2xlarge, 1-shard composite index, parquet primary + lucene secondary, ~19.9M docs, 0% errors) showed #22883 reducing indexing throughput by ~4% (mean 18,619 → 19,397 docs/s with the revert). At ~19k docs/s the removed scan accounts for ~185 ms of indexing-thread CPU per second, consistent with that gap. This PR has not yet been re-measured end-to-end.

### Related Issues

Follow-up to #22883.

### Check List
- [x] Functionality includes testing (existing `ParquetDocumentInputTests`, `ParquetWriterTests`, `VSRManagerTests`, `engine.*` — 97 tests pass; JMH benchmark added).
- [ ] API changes companion pull request created, if applicable. (N/A)
- [ ] Public documentation issue/PR created, if applicable. (N/A)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
