### PR TITLE
Poll for lag stat in IngestFromKafkaIT

### DIFF
--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -683,7 +683,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
 
         ensureGreen(indexName);
         // no messages published, expect 0 lag
-        assertTrue(validateOffsetBasedLagForPrimaryAndReplica(0));
+        waitForState(() -> validateOffsetBasedLagForPrimaryAndReplica(0));
 
         // pause ingestion
         pauseIngestionAndWait(indexName, 2);


### PR DESCRIPTION
The stat is populated asynchronously, so poll for the expected value.

Example failure: https://build.ci.opensearch.org/job/gradle-check/84759/testReport/org.opensearch.plugin.kafka/IngestFromKafkaIT/testAllActiveOffsetBasedLag/

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
