### PR TITLE
Fix incorrect aggregation results on wildcard fields

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/270_wildcard_fieldtype_queries.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/270_wildcard_fieldtype_queries.yml
@@ -544,6 +544,65 @@ setup:
   - match: { hits.hits.0._id: "8" }
 
 ---
+"aggregations on wildcard field":
+  - skip:
+      version: " - 3.8.99"
+      reason: "aggregations on wildcard fields returned wrong results before 3.9.0"
+  # Each aggregation runs in its own request: a sibling aggregation disables the
+  # affected precompute paths and would mask the defect.
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            values:
+              terms:
+                field: my_field
+                size: 20
+  - length: { aggregations.values.buckets: 8 }
+  - match: { aggregations.values.sum_other_doc_count: 0 }
+  - match: { aggregations.values.buckets.0.doc_count: 1 }
+  - match: { aggregations.values.buckets.7.doc_count: 1 }
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            distinct_count:
+              cardinality:
+                field: my_field
+  - match: { aggregations.distinct_count.value: 8 }
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            rare_values:
+              rare_terms:
+                field: my_field
+                max_doc_count: 1
+  - length: { aggregations.rare_values.buckets: 8 }
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            values:
+              composite:
+                size: 20
+                sources:
+                  - v:
+                      terms:
+                        field: my_field
+  - length: { aggregations.values.buckets: 8 }
+  - match: { aggregations.values.buckets.0.doc_count: 1 }
+  - match: { aggregations.values.buckets.7.doc_count: 1 }
+
+---
 teardown:
   - do:
       indices.delete:

--- a/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FilterFieldType.java
@@ -270,6 +270,11 @@ public abstract class FilterFieldType extends MappedFieldType {
     }
 
     @Override
