### PR TITLE
Optimize stored fields reads during version map restore

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -35,11 +35,14 @@ package org.opensearch.index.engine;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.MergePolicy;
@@ -72,6 +75,7 @@ import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.index.DerivedSourceDirectoryReader;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.lucene.uid.VersionsAndSeqNoResolver;
@@ -127,6 +131,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -143,6 +148,19 @@ import java.util.stream.Stream;
  * @opensearch.internal
  */
 public class InternalEngine extends Engine {
+
+    /**
+     * The inverse of the minimum matching-document density at which a sequential stored fields reader is used. A sequential reader
+     * eagerly decompresses whole stored-fields blocks, so sparse access can be slower even when doc IDs are visited in order. The
+     * measured break-even density is around 1/16 with best_speed and 1/128 with best_compression; 1/8 leaves margin for both codecs.
+     */
+    static final int SEQUENTIAL_STORED_FIELDS_MIN_DENSITY_INVERSE = 8;
+
+    /**
+     * Acquiring a merge instance and eagerly decompressing its first block has fixed overhead. This is the same conservative minimum
+     * batch size used by {@link LuceneChangesSnapshot} for sequential stored-fields reads.
+     */
+    static final int SEQUENTIAL_STORED_FIELDS_MIN_DOCS = 10;
 
     /**
      * UUID value that is updated every time the engine is force merged.
@@ -2714,6 +2732,10 @@ public class InternalEngine extends Engine {
             .add(Queries.newNonNestedFilter(), BooleanClause.Occur.MUST)
             .build();
         final Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        final long startTimeNanos = System.nanoTime();
+        long totalDocs = 0;
+        int scannedLeaves = 0;
+        int sequentialLeaves = 0;
         for (LeafReaderContext leaf : directoryReader.leaves()) {
             final Scorer scorer = weight.scorer(leaf);
             if (scorer == null) {
@@ -2722,9 +2744,20 @@ public class InternalEngine extends Engine {
             final CombinedDocValues dv = new CombinedDocValues(leaf.reader());
             final IdOnlyFieldVisitor idFieldVisitor = new IdOnlyFieldVisitor();
             final DocIdSetIterator iterator = scorer.iterator();
-            final StoredFields storedFields = leaf.reader().storedFields();
+            scannedLeaves++;
+            StoredFields storedFields = null;
+            if (useSequentialStoredFields(iterator.cost(), leaf.reader().maxDoc())) {
+                // Lucene stored fields readers are not thread-safe; this instance remains confined to the restore loop.
+                storedFields = sequentialStoredFields(leaf.reader());
+            }
+            if (storedFields == null) {
+                storedFields = leaf.reader().storedFields();
+            } else {
+                sequentialLeaves++;
+            }
             int docId;
             while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                totalDocs++;
                 final long primaryTerm = dv.docPrimaryTerm(docId);
                 final long seqNo = dv.docSeqNo(docId);
                 localCheckpointTracker.markSeqNoAsProcessed(seqNo);
@@ -2752,8 +2785,47 @@ public class InternalEngine extends Engine {
                 }
             }
         }
+        logger.debug(
+            "restored version map and checkpoint tracker from [{}] docs in [{}] leaves ([{}] read with a sequential stored fields "
+                + "reader), took [{}ms]",
+            totalDocs,
+            scannedLeaves,
+            sequentialLeaves,
+            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos)
+        );
         // remove live entries in the version map
         refresh("restore_version_map_and_checkpoint_tracker", SearcherScope.INTERNAL, true);
+    }
+
+    /**
+     * Returns whether the estimated matching-document density is high enough to use a sequential stored fields reader. This does not
+     * assume that an unsorted index has sequence-number order: replica operations may be applied out of order, and merges can interleave
+     * documents. Applying the same conservative threshold to every leaf avoids regressing sparse access in either sorted or unsorted
+     * indices.
+     */
+    static boolean useSequentialStoredFields(long cost, int maxDoc) {
+        final long minDocsForDensity = (maxDoc + SEQUENTIAL_STORED_FIELDS_MIN_DENSITY_INVERSE - 1L)
+            / SEQUENTIAL_STORED_FIELDS_MIN_DENSITY_INVERSE;
+        return cost >= Math.max(SEQUENTIAL_STORED_FIELDS_MIN_DOCS, minDocsForDensity);
+    }
+
+    /**
+     * Returns a {@link StoredFields} instance optimized for sequential access, or {@code null} when the reader chain does not expose one.
+     * Wrappers are unwrapped only until the first {@link SequentialStoredFieldsLeafReader}, preserving any stored-fields transformations.
+     * If {@link Lucene#wrapAllDocsLive} has exposed a bare codec reader for a leaf with hard deletes, use its merge instance directly.
+     */
+    static StoredFields sequentialStoredFields(LeafReader leafReader) throws IOException {
+        LeafReader reader = leafReader;
+        while (reader instanceof FilterLeafReader) {
+            if (reader instanceof SequentialStoredFieldsLeafReader) {
+                return ((SequentialStoredFieldsLeafReader) reader).getSequentialStoredFieldsReader();
+            }
+            reader = ((FilterLeafReader) reader).getDelegate();
+        }
+        if (reader instanceof CodecReader) {
+            return ((CodecReader) reader).getFieldsReader().getMergeInstance();
+        }
+        return null;
     }
 
 }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -45,7 +45,9 @@ import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.FilterLeafReader;
