### PR TITLE
Validate skipped optional should clauses

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
@@ -125,6 +125,12 @@ public class BoolQueryTranslator implements QueryTranslator {
         int requiredMatches = MinimumShouldMatchParser.calculateRequiredMatches(minimumShouldMatch, totalShould, hasRequired);
 
         if (requiredMatches == 0) {
+            // These clauses cannot affect which rows are returned, so they are not converted. The
+            // options they carry must still be rejected — otherwise the same clause is accepted
+            // here and rejected in any other position (#23011).
+            for (QueryBuilder shouldClause : shouldClauses) {
+                validateSkippedClause(shouldClause);
+            }
             return null;
         }
 
@@ -165,5 +171,43 @@ public class BoolQueryTranslator implements QueryTranslator {
                 + shouldConditions.size()
                 + ")"
         );
+    }
+
+    /**
+     * Rejects non-default {@code boost} and non-null {@code _name} on a clause that is skipped
+     * rather than converted, recursing into a nested bool's {@code must}, {@code filter},
+     * {@code should} and {@code must_not}.
+     *
+     * <p>Only types with a registered translator are checked, matching
+     * {@link QueryRegistry#convert}, which leaves an unregistered type to the analytics engine
+     * instead of rejecting it. Other clause-wrapping query types are not traversed — only bool.
+     *
+     * @param clause the clause that was skipped
+     * @throws ConversionException if the clause carries an option this path cannot honour
+     */
+    private void validateSkippedClause(QueryBuilder clause) throws ConversionException {
+        if (queryRegistry.hasTranslator(clause)) {
+            if (clause.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+                throw new ConversionException("'" + clause.getName() + "' query parameter 'boost' is not supported");
+            }
+            if (clause.queryName() != null) {
+                throw new ConversionException("'" + clause.getName() + "' query parameter '_name' is not supported");
+            }
+        }
+
+        if (clause instanceof BoolQueryBuilder nested) {
+            for (QueryBuilder child : nested.must()) {
+                validateSkippedClause(child);
+            }
+            for (QueryBuilder child : nested.filter()) {
+                validateSkippedClause(child);
+            }
+            for (QueryBuilder child : nested.should()) {
+                validateSkippedClause(child);
+            }
+            for (QueryBuilder child : nested.mustNot()) {
+                validateSkippedClause(child);
+            }
+        }
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistry.java
@@ -38,6 +38,20 @@ public class QueryRegistry {
     }
 
     /**
+     * Returns whether a translator is registered for this query's type.
+     *
+     * <p>Callers that validate a clause without converting it use this to stay aligned with
+     * {@link #convert}: an unregistered type is wrapped in {@link UnresolvedQueryCall} rather than
+     * rejected, so it receives no translator-level validation today.
+     *
+     * @param query the query builder to check
+     * @return true if a translator is registered for the query's type
+     */
+    public boolean hasTranslator(QueryBuilder query) {
+        return translators.containsKey(query.getClass());
+    }
+
+    /**
      * Converts a query using the registered translator for its type.
      * If no translator is registered, wraps the query in an {@link UnresolvedQueryCall}
      * for the analytics engine's optimizer to resolve or reject.

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/BoolQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/BoolQueryTranslatorTests.java
@@ -732,4 +732,103 @@ public class BoolQueryTranslatorTests extends OpenSearchTestCase {
         assertEquals(2, fieldRef.getIndex());
         assertTrue("brand field must be nullable in test schema", fieldRef.getType().isNullable());
     }
+
+    // ── Optional should clauses must still be validated (#23011) ───────────────
+
+    public void testOptionalShouldRejectsBoost() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("name", "laptop"))
+                    .should(QueryBuilders.termsQuery("brand", "acme").boost(5f)),
+                ctx
+            )
+        );
+        assertTrue("Must mention 'boost', got: " + ex.getMessage(), ex.getMessage().contains("boost"));
+    }
+
+    public void testOptionalShouldRejectsName() {
+        ConversionException ex = expectThrows(
+            ConversionException.class,
+            () -> translator.convert(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("name", "laptop"))
+                    .should(QueryBuilders.termsQuery("brand", "acme").queryName("my_terms")),
+                ctx
+            )
+        );
+        assertTrue("Must mention '_name', got: " + ex.getMessage(), ex.getMessage().contains("_name"));
+    }
+
+    public void testOptionalShouldRejectsBoostWithFilterAsRequiredClause() {
+        expectThrows(
+            ConversionException.class,
+            () -> translator.convert(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery("name", "laptop"))
+                    .should(QueryBuilders.termsQuery("brand", "acme").boost(5f)),
+                ctx
+            )
+        );
+    }
+
+    public void testOptionalShouldRejectsBoostWithExplicitZeroMinimumShouldMatch() {
+        expectThrows(
+            ConversionException.class,
+            () -> translator.convert(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("name", "laptop"))
+                    .should(QueryBuilders.termsQuery("brand", "acme").boost(5f))
+                    .minimumShouldMatch(0),
+                ctx
+            )
+        );
+    }
+
+    public void testOptionalShouldRejectsBoostNestedInsideBool() {
+        expectThrows(
+            ConversionException.class,
+            () -> translator.convert(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("name", "laptop"))
+                    .should(QueryBuilders.boolQuery().must(QueryBuilders.termsQuery("brand", "acme").boost(5f))),
+                ctx
+            )
+        );
+    }
+
+    public void testOptionalShouldWithDefaultOptionsKeepsPredicateUnchanged() throws ConversionException {
+        RexNode withOptionalShould = translator.convert(
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "laptop")).should(QueryBuilders.termsQuery("brand", "acme")),
+            ctx
+        );
+        RexNode mustOnly = translator.convert(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "laptop")), ctx);
+
+        // The optional clause is still skipped — validation must not change the plan.
+        assertEquals(mustOnly.toString(), withOptionalShould.toString());
+    }
+
+    public void testOptionalShouldAllowsOptionsOnUnregisteredQueryType() throws ConversionException {
+        // No translator is registered for match — QueryRegistry#convert leaves it to
+        // UnresolvedQueryCall rather than rejecting it, so validation must not reject it either.
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("name", "laptop"))
+                .should(QueryBuilders.matchQuery("brand", "acme").boost(5f).queryName("m")),
+            ctx
+        );
+        RexNode mustOnly = translator.convert(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "laptop")), ctx);
+        assertEquals(mustOnly.toString(), result.toString());
+    }
+
+    public void testOptionalShouldWithUnknownFieldIsNotConverted() throws ConversionException {
+        // Converting would throw for the unknown field; skipping must still skip.
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "laptop")).should(QueryBuilders.termQuery("nonexistent", "x")),
+            ctx
+        );
+        RexNode mustOnly = translator.convert(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "laptop")), ctx);
+        assertEquals(mustOnly.toString(), result.toString());
+    }
 }


### PR DESCRIPTION
### Description

A `bool` query with a required clause and no `minimum_should_match` leaves its `should` clauses
optional. `BoolQueryTranslator#processShouldClauses` returns before converting them, which is
correct — on this non-scoring path they cannot change which rows are returned. But validation lived
in conversion, so `boost` and `_name` on those clauses were silently accepted:

```json
{"bool": {"must":   [{"term": {"name": "laptop"}}],
          "should": [{"terms": {"brand": ["acme"], "boost": 5}}]}}
```

The same `terms` clause raises `ConversionException` on its own, and with
`"minimum_should_match": 1`.

This adds a `boost`/`_name`-only check over those clauses before the early return. The clauses are
still not converted, so the optimization is unchanged. Validation recurses into a nested `bool`'s
`must`, `filter`, `should` and `must_not` clauses. Other clause-wrapping query types are not
traversed.

Two constraints keep the change aligned with what conversion would have done, each pinned by a test:

- Only clause types with a registered translator are checked. `QueryRegistry#convert` wraps an
  unregistered type in `UnresolvedQueryCall` rather than rejecting it, so those types receive no
  such validation today; a blanket check would newly reject them. `QueryRegistry#hasTranslator` is
  added for this.
- `queryRegistry.convert(...)` is not called and discarded. That would validate, but it would also
  enforce every other check those translators perform (unknown field, unsupported types), a wider
  policy change than this fixes.

### Depends on

Depends on #22981 for consistent `boost`/`_name` rejection in the Term, Exists and MatchAll
translators. On this branch, regular conversion still accepts both options on Term and MatchAll,
and `_name` on Exists, while this change rejects them in optional `should` clauses. This draft
should be re-verified after #22981 lands.

### Testing

- `./gradlew -Dsandbox.enabled=true :sandbox:plugins:dsl-query-executor:test` — 551 tests passed.
- `./gradlew -Dsandbox.enabled=true :sandbox:plugins:dsl-query-executor:precommit` — passed.
- Reverting only the production files makes five of the eight new tests fail, each with "Expected
  exception ConversionException but no exception was thrown". The other three pass before and after
  by design — they pin the skipping optimization and the two constraints above.
- Rejection coverage: `boost` and `_name`; `filter` as the required clause; explicit
  `minimum_should_match: 0`; a clause nested inside a `bool` in the optional position.
- Constraint coverage: an unregistered type (`match`) carrying both options is still accepted; an
  optional clause with an unknown field is still skipped rather than converted; and a
  default-options optional `should` produces a predicate identical to the `must`-only one.

### Scope

`BoolQueryTranslator` has two other early returns that skip conversion the same way — the
pure-negative short circuit (`adjust_pure_negative: false`) and the unsatisfiable
`minimum_should_match` short circuit. Those two early returns are not changed here; clauses reached
through the recursion above are validated regardless of them.

New messages use `QueryBuilder#getName()`, so they read `'terms' query parameter 'boost' is not
supported`. Existing rejection messages are unchanged.

### Related Issues

Relates to #23011

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the
Apache 2.0 license.