+    public boolean indexedTermsMatchDocValues() {
+        return delegate.indexedTermsMatchDocValues();
+    }
+
+    @Override
     public boolean isMultiValued() {
         return delegate.isMultiValued();
     }

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -492,6 +492,16 @@ public abstract class MappedFieldType {
     }
 
     /**
+     * Returns whether the indexed terms of this field enumerate the same values as its doc values.
+     * Fields that index transformed tokens rather than the original value (such as {@code wildcard},
+     * which indexes ngrams) must return {@code false} so that aggregations do not substitute the
+     * postings term dictionary for doc values.
+     */
+    public boolean indexedTermsMatchDocValues() {
+        return true;
+    }
+
+    /**
      * Whether this field is declared to hold multiple values per document in columnar data
      * formats ({@code multi_value} mapping parameter). Lucene is inherently multi-valued, so
      * this flag only matters to pluggable formats whose column type is fixed per file (e.g.

--- a/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
@@ -380,6 +380,11 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
+        public boolean indexedTermsMatchDocValues() {
+            return false;
+        }
+
+        @Override
         public Query fuzzyQuery(
             Object value,
             Fuzziness fuzziness,

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
@@ -212,6 +212,7 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
         if (checkIfSortedDocsIsApplicable(reader, fieldType) == false
             || (fieldType == null || fieldType.unwrap() instanceof StringFieldType == false)
+            || fieldType.indexedTermsMatchDocValues() == false
             || (query != null && query.getClass() != MatchAllDocsQuery.class)) {
             return null;
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -249,6 +249,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
     SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
         if (checkIfSortedDocsIsApplicable(reader, fieldType) == false
             || (fieldType == null || fieldType.unwrap() instanceof StringFieldType == false)
+            || fieldType.indexedTermsMatchDocValues() == false
             || (query != null && query.getClass() != MatchAllDocsQuery.class)) {
             return null;
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -58,6 +58,7 @@ import org.opensearch.index.compositeindex.datacube.startree.index.StarTreeValue
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedNumericStarTreeValuesIterator;
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedSetStarTreeValuesIterator;
 import org.opensearch.index.mapper.DocCountFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationExecutionException;
 import org.opensearch.search.aggregations.Aggregator;
@@ -193,6 +194,12 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         Terms segmentTerms = ctx.reader().terms(this.fieldName);
         if (segmentTerms == null) {
             // Field is not indexed.
+            return false;
+        }
+
+        MappedFieldType fieldType = context.fieldType(this.fieldName);
+        if (fieldType == null || fieldType.indexedTermsMatchDocValues() == false) {
+            // The postings term dictionary does not correspond to the doc values ordinals.
             return false;
         }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
@@ -44,6 +44,7 @@ import org.opensearch.common.util.BytesRefHash;
 import org.opensearch.common.util.SetBackedScalingCuckooFilter;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
 import org.opensearch.index.mapper.DocCountFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.AggregatorFactories;
@@ -163,6 +164,12 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
         Terms stringTerms = ctx.reader().terms(fieldName);
         if (stringTerms == null) {
             // Field is not indexed.
+            return false;
+        }
+
+        MappedFieldType fieldType = context.fieldType(fieldName);
+        if (fieldType == null || fieldType.indexedTermsMatchDocValues() == false) {
+            // The postings term dictionary does not correspond to the doc values.
             return false;
         }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -249,7 +249,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     }
 
     private boolean canPrune(Aggregator parent, Aggregator[] subAggregators, ValuesSourceConfig valuesSourceConfig) {
-        return parent == null && subAggregators.length == 0 && valuesSourceConfig.missing() == null && valuesSourceConfig.script() == null;
+        return parent == null
+            && subAggregators.length == 0
+            && valuesSourceConfig.missing() == null
+            && valuesSourceConfig.script() == null
+            && valuesSourceConfig.fieldContext().fieldType().indexedTermsMatchDocValues();
     }
 
     private boolean exceedMaxThreshold(Terms terms) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
@@ -38,7 +38,14 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
 
     public void testIndexedTermsMatchDocValues() {
         // wildcard indexes trigram tokens, so its postings term dictionary differs from its doc values
-        assertFalse(new WildcardFieldMapper.WildcardFieldType("field").indexedTermsMatchDocValues());
+        MappedFieldType wildcard = new WildcardFieldMapper.WildcardFieldType("field");
+        assertFalse(wildcard.indexedTermsMatchDocValues());
+        assertFalse(new FilterFieldType(wildcard) {
+            @Override
+            public String typeName() {
+                return wildcard.typeName();
+            }
+        }.indexedTermsMatchDocValues());
         assertTrue(new KeywordFieldMapper.KeywordFieldType("field").indexedTermsMatchDocValues());
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldTypeTests.java
@@ -36,6 +36,12 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
         return ret;
     }
 
+    public void testIndexedTermsMatchDocValues() {
+        // wildcard indexes trigram tokens, so its postings term dictionary differs from its doc values
+        assertFalse(new WildcardFieldMapper.WildcardFieldType("field").indexedTermsMatchDocValues());
+        assertTrue(new KeywordFieldMapper.KeywordFieldType("field").indexedTermsMatchDocValues());
+    }
+
     public void testTermQuery() {
         MappedFieldType ft = new WildcardFieldMapper.WildcardFieldType("field");
         Set<String> expectedTerms = new HashSet<>();

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -47,6 +47,7 @@ import org.opensearch.index.mapper.IpFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -176,6 +177,37 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
         );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
+    }
+
+    public void testWildcardSorted() {
+        final MappedFieldType wildcard = new WildcardFieldMapper.WildcardFieldType("wildcard");
+        GlobalOrdinalValuesSource globalOrdinalsSource = new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            wildcard,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
+        IndexReader reader = mockIndexReader(1, 1);
+        assertNull(globalOrdinalsSource.createSortedDocsProducerOrNull(reader, new MatchAllDocsQuery()));
+        assertNull(globalOrdinalsSource.createSortedDocsProducerOrNull(reader, null));
+
+        BinaryValuesSource binarySource = new BinaryValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            (b) -> {},
+            wildcard,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
+        assertNull(binarySource.createSortedDocsProducerOrNull(reader, new MatchAllDocsQuery()));
+        assertNull(binarySource.createSortedDocsProducerOrNull(reader, null));
     }
 
     public void testNumericSorted() {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -61,10 +61,12 @@ import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NestedPathFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -74,6 +76,7 @@ import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.mapper.TextParams;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.mapper.WildcardFieldMapper;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -434,6 +437,54 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
             assertThat(((Terms) (children.asList().get(0))).getBuckets().size(), equalTo(1));
             assertThat(((Terms) (children.asList().get(0))).getBuckets().get(0).getKeyAsString(), equalTo("1"));
         });
+    }
+
+    public void testRareTermsDocValuesMismatchGuard() throws IOException {
+        // Every 5-character string over {a, b}: all 32 values are distinct, so all are rare
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 32; i++) {
+            StringBuilder value = new StringBuilder();
+            for (int bit = 4; bit >= 0; bit--) {
+                value.append(((i >> bit) & 1) == 0 ? 'a' : 'b');
+            }
+            values.add(value.toString());
+        }
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                Document document = new Document();
+                for (String value : values) {
+                    ADD_WILDCARD_FIELD_INDEXED.apply(document, KEYWORD_FIELD, value);
+                    indexWriter.addDocument(document);
+                    document.clear();
+                }
+            }
+            try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                RareTermsAggregationBuilder aggregationBuilder = new RareTermsAggregationBuilder("_name").field(KEYWORD_FIELD)
+                    .maxDocCount(1);
+                MappedFieldType fieldType = new WildcardFieldMapper.Builder(KEYWORD_FIELD).docValues(true)
+                    .build(new Mapper.BuilderContext(createIndexSettings().getSettings(), new ContentPath(1)))
+                    .fieldType();
+
+                // The precompute path must be skipped, so all documents are visited via normal collection
+                InternalMappedRareTerms<?, ?> result = searchAndReduceCounting(
+                    values.size(),
+                    null,
+                    indexSearcher,
+                    new MatchAllDocsQuery(),
+                    aggregationBuilder,
+                    -1,
+                    false,
+                    false,
+                    fieldType
+                );
+                assertEquals(values.size(), result.getBuckets().size());
+                for (int i = 0; i < values.size(); i++) {
+                    assertEquals(values.get(i), result.getBuckets().get(i).getKeyAsString());
+                    assertEquals(1L, result.getBuckets().get(i).getDocCount());
+                }
+            }
+        }
     }
 
     public void testInsideTerms() throws IOException {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -67,6 +67,7 @@ import org.opensearch.common.util.MockPageCacheRecycler;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.GeoPointFieldMapper;
 import org.opensearch.index.mapper.HllFieldMapper;
@@ -74,6 +75,7 @@ import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.IpFieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NestedPathFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -83,6 +85,7 @@ import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.mapper.TextParams;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.mapper.WildcardFieldMapper;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.script.MockScriptEngine;
@@ -414,6 +417,71 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     // With threshold=0, tryCollectFromTermFrequencies should bail out,
                     // so all 4 documents must be visited via normal collection
                     assertEquals(4, aggregator.getCollectCount().get());
+                }
+            }
+        }
+    }
+
+    /**
+     * Fields whose indexed terms differ from their doc values (e.g. wildcard, which indexes trigram
+     * tokens) must not use tryCollectFromTermFrequencies: the postings term dictionary does not
+     * correspond to the doc values ordinals, so buckets would be derived from the wrong term set.
+     * All documents must be visited via normal collection instead.
+     */
+    public void testTermFrequencyDocValuesMismatchGuard() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (
+                RandomIndexWriter indexWriter = new RandomIndexWriter(
+                    random(),
+                    directory,
+                    newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)
+                )
+            ) {
+                // Every 5-character string over {a, b}: all 32 values are distinct
+                List<String> values = new ArrayList<>();
+                for (int i = 0; i < 32; i++) {
+                    StringBuilder value = new StringBuilder();
+                    for (int bit = 4; bit >= 0; bit--) {
+                        value.append(((i >> bit) & 1) == 0 ? 'a' : 'b');
+                    }
+                    values.add(value.toString());
+                }
+                List<Document> documents = new ArrayList<>();
+                for (String value : values) {
+                    Document document = new Document();
+                    ADD_WILDCARD_FIELD_INDEXED.apply(document, "string", value);
+                    documents.add(document);
+                }
+                indexWriter.addDocuments(documents);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+
+                    TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
+                        .executionHint(TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS.toString())
+                        .field("string")
+                        .size(values.size())
+                        .order(BucketOrder.key(true));
+                    MappedFieldType fieldType = new WildcardFieldMapper.Builder("string").docValues(true)
+                        .build(new Mapper.BuilderContext(createIndexSettings().getSettings(), new ContentPath(1)))
+                        .fieldType();
+
+                    TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = false;
+                    TermsAggregatorFactory.REMAP_GLOBAL_ORDS = false;
+                    CountingAggregator aggregator = createCountingAggregator(aggregationBuilder, indexSearcher, false, fieldType);
+
+                    aggregator.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+                    Terms result = reduce(aggregator);
+                    assertEquals(values.size(), result.getBuckets().size());
+                    for (int i = 0; i < values.size(); i++) {
+                        assertEquals(values.get(i), result.getBuckets().get(i).getKeyAsString());
+                        assertEquals(1L, result.getBuckets().get(i).getDocCount());
+                    }
+
+                    // The precompute path must be skipped, so all documents are visited via normal collection
+                    assertEquals(values.size(), aggregator.getCollectCount().get());
                 }
             }
         }

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -33,6 +33,7 @@
 package org.opensearch.search.aggregations.metrics;
 
 import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KeywordField;