@@ -137,6 +139,7 @@ import org.opensearch.index.VersionType;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.Engine.IndexResult;
 import org.opensearch.index.fieldvisitor.FieldsVisitor;
+import org.opensearch.index.fieldvisitor.IdOnlyFieldVisitor;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.DocumentMapperForType;
 import org.opensearch.index.mapper.IdFieldMapper;
@@ -7591,6 +7594,58 @@ public class InternalEngineTests extends EngineTestCase {
                     engine.getMaxSeqNoOfUpdatesOrDeletes(),
                     equalTo(Math.max(currentMaxSeqNoOfUpdates, result.getSeqNo()))
                 );
+            }
+        }
+    }
+
+    public void testSequentialStoredFieldsDensityCriterion() {
+        assertTrue(InternalEngine.useSequentialStoredFields(128, 1024));
+        assertFalse(InternalEngine.useSequentialStoredFields(127, 1024));
+        assertTrue(InternalEngine.useSequentialStoredFields(10, 80));
+        assertFalse("small batches do not amortize the merge-instance overhead", InternalEngine.useSequentialStoredFields(9, 9));
+        assertFalse(InternalEngine.useSequentialStoredFields(10, 81));
+        assertFalse(InternalEngine.useSequentialStoredFields(0, 1));
+    }
+
+    public void testSequentialStoredFieldsReader() throws Exception {
+        final int numDocs = 10;
+        for (boolean hardDeletes : new boolean[] { false, true }) {
+            try (Directory directory = newDirectory()) {
+                final IndexWriterConfig config = new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setMergePolicy(NoMergePolicy.INSTANCE);
+                try (IndexWriter writer = new IndexWriter(directory, config)) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document document = new Document();
+                        document.add(new StringField(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)), Field.Store.YES));
+                        writer.addDocument(document);
+                    }
+                    if (hardDeletes) {
+                        writer.deleteDocuments(new Term(IdFieldMapper.NAME, Uid.encodeId("0")));
+                    }
+                    writer.commit();
+                }
+                try (
+                    DirectoryReader reader = Lucene.wrapAllDocsLive(
+                        OpenSearchDirectoryReader.wrap(DirectoryReader.open(directory), shardId)
+                    )
+                ) {
+                    assertThat(reader.leaves(), hasSize(1));
+                    final LeafReader leaf = reader.leaves().get(0).reader();
+                    final LeafReader delegate = ((FilterLeafReader) leaf).getDelegate();
+                    assertThat(delegate, hardDeletes ? instanceOf(CodecReader.class) : instanceOf(SequentialStoredFieldsLeafReader.class));
+
+                    final StoredFields sequential = InternalEngine.sequentialStoredFields(leaf);
+                    assertNotNull(sequential);
+                    final StoredFields randomAccess = leaf.storedFields();
+                    final IdOnlyFieldVisitor visitor = new IdOnlyFieldVisitor();
+                    for (int docId = 0; docId < leaf.maxDoc(); docId++) {
+                        sequential.document(docId, visitor);
+                        final String sequentialId = visitor.getId();
+                        visitor.reset();
+                        randomAccess.document(docId, visitor);
+                        assertEquals(sequentialId, visitor.getId());
+                        visitor.reset();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Description

I set up a nyc_taxis  (1P + 1R) workload with segment replication enabled and kill the primary, waiting for the replica promotion to complete, here is the flamegraph:

<img width="2208" height="1082" alt="image" src="https://github.com/user-attachments/assets/6bed3bf3-de83-44a5-a26c-cfba15694e2c" />

By adding more logs, the total recovery time breakdown is shown as follows:
1. restoreVersionMapAndCheckpointTracker: 163s
2. translog recovery: 95s
3. flush: 3s

The version map recovery is mainly contributed by the storefield decompression.

This change reduces repeated stored-fields decompression while `InternalEngine` restores its version map and local checkpoint tracker. The restore path scans documents whose sequence numbers are above the persisted local checkpoint and loads each document's `_id`. With the default random-access `StoredFields` reader, multiple documents from the same compressed block may cause that block to be decompressed repeatedly. 

For each leaf, this change uses a merge-instance stored-fields reader when both of these conservative conditions are met:

- The estimated number of matching documents is at least 10.
- The estimated matching-document density is at least 1/8 of the leaf.

The same criterion is applied to sorted and unsorted indexes. It deliberately does not assume sequence-number order maps to contiguous Lucene doc IDs, because replica operations, merges, and nested documents can produce non-contiguous layouts. Leaves below the threshold continue to use the existing random-access reader.

#### Benchmark

A local JMH run against the current `main` dependencies (Lucene 10.5.1 and JDK 25) used one fork, three 1-second warmups, five 1-second measurements, and one NIOFS segment with 200,000 documents. Each document had a 256-byte stored `_source`; the benchmark selected 1/8 of the documents while reading only `_id`. Times are microseconds per matching document.

| Codec | Layout | Random access | Sequential reader | Speedup |
| --- | --- | ---: | ---: | ---: |
| `best_compression` | scattered | 167.24 | 5.91 | 28.3x |
| `best_compression` | clustered | 166.65 | 0.94 | 177.2x |
| `best_speed` | scattered | 17.63 | 4.30 | 4.1x |
| `best_speed` | clustered | 16.96 | 0.64 | 26.4x |

The 1/8 threshold shows clear headroom for both codecs even in the scattered layout. Lower-density leaves keep the current random-access behavior even when their matching documents happen to be clustered.

This follows the same general approach as OpenSearch's contiguous history-read optimization in https://github.com/opensearch-project/OpenSearch/pull/22603.

#### Testing

- Added deterministic threshold-boundary coverage.
- Added one compact reader test covering both the normal `Lucene.wrapAllDocsLive` wrapper chain and its hard-delete `CodecReader` branch, including identical `_id` reads.
- Kept the existing randomized version-map/checkpoint reconstruction coverage.
- Ran:

```text
./gradlew :server:spotlessCheck :server:test \
  --tests org.opensearch.index.engine.InternalEngineTests \
  --tests org.opensearch.index.engine.LuceneChangesSnapshotTests
```

### Related Issues
<!-- Replace #TODO with the community issue discussed before submitting this PR. -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. (Not applicable: no REST API schema changes.)
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. (Not applicable: this is an internal implementation change with no new setting.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