@@ -59,11 +60,14 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.mapper.RangeFieldMapper;
 import org.opensearch.index.mapper.RangeType;
+import org.opensearch.index.mapper.WildcardFieldMapper;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.aggregations.AggregatorTestCase;
@@ -76,6 +80,7 @@ import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.aggregations.support.AggregationInspectionHelper;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -418,6 +423,37 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             fieldType,
             100,
             (collectCount) -> assertEquals(3, (int) collectCount)
+        );
+    }
+
+    public void testDynamicPruningDocValuesMismatchGuard() throws IOException {
+        final String fieldName = "testField";
+
+        // Every 5-character string over {a, b}: all 32 values are distinct
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 32; i++) {
+            StringBuilder value = new StringBuilder();
+            for (int bit = 4; bit >= 0; bit--) {
+                value.append(((i >> bit) & 1) == 0 ? 'a' : 'b');
+            }
+            values.add(value.toString());
+        }
+
+        MappedFieldType fieldType = new WildcardFieldMapper.Builder(fieldName).docValues(true)
+            .build(new Mapper.BuilderContext(createIndexSettings().getSettings(), new ContentPath(1)))
+            .fieldType();
+        final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("_name").field(fieldName);
+        testDynamicPruning(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            for (String value : values) {
+                Document document = new Document();
+                ADD_WILDCARD_FIELD_INDEXED.apply(document, fieldName, value);
+                iw.addDocument(document);
+            }
+        },
+            card -> { assertEquals(values.size(), card.getValue(), 0); },
+            fieldType,
+            100,
+            (collectCount) -> assertEquals(values.size(), (int) collectCount)
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
@@ -212,6 +212,15 @@ public abstract class AggregatorTestCase extends OpenSearchTestCase {
         document.add(new StringField(field, value, Field.Store.NO));
     };
 
+    // Mirrors WildcardFieldMapper's indexing: doc values hold the value, postings hold anchored trigram tokens
+    protected static final TriConsumer<Document, String, String> ADD_WILDCARD_FIELD_INDEXED = (document, field, value) -> {
+        document.add(new SortedSetDocValuesField(field, new BytesRef(value)));
+        String padded = "\u0000\u0000" + value + "\u0000\u0000";
+        for (int i = 0; i + 3 <= padded.length(); i++) {
+            document.add(new StringField(field, padded.substring(i, i + 3), Field.Store.NO));
+        }
+    };
+
     static {
         List<String> denylist = new ArrayList<>();
         denylist.add(ObjectMapper.CONTENT_TYPE); // Cannot aggregate objects


### PR DESCRIPTION
### Description
The `wildcard` field indexes trigram tokens while its doc values hold the original value, so its postings term dictionary and its doc values enumerate different term sets. Four aggregation optimizations assume the two match and silently return wrong results on `wildcard` fields:

- `terms`: `GlobalOrdinalsStringTermsAggregator#tryCollectFromTermFrequencies` maps postings ordinals onto doc-values ordinals — bucket counts sum to `sum_doc_freq` (214 over a 32-doc index in the repro)
- `rare_terms`: `StringRareTermsAggregator#tryPrecomputeAggregationForLeaf` uses postings terms as bucket keys — every trigram's doc frequency exceeds `max_doc_count`, so all real values are dropped
- `cardinality`: the dynamic pruning collector iterates the postings dictionary — returns 11 instead of 32
- `composite`: `TermsSortedDocsProducer#processLeaf` walks the postings dictionary — collapses everything into one bucket

This PR introduces `MappedFieldType#indexedTermsMatchDocValues()` (default `true`; `wildcard` returns `false`) and guards the four call sites (five including `BinaryValuesSource`, kept symmetric with `GlobalOrdinalValuesSource`). It is the aggregation-side counterpart of #18568, which fixed the same postings/doc-values mismatch for sort pruning.

Each new unit test reproduces the reported wrong values before the fix and passes after. The REST test runs the four aggregations in separate requests on purpose: a sibling aggregation disables the affected precompute paths and would mask the defect — which is likely why bundled tests never caught this.

One behavioral note for review: the change only disables postings-based shortcuts for fields whose indexed terms differ from their doc values; results come from doc values via normal collection, matching `keyword` semantics. The added Java API method is additive (`:server:japicmp` passes).

### Related Issues
Resolves #22992

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable. *(N/A — no REST API change)*
- [ ] Public documentation issue/PR created, if applicable. *(N/A — restores documented behavior)*